### PR TITLE
Update auto schema

### DIFF
--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -426,6 +426,13 @@ func FixEdges(codePathInfo *codegen.CodePath) {
 	runPythonCommand(codePathInfo.GetRootPathToConfigs(), "-f=True")
 }
 
+func RunAlembicCommand(codePathInfo *codegen.CodePath, command string, args...string) {
+	if len(args) == 0 {
+		runPythonCommand(codePathInfo.GetRootPathToConfigs(), fmt.Sprintf("--%s", command))
+	}
+	runPythonCommand(codePathInfo.GetRootPathToConfigs(), fmt.Sprintf("--%s=%s", command, strings.Join(args, ",")))
+}
+
 func (s *dbSchema) writeSchemaFile() {
 	util.Die(file.Write(&file.TemplatedBasedFileWriter{
 		Data:              s.getSchemaForTemplate(),

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -429,8 +429,9 @@ func FixEdges(codePathInfo *codegen.CodePath) {
 func RunAlembicCommand(codePathInfo *codegen.CodePath, command string, args...string) {
 	if len(args) == 0 {
 		runPythonCommand(codePathInfo.GetRootPathToConfigs(), fmt.Sprintf("--%s", command))
+	} else {
+		runPythonCommand(codePathInfo.GetRootPathToConfigs(), fmt.Sprintf("--%s=%s", command, strings.Join(args, ",")))
 	}
-	runPythonCommand(codePathInfo.GetRootPathToConfigs(), fmt.Sprintf("--%s=%s", command, strings.Join(args, ",")))
 }
 
 func (s *dbSchema) writeSchemaFile() {

--- a/python/auto_schema/CONTRIBUTING.MD
+++ b/python/auto_schema/CONTRIBUTING.MD
@@ -1,8 +1,10 @@
 make changes to code and then run as following:
 
 * `pipenv shell` to get into virtual environment.
-* run a test: `python -m pytest -k test_enum_type `
+* run a test: `python -m pytest -k test_enum_type`
 * run all tests: `python -m pytest`
+
+* `pipenv install` to install dependencies from `Pipfile`
 
 assumes a local postgres db named `autoschema_test` exists
 

--- a/python/auto_schema/CONTRIBUTING.MD
+++ b/python/auto_schema/CONTRIBUTING.MD
@@ -9,3 +9,11 @@ assumes a local postgres db named `autoschema_test` exists
 credentials: `postgresql://localhost/autoschema_test`
 
 or it uses the one provided via environment variable `DB_CONNECTION_STRING`
+
+To run `auto_schema` locally, from the `python/auto_schema` directory, run:
+
+```shell
+LOCAL_AUTO_SCHEMA=true python3 auto_schema/cli/__init__.py -e postgresql://ola:@localhost/tsent_test -s /Users/ola/code/ent/examples/simple/src/schema  --history
+```
+
+`LOCAL_AUTO_SCHEMA` is to ensure that your changes are seen over any installed `auto_schema`.

--- a/python/auto_schema/RELEASING.MD
+++ b/python/auto_schema/RELEASING.MD
@@ -18,7 +18,17 @@ Steps to release new version:
 * Recommend cleaning up after by running `rm -rf dist/`
 
 ## Testing
-To test, install as follows: `python3 -m pip install auto_schema=={version}`
+To test, install as follows: 
+
+```shell
+python3 -m pip install auto_schema=={version}
+```
+
+and test version:
+
+```shell
+python3 -m pip install --index-url https://test.pypi.org/simple/ auto-schema-test
+```
 
 If done in a `venv`, prerequisites are as follows:
 * `python3 -m venv .`

--- a/python/auto_schema/auto_schema/cli/__init__.py
+++ b/python/auto_schema/auto_schema/cli/__init__.py
@@ -1,6 +1,13 @@
 import os
 import sys
 import argparse
+from alembic.command import heads
+
+# if env variable is set, manipulate the path to put local
+# current directory over possibly installed auto_schema so that we 
+# see local changes
+if os.getenv('LOCAL_AUTO_SCHEMA') == 'true':
+    sys.path.insert(0, os.getcwd())
 
 # run from auto_schema root. conflicts with pip-installed auto_schema when that exists so can't have
 # that installed when runnning this...
@@ -9,7 +16,7 @@ from auto_schema.runner import Runner
 from importlib import import_module
 
 parser = argparse.ArgumentParser(
-    description="generate the db schema for an ent")
+    description="generate the db schema for an ent", prog='auto_schema')
 required = parser.add_argument_group('required arguments')
 required.add_argument(
     '-s', '--schema', help='path to the folder the generated schema file is in', required=True)
@@ -19,12 +26,15 @@ parser.add_argument('-f', '--fix_edges', help='fix edges in schema into db')
 parser.add_argument('-u', '--upgrade', help='upgrade')
 # this is getting bad and needs to be changed soon to something that's more extensible and makes more sense
 parser.add_argument('-d', '--downgrade', help='downgrade')
-
+parser.add_argument('--history', help='alembic history', action='store_true')
+parser.add_argument('--current', help='alembic current', action='store_true')
+parser.add_argument('--show', help='show revision')
+parser.add_argument('--heads', help='alembic heads', action='store_true')
+parser.add_argument('--branches', help='alembic branches', action='store_true')
+parser.add_argument('--stamp', help='alembic stamp')
+parser.add_argument('--edit', help='alembic edit')
 
 def main():
-    # TODO we need to support running each of the alembic commands directly e.g. upgrade head, upgrade +1, downgrade -1, current, history, etc
-    # so we need even more complicated things here
-
     args = parser.parse_args()
     sys.path.append(os.path.relpath(args.schema))
 
@@ -39,6 +49,20 @@ def main():
             r.upgrade()
         elif args.downgrade is not None:
             r.downgrade(args.downgrade)
+        elif args.history is True:
+            r.history()
+        elif args.current is True:
+            r.current()
+        elif args.heads is True:
+            r.heads()
+        elif args.branches is True:
+            r.branches()
+        elif args.show is not None:
+            r.show(args.show)
+        elif args.stamp is not None:
+            r.stamp(args.stamp)
+        elif args.edit is not None:
+            r.edit(args.edit)
         else:
             r.run()
 

--- a/python/auto_schema/auto_schema/cli/__init__.py
+++ b/python/auto_schema/auto_schema/cli/__init__.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import argparse
-from alembic.command import heads
 
 # if env variable is set, manipulate the path to put local
 # current directory over possibly installed auto_schema so that we 

--- a/python/auto_schema/auto_schema/cli/__init__.py
+++ b/python/auto_schema/auto_schema/cli/__init__.py
@@ -45,8 +45,8 @@ def main():
         Runner.fix_edges(metadata, args)
     else:
         r = Runner.from_command_line(metadata, args)
-        if args.upgrade:
-            r.upgrade()
+        if args.upgrade is not None:
+            r.upgrade(args.upgrade)
         elif args.downgrade is not None:
             r.downgrade(args.downgrade)
         elif args.history is True:

--- a/python/auto_schema/auto_schema/command.py
+++ b/python/auto_schema/auto_schema/command.py
@@ -56,3 +56,32 @@ class Command(object):
     # Simulates running the `alembic downgrade` command
     def downgrade(self, revision=''):
         command.downgrade(self.alembic_cfg, revision)
+
+    # Simulates running the `alembic history` command
+    def history(self):
+        command.history(self.alembic_cfg, indicate_current=True)
+
+    # Simulates running the `alembic current` command
+    def current(self):
+        command.current(self.alembic_cfg)
+
+    # Simulates running the `alembic show` command
+    def show(self, revision):
+        command.show(self.alembic_cfg, revision)
+
+    # Simulates running the `alembic heads` command
+    def heads(self):
+        command.heads(self.alembic_cfg, verbose=True)
+
+    # Simulates running the `alembic branches` command
+    def branches(self):
+        command.branches(self.alembic_cfg, verbose=True)
+
+    # Simulates running the `alembic stamp` command
+    def stamp(self, revision):
+        command.stamp(self.alembic_cfg, revision)
+
+    # Simulates running the `alembic edit` command
+    # this should probably not be exposed at the moment?
+    def edit(self, revision):
+        command.edit(self.alembic_cfg, revision)

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -304,8 +304,8 @@ class Runner(object):
         # understand diff and make changes as needed
         # pprint.pprint(migrations, indent=2, width=30)
 
-    def upgrade(self):
-        self.cmd.upgrade()
+    def upgrade(self, revision):
+        self.cmd.upgrade(revision)
 
     def downgrade(self, revision):
         self.cmd.downgrade(revision)

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -309,3 +309,24 @@ class Runner(object):
 
     def downgrade(self, revision):
         self.cmd.downgrade(revision)
+
+    def history(self):
+        self.cmd.history()
+    
+    def current(self):
+        self.cmd.current()
+
+    def show(self, revision):
+        self.cmd.show(revision)
+
+    def heads(self):
+        self.cmd.heads()
+
+    def branches(self):
+        self.cmd.branches()
+
+    def stamp(self, revision):
+        self.cmd.stamp(revision)
+
+    def edit(self, revision):
+        self.cmd.edit(revision)

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -304,7 +304,7 @@ class Runner(object):
         # understand diff and make changes as needed
         # pprint.pprint(migrations, indent=2, width=30)
 
-    def upgrade(self, revision):
+    def upgrade(self, revision='head'):
         self.cmd.upgrade(revision)
 
     def downgrade(self, revision):

--- a/python/auto_schema/setup.py
+++ b/python/auto_schema/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="auto_schema",  # auto_schema_test to test
-    version="0.0.6",  # 0.0.4 was last test version
+    version="0.0.7",  # 0.0.5 was last test version
     author="Ola Okelola",
     author_email="email@email.com",
     description="auto schema for a db",

--- a/tsent/cmd/alembic.go
+++ b/tsent/cmd/alembic.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lolopinto/ent/internal/codegen"
+	"github.com/lolopinto/ent/internal/db"
+	"github.com/spf13/cobra"
+)
+
+var validCmds= map[string]int{
+	"upgrade":1,
+	"downgrade":1,
+	"history":0,
+	"current":0,
+	"heads":0,
+	"branches":0,
+	"show":1,
+	"stamp":1,
+	"edit":1,
+}
+
+var alembicCmd = &cobra.Command{
+	Use:   "alembic",
+	Short: "alembic command",
+	Long:  `This runs the passed in alembic command`,
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error{
+		// another hardcoded place
+		codePathInfo := codegen.NewCodePath("src/schema", "")
+		command := args[0];
+		count, ok := validCmds[command]  
+		if !ok {
+			return fmt.Errorf("invalid alemvic command %s passed in", command)
+		}
+
+		if count + 1 != len(args) {
+			return fmt.Errorf("invalid number of args passed. expected %d", count+1)
+		}
+
+		db.RunAlembicCommand(codePathInfo, args[0], args[1:]...)
+		return nil
+	},
+}

--- a/tsent/cmd/root.go
+++ b/tsent/cmd/root.go
@@ -21,6 +21,7 @@ func init() {
 	rootCmd.AddCommand(downgradeCmd)
 	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(fixEdgesCmd)
+	rootCmd.AddCommand(alembicCmd)
 
 	codegenCmd.Flags().StringVarP(&codegenInfo.step, "step", "s", "", "limit to only run a particular step e.g. db, graphql, codegen")
 }


### PR DESCRIPTION
This adds support for more [alembic commands](https://alembic.sqlalchemy.org/en/latest/api/commands.html) to auto_schema.

The only ones left are `list_templates` (doesn't seem relevant) and `merge`: tracked at https://github.com/lolopinto/ent/issues/316

This also adds a blanket `tsent alembic` which can be used to run any alembic command instead of creating a top-level command for rarely used things. For example:

```shell
tsent alembic current
```

shows the current version

We still keep `upgrade` and `downgrade` as top level commands since they're used relatively often.

Also fixes `upgrade` to accept being passed a non 'heads' version

This also updates and publishes latest auto_schema version as 0.0.7

