### PR TITLE
add simple benchmarks

### DIFF
--- a/internal/test_schema/models/benchmark/benchmark_test.go
+++ b/internal/test_schema/models/benchmark/benchmark_test.go
@@ -1,0 +1,164 @@
+package benchmark
+
+import (
+	"testing"
+
+	"github.com/lolopinto/ent/ent"
+	"github.com/lolopinto/ent/internal/util"
+
+	"github.com/lolopinto/ent/ent/viewer"
+	"github.com/lolopinto/ent/ent/viewertesting"
+	"github.com/lolopinto/ent/internal/test_schema/models"
+	useraction "github.com/lolopinto/ent/internal/test_schema/models/user/action"
+	"github.com/lolopinto/ent/internal/test_schema/testschemaviewer"
+)
+
+// TODO need viewer|ent result per request memory cache and need to benchmark with/without that
+// TODO need multi-insert, multi-delete etc APIs
+
+func BenchmarkInsert(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := useraction.CreateUser(viewer.LoggedOutViewer()).
+			SetEmailAddress(util.GenerateRandEmail()).
+			SetPassword(util.GenerateRandPassword()).
+			SetFirstName("Jon").
+			SetLastName("Snow").
+			Save()
+
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func createUser(b *testing.B) (viewer.ViewerContext, *models.User) {
+	user, err := useraction.CreateUser(viewer.LoggedOutViewer()).
+		SetEmailAddress(util.GenerateRandEmail()).
+		SetPassword(util.GenerateRandPassword()).
+		SetFirstName("Jon").
+		SetLastName("Snow").
+		Save()
+
+	if err != nil {
+		b.FailNow()
+	}
+
+	v, err := testschemaviewer.NewViewerContext(user.ID)
+	if err != nil {
+		b.FailNow()
+	}
+
+	return v, user
+}
+
+func BenchmarkEdit(b *testing.B) {
+	v, user := createUser(b)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := useraction.EditUser(v, user).
+			SetFirstName("Dany" + util.GenerateRandCode(6)).
+			Save()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkDelete(b *testing.B) {
+	v, user := createUser(b)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := useraction.DeleteUser(v, user).
+			Save()
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+// TODO need read/raw and read-multi raw
+// will get that later
+
+func BenchmarkReadCacheDisabled(b *testing.B) {
+	v, user := createUser(b)
+	ent.DisableCache()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := models.LoadUser(v, user.ID)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReadCacheEnabled(b *testing.B) {
+	v, user := createUser(b)
+	ent.EnableCache()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := models.LoadUser(v, user.ID)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkReadCachePrimedAndEnabled(b *testing.B) {
+	v, user := createUser(b)
+	ent.EnableCache()
+	_, err := models.LoadUser(v, user.ID)
+	// prime the load first?
+	if err != nil {
+		b.FailNow()
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := models.LoadUser(v, user.ID)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkMultiReadCacheEnabled(b *testing.B) {
+	// some large enough number but not too large is what we care about
+	ids := make([]string, 30)
+	for i := 0; i < 30; i++ {
+		_, user := createUser(b)
+		ids[i] = user.ID
+	}
+	v := viewertesting.OmniViewerContext{}
+	ent.EnableCache()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := models.LoadUsers(v, ids...)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkMultiReadCacheDisabled(b *testing.B) {
+	// some large enough number but not too large is what we care about
+	ids := make([]string, 30)
+	for i := 0; i < 30; i++ {
+		_, user := createUser(b)
+		ids[i] = user.ID
+	}
+	v := viewertesting.OmniViewerContext{}
+	ent.DisableCache()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := models.LoadUsers(v, ids...)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}


### PR DESCRIPTION
useful as I'm changing things to not use reflection and changing things all over the place so getting a sense of if any of it is useful will be helpful.

Running everything separately because I’m not sure the best way to do this since turning cache on and off isn't done concurrently and want everything to be run independently of each other

```
goos: darwin
goarch: amd64
pkg: github.com/lolopinto/ent/internal/test_schema/models/benchmark
BenchmarkInsert-8           16    71096302 ns/op     31940 B/op      488 allocs/op
PASS
ok    github.com/lolopinto/ent/internal/test_schema/models/benchmark  1.393s
Success: Benchmarks passed.

goos: darwin
goarch: amd64
pkg: github.com/lolopinto/ent/internal/test_schema/models/benchmark
BenchmarkEdit-8         1459     1236181 ns/op      9439 B/op      182 allocs/op
PASS
ok    github.com/lolopinto/ent/internal/test_schema/models/benchmark  2.271s
Success: Benchmarks passed.

goos: darwin
goarch: amd64
pkg: github.com/lolopinto/ent/internal/test_schema/models/benchmark
BenchmarkDelete-8         3610      351388 ns/op      4045 B/op       78 allocs/op
PASS
ok    github.com/lolopinto/ent/internal/test_schema/models/benchmark  1.671s
Success: Benchmarks passed.

goos: darwin
goarch: amd64
pkg: github.com/lolopinto/ent/internal/test_schema/models/benchmark
BenchmarkReadCacheDisabled-8        1233      939379 ns/op     17999 B/op      300 allocs/op
PASS
ok    github.com/lolopinto/ent/internal/test_schema/models/benchmark  1.652s
Success: Benchmarks passed.

goos: darwin
goarch: amd64
pkg: github.com/lolopinto/ent/internal/test_schema/models/benchmark
BenchmarkReadCacheEnabled-8        55052       22567 ns/op      2338 B/op       51 allocs/op
PASS
ok    github.com/lolopinto/ent/internal/test_schema/models/benchmark  1.916s
Success: Benchmarks passed.

goos: darwin
goarch: amd64
pkg: github.com/lolopinto/ent/internal/test_schema/models/benchmark
BenchmarkReadCachePrimedAndEnabled-8       54242       21639 ns/op      2337 B/op       51 allocs/op
PASS
ok    github.com/lolopinto/ent/internal/test_schema/models/benchmark  1.947s
Success: Benchmarks passed.

goos: darwin
goarch: amd64
pkg: github.com/lolopinto/ent/internal/test_schema/models/benchmark
BenchmarkMultiReadCacheEnabled-8        2721      442897 ns/op     63824 B/op     1487 allocs/op
PASS
ok    github.com/lolopinto/ent/internal/test_schema/models/benchmark  7.999s
Success: Benchmarks passed.

goos: darwin
goarch: amd64
pkg: github.com/lolopinto/ent/internal/test_schema/models/benchmark
BenchmarkMultiReadCacheDisabled-8         2343      448497 ns/op     63855 B/op     1487 allocs/op
PASS
ok    github.com/lolopinto/ent/internal/test_schema/models/benchmark  8.162s
Success: Benchmarks passed.

```