### PR TITLE
call convertToGQLEnum for enums in graphql-land

### DIFF
--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -526,11 +526,11 @@ func (edgeGroup *AssociationEdgeGroup) GetStatusMethod() string {
 }
 
 func (edgeGroup *AssociationEdgeGroup) GetStatusMapMethod() string {
-	return fmt.Sprintf("get%sMap", edgeGroup.ConstType)
+	return fmt.Sprintf("get%sMap", strcase.ToCamel(edgeGroup.ConstType))
 }
 
 func (edgeGroup *AssociationEdgeGroup) GetEnumValuesMethod() string {
-	return fmt.Sprintf("get%sValues", edgeGroup.ConstType)
+	return fmt.Sprintf("get%sValues", strcase.ToCamel(edgeGroup.ConstType))
 }
 
 func (edgeGroup *AssociationEdgeGroup) EdgeIdentifier() string {

--- a/internal/schema/enum/enum.tmpl
+++ b/internal/schema/enum/enum.tmpl
@@ -9,7 +9,7 @@ export enum {{.Name}} {
 }
 
 {{$enumName := .Name}}
-export function get{{.Name}}Values() {
+export function get{{toCamel .Name}}Values() {
   return [
   {{ range $data := .Values -}} 
     {{$enumName}}.{{.Name}},

--- a/internal/tsimport/import.go
+++ b/internal/tsimport/import.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/iancoleman/strcase"
 )
 
 // Imports keeps track of imports in a generated typescript file
@@ -117,6 +119,7 @@ func (imps *Imports) FuncMap() template.FuncMap {
 		"exportAllAs":          imps.ExportAllAs,
 		"export":               imps.Export,
 		"dict":                 dict,
+		"toCamel":              strcase.ToCamel,
 	}
 }
 


### PR DESCRIPTION
followup to TODO in https://github.com/lolopinto/ent/pull/208/files

this makes it so that enums in generated gql-land are handled correctly e.g. 'foo' in TS-land vs 'FOO' in graphql-land

Test Plan: used in example in https://github.com/lolopinto/ent/pull/223