### PR TITLE
fix EntQuery time comparison

### DIFF
--- a/ts/src/core/query.ts
+++ b/ts/src/core/query.ts
@@ -102,7 +102,7 @@ class FirstFilter implements EdgeQueryFilter {
     // we sort by most recent first
     // so when paging, we fetch afterCursor X
     if (this.time) {
-      options.clause = clause.Less("time", this.time);
+      options.clause = clause.Less("time", new Date(this.time));
       // just to be explicit even though this is the default
       options.orderby = "time DESC";
     }
@@ -149,7 +149,7 @@ class LastFilter implements EdgeQueryFilter {
     // so when paging backwards, we fetch beforeCursor X
     return {
       ...options,
-      clause: clause.Greater("time", this.time),
+      clause: clause.Greater("time", new Date(this.time)),
       orderby: "time ASC",
       limit: this.limit + 1, // fetch an extra so we know if previous page
     };

--- a/ts/src/testutils/parse_sql.ts
+++ b/ts/src/testutils/parse_sql.ts
@@ -1,8 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
-import { Pool, PoolClient } from "pg";
-import { mocked } from "ts-jest/utils";
-import { ID, Ent, Data } from "../core/ent";
-import { Clause } from "../core/clause";
+import { Data } from "../core/ent";
 
 import {
   AST,

--- a/ts/tests/query.test.ts
+++ b/ts/tests/query.test.ts
@@ -979,3 +979,8 @@ describe("chained queries 3 steps", () => {
     await filter.testEnts();
   });
 });
+
+// TODO need to figure out a better way to test time. we had ms here
+// for times but we needed Date object comparions
+// tests work for both but production only works with Date comparisons
+// flaw with nosql parse_sql implementation


### PR DESCRIPTION
need to compare Dates via Date objects instead of milliseconds

don't really have a good test for it because our tests are currently with fake data instead of hitting postgres so added a TODO