### PR TITLE
catch errors in the scripts

### DIFF
--- a/ts/src/scripts/custom_graphql.ts
+++ b/ts/src/scripts/custom_graphql.ts
@@ -11,6 +11,7 @@ import * as readline from "readline";
 import * as path from "path";
 import * as fs from "fs";
 import { parseCustomInput, file } from "../imports";
+import { exit } from "process";
 
 // need to use the GQLCapture from the package so that when we call GQLCapture.enable()
 // we're affecting the local paths as opposed to a different instance
@@ -214,4 +215,9 @@ async function main() {
   );
 }
 
-Promise.resolve(main());
+main()
+  .then()
+  .catch((err) => {
+    console.error(err);
+    exit(1);
+  });

--- a/ts/src/scripts/read_schema.ts
+++ b/ts/src/scripts/read_schema.ts
@@ -1,9 +1,10 @@
-import { Schema, Field, Edge, AssocEdge, AssocEdgeGroup } from "../schema";
+import { Schema, Field, AssocEdge, AssocEdgeGroup } from "../schema";
 import glob from "glob";
 import * as path from "path";
 import { pascalCase } from "pascal-case";
 import minimist from "minimist";
 import { ActionField } from "../schema/schema";
+import { exit } from "process";
 
 function processFields(dst: {}[], src: Field[]) {
   for (const field of src) {
@@ -82,7 +83,7 @@ function processAction(action: InputAction): OutputAction {
   return ret;
 }
 
-async function main() {
+function main() {
   const options = minimist(process.argv.slice(2));
 
   if (!options.path) {
@@ -116,7 +117,6 @@ async function main() {
     // let's put patterns first just so we have id, created_at, updated_at first
     // ¯\_(ツ)_/¯
     let fields: Field[] = [];
-    //  let fields = [...schema.fields];
     if (schema.patterns) {
       for (const pattern of schema.patterns) {
         processFields(fields, pattern.fields);
@@ -164,4 +164,9 @@ async function main() {
   console.log(JSON.stringify(schemas));
 }
 
-Promise.resolve(main());
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  exit(1);
+}


### PR DESCRIPTION
was debugging and ran into this issue:

```shell
Creating ent-starter_app_run ... done
# ^[[B^A  
/bin/sh: 1: : not found
# ts-node-script --log-error --project /app/tsconfig.json -r /node_modules/tsconfig-paths/register ./node_modules/@snowtop/snowtop-ts/scripts/read_schema.js ./node_modules/@snowtop/snowtop-ts/scripts/read_schema.js --path /app/src/schema
(node:9) UnhandledPromiseRejectionWarning: Error: /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node: invalid ELF header
    at Object.Module._extensions..node (internal/modules/cjs/loader.js:1144:18)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:14)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at bindings (/app/node_modules/bindings/bindings.js:112:48)
    at Object.<anonymous> (/app/node_modules/better-sqlite3/lib/database.js:9:24)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:9) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:9) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
# 
```