### PR TITLE
make it so that importing "ID" works in actions for `UUIDType`

### DIFF
--- a/internal/enttype/type.go
+++ b/internal/enttype/type.go
@@ -33,6 +33,11 @@ type TSType interface {
 	GetTSType() string
 }
 
+type TSTypeWithImports interface {
+	TSType
+	GetTsTypeImports() []string
+}
+
 type TSGraphQLType interface {
 	// returns imports from outside in
 	// e.g. required string => []string{"GraphQLNonNull", "GraphQLString"}
@@ -189,6 +194,11 @@ func (t *idType) GetDBType() string {
 
 func (t *idType) GetZeroValue() string {
 	return ""
+}
+
+func (t *idType) GetTsTypeImports() []string {
+	// so that we "useImport ID" in the generation
+	return []string{"ID"}
 }
 
 type IDType struct {

--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -398,6 +398,10 @@ func (f *Field) TsBuilderType() string {
 }
 
 func (f *Field) TsBuilderImports() []string {
+	typ, ok := f.fieldType.(enttype.TSTypeWithImports)
+	if ok {
+		return typ.GetTsTypeImports()
+	}
 	typeName := f.getIDFieldTypeName()
 	if typeName == "" {
 		return []string{}


### PR DESCRIPTION
This makes something like

```ts
    UUIDType({
      name: "OwnerID",
      index: true,
      hideFromGraphQL: true,
    }),
``` 

work.

In the base class of the action,

```ts
  ownerID: ID;
```
was the generated line but it didn't have `ID` among its used imports

