### PR TITLE
TS: fix generating compound names like "PickupLocation"

### DIFF
--- a/internal/schema/input/parse_ts.go
+++ b/internal/schema/input/parse_ts.go
@@ -37,6 +37,7 @@ func ParseSchemaFromTSDir(dirPath string, fromTest bool) (*Schema, error) {
 	}
 
 	r := regexp.MustCompile(`(\w+).ts$`)
+	negR := regexp.MustCompile(`(\d+_read_schema).ts`)
 
 	var schemas []schemaData
 	for _, file := range files {
@@ -46,6 +47,10 @@ func ParseSchemaFromTSDir(dirPath string, fromTest bool) (*Schema, error) {
 		match := r.FindStringSubmatch(file.Name())
 		// generated schema.py anything else...
 		if len(match) != 2 {
+			continue
+		}
+		// found a schema file from a previous broken thing. ignore
+		if len(negR.FindStringSubmatch(file.Name())) == 2 {
 			continue
 		}
 		// assumption is upper case file.

--- a/internal/schema/node_map.go
+++ b/internal/schema/node_map.go
@@ -577,13 +577,15 @@ func (m NodeMapInfo) parseInputSchema(schema *input.Schema, lang base.Language) 
 
 	for nodeName, node := range schema.Nodes {
 
-		nodeName = strcase.ToSnake(strings.ToLower(nodeName))
+		// order of operations matters here
+		// PickupLocation -> pickup_location
+		packageName := strings.ToLower(strcase.ToSnake(nodeName))
 		// user.ts, address.ts etc
-		nodeData := newNodeData(nodeName)
+		nodeData := newNodeData(packageName)
 
 		// default nodeName goes from address -> addresses, user -> users etc
 		if node.TableName == nil {
-			nodeData.TableName = inflection.Plural(nodeName)
+			nodeData.TableName = inflection.Plural(packageName)
 		} else {
 			nodeData.TableName = *node.TableName
 		}
@@ -596,12 +598,12 @@ func (m NodeMapInfo) parseInputSchema(schema *input.Schema, lang base.Language) 
 			return nil, err
 		}
 
-		nodeData.EdgeInfo, err = edge.EdgeInfoFromInput(nodeName, node)
+		nodeData.EdgeInfo, err = edge.EdgeInfoFromInput(packageName, node)
 		if err != nil {
 			return nil, err
 		}
 
-		nodeData.ActionInfo, err = action.ParseFromInput(nodeName, node.Actions, nodeData.FieldInfo, nodeData.EdgeInfo, lang)
+		nodeData.ActionInfo, err = action.ParseFromInput(packageName, node.Actions, nodeData.FieldInfo, nodeData.EdgeInfo, lang)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/schema/node_map_input_test.go
+++ b/internal/schema/node_map_input_test.go
@@ -13,15 +13,15 @@ import (
 func TestParseFromInputSchema(t *testing.T) {
 	inputSchema := &input.Schema{
 		Nodes: map[string]*input.Node{
-			"User": &input.Node{
+			"User": {
 				Fields: []*input.Field{
-					&input.Field{
+					{
 						Name: "id",
 						Type: &input.FieldType{
 							DBType: input.UUID,
 						},
 					},
-					&input.Field{
+					{
 						Name: "firstName",
 						Type: &input.FieldType{
 							DBType: input.String,
@@ -48,15 +48,57 @@ func TestParseFromInputSchema(t *testing.T) {
 	assert.NotNil(t, field)
 }
 
+func TestCompoundName(t *testing.T) {
+	inputSchema := &input.Schema{
+		Nodes: map[string]*input.Node{
+			"PickupLocation": {
+				Fields: []*input.Field{
+					{
+						Name: "id",
+						Type: &input.FieldType{
+							DBType: input.UUID,
+						},
+					},
+					{
+						Name: "name",
+						Type: &input.FieldType{
+							DBType: input.String,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	schema, err := schema.ParseFromInputSchema(inputSchema, base.GoLang)
+
+	require.Nil(t, err)
+	assert.Len(t, schema.Nodes, 1)
+
+	// still config name because of artifact of go and old schema
+	config := schema.Nodes["PickupLocationConfig"]
+	assert.NotNil(t, config)
+
+	nodeData := config.NodeData
+	// no table name provided and one automatically generated
+	assert.Equal(t, "pickup_locations", nodeData.TableName)
+
+	// package name correct
+	assert.Equal(t, "pickup_location", nodeData.PackageName)
+	field, err := schema.GetFieldByName("PickupLocationConfig", "id")
+	assert.Nil(t, err)
+	assert.NotNil(t, field)
+}
+
 func TestParseInputWithOverridenTable(t *testing.T) {
 	// rename of user -> accounts or something
 	tableName := "accounts"
 	inputSchema := &input.Schema{
 		Nodes: map[string]*input.Node{
-			"User": &input.Node{
+			"User": {
 				TableName: &tableName,
 				Fields: []*input.Field{
-					&input.Field{
+					{
 						Name: "id",
 						Type: &input.FieldType{
 							DBType: input.UUID,
@@ -82,9 +124,9 @@ func TestParseInputWithOverridenTable(t *testing.T) {
 func TestParseInputWithForeignKey(t *testing.T) {
 	inputSchema := &input.Schema{
 		Nodes: map[string]*input.Node{
-			"User": &input.Node{
+			"User": {
 				Fields: []*input.Field{
-					&input.Field{
+					{
 						Name: "id",
 						Type: &input.FieldType{
 							DBType: input.UUID,
@@ -92,15 +134,15 @@ func TestParseInputWithForeignKey(t *testing.T) {
 					},
 				},
 			},
-			"Event": &input.Node{
+			"Event": {
 				Fields: []*input.Field{
-					&input.Field{
+					{
 						Name: "id",
 						Type: &input.FieldType{
 							DBType: input.UUID,
 						},
 					},
-					&input.Field{
+					{
 						Name: "UserID",
 						Type: &input.FieldType{
 							DBType: input.UUID,
@@ -135,9 +177,9 @@ func TestParseInputWithForeignKey(t *testing.T) {
 func TestParseInputWithFieldEdge(t *testing.T) {
 	inputSchema := &input.Schema{
 		Nodes: map[string]*input.Node{
-			"User": &input.Node{
+			"User": {
 				Fields: []*input.Field{
-					&input.Field{
+					{
 						Name: "id",
 						Type: &input.FieldType{
 							DBType: input.UUID,
@@ -145,21 +187,21 @@ func TestParseInputWithFieldEdge(t *testing.T) {
 					},
 				},
 				AssocEdges: []*input.AssocEdge{
-					&input.AssocEdge{
+					{
 						Name:       "CreatedEvents",
 						SchemaName: "Event",
 					},
 				},
 			},
-			"Event": &input.Node{
+			"Event": {
 				Fields: []*input.Field{
-					&input.Field{
+					{
 						Name: "id",
 						Type: &input.FieldType{
 							DBType: input.UUID,
 						},
 					},
-					&input.Field{
+					{
 						Name: "UserID",
 						Type: &input.FieldType{
 							DBType: input.UUID,
@@ -195,9 +237,9 @@ func TestParseInputWithFieldEdge(t *testing.T) {
 func TestParseInputWithAssocEdgeGroup(t *testing.T) {
 	inputSchema := &input.Schema{
 		Nodes: map[string]*input.Node{
-			"User": &input.Node{
+			"User": {
 				Fields: []*input.Field{
-					&input.Field{
+					{
 						Name: "id",
 						Type: &input.FieldType{
 							DBType: input.UUID,
@@ -205,17 +247,17 @@ func TestParseInputWithAssocEdgeGroup(t *testing.T) {
 					},
 				},
 				AssocEdgeGroups: []*input.AssocEdgeGroup{
-					&input.AssocEdgeGroup{
+					{
 						Name:            "Friendships",
 						GroupStatusName: "FriendshipStatus",
 						AssocEdges: []*input.AssocEdge{
-							&input.AssocEdge{
+							{
 								Name:       "Friends",
 								SchemaName: "User",
 								Symmetric:  true,
 							},
 							// has inverse too!
-							&input.AssocEdge{
+							{
 								Name:       "FriendRequestsSent",
 								SchemaName: "User",
 								InverseEdge: &input.InverseAssocEdge{

--- a/internal/schema/node_map_test.go
+++ b/internal/schema/node_map_test.go
@@ -568,10 +568,10 @@ func TestGeneratedConstants(t *testing.T) {
 		t,
 		accountInfo,
 		map[string]map[string]string{
-			"ent.NodeType": map[string]string{
+			"ent.NodeType": {
 				"AccountType": "account",
 			},
-			"ent.EdgeType": map[string]string{
+			"ent.EdgeType": {
 				"AccountToFriendsEdge": "",
 			},
 		},
@@ -583,7 +583,7 @@ func TestGeneratedConstants(t *testing.T) {
 		t,
 		todoInfo,
 		map[string]map[string]string{
-			"ent.NodeType": map[string]string{
+			"ent.NodeType": {
 				"TodoType": "todo",
 			},
 		},
@@ -933,10 +933,10 @@ func (suite *edgeTestSuite) TestInverseAssocEdgeAddedAfter() {
 		suite.T(),
 		accountInfo,
 		map[string]map[string]string{
-			"ent.NodeType": map[string]string{
+			"ent.NodeType": {
 				"AccountType": "account",
 			},
-			"ent.EdgeType": map[string]string{
+			"ent.EdgeType": {
 				"AccountToFriendRequestsEdge": "",
 			},
 		},


### PR DESCRIPTION
When we have a schema like "PickupLocation", we want to make sure the files generated are consistently generated as snake case e.g. `PickupLocation` - > `pickup_location`.

Prior to this, we were generating `pickuplocation` in a few places