### PR TITLE
add built-in graphql interfaces and make generated code implement it

### DIFF
--- a/internal/graphql/custom_ts.go
+++ b/internal/graphql/custom_ts.go
@@ -502,7 +502,7 @@ func buildObjectType(data *codegen.Data, cd *customData, s *gqlSchema, item Cust
 
 			customInt.Fields = append(customInt.Fields, newInt)
 		}
-		typ.Interfaces = []*interfaceType{customInt}
+		typ.TSInterfaces = []*interfaceType{customInt}
 	}
 	return typ, nil
 }
@@ -620,17 +620,21 @@ func processCustomQueries(data *codegen.Data, cd *customData, s *gqlSchema) erro
 
 func getGraphQLImportsForField(cd *customData, f CustomField, s *gqlSchema) ([]*fileImport, error) {
 	graphqlScalars := map[string]string{
-		"String":  "GraphQLString",
-		"Date":    "Time",
-		"Int":     "GraphQLInt",
-		"Float":   "GraphQLFloat",
-		"Boolean": "GraphQLBoolean",
-		"ID":      "GraphQLID",
+		"String":     "GraphQLString",
+		"Date":       "Time",
+		"Int":        "GraphQLInt",
+		"Float":      "GraphQLFloat",
+		"Boolean":    "GraphQLBoolean",
+		"ID":         "GraphQLID",
+		"Node":       "GraphQLNodeInterface",
+		"Edge":       "GraphQLEdgeInterface",
+		"Connection": "GraphQLConnectionInterface",
 	}
 
 	var imports []*fileImport
 	addGQLImports := func(imps ...string) {
 		for _, imp := range imps {
+			// TODO this doesn't work for the new custom types?
 			imports = append(imports, &fileImport{
 				ImportPath: "graphql",
 				Type:       imp,

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -448,10 +448,10 @@ func (obj gqlobjectData) Imports() []*fileImport {
 	return result
 }
 
-func (obj gqlobjectData) Interfaces() []*interfaceType {
+func (obj gqlobjectData) TSInterfaces() []*interfaceType {
 	var result []*interfaceType
 	for _, node := range obj.GQLNodes {
-		result = append(result, node.Interfaces...)
+		result = append(result, node.TSInterfaces...)
 	}
 	return result
 }
@@ -465,7 +465,7 @@ func (obj gqlobjectData) ForeignImport(name string) bool {
 			obj.m[node.Type] = true
 
 			// same for interfaces
-			for _, in := range node.Interfaces {
+			for _, in := range node.TSInterfaces {
 				obj.m[in.Name] = true
 			}
 		}
@@ -836,6 +836,12 @@ func buildNodeForObject(nodeMap schema.NodeMapInfo, nodeData *schema.NodeData) *
 		TSType:   nodeData.Node,
 		GQLType:  "GraphQLObjectType",
 		Exported: true,
+		// import NodeInterface because ents are always Nodes
+		Imports: []*fileImport{{
+			ImportPath: codepath.GraphQLPackage,
+			Type:       "GraphQLNodeInterface",
+		}},
+		GQLInterfaces: []string{"GraphQLNodeInterface"},
 	}
 
 	for _, node := range nodeData.GetUniqueNodes() {
@@ -853,7 +859,7 @@ func buildNodeForObject(nodeMap schema.NodeMapInfo, nodeData *schema.NodeData) *
 		Type:       nodeData.Node,
 	})
 
-	result.Interfaces = append(result.Interfaces, &interfaceType{
+	result.TSInterfaces = append(result.TSInterfaces, &interfaceType{
 		Name: fmt.Sprintf("%sQueryArgs", nodeData.Node),
 		Fields: []*interfaceField{
 			{
@@ -1060,7 +1066,7 @@ func buildActionInputNode(nodeData *schema.NodeData, a action.Action, actionPref
 			}
 		}
 
-		result.Interfaces = []*interfaceType{intType}
+		result.TSInterfaces = []*interfaceType{intType}
 	}
 
 	// TODO non ent fields 	e.g. status etc
@@ -1117,7 +1123,7 @@ func buildActionResponseNode(nodeData *schema.NodeData, a action.Action, actionP
 			},
 		})
 
-		result.Interfaces = []*interfaceType{
+		result.TSInterfaces = []*interfaceType{
 			{
 				Exported: false,
 				Name:     fmt.Sprintf("%sResponse", actionPrefix),
@@ -1136,7 +1142,7 @@ func buildActionResponseNode(nodeData *schema.NodeData, a action.Action, actionP
 			FieldImports: getGQLFileImportsFromStrings([]string{"GraphQLID"}),
 		})
 
-		result.Interfaces = []*interfaceType{
+		result.TSInterfaces = []*interfaceType{
 			{
 				Exported: false,
 				Name:     fmt.Sprintf("%sResponse", actionPrefix),
@@ -1282,7 +1288,10 @@ type objectType struct {
 
 	DefaultImports []*fileImport
 	Imports        []*fileImport
-	Interfaces     []*interfaceType
+	TSInterfaces   []*interfaceType
+
+	// make this a string for now since we're only doing built-in interfaces
+	GQLInterfaces []string
 }
 
 type fieldType struct {

--- a/internal/graphql/ts_templates/object.tmpl
+++ b/internal/graphql/ts_templates/object.tmpl
@@ -1,6 +1,6 @@
 {{reserveImport "graphql" "GraphQLSchema" "GraphQLObjectType" "GraphQLInputObjectType" "GraphQLID" "GraphQLString" "GraphQLEnumType" "GraphQLNonNull" "GraphQLList" "GraphQLFloat" "GraphQLInt" "GraphQLFieldConfig" "GraphQLFieldConfigMap" "GraphQLResolveInfo" "GraphQLInputFieldConfigMap" "GraphQLBoolean" }}
 {{reserveImport .Package.PackagePath "ID" "RequestContext" }}
-{{reserveImport .Package.GraphQLPackagePath "GraphQLTime"}}
+{{reserveImport .Package.GraphQLPackagePath "GraphQLTime" "GraphQLNodeInterface" "GraphQLEdgeInterface" "GraphQLConnectionInterface"}}
 
 {{ define "renderArgs"  -}}
   {{if .Args -}}
@@ -33,7 +33,7 @@
   {{reserveDefaultImport .ImportPath .Type}}
 {{ end -}}
 
-{{ range $baseObj.Interfaces -}}
+{{ range $baseObj.TSInterfaces -}}
   {{ range .Extends}}
     {{ if $baseObj.ForeignImport . -}}
       {{$ignored := useImport . -}}
@@ -88,6 +88,13 @@
         },
       {{end -}}
     }),
+    {{if .GQLInterfaces -}}
+    interfaces: [
+      {{range $interface := .GQLInterfaces -}}
+        {{useImport $interface}},
+      {{end -}}
+    ],
+    {{end -}}
   });
   
 {{end}}

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lolopinto/ent",
-  "version": "0.0.38",
+  "version": "0.0.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lolopinto/ent",
-  "version": "0.0.44",
+  "version": "0.0.47",
   "description": "ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/graphql/builtins/connection.ts
+++ b/ts/src/graphql/builtins/connection.ts
@@ -1,0 +1,20 @@
+import { GraphQLInterfaceType, GraphQLList, GraphQLNonNull } from "graphql";
+import { GraphQLNodeInterface } from "./node";
+import { GraphQLEdgeInterface } from "./edge";
+import { GraphQLPageInfo } from "../query/page_info";
+
+export const GraphQLConnectionInterface = new GraphQLInterfaceType({
+  name: "Connection",
+  description: "connection interface",
+  fields: () => ({
+    edges: {
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLEdgeInterface))),
+    },
+    nodes: {
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLNodeInterface))),
+    },
+    pageInfo: {
+      type: GraphQLNonNull(GraphQLPageInfo),
+    },
+  }),
+});

--- a/ts/src/graphql/builtins/edge.ts
+++ b/ts/src/graphql/builtins/edge.ts
@@ -1,0 +1,15 @@
+import { GraphQLInterfaceType, GraphQLNonNull, GraphQLString } from "graphql";
+import { GraphQLNodeInterface } from "./node";
+
+export const GraphQLEdgeInterface = new GraphQLInterfaceType({
+  name: "Edge",
+  description: "edge interface",
+  fields: () => ({
+    node: {
+      type: GraphQLNonNull(GraphQLNodeInterface),
+    },
+    cursor: {
+      type: GraphQLNonNull(GraphQLString),
+    },
+  }),
+});

--- a/ts/src/graphql/builtins/node.ts
+++ b/ts/src/graphql/builtins/node.ts
@@ -1,0 +1,11 @@
+import { GraphQLInterfaceType, GraphQLNonNull, GraphQLID } from "graphql";
+
+export const GraphQLNodeInterface = new GraphQLInterfaceType({
+  name: "Node",
+  description: "node interface",
+  fields: () => ({
+    id: {
+      type: GraphQLNonNull(GraphQLID),
+    },
+  }),
+});

--- a/ts/src/graphql/index.ts
+++ b/ts/src/graphql/index.ts
@@ -19,3 +19,6 @@ export {
   GraphQLEdgeType,
   GraphQLConnectionType,
 } from "./query/connection_type";
+export { GraphQLNodeInterface } from "./builtins/node";
+export { GraphQLConnectionInterface } from "./builtins/connection";
+export { GraphQLEdgeInterface } from "./builtins/edge";

--- a/ts/src/graphql/query/connection_type.ts
+++ b/ts/src/graphql/query/connection_type.ts
@@ -7,9 +7,10 @@ import {
   GraphQLString,
 } from "graphql";
 import { RequestContext } from "src/core/context";
-import { AssocEdge, Ent } from "src/core/ent";
 import { GraphQLEdge, GraphQLEdgeConnection } from "./edge_connection";
 import { GraphQLPageInfo } from "./page_info";
+import { GraphQLEdgeInterface } from "../builtins/edge";
+import { GraphQLConnectionInterface } from "../builtins/connection";
 
 export class GraphQLEdgeType<
   TNode extends GraphQLObjectType
@@ -28,6 +29,7 @@ export class GraphQLEdgeType<
           },
         },
       }),
+      interfaces: [GraphQLEdgeInterface],
     });
   }
 }
@@ -69,6 +71,7 @@ export class GraphQLConnectionType<
           },
         },
       }),
+      interfaces: [GraphQLConnectionInterface],
     });
   }
 }


### PR DESCRIPTION
This adds default `Node`, `Edge`, `Connection` to the graphql schema and changes the generated code so that this interface is implemented by them

will be used in subsequent diffs

After this, we'll see the following changes in schema.gql:

* node object:
 `type User implements Node {` 
* edge object:
`type OrganizationToPickupLocationsEdge implements Edge {`
* connection object
`type OrganizationToMembersConnection implements Connection {`