### PR TITLE
rename ent.Edge to ent.AssocEdge and other related things

### DIFF
--- a/ent/actions/action_edge_test.go
+++ b/ent/actions/action_edge_test.go
@@ -61,7 +61,7 @@ func (suite *actionEdgesSuite) TestUniqueEdges() {
 
 	edge, err := ent.LoadEdgeByType(event.ID, user.ID, models.EventToCreatorEdge)
 	assert.Nil(suite.T(), err)
-	testingutils.VerifyEdge(suite.T(), &ent.Edge{
+	testingutils.VerifyEdge(suite.T(), &ent.AssocEdge{
 		ID1:      event.GetID(),
 		ID1Type:  event.GetType(),
 		ID2:      user.GetID(),

--- a/ent/actions/mutation_builder_test.go
+++ b/ent/actions/mutation_builder_test.go
@@ -257,7 +257,7 @@ func (suite *mutationBuilderSuite) TestManualDataField() {
 
 	edge, err := ent.LoadEdgeByType(user.ID, user2.ID, models.UserToFamilyMembersEdge)
 	assert.Nil(suite.T(), err)
-	testingutils.VerifyEdge(suite.T(), &ent.Edge{
+	testingutils.VerifyEdge(suite.T(), &ent.AssocEdge{
 		ID1:      user.ID,
 		ID2:      user2.ID,
 		EdgeType: models.UserToFamilyMembersEdge,
@@ -301,7 +301,7 @@ func (suite *mutationBuilderSuite) TestManualTimeField() {
 
 		edge, err := ent.LoadEdgeByType(user.ID, user2.ID, models.UserToFamilyMembersEdge)
 		assert.Nil(suite.T(), err)
-		testingutils.VerifyEdge(suite.T(), &ent.Edge{
+		testingutils.VerifyEdge(suite.T(), &ent.AssocEdge{
 			ID1:      user.ID,
 			ID2:      user2.ID,
 			EdgeType: models.UserToFamilyMembersEdge,

--- a/ent/edge.go
+++ b/ent/edge.go
@@ -8,14 +8,14 @@ import (
 	"github.com/lolopinto/ent/ent/viewer"
 )
 
-// Edge is the information about an edge between two Nodes
+// AssocEdge is the information about an edge between two Nodes
 // It's generic enough so that it applies across all types.
 // Doesn't care what table it's stored in.
 // TODO fix comment about where edges are stored.
 // By default, edges are stored in the `edges_info` table but we
 // can have custom edge tables for specific edges where we know
 // there'll be a lot of data
-type Edge struct {
+type AssocEdge struct {
 	ID1      string    `db:"id1"`
 	ID1Type  NodeType  `db:"id1_type"`
 	EdgeType EdgeType  `db:"edge_type"`
@@ -25,7 +25,7 @@ type Edge struct {
 	Data     string    `db:"data"` // nullable TODO nullable strings
 }
 
-func (edge *Edge) DBFields() DBFields {
+func (edge *AssocEdge) DBFields() DBFields {
 	return DBFields{
 		"id1": func(v interface{}) error {
 			var err error
@@ -65,15 +65,15 @@ func (edge *Edge) DBFields() DBFields {
 	}
 }
 
-// EdgeResult stores the result of loading an Edge concurrently
-type EdgeResult struct {
-	Edge  *Edge
+// AssocEdgeResult stores the result of loading an Edge concurrently
+type AssocEdgeResult struct {
+	Edge  *AssocEdge
 	Error error
 }
 
-// EdgesResult stores the result of loading a slice of edges concurrently
-type EdgesResult struct {
-	Edges []*Edge
+// AssocEdgesResult stores the result of loading a slice of edges concurrently
+type AssocEdgesResult struct {
+	Edges []*AssocEdge
 	Error error
 }
 

--- a/ent/loader.go
+++ b/ent/loader.go
@@ -382,7 +382,7 @@ func (l *loadNodeFromPKey) GetCacheKey() string {
 type loadEdgesByType struct {
 	id         string
 	edgeType   EdgeType
-	edges      []*Edge
+	edges      []*AssocEdge
 	outputID2s bool
 	options    []func(*LoadEdgeConfig)
 	cfg        LoadEdgeConfig
@@ -426,7 +426,7 @@ func (l *loadEdgesByType) GetCacheKey() string {
 }
 
 func (l *loadEdgesByType) GetNewInstance() interface{} {
-	var edge Edge
+	var edge AssocEdge
 	l.edges = append(l.edges, &edge)
 	return &edge
 }
@@ -447,7 +447,7 @@ func (l *loadEdgesByType) GetOutput() interface{} {
 	return l.edges
 }
 
-func (l *loadEdgesByType) LoadData() ([]*Edge, error) {
+func (l *loadEdgesByType) LoadData() ([]*AssocEdge, error) {
 	err := loadData(l)
 	if err != nil {
 		return nil, err

--- a/ent/models.go
+++ b/ent/models.go
@@ -433,7 +433,7 @@ func Limit(limit int) func(*LoadEdgeConfig) {
 	}
 }
 
-func LoadEdgesByType(id string, edgeType EdgeType, options ...func(*LoadEdgeConfig)) ([]*Edge, error) {
+func LoadEdgesByType(id string, edgeType EdgeType, options ...func(*LoadEdgeConfig)) ([]*AssocEdge, error) {
 	l := &loadEdgesByType{
 		id:       id,
 		edgeType: edgeType,
@@ -441,7 +441,7 @@ func LoadEdgesByType(id string, edgeType EdgeType, options ...func(*LoadEdgeConf
 	return l.LoadData()
 }
 
-func LoadUniqueEdgeByType(id string, edgeType EdgeType) (*Edge, error) {
+func LoadUniqueEdgeByType(id string, edgeType EdgeType) (*AssocEdge, error) {
 	edges, err := LoadEdgesByType(id, edgeType, Limit(1))
 	if err != nil {
 		return nil, err
@@ -452,37 +452,37 @@ func LoadUniqueEdgeByType(id string, edgeType EdgeType) (*Edge, error) {
 // GenLoadEdgesByType handles loading of edges concurrently.
 // Because we get strong typing across all edges and for a consistent API with loading Nodes,
 // we use the EdgesResult struct here
-func GenLoadEdgesByType(id string, edgeType EdgeType, chanEdgesResult chan<- EdgesResult, options ...func(*LoadEdgeConfig)) {
+func GenLoadEdgesByType(id string, edgeType EdgeType, chanEdgesResult chan<- AssocEdgesResult, options ...func(*LoadEdgeConfig)) {
 	edges, err := LoadEdgesByType(id, edgeType, options...)
 	// var edges []*Edge
 	// chanErr := make(chan error)
 	// go GenLoadEdgesByType(id, edgeType, &edges, chanErr)
 	//	err := <-chanErr
-	chanEdgesResult <- EdgesResult{
+	chanEdgesResult <- AssocEdgesResult{
 		Edges: edges,
 		Error: err,
 	}
 }
 
-func GenLoadUniqueEdgeByType(id string, edgeType EdgeType, chanEdgeResult chan<- EdgeResult) {
+func GenLoadUniqueEdgeByType(id string, edgeType EdgeType, chanEdgeResult chan<- AssocEdgeResult) {
 	edge, err := LoadUniqueEdgeByType(id, edgeType)
-	chanEdgeResult <- EdgeResult{
+	chanEdgeResult <- AssocEdgeResult{
 		Edge:  edge,
 		Error: err,
 	}
 }
 
 // GenLoadEdgeByType is the concurrent version of LoadEdgeByType
-func GenLoadEdgeByType(id1, id2 string, edgeType EdgeType, chanEdgeResult chan<- EdgeResult) {
+func GenLoadEdgeByType(id1, id2 string, edgeType EdgeType, chanEdgeResult chan<- AssocEdgeResult) {
 	edge, err := LoadEdgeByType(id1, id2, edgeType)
-	chanEdgeResult <- EdgeResult{
+	chanEdgeResult <- AssocEdgeResult{
 		Edge:  edge,
 		Error: err,
 	}
 }
 
 // LoadEdgeByType checks if an edge exists between 2 ids
-func LoadEdgeByType(id string, id2 string, edgeType EdgeType) (*Edge, error) {
+func LoadEdgeByType(id string, id2 string, edgeType EdgeType) (*AssocEdge, error) {
 	// check if we can use the standard id1->edgeType cache
 	edges, err := LoadEdgesByType(id, edgeType)
 	if err != nil {
@@ -494,7 +494,7 @@ func LoadEdgeByType(id string, id2 string, edgeType EdgeType) (*Edge, error) {
 		}
 	}
 	// no edge
-	return &Edge{}, nil
+	return &AssocEdge{}, nil
 
 	// this checks if the edge exists based on the cache key and then does nothing about it
 	// I think this approach is the best longterm approach but we don't have the way to delete

--- a/ent/models_test.go
+++ b/ent/models_test.go
@@ -149,14 +149,14 @@ func (suite *modelsTestSuite) TestGetEdgeInfo() {
 }
 
 func (suite *modelsTestSuite) TestLoadEdgesByType() {
-	testLoadEdgesByType(suite, func(id string) ([]*ent.Edge, error) {
+	testLoadEdgesByType(suite, func(id string) ([]*ent.AssocEdge, error) {
 		return ent.LoadEdgesByType(id, models.UserToEventsEdge)
 	})
 }
 
 func (suite *modelsTestSuite) TestGenLoadEdgesByType() {
-	testLoadEdgesByType(suite, func(id string) ([]*ent.Edge, error) {
-		chanResult := make(chan ent.EdgesResult)
+	testLoadEdgesByType(suite, func(id string) ([]*ent.AssocEdge, error) {
+		chanResult := make(chan ent.AssocEdgesResult)
 		go ent.GenLoadEdgesByType(id, models.UserToEventsEdge, chanResult)
 		result := <-chanResult
 		return result.Edges, result.Error
@@ -170,7 +170,7 @@ func (suite *modelsTestSuite) TestGeneratedLoadEdgesByType() {
 
 	verifyEdges(
 		suite,
-		func() ([]*ent.Edge, error) {
+		func() ([]*ent.AssocEdge, error) {
 			v := viewertesting.LoggedinViewerContext{ViewerID: user.ID}
 
 			user, err := models.LoadUser(v, user.ID)
@@ -192,12 +192,12 @@ func (suite *modelsTestSuite) TestGeneratedGenLoadEdgesByType() {
 
 	verifyEdges(
 		suite,
-		func() ([]*ent.Edge, error) {
+		func() ([]*ent.AssocEdge, error) {
 			v := viewertesting.LoggedinViewerContext{ViewerID: user.ID}
 			user, err := models.LoadUser(v, user.ID)
 			util.Die(err)
 
-			var result ent.EdgesResult
+			var result ent.AssocEdgesResult
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go user.GenEventsEdges(&result, &wg)
@@ -212,7 +212,7 @@ func (suite *modelsTestSuite) TestGeneratedGenLoadEdgesByType() {
 	)
 }
 
-func testLoadEdgesByType(suite *modelsTestSuite, f func(id string) ([]*ent.Edge, error)) {
+func testLoadEdgesByType(suite *modelsTestSuite, f func(id string) ([]*ent.AssocEdge, error)) {
 	user := testingutils.CreateTestUser(suite.T())
 	event := testingutils.CreateTestEvent(suite.T(), user)
 	event2 := testingutils.CreateTestEvent(suite.T(), user)
@@ -238,7 +238,7 @@ func testLoadEdgesByType(suite *modelsTestSuite, f func(id string) ([]*ent.Edge,
 	for _, tt := range testCases {
 		verifyEdges(
 			suite,
-			func() ([]*ent.Edge, error) {
+			func() ([]*ent.AssocEdge, error) {
 				return f(tt.id1)
 			},
 			[]string{event.ID, event2.ID},
@@ -249,7 +249,7 @@ func testLoadEdgesByType(suite *modelsTestSuite, f func(id string) ([]*ent.Edge,
 
 func verifyEdges(
 	suite *modelsTestSuite,
-	f func() ([]*ent.Edge, error),
+	f func() ([]*ent.AssocEdge, error),
 	expectedIds []string,
 	foundResult bool,
 ) {
@@ -270,14 +270,14 @@ func verifyEdges(
 }
 
 func (suite *modelsTestSuite) TestLoadEdgeByType() {
-	testLoadEdgeByType(suite, func(id1, id2 string) (*ent.Edge, error) {
+	testLoadEdgeByType(suite, func(id1, id2 string) (*ent.AssocEdge, error) {
 		return ent.LoadEdgeByType(id1, id2, models.UserToEventsEdge)
 	})
 }
 
 func (suite *modelsTestSuite) TestGenLoadEdgeByType() {
-	testLoadEdgeByType(suite, func(id1, id2 string) (*ent.Edge, error) {
-		chanResult := make(chan ent.EdgeResult)
+	testLoadEdgeByType(suite, func(id1, id2 string) (*ent.AssocEdge, error) {
+		chanResult := make(chan ent.AssocEdgeResult)
 		go ent.GenLoadEdgeByType(id1, id2, models.UserToEventsEdge, chanResult)
 		result := <-chanResult
 		return result.Edge, result.Error
@@ -290,7 +290,7 @@ func (suite *modelsTestSuite) TestGeneratedLoadEdgeByType() {
 
 	verifyEdgeByType(
 		suite,
-		func() (*ent.Edge, error) {
+		func() (*ent.AssocEdge, error) {
 			v := viewertesting.LoggedinViewerContext{ViewerID: user.ID}
 
 			user, err := models.LoadUser(v, user.ID)
@@ -303,14 +303,14 @@ func (suite *modelsTestSuite) TestGeneratedLoadEdgeByType() {
 }
 
 func (suite *modelsTestSuite) TestUniqueLoadEdgeByType() {
-	testUniqueLoadEdgeByType(suite, func(id1 string) (*ent.Edge, error) {
+	testUniqueLoadEdgeByType(suite, func(id1 string) (*ent.AssocEdge, error) {
 		return ent.LoadUniqueEdgeByType(id1, models.EventToCreatorEdge)
 	})
 }
 
 func (suite *modelsTestSuite) TestGenUniqueLoadEdgeByType() {
-	testUniqueLoadEdgeByType(suite, func(id1 string) (*ent.Edge, error) {
-		chanResult := make(chan ent.EdgeResult)
+	testUniqueLoadEdgeByType(suite, func(id1 string) (*ent.AssocEdge, error) {
+		chanResult := make(chan ent.AssocEdgeResult)
 		go ent.GenLoadUniqueEdgeByType(id1, models.EventToCreatorEdge, chanResult)
 		result := <-chanResult
 		return result.Edge, result.Error
@@ -318,7 +318,7 @@ func (suite *modelsTestSuite) TestGenUniqueLoadEdgeByType() {
 }
 
 func (suite *modelsTestSuite) TestGeneratedUniqueLoadEdgeByType() {
-	testUniqueLoadEdgeByType(suite, func(id1 string) (*ent.Edge, error) {
+	testUniqueLoadEdgeByType(suite, func(id1 string) (*ent.AssocEdge, error) {
 		v := viewertesting.OmniViewerContext{}
 		event, err := models.LoadEvent(v, id1)
 		util.Die(err)
@@ -327,12 +327,12 @@ func (suite *modelsTestSuite) TestGeneratedUniqueLoadEdgeByType() {
 }
 
 func (suite *modelsTestSuite) TestGeneratedGenUniqueLoadEdgeByType() {
-	testUniqueLoadEdgeByType(suite, func(id1 string) (*ent.Edge, error) {
+	testUniqueLoadEdgeByType(suite, func(id1 string) (*ent.AssocEdge, error) {
 		v := viewertesting.OmniViewerContext{}
 		event, err := models.LoadEvent(v, id1)
 		util.Die(err)
 		var wg sync.WaitGroup
-		var result ent.EdgeResult
+		var result ent.AssocEdgeResult
 		wg.Add(1)
 		go event.GenCreatorEdge(&result, &wg)
 		wg.Wait()
@@ -369,14 +369,14 @@ func (suite *modelsTestSuite) TestGeneratedGenLoadEdgeByType() {
 
 	verifyEdgeByType(
 		suite,
-		func() (*ent.Edge, error) {
+		func() (*ent.AssocEdge, error) {
 			v := viewertesting.LoggedinViewerContext{ViewerID: user.ID}
 
 			user, err := models.LoadUser(v, user.ID)
 			util.Die(err)
 
 			var wg sync.WaitGroup
-			var result ent.EdgeResult
+			var result ent.AssocEdgeResult
 			wg.Add(1)
 			go user.GenLoadEventsEdgeFor(event.ID, &result, &wg)
 			wg.Wait()
@@ -410,13 +410,13 @@ func (suite *modelsTestSuite) TestLoadEdgeByTypeEmptyID2() {
 	assert.Zero(suite.T(), *edge)
 }
 
-func testLoadEdgeByType(suite *modelsTestSuite, f func(id, id2 string) (*ent.Edge, error)) {
+func testLoadEdgeByType(suite *modelsTestSuite, f func(id, id2 string) (*ent.AssocEdge, error)) {
 	user := testingutils.CreateTestUser(suite.T())
 	event := testingutils.CreateTestEvent(suite.T(), user)
 
 	verifyEdgeByType(
 		suite,
-		func() (*ent.Edge, error) {
+		func() (*ent.AssocEdge, error) {
 			return f(user.ID, event.ID)
 		},
 		user.ID,
@@ -424,13 +424,13 @@ func testLoadEdgeByType(suite *modelsTestSuite, f func(id, id2 string) (*ent.Edg
 	)
 }
 
-func testUniqueLoadEdgeByType(suite *modelsTestSuite, f func(id string) (*ent.Edge, error)) {
+func testUniqueLoadEdgeByType(suite *modelsTestSuite, f func(id string) (*ent.AssocEdge, error)) {
 	user := testingutils.CreateTestUser(suite.T())
 	event := testingutils.CreateTestEvent(suite.T(), user)
 
 	verifyEdgeByType(
 		suite,
-		func() (*ent.Edge, error) {
+		func() (*ent.AssocEdge, error) {
 			return f(event.ID)
 		},
 		event.ID,
@@ -448,7 +448,7 @@ func testUniqueLoadNodeByType(suite *modelsTestSuite, f func(id string) (*models
 	assert.Equal(suite.T(), user.ID, node.ID)
 }
 
-func verifyEdgeByType(suite *modelsTestSuite, f func() (*ent.Edge, error), id1, id2 string) {
+func verifyEdgeByType(suite *modelsTestSuite, f func() (*ent.AssocEdge, error), id1, id2 string) {
 	edge, err := f()
 	assert.Nil(suite.T(), err)
 	assert.NotZero(suite.T(), edge)

--- a/ent/privacy_loading.go
+++ b/ent/privacy_loading.go
@@ -277,7 +277,7 @@ func LoadUniqueNodeByType(viewer viewer.ViewerContext, id string, edgeType EdgeT
 
 func GenLoadUniqueNodeByType(viewer viewer.ViewerContext, id string, edgeType EdgeType, node Entity, entConfig Config, errChan chan<- error) {
 	//	chanErr := make(chan error)
-	edgeResultChan := make(chan EdgeResult)
+	edgeResultChan := make(chan AssocEdgeResult)
 	go GenLoadUniqueEdgeByType(id, edgeType, edgeResultChan)
 	edgeResult := <-edgeResultChan
 	if edgeResult.Error != nil {

--- a/ent/privacy_loading_test.go
+++ b/ent/privacy_loading_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/lolopinto/ent/ent"
-	"github.com/lolopinto/ent/internal/test_schema/models"
-	"github.com/lolopinto/ent/internal/test_schema/models/configs"
 	"github.com/lolopinto/ent/ent/viewer"
 	"github.com/lolopinto/ent/ent/viewertesting"
 	entreflect "github.com/lolopinto/ent/internal/reflect"
+	"github.com/lolopinto/ent/internal/test_schema/models"
+	"github.com/lolopinto/ent/internal/test_schema/models/configs"
 	"github.com/lolopinto/ent/internal/testingutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"

--- a/internal/code/node.gotmpl
+++ b/internal/code/node.gotmpl
@@ -165,14 +165,14 @@ func GenLoad{{.Node}}(viewer viewer.ViewerContext, id string, result *{{.NodeRes
 
         {{ if $uniqueEdge -}}
           // Load{{$edgeName}}Edge returns the {{$edgeName}} edge associated with the {{$currentNode}} instance
-          func ({{$currentNodeInstance}} *{{$currentNode}}) Load{{$edgeName}}Edge() (*ent.Edge, error) {
+          func ({{$currentNodeInstance}} *{{$currentNode}}) Load{{$edgeName}}Edge() (*ent.AssocEdge, error) {
             return ent.LoadUniqueEdgeByType({{$currentNodeInstance}}.ID, {{$edge.EdgeConst}})
           }
 
           // Gen{{$edgeName}}Edge returns the {{$edgeName}} edge associated with the {{$currentNode}} instance
-          func ({{$currentNodeInstance}} *{{$currentNode}}) Gen{{$edgeName}}Edge(result *ent.EdgeResult, wg *sync.WaitGroup) {
+          func ({{$currentNodeInstance}} *{{$currentNode}}) Gen{{$edgeName}}Edge(result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
             defer wg.Done()
-            edgeResultChan := make(chan ent.EdgeResult)
+            edgeResultChan := make(chan ent.AssocEdgeResult)
             go ent.GenLoadUniqueEdgeByType({{$currentNodeInstance}}.ID, {{$edge.EdgeConst}}, edgeResultChan)
             *result = <- edgeResultChan
           }
@@ -196,14 +196,14 @@ func GenLoad{{.Node}}(viewer viewer.ViewerContext, id string, result *{{.NodeRes
           }
         {{else -}}
           // Load{{$edgeName}}Edges returns the {{$edgeName}} edges associated with the {{$currentNode}} instance
-          func ({{$currentNodeInstance}} *{{$currentNode}}) Load{{$edgeName}}Edges() ([]*ent.Edge, error) {
+          func ({{$currentNodeInstance}} *{{$currentNode}}) Load{{$edgeName}}Edges() ([]*ent.AssocEdge, error) {
             return ent.LoadEdgesByType({{$currentNodeInstance}}.ID, {{$edge.EdgeConst}})
           }
 
           // Gen{{$edgeName}}Edges returns the {{.Node}} edges associated with the {{$currentNode}} instance
-          func ({{$currentNodeInstance}} *{{$currentNode}}) Gen{{$edgeName}}Edges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+          func ({{$currentNodeInstance}} *{{$currentNode}}) Gen{{$edgeName}}Edges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
             defer wg.Done()
-            edgesResultChan := make(chan ent.EdgesResult)
+            edgesResultChan := make(chan ent.AssocEdgesResult)
             go ent.GenLoadEdgesByType({{$currentNodeInstance}}.ID, {{$edge.EdgeConst}}, edgesResultChan)
             *result = <- edgesResultChan
           }
@@ -228,15 +228,15 @@ func GenLoad{{.Node}}(viewer viewer.ViewerContext, id string, result *{{.NodeRes
         {{end -}}
 
 
-        // Load{{$edgeName}}EdgeFor loads the ent.Edge between the current node and the given id2 for the {{$edgeName}} edge.
-        func ({{$currentNodeInstance}} *{{$currentNode}}) Load{{$edgeName}}EdgeFor(id2 string) (*ent.Edge, error) {
+        // Load{{$edgeName}}EdgeFor loads the ent.AssocEdge between the current node and the given id2 for the {{$edgeName}} edge.
+        func ({{$currentNodeInstance}} *{{$currentNode}}) Load{{$edgeName}}EdgeFor(id2 string) (*ent.AssocEdge, error) {
           return ent.LoadEdgeByType({{$currentNodeInstance}}.ID, id2, {{$edge.EdgeConst}})
         }
 
-        // Gen{{$edgeName}}EdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the {{$edgeName}} edge.
-        func ({{$currentNodeInstance}} *{{$currentNode}}) GenLoad{{$edgeName}}EdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+        // Gen{{$edgeName}}EdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the {{$edgeName}} edge.
+        func ({{$currentNodeInstance}} *{{$currentNode}}) GenLoad{{$edgeName}}EdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
           defer wg.Done()
-          edgeResultChan := make(chan ent.EdgeResult)
+          edgeResultChan := make(chan ent.AssocEdgeResult)
           go ent.GenLoadEdgeByType({{$currentNodeInstance}}.ID, id2, {{$edge.EdgeConst}}, edgeResultChan)
           *result = <- edgeResultChan
         }
@@ -252,7 +252,7 @@ func GenLoad{{.Node}}(viewer viewer.ViewerContext, id string, result *{{.NodeRes
       		return &ret, nil
         }
         statusMap := {{$currentNodeInstance}}.{{$assocEdgeGroup.GroupStatusName}}Map()
-        edges := make(map[string]*ent.Edge)
+        edges := make(map[string]*ent.AssocEdge)
         errs := make(map[string]error)
         for key, data := range statusMap {
           // TODO concurrent versions

--- a/internal/test_schema/models/contact.go
+++ b/internal/test_schema/models/contact.go
@@ -114,14 +114,14 @@ func (contact *Contact) LoadContactEmails() ([]*ContactEmail, error) {
 }
 
 // LoadAllowListEdges returns the AllowList edges associated with the Contact instance
-func (contact *Contact) LoadAllowListEdges() ([]*ent.Edge, error) {
+func (contact *Contact) LoadAllowListEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(contact.ID, ContactToAllowListEdge)
 }
 
 // GenAllowListEdges returns the User edges associated with the Contact instance
-func (contact *Contact) GenAllowListEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (contact *Contact) GenAllowListEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(contact.ID, ContactToAllowListEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -144,15 +144,15 @@ func (contact *Contact) LoadAllowList() ([]*User, error) {
 	return users, err
 }
 
-// LoadAllowListEdgeFor loads the ent.Edge between the current node and the given id2 for the AllowList edge.
-func (contact *Contact) LoadAllowListEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadAllowListEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the AllowList edge.
+func (contact *Contact) LoadAllowListEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(contact.ID, id2, ContactToAllowListEdge)
 }
 
-// GenAllowListEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the AllowList edge.
-func (contact *Contact) GenLoadAllowListEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenAllowListEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the AllowList edge.
+func (contact *Contact) GenLoadAllowListEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(contact.ID, id2, ContactToAllowListEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }

--- a/internal/test_schema/models/event.go
+++ b/internal/test_schema/models/event.go
@@ -125,14 +125,14 @@ func (event *Event) LoadUser() (*User, error) {
 }
 
 // LoadHostsEdges returns the Hosts edges associated with the Event instance
-func (event *Event) LoadHostsEdges() ([]*ent.Edge, error) {
+func (event *Event) LoadHostsEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(event.ID, EventToHostsEdge)
 }
 
 // GenHostsEdges returns the User edges associated with the Event instance
-func (event *Event) GenHostsEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (event *Event) GenHostsEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(event.ID, EventToHostsEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -155,28 +155,28 @@ func (event *Event) LoadHosts() ([]*User, error) {
 	return users, err
 }
 
-// LoadHostsEdgeFor loads the ent.Edge between the current node and the given id2 for the Hosts edge.
-func (event *Event) LoadHostsEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadHostsEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the Hosts edge.
+func (event *Event) LoadHostsEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(event.ID, id2, EventToHostsEdge)
 }
 
-// GenHostsEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the Hosts edge.
-func (event *Event) GenLoadHostsEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenHostsEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the Hosts edge.
+func (event *Event) GenLoadHostsEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(event.ID, id2, EventToHostsEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadCreatorEdge returns the Creator edge associated with the Event instance
-func (event *Event) LoadCreatorEdge() (*ent.Edge, error) {
+func (event *Event) LoadCreatorEdge() (*ent.AssocEdge, error) {
 	return ent.LoadUniqueEdgeByType(event.ID, EventToCreatorEdge)
 }
 
 // GenCreatorEdge returns the Creator edge associated with the Event instance
-func (event *Event) GenCreatorEdge(result *ent.EdgeResult, wg *sync.WaitGroup) {
+func (event *Event) GenCreatorEdge(result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadUniqueEdgeByType(event.ID, EventToCreatorEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
@@ -199,28 +199,28 @@ func (event *Event) LoadCreator() (*User, error) {
 	return &user, err
 }
 
-// LoadCreatorEdgeFor loads the ent.Edge between the current node and the given id2 for the Creator edge.
-func (event *Event) LoadCreatorEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadCreatorEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the Creator edge.
+func (event *Event) LoadCreatorEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(event.ID, id2, EventToCreatorEdge)
 }
 
-// GenCreatorEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the Creator edge.
-func (event *Event) GenLoadCreatorEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenCreatorEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the Creator edge.
+func (event *Event) GenLoadCreatorEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(event.ID, id2, EventToCreatorEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadInvitedEdges returns the Invited edges associated with the Event instance
-func (event *Event) LoadInvitedEdges() ([]*ent.Edge, error) {
+func (event *Event) LoadInvitedEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(event.ID, EventToInvitedEdge)
 }
 
 // GenInvitedEdges returns the User edges associated with the Event instance
-func (event *Event) GenInvitedEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (event *Event) GenInvitedEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(event.ID, EventToInvitedEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -243,28 +243,28 @@ func (event *Event) LoadInvited() ([]*User, error) {
 	return users, err
 }
 
-// LoadInvitedEdgeFor loads the ent.Edge between the current node and the given id2 for the Invited edge.
-func (event *Event) LoadInvitedEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadInvitedEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the Invited edge.
+func (event *Event) LoadInvitedEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(event.ID, id2, EventToInvitedEdge)
 }
 
-// GenInvitedEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the Invited edge.
-func (event *Event) GenLoadInvitedEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenInvitedEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the Invited edge.
+func (event *Event) GenLoadInvitedEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(event.ID, id2, EventToInvitedEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadAttendingEdges returns the Attending edges associated with the Event instance
-func (event *Event) LoadAttendingEdges() ([]*ent.Edge, error) {
+func (event *Event) LoadAttendingEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(event.ID, EventToAttendingEdge)
 }
 
 // GenAttendingEdges returns the User edges associated with the Event instance
-func (event *Event) GenAttendingEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (event *Event) GenAttendingEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(event.ID, EventToAttendingEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -287,28 +287,28 @@ func (event *Event) LoadAttending() ([]*User, error) {
 	return users, err
 }
 
-// LoadAttendingEdgeFor loads the ent.Edge between the current node and the given id2 for the Attending edge.
-func (event *Event) LoadAttendingEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadAttendingEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the Attending edge.
+func (event *Event) LoadAttendingEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(event.ID, id2, EventToAttendingEdge)
 }
 
-// GenAttendingEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the Attending edge.
-func (event *Event) GenLoadAttendingEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenAttendingEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the Attending edge.
+func (event *Event) GenLoadAttendingEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(event.ID, id2, EventToAttendingEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadDeclinedEdges returns the Declined edges associated with the Event instance
-func (event *Event) LoadDeclinedEdges() ([]*ent.Edge, error) {
+func (event *Event) LoadDeclinedEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(event.ID, EventToDeclinedEdge)
 }
 
 // GenDeclinedEdges returns the User edges associated with the Event instance
-func (event *Event) GenDeclinedEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (event *Event) GenDeclinedEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(event.ID, EventToDeclinedEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -331,15 +331,15 @@ func (event *Event) LoadDeclined() ([]*User, error) {
 	return users, err
 }
 
-// LoadDeclinedEdgeFor loads the ent.Edge between the current node and the given id2 for the Declined edge.
-func (event *Event) LoadDeclinedEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadDeclinedEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the Declined edge.
+func (event *Event) LoadDeclinedEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(event.ID, id2, EventToDeclinedEdge)
 }
 
-// GenDeclinedEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the Declined edge.
-func (event *Event) GenLoadDeclinedEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenDeclinedEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the Declined edge.
+func (event *Event) GenLoadDeclinedEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(event.ID, id2, EventToDeclinedEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
@@ -350,7 +350,7 @@ func (event *Event) ViewerRsvpStatus() (*EventRsvpStatus, error) {
 		return &ret, nil
 	}
 	statusMap := event.RsvpStatusMap()
-	edges := make(map[string]*ent.Edge)
+	edges := make(map[string]*ent.AssocEdge)
 	errs := make(map[string]error)
 	for key, data := range statusMap {
 		// TODO concurrent versions

--- a/internal/test_schema/models/user.go
+++ b/internal/test_schema/models/user.go
@@ -121,14 +121,14 @@ func (user *User) LoadContacts() ([]*Contact, error) {
 }
 
 // LoadEventsEdges returns the Events edges associated with the User instance
-func (user *User) LoadEventsEdges() ([]*ent.Edge, error) {
+func (user *User) LoadEventsEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(user.ID, UserToEventsEdge)
 }
 
 // GenEventsEdges returns the Event edges associated with the User instance
-func (user *User) GenEventsEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (user *User) GenEventsEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(user.ID, UserToEventsEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -151,28 +151,28 @@ func (user *User) LoadEvents() ([]*Event, error) {
 	return events, err
 }
 
-// LoadEventsEdgeFor loads the ent.Edge between the current node and the given id2 for the Events edge.
-func (user *User) LoadEventsEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadEventsEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the Events edge.
+func (user *User) LoadEventsEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(user.ID, id2, UserToEventsEdge)
 }
 
-// GenEventsEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the Events edge.
-func (user *User) GenLoadEventsEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenEventsEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the Events edge.
+func (user *User) GenLoadEventsEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(user.ID, id2, UserToEventsEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadFamilyMembersEdges returns the FamilyMembers edges associated with the User instance
-func (user *User) LoadFamilyMembersEdges() ([]*ent.Edge, error) {
+func (user *User) LoadFamilyMembersEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(user.ID, UserToFamilyMembersEdge)
 }
 
 // GenFamilyMembersEdges returns the User edges associated with the User instance
-func (user *User) GenFamilyMembersEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (user *User) GenFamilyMembersEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(user.ID, UserToFamilyMembersEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -195,28 +195,28 @@ func (user *User) LoadFamilyMembers() ([]*User, error) {
 	return users, err
 }
 
-// LoadFamilyMembersEdgeFor loads the ent.Edge between the current node and the given id2 for the FamilyMembers edge.
-func (user *User) LoadFamilyMembersEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadFamilyMembersEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the FamilyMembers edge.
+func (user *User) LoadFamilyMembersEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(user.ID, id2, UserToFamilyMembersEdge)
 }
 
-// GenFamilyMembersEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the FamilyMembers edge.
-func (user *User) GenLoadFamilyMembersEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenFamilyMembersEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the FamilyMembers edge.
+func (user *User) GenLoadFamilyMembersEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(user.ID, id2, UserToFamilyMembersEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadFriendsEdges returns the Friends edges associated with the User instance
-func (user *User) LoadFriendsEdges() ([]*ent.Edge, error) {
+func (user *User) LoadFriendsEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(user.ID, UserToFriendsEdge)
 }
 
 // GenFriendsEdges returns the User edges associated with the User instance
-func (user *User) GenFriendsEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (user *User) GenFriendsEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(user.ID, UserToFriendsEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -239,28 +239,28 @@ func (user *User) LoadFriends() ([]*User, error) {
 	return users, err
 }
 
-// LoadFriendsEdgeFor loads the ent.Edge between the current node and the given id2 for the Friends edge.
-func (user *User) LoadFriendsEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadFriendsEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the Friends edge.
+func (user *User) LoadFriendsEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(user.ID, id2, UserToFriendsEdge)
 }
 
-// GenFriendsEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the Friends edge.
-func (user *User) GenLoadFriendsEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenFriendsEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the Friends edge.
+func (user *User) GenLoadFriendsEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(user.ID, id2, UserToFriendsEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadInvitedEventsEdges returns the InvitedEvents edges associated with the User instance
-func (user *User) LoadInvitedEventsEdges() ([]*ent.Edge, error) {
+func (user *User) LoadInvitedEventsEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(user.ID, UserToInvitedEventsEdge)
 }
 
 // GenInvitedEventsEdges returns the Event edges associated with the User instance
-func (user *User) GenInvitedEventsEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (user *User) GenInvitedEventsEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(user.ID, UserToInvitedEventsEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -283,28 +283,28 @@ func (user *User) LoadInvitedEvents() ([]*Event, error) {
 	return events, err
 }
 
-// LoadInvitedEventsEdgeFor loads the ent.Edge between the current node and the given id2 for the InvitedEvents edge.
-func (user *User) LoadInvitedEventsEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadInvitedEventsEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the InvitedEvents edge.
+func (user *User) LoadInvitedEventsEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(user.ID, id2, UserToInvitedEventsEdge)
 }
 
-// GenInvitedEventsEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the InvitedEvents edge.
-func (user *User) GenLoadInvitedEventsEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenInvitedEventsEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the InvitedEvents edge.
+func (user *User) GenLoadInvitedEventsEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(user.ID, id2, UserToInvitedEventsEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadEventsAttendingEdges returns the EventsAttending edges associated with the User instance
-func (user *User) LoadEventsAttendingEdges() ([]*ent.Edge, error) {
+func (user *User) LoadEventsAttendingEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(user.ID, UserToEventsAttendingEdge)
 }
 
 // GenEventsAttendingEdges returns the Event edges associated with the User instance
-func (user *User) GenEventsAttendingEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (user *User) GenEventsAttendingEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(user.ID, UserToEventsAttendingEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -327,28 +327,28 @@ func (user *User) LoadEventsAttending() ([]*Event, error) {
 	return events, err
 }
 
-// LoadEventsAttendingEdgeFor loads the ent.Edge between the current node and the given id2 for the EventsAttending edge.
-func (user *User) LoadEventsAttendingEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadEventsAttendingEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the EventsAttending edge.
+func (user *User) LoadEventsAttendingEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(user.ID, id2, UserToEventsAttendingEdge)
 }
 
-// GenEventsAttendingEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the EventsAttending edge.
-func (user *User) GenLoadEventsAttendingEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenEventsAttendingEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the EventsAttending edge.
+func (user *User) GenLoadEventsAttendingEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(user.ID, id2, UserToEventsAttendingEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }
 
 // LoadDeclinedEventsEdges returns the DeclinedEvents edges associated with the User instance
-func (user *User) LoadDeclinedEventsEdges() ([]*ent.Edge, error) {
+func (user *User) LoadDeclinedEventsEdges() ([]*ent.AssocEdge, error) {
 	return ent.LoadEdgesByType(user.ID, UserToDeclinedEventsEdge)
 }
 
 // GenDeclinedEventsEdges returns the Event edges associated with the User instance
-func (user *User) GenDeclinedEventsEdges(result *ent.EdgesResult, wg *sync.WaitGroup) {
+func (user *User) GenDeclinedEventsEdges(result *ent.AssocEdgesResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgesResultChan := make(chan ent.EdgesResult)
+	edgesResultChan := make(chan ent.AssocEdgesResult)
 	go ent.GenLoadEdgesByType(user.ID, UserToDeclinedEventsEdge, edgesResultChan)
 	*result = <-edgesResultChan
 }
@@ -371,15 +371,15 @@ func (user *User) LoadDeclinedEvents() ([]*Event, error) {
 	return events, err
 }
 
-// LoadDeclinedEventsEdgeFor loads the ent.Edge between the current node and the given id2 for the DeclinedEvents edge.
-func (user *User) LoadDeclinedEventsEdgeFor(id2 string) (*ent.Edge, error) {
+// LoadDeclinedEventsEdgeFor loads the ent.AssocEdge between the current node and the given id2 for the DeclinedEvents edge.
+func (user *User) LoadDeclinedEventsEdgeFor(id2 string) (*ent.AssocEdge, error) {
 	return ent.LoadEdgeByType(user.ID, id2, UserToDeclinedEventsEdge)
 }
 
-// GenDeclinedEventsEdgeFor provides a concurrent API to load the ent.Edge between the current node and the given id2 for the DeclinedEvents edge.
-func (user *User) GenLoadDeclinedEventsEdgeFor(id2 string, result *ent.EdgeResult, wg *sync.WaitGroup) {
+// GenDeclinedEventsEdgeFor provides a concurrent API to load the ent.AssocEdge between the current node and the given id2 for the DeclinedEvents edge.
+func (user *User) GenLoadDeclinedEventsEdgeFor(id2 string, result *ent.AssocEdgeResult, wg *sync.WaitGroup) {
 	defer wg.Done()
-	edgeResultChan := make(chan ent.EdgeResult)
+	edgeResultChan := make(chan ent.AssocEdgeResult)
 	go ent.GenLoadEdgeByType(user.ID, id2, UserToDeclinedEventsEdge, edgeResultChan)
 	*result = <-edgeResultChan
 }

--- a/internal/testingutils/test_helpers.go
+++ b/internal/testingutils/test_helpers.go
@@ -27,7 +27,7 @@ func VerifyEventObj(t *testing.T, event *models.Event, user *models.User) {
 func VerifyFamilyEdge(t *testing.T, user, user2 *models.User) {
 	edge, err := ent.LoadEdgeByType(user.ID, user2.ID, models.UserToFamilyMembersEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      user.ID,
 		ID2:      user2.ID,
 		EdgeType: models.UserToFamilyMembersEdge,
@@ -46,7 +46,7 @@ func VerifyNoFamilyEdge(t *testing.T, user, user2 *models.User) {
 func VerifyInvitedToEventEdge(t *testing.T, user *models.User, event *models.Event) {
 	invitedEdge, err := ent.LoadEdgeByType(event.ID, user.ID, models.EventToInvitedEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      event.ID,
 		ID1Type:  event.GetType(),
 		ID2:      user.ID,
@@ -57,7 +57,7 @@ func VerifyInvitedToEventEdge(t *testing.T, user *models.User, event *models.Eve
 
 	userInvitedEdge, err := ent.LoadEdgeByType(user.ID, event.ID, models.UserToInvitedEventsEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      user.ID,
 		ID1Type:  user.GetType(),
 		ID2:      event.ID,
@@ -79,7 +79,7 @@ func VerifyNoInvitedToEventEdge(t *testing.T, user *models.User, event *models.E
 func VerifyUserAttendingEventEdge(t *testing.T, user *models.User, event *models.Event) {
 	attendingEdge, err := ent.LoadEdgeByType(event.ID, user.ID, models.EventToAttendingEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      event.ID,
 		ID1Type:  event.GetType(),
 		ID2:      user.ID,
@@ -90,7 +90,7 @@ func VerifyUserAttendingEventEdge(t *testing.T, user *models.User, event *models
 
 	userAttendingEdge, err := ent.LoadEdgeByType(user.ID, event.ID, models.UserToEventsAttendingEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      user.ID,
 		ID1Type:  user.GetType(),
 		ID2:      event.ID,
@@ -112,7 +112,7 @@ func VerifyNoUserAttendingEventEdge(t *testing.T, user *models.User, event *mode
 func VerifyUserDeclinedEventEdge(t *testing.T, user *models.User, event *models.Event) {
 	declinedEdge, err := ent.LoadEdgeByType(event.ID, user.ID, models.EventToDeclinedEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      event.ID,
 		ID1Type:  event.GetType(),
 		ID2:      user.ID,
@@ -123,7 +123,7 @@ func VerifyUserDeclinedEventEdge(t *testing.T, user *models.User, event *models.
 
 	userDeclinedEdge, err := ent.LoadEdgeByType(user.ID, event.ID, models.UserToDeclinedEventsEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      user.ID,
 		ID1Type:  user.GetType(),
 		ID2:      event.ID,
@@ -145,7 +145,7 @@ func VerifyNoUserDeclinedEventEdge(t *testing.T, user *models.User, event *model
 func VerifyUserToEventEdge(t *testing.T, user *models.User, event *models.Event) {
 	userToEventEdge, err := ent.LoadEdgeByType(user.ID, event.ID, models.UserToEventsEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      user.ID,
 		ID1Type:  user.GetType(),
 		ID2:      event.ID,
@@ -164,7 +164,7 @@ func VerifyNoUserToEventEdge(t *testing.T, user *models.User, event *models.Even
 func VerifyEventToHostEdge(t *testing.T, event *models.Event, user *models.User) {
 	edge, err := ent.LoadEdgeByType(event.ID, user.ID, models.EventToHostsEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      event.GetID(),
 		ID1Type:  event.GetType(),
 		ID2:      user.GetID(),
@@ -177,7 +177,7 @@ func VerifyEventToHostEdge(t *testing.T, event *models.Event, user *models.User)
 func VerifyEventToCreatorEdge(t *testing.T, event *models.Event, user *models.User) {
 	edge, err := ent.LoadEdgeByType(event.ID, user.ID, models.EventToCreatorEdge)
 	assert.Nil(t, err)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      event.GetID(),
 		ID1Type:  event.GetType(),
 		ID2:      user.GetID(),
@@ -193,7 +193,7 @@ func VerifyFriendsEdge(t *testing.T, user, user2 *models.User) {
 	friends2Edge, err := ent.LoadEdgeByType(user2.ID, user.ID, models.UserToFriendsEdge)
 	assert.Nil(t, err)
 
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      user.ID,
 		ID1Type:  user.GetType(),
 		ID2:      user2.ID,
@@ -201,7 +201,7 @@ func VerifyFriendsEdge(t *testing.T, user, user2 *models.User) {
 		EdgeType: models.UserToFriendsEdge,
 		Data:     "",
 	}, friends1Edge)
-	VerifyEdge(t, &ent.Edge{
+	VerifyEdge(t, &ent.AssocEdge{
 		ID1:      user2.ID,
 		ID1Type:  user2.GetType(),
 		ID2:      user.ID,
@@ -220,7 +220,7 @@ func VerifyNoFriendsEdge(t *testing.T, user, user2 *models.User) {
 	assert.Zero(t, *friends2Edge)
 }
 
-func VerifyEdge(t *testing.T, expectedEdge, edge *ent.Edge) {
+func VerifyEdge(t *testing.T, expectedEdge, edge *ent.AssocEdge) {
 	assert.Equal(t, expectedEdge.EdgeType, edge.EdgeType)
 	assert.Equal(t, expectedEdge.ID1, edge.ID1)
 	assert.Equal(t, expectedEdge.ID2, edge.ID2)


### PR DESCRIPTION
this PR renames the following:

* ent.Edge -> ent.AssocEdge
* ent.EdgeResult -> ent.AssocEdgeResult
* ent.EdgesResult -> ent.AssocEdgesResult

This allows us to create a new ent.Edge interface later