### PR TITLE
update workflow path

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ master ]
     paths:
-      - '*.go'
+      - '**.go'
       - ts/src/**
       - .github/workflows/go_ci.yml
 


### PR DESCRIPTION
wasn't seeing the `Go CI` check triggered for https://github.com/lolopinto/ent/pull/290

looked at the examples at https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions and it has '**' instead of '*' so updating that...