### PR TITLE
update pg version

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ent",
+  "name": "@lolopinto/ent",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -3751,15 +3751,15 @@
       "dev": true
     },
     "pg": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
-      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.0.3.tgz",
+      "integrity": "sha512-fvcNXn4o/iq4jKq15Ix/e58q3jPSmzOp6/8C3CaHoSR/bsxdg+1FXfDRePdtE/zBb3++TytvOrS1hNef3WC/Kg==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
-        "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.10",
+        "pg-pool": "^3.1.1",
+        "pg-protocol": "^1.2.2",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
@@ -3775,15 +3775,15 @@
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
-    "pg-packet-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
-      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
-    },
     "pg-pool": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
-      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
+      "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA=="
+    },
+    "pg-protocol": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.5.tgz",
+      "integrity": "sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -3852,9 +3852,9 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
-      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz",
+      "integrity": "sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA=="
     },
     "postgres-interval": {
       "version": "1.2.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -22,7 +22,7 @@
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
     "passport-strategy": "^1.0.0",
-    "pg": "^7.18.2",
+    "pg": "^8.0.3",
     "prettier": "^1.19.1",
     "reflect-metadata": "^0.1.13",
     "snake-case": "^3.0.3",
@@ -56,9 +56,9 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-	  "url": "git@github.com:lolopinto/ent.git"
+    "url": "git@github.com:lolopinto/ent.git"
   },
   "publishConfig": {
-    "registry":"https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
sql queries randomly stopped working and i apparently moved to node 14.6 and an old version of pg not compatible with node

according to https://github.com/brianc/node-postgres/issues/2069#issuecomment-619456031, `8.0.2` not compatible with node 14

considering i was at `7.18.2`, that's confusing. probably a bunch of things broken until `8.0.3`

this change was made by running `npm install pg@8.0.3`