### PR TITLE
Update go ci

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -4,11 +4,8 @@ on:
   pull_request:
     branches: [ master ]
     paths:
-      - ent/*
-      - internal/*
-      - ts/src/*
-      - gent/*
-      - tsent/*
+      - '*.go'
+      - ts/src/**
       - .github/workflows/go_ci.yml
 
 


### PR DESCRIPTION
update Go CI to only run when relevant files change
    
it's running too often and it's so slow...
    
basically only for go files and ts/src/** files since quite a few tests depend on the schema
could probably do ts/src/schema/** but may be too restrictive