### PR TITLE
auto_schema: include script.py.mako in the tar

### DIFF
--- a/python/auto_schema/MANIFEST.in
+++ b/python/auto_schema/MANIFEST.in
@@ -1,0 +1,1 @@
+include auto_schema/script.py.mako

--- a/python/auto_schema/RELEASING.MD
+++ b/python/auto_schema/RELEASING.MD
@@ -10,7 +10,9 @@ Can get the latest of each via the following command: `python3 -m pip install --
 Run the following command from `python/auto_schema` (where `setup.py` is located): `python3 setup.py sdist bdist_wheel
 `.
 
-Run `python3 -m twine upload --repository pypi dist/*` to upload to pypi. You need to be added to the project and have a token in `~/.pypirc` or equivalent location.
+Run `python3 -m twine upload --repository pypi dist/*` to upload to pypi OR `python3 -m twine upload --repository testpypi dist/*`. You need to be added to the project and have a [token](https://pypi.org/help/#apitoken) (or [test token](https://test.pypi.org/help/#apitoken))  in `~/.pypirc` or equivalent location.
+
+Recommend cleaning up after by running `rm -rf dist/`
 
 To test, install as follows: `python3 -m pip install auto_schema`
 

--- a/python/auto_schema/setup.py
+++ b/python/auto_schema/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="auto_schema",  # auto_schema_test to test
-    version="0.0.1",  # 0.0.2 was last test version
+    version="0.0.2",  # 0.0.3 was last test version
     author="Ola Okelola",
     author_email="email@email.com",
     description="auto schema for a db",
@@ -22,4 +22,5 @@ setuptools.setup(
     install_requires=["sqlalchemy>=1.3.20",
                       "alembic>=1.4.3", "datetime>=4.3", "psycopg2>=2.8.6", "autopep8>=1.5.4"],
     entry_points={'console_scripts': ["auto_schema = auto_schema.cli:main"]},
+    include_package_data=True
 )


### PR DESCRIPTION
we need this when generating version files 