### PR TITLE
fix for when we're trying to import a file that's higher in the directory tree that looks like it's a parent of current

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
     "PATH_TO_DB_FILE": "testdata/config/database.yml",
     "DB_CONNECTION_STRING": "postgres://ola:@localhost/ent_test?sslmode=disable"
   },
-  "go.testTimeout": "30s"
+  "go.testTimeout": "30s",
+  "prettier.configPath": "ts/.prettierrc"
 }

--- a/ts/examples/simple/src/index.ts
+++ b/ts/examples/simple/src/index.ts
@@ -1,12 +1,22 @@
-import User from "src/ent/user";
+import User from "src/ent/user.ts"; // default removes the suffix and transforms it...
 import { IDViewer } from "src/util/id_viewer";
-async function load() {
-  return await User.load(
+import CreateContactAction from "./ent/contact/actions/create_contact_action";
+import { randomEmail } from "./util/random";
+
+async function loadUserAndCreate() {
+  let user = await User.loadX(
     new IDViewer("6910e947-7bc1-4ed2-b8a8-5a07e6708830"),
     "6910e947-7bc1-4ed2-b8a8-5a07e6708830",
   );
+
+  return await CreateContactAction.create(user.viewer, {
+    firstName: "firstName",
+    lastName: "lastName",
+    emailAddress: randomEmail(),
+    userID: user.id,
+  }).saveX()
 }
 
-load().then((user) => {
+loadUserAndCreate().then((user) => {
   console.log(user);
 });


### PR DESCRIPTION
if we have a line like `import User from "src/ent/user";` from within `src/ent/user/actions/generated/create_user_action_base.ts`, it seems like we're referring to directory `user/` which is a parent of the current file when we actually mean to refer to `user.ts`. 

The generated import statement looks something like `../..` which fails because there's nothing there.

After this change, generated line looks like `var user_1 = __importDefault(require("../../../user"));`

Didn't previously catch it because action path wasn't being tested in JS land. Now that graphql is being worked on, running into it now

Test Plan: forced the example in src/index.ts to run into this issue by changing it to use an action and confirm it works now by running `node --harmony dist/examples/simple/src/index.js` after compile