### PR TITLE
fix ent-graphql-tests when we're querying for scalar lists

### DIFF
--- a/ts/packages/ent-graphql-tests/package.json
+++ b/ts/packages/ent-graphql-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lolopinto/ent-graphql-tests",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "easy ways to test ent and graphql",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/ts/packages/ent-graphql-tests/src/index.ts
+++ b/ts/packages/ent-graphql-tests/src/index.ts
@@ -385,7 +385,6 @@ async function expectFromRoot(
   let fieldArgs = field.args;
 
   let queryParams: string[] = [];
-
   fieldArgs.forEach((fieldArg) => {
     let arg = config.args[fieldArg.name];
     // let the graphql runtime handle this (it may be optional for example)

--- a/ts/packages/ent-graphql-tests/src/test.ts
+++ b/ts/packages/ent-graphql-tests/src/test.ts
@@ -786,46 +786,43 @@ describe("inline fragments", () => {
       },
     ]);
   });
-});
 
-test("inline root fragment", async () => {
-  let rootQuery = new GraphQLObjectType({
-    name: "RootQueryType",
-    fields: {
-      node: {
-        args: {
-          id: {
-            type: GraphQLNonNull(GraphQLID),
-          },
-        },
-        type: GraphQLNodeInterface,
-        resolve(_source, { id }) {
-          return getUser(id);
-        },
+  test("inline fragment root", async () => {
+    let cfg: queryRootConfig = {
+      schema: schema,
+      args: {
+        id: "10",
       },
-    },
+      root: "node",
+      inlineFragmentRoot: "User",
+    };
+
+    await expectQueryFromRoot(
+      cfg,
+      ["id", "10"],
+      ["firstName", "Jon"],
+      ["lastName", "Snow"],
+    );
   });
 
-  let schema = new GraphQLSchema({
-    query: rootQuery,
-    types: [userType, contactType, addressType],
+  test("inline fragment root with list", async () => {
+    let cfg: queryRootConfig = {
+      schema: schema,
+      args: {
+        id: "1001",
+      },
+      root: "node",
+      inlineFragmentRoot: "User",
+    };
+
+    await expectQueryFromRoot(
+      cfg,
+      ["id", "1001"],
+      ["firstName", "Jon"],
+      ["lastName", "Snow"],
+      ["nicknames", NickNames],
+    );
   });
-
-  let cfg: queryRootConfig = {
-    schema: schema,
-    args: {
-      id: "10",
-    },
-    root: "node",
-    inlineFragmentRoot: "User",
-  };
-
-  await expectQueryFromRoot(
-    cfg,
-    ["id", "10"],
-    ["firstName", "Jon"],
-    ["lastName", "Snow"],
-  );
 });
 
 describe("file upload", () => {

--- a/ts/src/graphql/node_resolver.test.ts
+++ b/ts/src/graphql/node_resolver.test.ts
@@ -394,7 +394,7 @@ describe("postgres", () => {
 });
 
 describe("sqlite", () => {
-  setupSqlite(`sqlite:///index_loader.db`, tempDBTables);
+  setupSqlite(`sqlite:///node_resolver.db`, tempDBTables);
 
   beforeEach(async () => {
     await createEdges();

--- a/ts/src/testutils/ent-graphql-tests/index.ts
+++ b/ts/src/testutils/ent-graphql-tests/index.ts
@@ -10,6 +10,9 @@ import {
   isWrappingType,
   GraphQLArgument,
   GraphQLList,
+  isScalarType,
+  GraphQLField,
+  GraphQLFieldMap,
 } from "graphql";
 import { buildContext, registerAuthHandler } from "../../auth";
 import { IncomingMessage, ServerResponse } from "http";
@@ -48,6 +51,16 @@ function server(config: queryConfig): Express {
   return app;
 }
 
+function getInnerType(typ, list) {
+  if (isWrappingType(typ)) {
+    if (typ instanceof GraphQLList) {
+      return getInnerType(typ.ofType, true);
+    }
+    return getInnerType(typ.ofType, list);
+  }
+  return [typ, list];
+}
+
 function makeGraphQLRequest(
   config: queryConfig,
   query: string,
@@ -63,16 +76,6 @@ function makeGraphQLRequest(
     }
   } else {
     test = supertest(server(config));
-  }
-
-  function getInnerType(typ, list) {
-    if (isWrappingType(typ)) {
-      if (typ instanceof GraphQLList) {
-        return getInnerType(typ.ofType, true);
-      }
-      return getInnerType(typ.ofType, list);
-    }
-    return [typ, list];
   }
 
   let files = new Map();
@@ -144,7 +147,16 @@ function makeGraphQLRequest(
   }
 }
 
-function buildTreeFromQueryPaths(...options: Option[]) {
+function buildTreeFromQueryPaths(
+  schema: GraphQLSchema,
+  field: GraphQLField<any, any, any>,
+  ...options: Option[]
+) {
+  const outputType = field.type;
+  let fields: GraphQLFieldMap<any, any>;
+  if (outputType instanceof GraphQLObjectType) {
+    fields = outputType.getFields();
+  }
   let topLevelTree = {};
   options.forEach((option) => {
     let path = option[0];
@@ -153,6 +165,14 @@ function buildTreeFromQueryPaths(...options: Option[]) {
     if (match) {
       // fragment, keep the part of the fragment e.g.  ...onUser, and then split the rest....
       parts = [match[0], ...match[2].split(".")];
+
+      const typ = schema.getType(match[1]);
+      if (!typ) {
+        throw new Error(`can't find type for ${match[1]} in schema`);
+      }
+      if (typ instanceof GraphQLObjectType) {
+        fields = typ.getFields();
+      }
     } else {
       parts = splitPath(path);
     }
@@ -186,12 +206,32 @@ function buildTreeFromQueryPaths(...options: Option[]) {
             tree[key] = {};
           }
           if (typeof obj[key] === "object") {
-            handleSubtree(obj[key], tree[key]);
+            if (!isScalarField(key)) {
+              handleSubtree(obj[key], tree[key]);
+            }
           }
         }
       }
+
+      // TODO this needs to work for super complicated objects and have fields update as nesting applies...
+      function isScalarField(f: string) {
+        const subField = fields?.[f];
+        if (!subField) {
+          return false;
+        }
+        if (!isWrappingType(subField.type)) {
+          return false;
+        }
+
+        // only spread out if an object
+        const [typ, _] = getInnerType(subField.type, true);
+        return isScalarType(typ);
+      }
+
       if (i === parts.length - 1 && typeof option[1] === "object") {
-        handleSubtree(option[1], tree);
+        if (!isScalarField(part)) {
+          handleSubtree(option[1], tree);
+        }
       }
     }
   });
@@ -213,8 +253,12 @@ function constructQueryFromTreePath(treePath: {}) {
   return query.join(",");
 }
 
-function expectQueryResult(...options: Option[]) {
-  let topLevelTree = buildTreeFromQueryPaths(...options);
+function expectQueryResult(
+  schema: GraphQLSchema,
+  field: GraphQLField<any, any, any>,
+  ...options: Option[]
+) {
+  let topLevelTree = buildTreeFromQueryPaths(schema, field, ...options);
   //  console.log(topLevelTree);
 
   let query = constructQueryFromTreePath(topLevelTree);
@@ -352,7 +396,7 @@ async function expectFromRoot(
   for (let key in config.args) {
     params.push(`${key}: $${key}`);
   }
-  let q = expectQueryResult(...options);
+  let q = expectQueryResult(config.schema, field, ...options);
   let queryVar = "";
   let callVar = "";
   if (queryParams.length) {


### PR DESCRIPTION
when querying for a field which was a scalar list e.g. list of strings, we were trying to expand that and query subfields which didn't exist.