### PR TITLE
Update dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 See [ent starter](https://github.com/lolopinto/ent-starter) and start by clicking the "Use this template" button to generate a new repo with the right base
 
-Also need github access to the following:
-* https://github.com/lolopinto/ent-starter
-* https://github.com/users/lolopinto/packages/container/package/ent
+See docs at https://ent-docs.onrender.com/.

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source https://github.com/lolopinto/ent
 RUN apt update && apt --assume-yes install zsh
 
 # install auto_schema
-RUN python3 -m pip install auto_schema==0.0.6
+RUN python3 -m pip install auto_schema==0.0.7
 
 # get go
 RUN wget https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz
@@ -15,16 +15,12 @@ RUN tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz
 
 ENV PATH $PATH:/usr/local/go/bin
 
-ARG GITHUB_TOKEN=$GITHUB_TOKEN
-RUN go env -w GOPRIVATE=github.com/lolopinto/ent
-RUN git config --global url."https://golang:$GITHUB_TOKEN@github.com".insteadOf "https://github.com"
-
 # default path but make it explicit
 ENV GOPATH=$HOME/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOPATH/bin
 
-RUN go install github.com/lolopinto/ent/tsent@v0.0.11
+RUN go install github.com/lolopinto/ent/tsent@v0.0.12
 
 # needed to tell tsent where to get tsconfig-paths + make it possible to test locally 
 ENV TSCONFIG_PATHS="/node_modules/tsconfig-paths/register"

--- a/ts/RELEASING.MD
+++ b/ts/RELEASING.MD
@@ -4,7 +4,7 @@ Steps to update docker image:
 high level following [these steps](https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/pushing-and-pulling-docker-images#authenticating-to-github-container-registry):
 
 * `echo "{TOKEN}" | docker login ghcr.io -u USERNAME --password-stdin`
-* `docker build  --build-arg GITHUB_TOKEN={token} --no-cache -t ent .`
+* `docker build --no-cache -t ent .`
 * `docker tag ent ghcr.io/lolopinto/ent:(tag)`
 * `docker tag ent ghcr.io/lolopinto/ent:latest`
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lolopinto/ent",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lolopinto/ent",
-      "version": "0.0.94",
+      "version": "0.0.95",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^15.0.2",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lolopinto/ent",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "description": "ent framework",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
following changes:

* update to new [auto_schema](https://github.com/lolopinto/ent/pull/349)
* package is public now so don't need `GITHUB_TOKEN`
* point to latest go release: https://github.com/lolopinto/ent/releases/tag/v0.0.12

+ bump `@lolopinto/ent` package while here

+ update README to link to docs

