### PR TITLE
change field.TsBuilderImports to be more flexible

### DIFF
--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -398,21 +398,21 @@ func (f *Field) TsBuilderType() string {
 }
 
 func (f *Field) TsBuilderImports() []string {
+	ret := []string{}
 	typ, ok := f.fieldType.(enttype.TSTypeWithImports)
 	if ok {
-		return typ.GetTsTypeImports()
+		ret = typ.GetTsTypeImports()
 	}
 	typeName := f.getIDFieldTypeName()
 	if typeName == "" {
-		return []string{}
+		return ret
 	}
 	match := structNameRegex.FindStringSubmatch(typeName)
 	if len(match) != 2 {
 		panic("invalid config name")
 	}
-	return []string{
-		match[1], "ID", "Builder",
-	}
+	ret = append(ret, match[1], "ID", "Builder")
+	return ret
 }
 
 func (f *Field) GetNotNullableTsType() string {


### PR DESCRIPTION
e.g. if we see an ID field, we should add "Builder", "ID", {NodeName} to what's being returned from enttype.TSTypeWithImports

This makes
```ts
    UUIDType({
      name: "orgID",
      fieldEdge: ["Organization", "PickupLocations"],
    }),
```
work so that `import Organization from "src/ent/organization";` is added to the builder file

this is https://github.com/lolopinto/ent/pull/102 but merged into the right branch