### PR TITLE
some small fixes to phone number type.

### DIFF
--- a/ts/src/field/phonenumber.test.ts
+++ b/ts/src/field/phonenumber.test.ts
@@ -144,18 +144,34 @@ describe("invalid", () => {
     });
   });
 
-  test("invalid number for region", () => {
+  test("valid area code. invalid number", () => {
+    testCase({
+      input: "4152",
+      pre: (typ) => typ.validateForRegion(false),
+      output: "+14152",
+    });
+  });
+
+  test("valid area code. invalid number", () => {
+    testCase({
+      input: "4152",
+      invalid: true,
+    });
+  });
+
+  test("invalid number for region. disable validation", () => {
     testCase({
       input: "07911 123456",
-      // just formats it incorrectly
+      // disable validation for the region
+      pre: (typ) => typ.validateForRegion(false),
+      // formats it incorrectly
       output: "+107911123456",
     });
   });
 
-  test("invalid number for region.validate for region", () => {
+  test("invalid number for region. validate (default)", () => {
     testCase({
       input: "07911 123456",
-      pre: (typ) => typ.validateForRegion(true),
       invalid: true,
     });
   });


### PR DESCRIPTION
found out that the default validation is not as strict as expected

e.g. "1" is an invalid US number but "4152" is not

Looking at the code, it says to call isPossible() by default and to not call isValid() because that's a whole mess

so, changing the behavior so the default behavior calls isPossible() (and doesn't allow obviously invalid numbers) while providing an option to disable that. Also provides an option to call isValid() and for custom validation