### PR TITLE
 fix loading data when row doesn't exist

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lolopinto/ent",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "description": "ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/context.ts
+++ b/ts/src/core/context.ts
@@ -27,7 +27,7 @@ export interface RequestContext extends Context {
 }
 
 export class ContextCache {
-  loaders: Map<string, DataLoader<ID, Data>> = new Map();
+  loaders: Map<string, DataLoader<ID, Data | null>> = new Map();
 
   // only create as needed for the "requests" which need it
   getEntLoader(loaderOptions: SelectDataOptions) {

--- a/ts/src/core/privacy.ts
+++ b/ts/src/core/privacy.ts
@@ -145,7 +145,7 @@ export const AllowIfHasIdentity = {
 
 export const AllowIfViewerRule = {
   async apply(v: Viewer, ent?: Ent): Promise<PrivacyResult> {
-    if (v.viewerID === ent?.id) {
+    if (v.viewerID && v.viewerID === ent?.id) {
       return Allow();
     }
     return Skip();

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -1,9 +1,5 @@
 import { Ent, ID, Viewer, Data, EntConstructor } from "../core/ent";
-import {
-  PrivacyPolicy,
-  AlwaysAllowRule,
-  AlwaysAllowPrivacyPolicy,
-} from "../core/privacy";
+import { AlwaysAllowPrivacyPolicy } from "../core/privacy";
 import { Orchestrator } from "../action/orchestrator";
 import {
   Action,
@@ -25,9 +21,8 @@ export class User implements Ent {
   id: ID;
   accountID: string;
   nodeType = "User";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AlwaysAllowRule],
-  };
+  privacyPolicy = AlwaysAllowPrivacyPolicy;
+
   constructor(public viewer: Viewer, id: ID, public data: Data) {
     this.id = id;
   }
@@ -37,9 +32,8 @@ export class Event implements Ent {
   id: ID;
   accountID: string;
   nodeType = "Event";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AlwaysAllowRule],
-  };
+  privacyPolicy = AlwaysAllowPrivacyPolicy;
+
   constructor(public viewer: Viewer, id: ID, public data: Data) {
     this.id = id;
   }
@@ -49,9 +43,8 @@ export class Contact implements Ent {
   id: ID;
   accountID: string;
   nodeType = "Contact";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AlwaysAllowRule],
-  };
+  privacyPolicy = AlwaysAllowPrivacyPolicy;
+
   constructor(public viewer: Viewer, id: ID, public data: Data) {
     this.id = id;
   }
@@ -61,9 +54,8 @@ export class Group implements Ent {
   id: ID;
   accountID: string;
   nodeType = "Group";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AlwaysAllowRule],
-  };
+  privacyPolicy = AlwaysAllowPrivacyPolicy;
+
   constructor(public viewer: Viewer, id: ID, public data: Data) {
     this.id = id;
   }
@@ -73,9 +65,8 @@ export class Message implements Ent {
   id: ID;
   accountID: string;
   nodeType = "Message";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AlwaysAllowRule],
-  };
+  privacyPolicy = AlwaysAllowPrivacyPolicy;
+
   constructor(public viewer: Viewer, id: ID, public data: Data) {
     this.id = id;
   }
@@ -85,9 +76,8 @@ export class Address implements Ent {
   id: ID;
   accountID: string;
   nodeType = "Address";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AlwaysAllowRule],
-  };
+  privacyPolicy = AlwaysAllowPrivacyPolicy;
+
   constructor(public viewer: Viewer, id: ID, public data: Data) {
     this.id = id;
   }


### PR DESCRIPTION
broken by https://github.com/lolopinto/ent/pull/219

`User.load(viewer, {non-existent-id})` was throwing when it should have returned null.

Now back to returning null