### PR TITLE
ent-passport: update API for couple methods

### DIFF
--- a/ts/packages/ent-passport/package-lock.json
+++ b/ts/packages/ent-passport/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lolopinto/ent-passport",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lolopinto/ent-passport",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "express-session": "^1.17.1",
@@ -16,7 +16,7 @@
         "passport-strategy": "^1.0.0"
       },
       "devDependencies": {
-        "@lolopinto/ent": "0.0.67",
+        "@lolopinto/ent": "0.0.83",
         "@lolopinto/ent-graphql-tests": "0.0.11",
         "@types/express-session": "^1.17.3",
         "@types/jest": "^26.0.20",
@@ -722,14 +722,16 @@
       }
     },
     "node_modules/@lolopinto/ent": {
-      "version": "0.0.67",
-      "resolved": "https://npm.pkg.github.com/download/@lolopinto/ent/0.0.67/11ea11ce7f06e04283644b6f6dbfddec541ce3414172f174d3dd57fe5208cd0a",
-      "integrity": "sha512-FYIDaeFXSuWvVTC8e1a+EedH4gUYNP9mhHqjCSgID4Nq0GAlGuYpO8WNhKdra3B1DHDl182w8fxDGrbwhVfwbA==",
+      "version": "0.0.83",
+      "resolved": "https://npm.pkg.github.com/download/@lolopinto/ent/0.0.83/1a48dda8b671cde599ff73f7e049e84db30a63483a00da897caa8f237af1279c",
+      "integrity": "sha512-VyZxwt4+dUVtIj+Y+TueJz3PAu6fMo99pC3ETZYc1OPmKtlJcQMJq587YmHKWthBCQXSrFsXsIFU2rA8+n5lkQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@types/bcryptjs": "^2.4.2",
         "@types/glob": "^7.1.1",
         "@types/js-yaml": "^3.12.2",
+        "@types/luxon": "^1.25.1",
         "@types/minimist": "^1.2.0",
         "@types/passport": "^1.0.3",
         "@types/passport-jwt": "^3.0.3",
@@ -739,10 +741,9 @@
         "graph-data-structure": "^1.12.0",
         "js-yaml": "^3.13.1",
         "json5": "^2.1.3",
+        "luxon": "^1.25.0",
         "minimist": "^1.2.5",
-        "passport": "^0.4.1",
-        "passport-jwt": "^4.0.0",
-        "passport-strategy": "^1.0.0",
+        "pascal-case": "^3.1.2",
         "pg": "^8.0.3",
         "prettier": "^1.19.1",
         "reflect-metadata": "^0.1.13",
@@ -755,6 +756,9 @@
       "bin": {
         "ent-custom-compiler": "scripts/custom_compiler.js",
         "ent-custom-graphql": "scripts/custom_graphql.js"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0"
       }
     },
     "node_modules/@lolopinto/ent-graphql-tests": {
@@ -1037,6 +1041,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "1.26.3",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.26.3.tgz",
+      "integrity": "sha512-2TELN+Pd3Ocde87sKJMSQ9Wdj0zc/okHK3/+fOQHr3CaWv4jtVtcMzmt1Foww1+5YvPd9B5vL3XR6u5KF0daEA==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -4599,6 +4609,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/luxon": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5166,6 +5185,16 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/pascalcase": {
@@ -8003,14 +8032,15 @@
       }
     },
     "@lolopinto/ent": {
-      "version": "0.0.67",
-      "resolved": "https://npm.pkg.github.com/download/@lolopinto/ent/0.0.67/11ea11ce7f06e04283644b6f6dbfddec541ce3414172f174d3dd57fe5208cd0a",
-      "integrity": "sha512-FYIDaeFXSuWvVTC8e1a+EedH4gUYNP9mhHqjCSgID4Nq0GAlGuYpO8WNhKdra3B1DHDl182w8fxDGrbwhVfwbA==",
+      "version": "0.0.83",
+      "resolved": "https://npm.pkg.github.com/download/@lolopinto/ent/0.0.83/1a48dda8b671cde599ff73f7e049e84db30a63483a00da897caa8f237af1279c",
+      "integrity": "sha512-VyZxwt4+dUVtIj+Y+TueJz3PAu6fMo99pC3ETZYc1OPmKtlJcQMJq587YmHKWthBCQXSrFsXsIFU2rA8+n5lkQ==",
       "dev": true,
       "requires": {
         "@types/bcryptjs": "^2.4.2",
         "@types/glob": "^7.1.1",
         "@types/js-yaml": "^3.12.2",
+        "@types/luxon": "^1.25.1",
         "@types/minimist": "^1.2.0",
         "@types/passport": "^1.0.3",
         "@types/passport-jwt": "^3.0.3",
@@ -8020,10 +8050,9 @@
         "graph-data-structure": "^1.12.0",
         "js-yaml": "^3.13.1",
         "json5": "^2.1.3",
+        "luxon": "^1.25.0",
         "minimist": "^1.2.5",
-        "passport": "^0.4.1",
-        "passport-jwt": "^4.0.0",
-        "passport-strategy": "^1.0.0",
+        "pascal-case": "^3.1.2",
         "pg": "^8.0.3",
         "prettier": "^1.19.1",
         "reflect-metadata": "^0.1.13",
@@ -8310,6 +8339,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/luxon": {
+      "version": "1.26.3",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.26.3.tgz",
+      "integrity": "sha512-2TELN+Pd3Ocde87sKJMSQ9Wdj0zc/okHK3/+fOQHr3CaWv4jtVtcMzmt1Foww1+5YvPd9B5vL3XR6u5KF0daEA==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -11261,6 +11296,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -11711,6 +11752,16 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "pascalcase": {
       "version": "0.1.1",

--- a/ts/packages/ent-passport/package.json
+++ b/ts/packages/ent-passport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lolopinto/ent-passport",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "ent passport integration",
   "main": "dist/passport.js",
   "types": "dist/passport.d.ts",
@@ -34,7 +34,7 @@
     "@lolopinto/ent": "0.0.83"
   },
   "devDependencies": {
-    "@lolopinto/ent": "0.0.67",
+    "@lolopinto/ent": "0.0.83",
     "@lolopinto/ent-graphql-tests": "0.0.11",
     "@types/express-session": "^1.17.3",
     "@types/jest": "^26.0.20",

--- a/ts/packages/ent-passport/src/passport.ts
+++ b/ts/packages/ent-passport/src/passport.ts
@@ -309,19 +309,21 @@ export async function useAndAuth(
 
 export async function useAndVerifyAuth(
   context: RequestContext,
-  verifyFn: () => Promise<ID | null>,
+  verifyFn: () => Promise<Viewer | ID | null>,
   loadOptions?: LoadEntOptions<Ent>,
   options?: AuthenticateOptions,
 ): Promise<AuthViewer> {
   const strategy = new LocalStrategy({
     verifyFn: async (ctx: RequestContext) => {
-      const viewerID = await verifyFn();
-      if (!viewerID) {
+      const viewerMaybe = await verifyFn();
+      if (!viewerMaybe) {
         return null;
       }
-      const reqToViewer = defaultReqToViewer(loadOptions);
-      const v = await reqToViewer(ctx, viewerID);
-      return v;
+      return await toViewer(
+        context,
+        viewerMaybe,
+        defaultReqToViewer(loadOptions),
+      );
     },
   });
 
@@ -343,7 +345,7 @@ export function defaultViewerToPayload(viewer: Viewer): {} {
 
 export async function useAndVerifyAuthJWT(
   context: RequestContext,
-  verifyFn: () => Promise<ID | null>,
+  verifyFn: () => Promise<ID | Viewer | null>,
   jwtOptions: JWTOptions,
   loadOptions?: LoadEntOptions<Ent>,
   options?: AuthenticateOptions,


### PR DESCRIPTION
 ent-passport 's `useAndVerifyAuth` and `useAndVerifyAuthJWT` to allow `verifyFn` return Viewer