### PR TITLE
add index to foreign keys

### DIFF
--- a/internal/field/field.go
+++ b/internal/field/field.go
@@ -169,9 +169,10 @@ func (fieldInfo *FieldInfo) GraphQLFields() []*Field {
 
 // ForeignKeyInfo stores config and field name of the foreign key object
 type ForeignKeyInfo struct {
-	Config string
-	Field  string
-	Name   string
+	Config       string
+	Field        string
+	Name         string
+	DisableIndex bool
 }
 
 func GetNilableGoType(f *Field) string {

--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -151,10 +151,14 @@ func newFieldFromInput(f *input.Field) (*Field, error) {
 	}
 
 	if f.ForeignKey != nil {
+		if !f.ForeignKey.DisableIndex && !f.Unique {
+			ret.index = true
+		}
 		ret.fkey = &ForeignKeyInfo{
-			Config: getConfigName(f.ForeignKey.Schema),
-			Field:  f.ForeignKey.Column,
-			Name:   f.ForeignKey.Name,
+			Config:       getConfigName(f.ForeignKey.Schema),
+			Field:        f.ForeignKey.Column,
+			Name:         f.ForeignKey.Name,
+			DisableIndex: f.ForeignKey.DisableIndex,
 		}
 	}
 
@@ -243,6 +247,10 @@ func (f *Field) AddForeignKeyEdgeToInverseEdgeInfo(edgeInfo *edge.EdgeInfo, node
 	fkeyInfo := f.ForeignKeyInfo()
 	if fkeyInfo == nil {
 		panic(fmt.Errorf("invalid field %s added", f.FieldName))
+	}
+	// nothing to do here
+	if fkeyInfo.DisableIndex {
+		return
 	}
 	edgeName := fkeyInfo.Name
 	if edgeName == "" {

--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -98,9 +98,10 @@ type Field struct {
 }
 
 type ForeignKey struct {
-	Schema string `json:"schema"`
-	Column string `json:"column"`
-	Name   string `json:"name"`
+	Schema       string `json:"schema"`
+	Column       string `json:"column"`
+	Name         string `json:"name"`
+	DisableIndex bool   `json:"disableIndex"`
 }
 
 type FieldEdge struct {

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lolopinto/ent",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "description": "ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -178,6 +178,7 @@ export interface ForeignKey {
   column: string;
   name?: string; // optional but if we have multiple foreign keys to the same schema, it becomes required for all but one
   // defaults to pluralize(schema) if not provided
+  disableIndex?: boolean;
 }
 
 export interface FieldEdge {


### PR DESCRIPTION
foreign keys aren't currently indexed and we end up querying via them a lot. now, we default to these fields being indexed and provide the option to not index them.

a subsequent PR will change it so that we don't query for non indexed fields.

fixes https://github.com/lolopinto/ent/issues/281