### PR TITLE
bump Docker version to new release

### DIFF
--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -24,7 +24,7 @@ ENV GOPATH=$HOME/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOPATH/bin
 
-RUN go install github.com/lolopinto/ent/tsent@v0.0.10
+RUN go install github.com/lolopinto/ent/tsent@v0.0.11
 
 # needed to tell tsent where to get tsconfig-paths + make it possible to test locally 
 ENV TSCONFIG_PATHS="/node_modules/tsconfig-paths/register"


### PR DESCRIPTION
new release: https://github.com/lolopinto/ent/releases/tag/v0.0.11

new docker version: https://github.com/users/lolopinto/packages/container/package/ent