### PR TITLE
handle custom Scalar Types passed in

### DIFF
--- a/internal/graphql/custom_ts_test.go
+++ b/internal/graphql/custom_ts_test.go
@@ -535,7 +535,7 @@ func TestCustomUploadType(t *testing.T) {
 	assert.Equal(t, arg.Nullable, NullableItem(""))
 	assert.Equal(t, arg.List, false)
 	assert.Equal(t, arg.IsContextArg, false)
-	assert.Equal(t, arg.TSType, "")
+	assert.Equal(t, arg.TSType, "FileUpload")
 
 	require.Len(t, item.Results, 1)
 	result := item.Results[0]

--- a/ts/src/graphql/graphql_custom.test.ts
+++ b/ts/src/graphql/graphql_custom.test.ts
@@ -386,6 +386,7 @@ test("custom type", () => {
           type: "GraphQLUpload",
           name: "file",
           needsResolving: true,
+          tsType: "FileUpload",
         },
       ],
     },

--- a/ts/src/graphql/graphql_field_helpers.ts
+++ b/ts/src/graphql/graphql_field_helpers.ts
@@ -93,7 +93,7 @@ export function validateFields(actual: Field[], expected: Field[]) {
 
     // TODO set this for everyone and then don't need this...
     if (expField.tsType) {
-      expect(field.tsType, expField.tsType);
+      expect(field.tsType).toBe(expField.tsType);
     }
   }
 }

--- a/ts/src/graphql/query/connection_type.ts
+++ b/ts/src/graphql/query/connection_type.ts
@@ -11,7 +11,7 @@ import { GraphQLEdge, GraphQLEdgeConnection } from "./edge_connection";
 import { GraphQLPageInfo } from "./page_info";
 import { GraphQLEdgeInterface } from "../builtins/edge";
 import { GraphQLConnectionInterface } from "../builtins/connection";
-import { Data } from "src/core/base";
+import { Data } from "../../core/base";
 
 export class GraphQLEdgeType<
   TNode extends GraphQLObjectType,


### PR DESCRIPTION
would need to change both TypeScript and Go to support this. so intead just throw an exception and move on.

Error thrown by Go: `Error: found a type Point which was not part of the schema`

fixes https://github.com/lolopinto/ent/issues/335

original relevant PRs: https://github.com/lolopinto/ent/pull/65 and https://github.com/lolopinto/ent/pull/241