### PR TITLE
TS: constraints API

### DIFF
--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -21,6 +21,7 @@ type Node struct {
 	Actions         []*Action                `json:"actions"`
 	EnumTable       bool                     `json:"enumTable"`
 	DBRows          []map[string]interface{} `json:"dbRows"`
+	Constraints     []*Constraint            `json:"constraints"`
 }
 
 func (n *Node) AddAssocEdge(edge *AssocEdge) {
@@ -192,6 +193,40 @@ type Action struct {
 	CustomInputName   string              `json:"inputName"`
 	HideFromGraphQL   bool                `json:"hideFromGraphQL"`
 }
+
+type Constraint struct {
+	Name       string          `json:"name"`
+	Type       ConstraintType  `json:"type"`
+	Columns    []string        `json:"columns"`
+	ForeignKey *ForeignKeyInfo `json:"fkey"`
+	Condition  string          `json:"condition"`
+}
+
+type ConstraintType string
+
+const (
+	// Note that these type should match enum ConstraintType in schema.ts
+	PrimaryKey ConstraintType = "primary"
+	ForeignKey                = "foreign"
+	Unique                    = "unique"
+	Check                     = "check"
+)
+
+type ForeignKeyInfo struct {
+	TableName string       `json:"tableName"`
+	OnDelete  OnDeleteFkey `json:"ondelete"`
+}
+
+type OnDeleteFkey string
+
+const (
+	// Note that these type should match enum ForeignKeyInfo.ondelete in schema.ts
+	Restrict   OnDeleteFkey = "RESTRICT"
+	Cascade                 = "CASCADE"
+	SetNull                 = "SET NULL"
+	SetDefault              = "SET DEFAULT"
+	NoAction                = "NO ACTION"
+)
 
 func (g *AssocEdgeGroup) AddAssocEdge(edge *AssocEdge) {
 	g.AssocEdges = append(g.AssocEdges, edge)

--- a/internal/schema/input/parse_ts_constraints_test.go
+++ b/internal/schema/input/parse_ts_constraints_test.go
@@ -1,0 +1,463 @@
+package input_test
+
+import (
+	"testing"
+
+	"github.com/lolopinto/ent/internal/schema/input"
+)
+
+func TestConstraints(t *testing.T) {
+	testCases := map[string]testCase{
+		"multi-column-primary key": {
+			code: map[string]string{
+				"user_photo.ts": getCodeWithSchema(`
+					import {Schema, Field, UUIDType, Constraint, ConstraintType} from "{schema}";
+
+					export default class UserPhoto implements Schema {
+						fields: Field[] = [
+							UUIDType({
+								name: 'UserID',
+							}),
+							UUIDType({
+								name: 'PhotoID',
+							}),
+						];
+
+						constraints: Constraint[] = [
+							{
+								name: "user_photos_pkey",
+								type: ConstraintType.PrimaryKey,
+								columns: ["UserID", "PhotoID"],
+							},
+						];
+					}
+				`),
+			},
+			expectedOutput: map[string]node{
+				"UserPhoto": {
+					fields: []field{
+						{
+							name:   "UserID",
+							dbType: input.UUID,
+						},
+						{
+							name:   "PhotoID",
+							dbType: input.UUID,
+						},
+					},
+					constraints: []constraint{
+						{
+							name:    "user_photos_pkey",
+							typ:     input.PrimaryKey,
+							columns: []string{"UserID", "PhotoID"},
+						},
+					},
+				},
+			},
+		},
+		"single-column-primary key": {
+			code: map[string]string{
+				"username.ts": getCodeWithSchema(`
+					import {Schema, Field, StringType, Constraint, ConstraintType} from "{schema}";
+
+					export default class Username implements Schema {
+						fields: Field[] = [
+							StringType({
+								name: 'username',
+							}),
+						];
+
+						constraints: Constraint[] = [
+							{
+								name: "username_pkey",
+								type: ConstraintType.PrimaryKey,
+								columns: ["username"],
+							},
+						];
+					}
+				`),
+			},
+			expectedOutput: map[string]node{
+				"Username": {
+					fields: []field{
+						{
+							name:   "username",
+							dbType: input.String,
+						},
+					},
+					constraints: []constraint{
+						{
+							name:    "username_pkey",
+							typ:     input.PrimaryKey,
+							columns: []string{"username"},
+						},
+					},
+				},
+			},
+		},
+		"multi-column unique key": {
+			code: map[string]string{
+				"user.ts": getCodeWithSchema(`
+					import {Field, StringType, BaseEntSchema} from "{schema}";
+
+					export default class User extends BaseEntSchema {
+						fields: Field[] = [
+							StringType({
+								name: 'firstName',
+							}),
+							StringType({
+								name: 'lastName',
+							}),
+						];
+					}
+					`),
+				"contact.ts": getCodeWithSchema(`
+					import {BaseEntSchema, Field, UUIDType, StringType, Constraint, ConstraintType} from "{schema}";
+
+					export default class Contact extends BaseEntSchema {
+						fields: Field[] = [
+							StringType({
+								name: "firstName",
+							}),
+							StringType({
+								name: "lastName",
+							}),
+							// this *should* be EmailType but not worth it
+							StringType({
+								name: "emailAddress",
+							}),
+							UUIDType({
+								name: "userID",
+								foreignKey: ["User", "ID"],
+							}),
+						];
+
+						constraints: Constraint[] = [
+							{
+								name: "contacts_unique_email",
+								type: ConstraintType.Unique,
+								columns: ["emailAddress", "userID"],
+							},
+						];
+					}
+				`),
+			},
+			expectedOutput: map[string]node{
+				"User": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "firstName",
+							dbType: input.String,
+						},
+						field{
+							name:   "lastName",
+							dbType: input.String,
+						},
+					),
+				},
+				"Contact": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "firstName",
+							dbType: input.String,
+						},
+						field{
+							name:   "lastName",
+							dbType: input.String,
+						},
+						field{
+							name:   "emailAddress",
+							dbType: input.String,
+						},
+						field{
+							name:       "userID",
+							dbType:     input.UUID,
+							foreignKey: &[2]string{"User", "ID"},
+						}),
+					constraints: []constraint{
+						{
+							name:    "contacts_unique_email",
+							typ:     input.Unique,
+							columns: []string{"emailAddress", "userID"},
+						},
+					},
+				},
+			},
+		},
+		"single column foreign key": {
+			code: map[string]string{
+				"user.ts": getCodeWithSchema(`
+					import {Field, StringType, BaseEntSchema} from "{schema}";
+
+					export default class User extends BaseEntSchema {
+						fields: Field[] = [
+							StringType({
+								name: 'firstName',
+							}),
+							StringType({
+								name: 'lastName',
+							}),
+						];
+					}
+					`),
+				"contact.ts": getCodeWithSchema(`
+					import {BaseEntSchema, Field, UUIDType, StringType, Constraint, ConstraintType} from "{schema}";
+
+					export default class Contact extends BaseEntSchema {
+						fields: Field[] = [
+							UUIDType({
+								name: "userID",
+							}),
+						];
+
+						// using constraint instead of foreignKey field...
+						constraints: Constraint[] = [
+							{
+								name: "contacts_user_fkey",
+								type: ConstraintType.ForeignKey,
+								columns: ["userID"],
+								// TODO input validation. this is required when type is ForeignKey
+								fkey: {
+									tableName: "User",
+								}
+							},
+						];
+					}
+				`),
+			},
+			expectedOutput: map[string]node{
+				"User": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "firstName",
+							dbType: input.String,
+						},
+						field{
+							name:   "lastName",
+							dbType: input.String,
+						},
+					),
+				},
+				"Contact": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "userID",
+							dbType: input.UUID,
+						}),
+					constraints: []constraint{
+						{
+							name:    "contacts_user_fkey",
+							typ:     input.ForeignKey,
+							columns: []string{"userID"},
+							fkey: &fkeyInfo{
+								tableName: "User",
+							},
+						},
+					},
+				},
+			},
+		},
+		"multi column foreign key": {
+			code: map[string]string{
+				"user.ts": getCodeWithSchema(`
+					import {Field, StringType, BaseEntSchema} from "{schema}";
+
+					export default class User extends BaseEntSchema {
+						fields: Field[] = [
+							StringType({
+								name: 'firstName',
+							}),
+							StringType({
+								name: 'lastName',
+							}),
+							StringType({
+								name: 'emailAddress',
+								unique: true,
+							}),
+						];
+					}
+					`),
+				"contact.ts": getCodeWithSchema(`
+					import {BaseEntSchema, Field, UUIDType, StringType, Constraint, ConstraintType} from "{schema}";
+
+					export default class Contact extends BaseEntSchema {
+						fields: Field[] = [
+							UUIDType({
+								name: "userID",
+							}),
+							StringType({
+								name: 'emailAddress',
+							}),
+						];
+
+						constraints: Constraint[] = [
+							{
+								name: "contacts_user_fkey",
+								type: ConstraintType.ForeignKey,
+								columns: ["userID", "emailAddress"],
+								// TODO input validation. this is required when type is ForeignKey
+								fkey: {
+									tableName: "User",
+									ondelete: "CASCADE",
+								}
+							},
+						];
+					}
+				`),
+			},
+			expectedOutput: map[string]node{
+				"User": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "firstName",
+							dbType: input.String,
+						},
+						field{
+							name:   "lastName",
+							dbType: input.String,
+						},
+					),
+				},
+				"Contact": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "userID",
+							dbType: input.UUID,
+						}),
+					constraints: []constraint{
+						{
+							name:    "contacts_user_fkey",
+							typ:     input.ForeignKey,
+							columns: []string{"userID", "emailAddress"},
+							fkey: &fkeyInfo{
+								tableName: "User",
+								ondelete:  input.Cascade,
+							},
+						},
+					},
+				},
+			},
+		},
+		"check constraint no columns": {
+			code: map[string]string{
+				"item.ts": getCodeWithSchema(`
+					import {Field, FloatType, BaseEntSchema, Constraint, ConstraintType} from "{schema}";
+
+					export default class Item extends BaseEntSchema {
+						fields: Field[] = [
+							FloatType({
+								name: 'price',
+							}),
+						];
+
+						constraints: Constraint[] = [
+							{
+								name: "item_positive_price",
+								type: ConstraintType.Check,
+								// TODO condition is required when type == Check
+								condition: 'price > 0',
+								columns: [],
+							},
+						];
+					}`),
+			},
+			expectedOutput: map[string]node{
+				"Item": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "price",
+							dbType: input.Float,
+						},
+					),
+					constraints: []constraint{
+						{
+							name:      "item_positive_price",
+							typ:       input.Check,
+							condition: "price > 0",
+							columns:   []string{},
+						},
+					},
+				},
+			},
+		},
+		"check constraint multiple columns": {
+			code: map[string]string{
+				"item.ts": getCodeWithSchema(`
+					import {Field, FloatType, BaseEntSchema, Constraint, ConstraintType} from "{schema}";
+
+					export default class Item extends BaseEntSchema {
+						fields: Field[] = [
+							FloatType({
+								name: 'price',
+							}),
+							FloatType({
+								name: 'discount_price',
+							}),
+						];
+
+						constraints: Constraint[] = [
+							{
+								name: "item_positive_price",
+								type: ConstraintType.Check,
+								// TODO condition is required when type == Check
+								condition: 'price > 0',
+								// TODO need to test this later when we have mixed everything in since we may not 
+								// want this...
+								columns: ['price'],
+							},
+							{
+								name: "item_positive_discount_price",
+								type: ConstraintType.Check,
+								// TODO condition is required when type == Check
+								condition: 'discount_price > 0',
+								columns: ['discount_price'],
+							},
+							{
+								name: "item_price_greater_than_discount",
+								type: ConstraintType.Check,
+								// TODO condition is required when type == Check
+								condition: 'price > discount_price',
+								columns: ['price', 'discount_price'],
+							},
+						];
+					}`),
+			},
+			expectedOutput: map[string]node{
+				"Item": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "price",
+							dbType: input.Float,
+						},
+						field{
+							name:   "discount_price",
+							dbType: input.Float,
+						},
+					),
+					constraints: []constraint{
+						{
+							name:      "item_positive_price",
+							typ:       input.Check,
+							condition: "price > 0",
+							columns:   []string{"price"},
+						},
+						{
+							name:      "item_positive_discount_price",
+							typ:       input.Check,
+							condition: "discount_price > 0",
+							columns:   []string{"discount_price"},
+						},
+						{
+							name:      "item_price_greater_than_discount",
+							typ:       input.Check,
+							condition: "price > discount_price",
+							columns:   []string{"price", "discount_price"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runTestCases(t, testCases)
+}

--- a/internal/schema/input/parse_ts_enum_table_test.go
+++ b/internal/schema/input/parse_ts_enum_table_test.go
@@ -156,5 +156,4 @@ func TestEnumTable(t *testing.T) {
 	}
 
 	runTestCases(t, testCases)
-
 }

--- a/internal/schema/input/parse_ts_field_test.go
+++ b/internal/schema/input/parse_ts_field_test.go
@@ -264,34 +264,12 @@ func TestParseFields(t *testing.T) {
 			},
 			expectedOutput: map[string]node{
 				"User": {
-					fields: []field{
-						{
-							name:                    "ID",
-							dbType:                  input.UUID,
-							primaryKey:              true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-						},
-						{
-							name:                    "createdAt",
-							dbType:                  input.Time,
-							hideFromGraphQL:         true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-						},
-						{
-							name:                    "updatedAt",
-							dbType:                  input.Time,
-							hideFromGraphQL:         true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-							hasDefaultValueOnEdit:   true,
-						},
-						{
+					fields: fieldsWithNodeFields(
+						field{
 							name:   "firstName",
 							dbType: input.String,
 						},
-					},
+					),
 				},
 			},
 		},
@@ -323,97 +301,53 @@ func TestParseFields(t *testing.T) {
 			},
 			expectedOutput: map[string]node{
 				"User": {
-					fields: []field{
-						{
-							name:                    "ID",
-							dbType:                  input.UUID,
-							primaryKey:              true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-						},
-						{
-							name:                    "createdAt",
-							dbType:                  input.Time,
-							hideFromGraphQL:         true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-						},
-						{
-							name:                    "updatedAt",
-							dbType:                  input.Time,
-							hideFromGraphQL:         true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-							hasDefaultValueOnEdit:   true,
-						},
-						{
+					fields: fieldsWithNodeFields(
+						field{
 							name:   "first_name",
 							dbType: input.String,
 						},
-						{
+						field{
 							name:   "last_name",
 							dbType: input.String,
 						},
-						{
+						field{
 							name:   "email",
 							dbType: input.String,
 							unique: true,
 						},
-						{
+						field{
 							name:            "password",
 							dbType:          input.String,
 							private:         true,
 							hideFromGraphQL: true,
 						},
-					},
+					),
 				},
 				"Event": {
-					fields: []field{
-						{
-							name:                    "ID",
-							dbType:                  input.UUID,
-							primaryKey:              true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-						},
-						{
-							name:                    "createdAt",
-							dbType:                  input.Time,
-							hideFromGraphQL:         true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-						},
-						{
-							name:                    "updatedAt",
-							dbType:                  input.Time,
-							hideFromGraphQL:         true,
-							disableUserEditable:     true,
-							hasDefaultValueOnCreate: true,
-							hasDefaultValueOnEdit:   true,
-						},
-						{
+					fields: fieldsWithNodeFields(
+						field{
 							name:   "name",
 							dbType: input.String,
 						},
-						{
+						field{
 							name:       "creator_id",
 							dbType:     input.UUID,
 							foreignKey: &[2]string{"User", "ID"},
 						},
-						{
+						field{
 							name:   "start_time",
 							dbType: input.Time,
 						},
-						{
+						field{
 							name:     "end_time",
 							dbType:   input.Time,
 							nullable: true,
 						},
-						{
+						field{
 							name:   "location",
 							dbType: input.String,
 						},
-					},
+					),
 				},
 			},
 		},

--- a/internal/schema/input/read_schema.tmpl
+++ b/internal/schema/input/read_schema.tmpl
@@ -54,6 +54,7 @@ for (const key in potentialSchemas) {
     actions: schema.actions,
     enumTable: schema.enumTable,
     dbRows: schema.dbRows,
+    constraints: schema.constraints,
   };
 }
 

--- a/ts/src/schema/index.ts
+++ b/ts/src/schema/index.ts
@@ -20,6 +20,9 @@ export {
   Action,
   EdgeAction,
   NoFields,
+  Constraint,
+  ConstraintType,
+  ForeignKeyInfo,
 } from "./schema";
 
 export {

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -23,6 +23,9 @@ export default interface Schema {
   // data that should be saved in the db corresponding for this table
   // keys should map to either field names or storage_key
   dbRows?: { [key: string]: any }[];
+
+  // constraints applied to the schema e.g. multi-fkey, multi-column unique keys, join table primary keys etc
+  constraints?: Constraint[];
 }
 
 // An AssocEdge is an edge between 2 ids that has a common table/edge format
@@ -296,3 +299,26 @@ export interface Action {
 // required to differentiate against default value of no fields being set to indicate
 // all fields in a create/edit mutation
 export const NoFields = "__NO_FIELDS__";
+
+// no nullable constraint here since simple enough it's just part of the field
+export interface Constraint {
+  name: string;
+  type: ConstraintType;
+  columns: string[];
+  fkey?: ForeignKeyInfo;
+  condition?: string; // only applies in check constraint
+}
+
+export interface ForeignKeyInfo {
+  tableName: string;
+  ondelete?: "RESTRICT" | "CASCADE" | "SET NULL" | "SET DEFAULT" | "NO ACTION";
+  // no on update, match full etc
+}
+
+export enum ConstraintType {
+  PrimaryKey = "primary",
+  ForeignKey = "foreign",
+  Unique = "unique",
+  Check = "check",
+  // index not a constraint and will be its own indices field
+}


### PR DESCRIPTION
This updates the schema API to support constraints.

Supported constraints:

* multi column primary keys 
* multi column foreign keys 
* multi column unique constraints
* (multi column) check constraints not tied to a particular column 

builds on https://github.com/lolopinto/ent/pull/134 by exposing this to the developer

for example, a multi-column unique constraint for a `Contact` object in the schema is indicated as such:

```ts
export default class Contact extends BaseEntSchema {
  fields: Field[] = [
    StringType({
      name: "firstName",
    }),
    StringType({
      name: "lastName",
    }),
    EmailType({
      name: "emailAddress",
    }),
    UUIDType({
      name: "userID",
      foreignKey: ["User", "ID"],
    }),
  ];
  constraints: Constraint[] = [
    {
      name: "contacts_unique_email",
      type: ConstraintType.Unique,
      columns: ["emailAddress", "userID"],
    },
  ];
}
```

A unique constraint on emailAddress/userID combo is created based on this
