### PR TITLE
change config in go-lang to check env file before config/database.yml

### DIFF
--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -341,6 +341,10 @@ func getFilePathForCustomQuery(name string) string {
 	return fmt.Sprintf("src/graphql/resolvers/generated/%s_type.ts", strcase.ToSnake(name))
 }
 
+func getTsconfigPaths() string {
+	return util.GetEnv("TSCONFIG_PATHS", "tsconfig-paths/register")
+}
+
 func parseCustomData(data *codegen.Data) chan *customData {
 	var res = make(chan *customData)
 	go func() {
@@ -364,7 +368,7 @@ func parseCustomData(data *codegen.Data) chan *customData {
 			// TODO this should find the tsconfig.json and not assume there's one at the root but fine for now
 			filepath.Join(data.CodePath.GetAbsPathToRoot(), "tsconfig.json"),
 			"-r",
-			"/node_modules/tsconfig-paths/register",
+			getTsconfigPaths(),
 			// local...
 			// this assumes package already installed
 			fmt.Sprintf("./node_modules/%s/scripts/custom_graphql.js", codepath.Package),
@@ -1521,7 +1525,7 @@ func generateSchemaFile(hasMutations bool) error {
 		return errors.Wrap(err, "error writing temporary schema file")
 	}
 
-	cmd := exec.Command("ts-node", "-r", "/node_modules/tsconfig-paths/register", filePath)
+	cmd := exec.Command("ts-node", "-r", getTsconfigPaths(), filePath)
 	// TODO check this and do something useful with it
 	// and then apply this in more places
 	// for now we'll just spew it when there's an error as it's a hint as to what

--- a/internal/util/os.go
+++ b/internal/util/os.go
@@ -1,0 +1,11 @@
+package util
+
+import "os"
+
+func GetEnv(key, defaultValue string) string {
+	val, ok := os.LookupEnv(key)
+	if ok {
+		return val
+	}
+	return defaultValue
+}


### PR DESCRIPTION
that's consistent with what we do in typescript

also, it makes more sense this way and easier to override the env variable than the file

not sure what it does for go-ent but most of that is currently unsupported so that's fine

also this adds an environment variable `TSCONFIG_PATHS` to tell `tsent` where to get `tsconfig-paths` + make it possible to test locally 
In production, `tsconfig-paths` will be set in `Dockerfile`
better version of what was being done at https://github.com/lolopinto/ent/pull/167