### PR TITLE
update ent-graphql-tests 

### DIFF
--- a/ts/packages/ent-graphql-tests/package.json
+++ b/ts/packages/ent-graphql-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lolopinto/ent-graphql-tests",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "easy ways to test ent and graphql",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
* function calls/args so that things like `['user.friends(first:2).nodes[0].id', 'id']` works
* make the 2nd argument to `expectQueryFromRoot` or `expectMutation` to support an Array or Object so that complicated things can just be passed in once and the path taken from that instead of copying the different paths as needed