### PR TITLE
Custom queries ent query

### DIFF
--- a/internal/tscode/ent_query_base.tmpl
+++ b/internal/tscode/ent_query_base.tmpl
@@ -33,10 +33,10 @@
 
   {{range $edge := .EdgeInfo.GetEdgesForIndexLoader -}}
     {{$node := useImport $edge.GetNodeInfo.Node -}}
-      export const {{$edge.GetCountFactoryName}} = new {{useImport "RawCountLoaderFactory"}}(
-        {{$node}}.loaderOptions(),
-        {{$edge.QuotedDBColName}},
-      );
+      export const {{$edge.GetCountFactoryName}} = new {{useImport "RawCountLoaderFactory"}}({
+        ...{{$node}}.loaderOptions(),
+        groupCol: {{$edge.QuotedDBColName}},
+      });
       export const {{$edge.GetDataFactoryName}} = new {{useImport "IndexLoaderFactory"}}(
         {{$node}}.loaderOptions(),
         {{$edge.QuotedDBColName}},

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/snowtop-ts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -500,6 +500,8 @@ interface GroupQueryOptions {
 
   // extra clause to join
   clause?: clause.Clause;
+
+  // TODO rename from fkeyColumn to groupColumn or something like that
   fkeyColumn: string;
   fields: string[];
   values: any[];

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -33,6 +33,7 @@ import * as clause from "./clause";
 import { WriteOperation, Builder } from "../action";
 import { log, logEnabled, logTrace } from "./logger";
 import DataLoader from "dataloader";
+import { SqliteError } from "better-sqlite3";
 
 // TODO kill this and createDataLoader
 class cacheMap {

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -501,9 +501,7 @@ interface GroupQueryOptions {
 
   // extra clause to join
   clause?: clause.Clause;
-
-  // TODO rename from fkeyColumn to groupColumn or something like that
-  fkeyColumn: string;
+  groupColumn: string;
   fields: string[];
   values: any[];
   orderby?: string;
@@ -516,7 +514,7 @@ export function buildGroupQuery(
 ): [string, clause.Clause] {
   const fields = [...options.fields, "row_number()"];
 
-  let cls = clause.In(options.fkeyColumn, ...options.values);
+  let cls = clause.In(options.groupColumn, ...options.values);
   if (options.clause) {
     cls = clause.And(cls, options.clause);
   }
@@ -529,7 +527,7 @@ export function buildGroupQuery(
   //    https://www.sqlite.org/windowfunctions.html
   return [
     `SELECT * FROM (SELECT ${fields.join(",")} OVER (PARTITION BY ${
-      options.fkeyColumn
+      options.groupColumn
     } ${orderby}) as row_num FROM ${options.tableName} WHERE ${cls.clause(
       1,
     )}) t WHERE row_num <= ${options.limit}`,

--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -38,7 +38,7 @@ describe("postgres", () => {
 
 describe("sqlite", () => {
   setupSqlite(
-    `sqlite:///ent_data_test.db`,
+    `sqlite:///ent_custom_data_test.db`,
     () => [
       table(
         "users",

--- a/ts/src/core/loaders/assoc_count_loader.test.ts
+++ b/ts/src/core/loaders/assoc_count_loader.test.ts
@@ -54,7 +54,7 @@ describe("sqlite", () => {
     ml.mock();
   });
 
-  afterEach(() => {
+  beforeEach(() => {
     ml.clear();
   });
 

--- a/ts/src/core/loaders/assoc_count_loader.ts
+++ b/ts/src/core/loaders/assoc_count_loader.ts
@@ -22,11 +22,11 @@ export class AssocEdgeCountLoader implements Loader<ID, number> {
       throw new Error(`error loading edge data for ${this.edgeType}`);
     }
 
-    this.loader = createCountDataLoader(
-      { tableName: edgeData.edgeTable },
-      "id1",
-      clause.Eq("edge_type", this.edgeType),
-    );
+    this.loader = createCountDataLoader({
+      tableName: edgeData.edgeTable,
+      groupCol: "id1",
+      clause: clause.Eq("edge_type", this.edgeType),
+    });
     return this.loader;
   }
 

--- a/ts/src/core/loaders/assoc_edge_loader.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.ts
@@ -68,7 +68,6 @@ function createLoader<T extends AssocEdge>(
         "id1",
         "id2",
         "edge_type",
-        "time",
         "id1_type",
         "id2_type",
         "data",

--- a/ts/src/core/loaders/assoc_edge_loader.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.ts
@@ -76,7 +76,7 @@ function createLoader<T extends AssocEdge>(
       values: keys,
       orderby: options.orderby,
       limit: options.limit || DefaultLimit,
-      fkeyColumn: "id1",
+      groupColumn: "id1",
       clause: clause.Eq("edge_type", edgeType),
     });
 

--- a/ts/src/core/loaders/index.ts
+++ b/ts/src/core/loaders/index.ts
@@ -9,8 +9,9 @@ export {
   AssocEdgeLoader,
   AssocEdgeLoaderFactory,
 } from "./assoc_edge_loader";
+export { IndexLoaderFactory } from "./index_loader";
 export {
-  IndexDirectLoader,
-  IndexLoader,
-  IndexLoaderFactory,
-} from "./index_loader";
+  QueryLoader,
+  QueryDirectLoader,
+  QueryLoaderFactory,
+} from "./query_loader";

--- a/ts/src/core/loaders/index_loader.test.ts
+++ b/ts/src/core/loaders/index_loader.test.ts
@@ -398,9 +398,8 @@ async function testMultiQueryDataAvail(
   // reload data
   const edges2 = await Promise.all(ids.map(async (id) => loader.load(id)));
 
-  //verifyGroupedData(ids, users, edges2, m);
   // same data
-  verifyEdges(edges, edges2);
+  expect(edges).toStrictEqual(edges2);
 
   verifyPostSecondQuery(ids, slice);
 }
@@ -439,7 +438,7 @@ async function testMultiQueryDataOffset(
     }
     expect(
       edges[i].length,
-      `count for idx ${i} for id ${ids[0]} was not as expected`,
+      `count for idx ${i} for id ${ids[i]} was not as expected`,
       // 1 row returned for everything but first one
     ).toBe(expContacts.length);
 
@@ -467,7 +466,7 @@ async function testMultiQueryDataOffset(
 
   // query again, same data
   // if context, we hit local cache. otherwise, hit db
-  verifyEdges(edges, edges2);
+  expect(edges).toStrictEqual(edges2);
   verifyMultiCountQueryOffset(ids, m);
 }
 
@@ -487,7 +486,7 @@ function verifyGroupedData(
 
     expect(
       edges[i].length,
-      `count for idx ${i} for id ${ids[0]} was not as expected`,
+      `count for idx ${i} for id ${ids[i]} was not as expected`,
     ).toBe(contacts.length);
 
     // verify the edges are as expected
@@ -548,29 +547,4 @@ function verifyMultiCountQueryOffset(ids: ID[], m: Map<ID, FakeContact[]>) {
       values: [ids[idx], contacts[0].createdAt.toISOString()],
     });
   });
-}
-
-function verifyEdges(edgess: Data[][], edgess2: Data[][]) {
-  if (edgess.length !== edgess2.length) {
-    fail("edges of different length");
-  }
-  for (let j = 0; j < edgess.length; j++) {
-    const edges = edgess[j];
-    const edges2 = edgess2[j];
-    for (let i = 0; i < edges.length; i++) {
-      const edge = edges[i];
-      const edge2 = edges2[i];
-
-      // sqlite issues
-      if (typeof edge.created_at === "string") {
-        edge.created_at = new Date(Date.parse(edge.created_at));
-        edge.updated_at = new Date(Date.parse(edge.updated_at));
-      }
-      if (typeof edge2.created_at === "string") {
-        edge2.created_at = new Date(Date.parse(edge2.created_at));
-        edge2.updated_at = new Date(Date.parse(edge2.updated_at));
-      }
-    }
-  }
-  expect(edgess).toStrictEqual(edgess2);
 }

--- a/ts/src/core/loaders/index_loader.ts
+++ b/ts/src/core/loaders/index_loader.ts
@@ -1,261 +1,48 @@
-import DataLoader from "dataloader";
 import {
   ID,
   SelectBaseDataOptions,
   Context,
   Data,
-  Loader,
   LoaderFactory,
   EdgeQueryableDataOptions,
-  PrimableLoader,
 } from "../base";
-import {
-  performRawQuery,
-  buildGroupQuery,
-  loadRows,
-  DefaultLimit,
-} from "../ent";
 import * as clause from "../clause";
-import { logEnabled } from "../logger";
-import { cacheMap, getCustomLoader, getLoader } from "./loader";
 import { ObjectLoaderFactory } from "./object_loader";
-import memoizee from "memoizee";
+import { QueryLoaderFactory } from "./query_loader";
 
-async function simpleCase(
-  options: SelectBaseDataOptions,
-  col: string,
-  id: ID,
-  opts?: {
-    queryOptions?: EdgeQueryableDataOptions;
-    extraClause?: clause.Clause;
-    sortColumn?: string;
-  },
-) {
-  let cls: clause.Clause = clause.Eq(col, id);
-  if (opts?.extraClause) {
-    cls = clause.And(cls, opts.extraClause);
-  }
-  if (opts?.queryOptions?.clause) {
-    cls = clause.And(cls, opts.queryOptions.clause);
-  }
-  let sortCol = opts?.sortColumn || "created_at";
-  let orderby = opts?.queryOptions?.orderby || `${sortCol} DESC`;
-
-  return await loadRows({
-    ...options,
-    fields: options.fields,
-    clause: cls,
-    orderby: orderby,
-    limit: opts?.queryOptions?.limit || DefaultLimit,
-  });
-}
-
-function createLoader(
-  options: SelectBaseDataOptions,
-  col: string,
-  extraClause?: clause.Clause,
-  sortColumn?: string,
-  queryOptions?: EdgeQueryableDataOptions,
-): DataLoader<ID, Data[]> {
-  if (!sortColumn) {
-    sortColumn = "created_at";
-  }
-
-  const loaderOptions: DataLoader.Options<ID, Data[]> = {};
-
-  // if query logging is enabled, we should log what's happening with loader
-  if (logEnabled("query")) {
-    loaderOptions.cacheMap = new cacheMap(options);
-  }
-
-  return new DataLoader(async (keys: ID[]) => {
-    if (!keys.length) {
-      return [];
-    }
-
-    // keep query simple if we're only fetching for one id
-    if (keys.length == 1) {
-      const rows = await simpleCase(options, col, keys[0], {
-        sortColumn,
-        extraClause,
-        queryOptions,
-      });
-      return [rows];
-    }
-
-    let cls: clause.Clause = clause.In(col, ...keys);
-    if (extraClause) {
-      cls = clause.And(cls, extraClause);
-    }
-
-    let m = new Map<ID, number>();
-    let result: Data[][] = [];
-    for (let i = 0; i < keys.length; i++) {
-      result.push([]);
-      // store the index....
-      m.set(keys[i], i);
-    }
-
-    const [query, cls2] = buildGroupQuery({
-      tableName: options.tableName,
-      fields: options.fields,
-      values: keys,
-      orderby: queryOptions?.orderby || `${sortColumn} DESC`,
-      limit: queryOptions?.limit || DefaultLimit,
-      fkeyColumn: col,
-      clause: extraClause,
-    });
-
-    const rows = await performRawQuery(query, cls2.values(), cls2.logValues());
-    for (const row of rows) {
-      const srcID = row[col];
-      const idx = m.get(srcID);
-      delete row.row_num;
-      if (idx === undefined) {
-        throw new Error(
-          `malformed query. got ${srcID} back but didn't query for it`,
-        );
-      }
-      result[idx].push(row);
-    }
-    return result;
-  }, loaderOptions);
-}
-
-export class IndexDirectLoader implements Loader<ID, Data[]> {
-  constructor(
-    private options: SelectBaseDataOptions,
-    private col: string,
-    private opts: {
-      queryOptions: EdgeQueryableDataOptions;
-      extraClause?: clause.Clause;
-      sortColumn?: string;
-    },
-  ) {}
-
-  async load(id: ID): Promise<Data[]> {
-    return simpleCase(this.options, this.col, id, this.opts);
-  }
-
-  clearAll() {}
-}
-
-// for now this only works for single column counts
-// e.g. foreign key count
-export class IndexLoader implements Loader<ID, Data[]> {
-  private loader: DataLoader<ID, Data[]> | undefined;
-  private primedLoaders:
-    | Map<string, PrimableLoader<any, Data | null>>
-    | undefined;
-  private memoizedInitPrime: () => void;
-
-  constructor(
-    private options: SelectBaseDataOptions,
-    private col: string,
-    public context?: Context,
-    private opts?: {
-      extraClause?: clause.Clause;
-      sortColumn?: string;
-      queryOptions?: EdgeQueryableDataOptions;
-      toPrime?: ObjectLoaderFactory<ID>[];
-    },
-  ) {
-    if (context) {
-      this.loader = createLoader(
-        options,
-        this.col,
-        opts?.extraClause,
-        opts?.sortColumn,
-        opts?.queryOptions,
-      );
-    }
-    this.memoizedInitPrime = memoizee(this.initPrime.bind(this));
-  }
-
-  private initPrime() {
-    if (!this.context || !this.opts?.toPrime) {
-      return;
-    }
-
-    let primedLoaders = new Map();
-    this.opts.toPrime.forEach((prime) => {
-      const l2 = prime.createLoader(this.context);
-      if ((l2 as PrimableLoader<any, Data | null>).prime === undefined) {
-        return;
-      }
-      primedLoaders.set(prime.options.key, l2);
-    });
-    this.primedLoaders = primedLoaders;
-  }
-
-  async load(id: ID): Promise<Data[]> {
-    if (this.loader) {
-      this.memoizedInitPrime();
-      const rows = await this.loader.load(id);
-      if (this.primedLoaders) {
-        for (const row of rows) {
-          for (const [key, loader] of this.primedLoaders) {
-            const value = row[key];
-            if (value !== undefined) {
-              loader.prime(row);
-            }
-          }
-        }
-      }
-      return rows;
-    }
-
-    return simpleCase(this.options, this.col, id, this.opts);
-  }
-
-  clearAll() {
-    this.loader && this.loader.clearAll();
-  }
-}
-
+// we're keeping this for legacy reasons so as to not break existing callers
+// and to decouple the change here but all callers can safely be changed here to use IndexLoaderFactory
 export class IndexLoaderFactory implements LoaderFactory<ID, Data[]> {
   name: string;
+  private factory: QueryLoaderFactory<ID>;
   constructor(
-    private options: SelectBaseDataOptions,
-    private col: string,
-    private opts?: {
+    options: SelectBaseDataOptions,
+    col: string,
+    opts?: {
       extraClause?: clause.Clause;
       sortColumn?: string;
       toPrime?: ObjectLoaderFactory<ID>[];
     },
   ) {
-    this.name = `indexLoader:${options.tableName}:${this.col}`;
+    this.factory = new QueryLoaderFactory({
+      fields: options.fields,
+      tableName: options.tableName,
+      groupCol: col,
+      clause: opts?.extraClause,
+      sortColumn: opts?.sortColumn,
+      toPrime: opts?.toPrime,
+    });
+    this.name = `indexLoader:${options.tableName}:${col}`;
   }
 
   createLoader(context?: Context) {
-    return getLoader(
-      this,
-      () => new IndexLoader(this.options, this.col, context, this.opts),
-      context,
-    );
+    return this.factory.createLoader(context);
   }
 
   createConfigurableLoader(
     options: EdgeQueryableDataOptions,
     context?: Context,
   ) {
-    if (options?.clause || !context) {
-      return new IndexDirectLoader(this.options, this.col, {
-        ...this.opts,
-        queryOptions: options,
-      });
-    }
-
-    // we create a loader which can combine first X queries in the same fetch
-    const key = `${this.name}:limit:${options.limit}:orderby:${options.orderby}`;
-    return getCustomLoader(
-      key,
-      () =>
-        new IndexLoader(this.options, this.col, context, {
-          ...this.opts,
-          queryOptions: options,
-        }),
-      context,
-    );
+    return this.factory.createConfigurableLoader(options, context);
   }
 }

--- a/ts/src/core/loaders/index_loader.ts
+++ b/ts/src/core/loaders/index_loader.ts
@@ -11,7 +11,7 @@ import { ObjectLoaderFactory } from "./object_loader";
 import { QueryLoaderFactory } from "./query_loader";
 
 // we're keeping this for legacy reasons so as to not break existing callers
-// and to decouple the change here but all callers can safely be changed here to use IndexLoaderFactory
+// and to decouple the change here but all callers can safely be changed here to use QueryLoaderFactory
 export class IndexLoaderFactory implements LoaderFactory<ID, Data[]> {
   name: string;
   private factory: QueryLoaderFactory<ID>;

--- a/ts/src/core/loaders/query_loader.test.ts
+++ b/ts/src/core/loaders/query_loader.test.ts
@@ -118,7 +118,7 @@ describe("sqlite", () => {
     // reset context for each test
     ctx = new TestContext();
     // create once
-    await createEdges();
+    //    await createEdges();
   });
 
   afterEach(() => {

--- a/ts/src/core/loaders/query_loader.test.ts
+++ b/ts/src/core/loaders/query_loader.test.ts
@@ -1,0 +1,649 @@
+import { TestContext } from "../../testutils/context/test_context";
+import { setLogLevels } from "../logger";
+import { MockLogs } from "../../testutils/mock_log";
+import { buildQuery, DefaultLimit } from "../ent";
+import * as clause from "../clause";
+
+import { Data, EdgeQueryableDataOptions, ID, Loader } from "../base";
+import { setupSqlite, TempDB } from "../../testutils/db/test_db";
+import {
+  FakeUser,
+  FakeEvent,
+  EventCreateInput,
+} from "../../testutils/fake_data/index";
+import {
+  createAllEvents,
+  createEdges,
+  createTestUser,
+  setupTempDB,
+  tempDBTables,
+} from "../../testutils/fake_data/test_helpers";
+
+import { QueryLoaderFactory } from "./query_loader";
+import { advanceBy, clear } from "jest-date-mock";
+import { Interval } from "luxon";
+
+const ml = new MockLogs();
+let tdb: TempDB;
+
+let ctx: TestContext;
+
+// we get 7 back because we're looking at a week
+const DAYS = 7;
+const HOW_MANY = 10;
+// every 24 hours
+const INTERVAL = 24 * 60 * 60 * 1000;
+
+const getClause = () => {
+  // get events starting within the next week
+
+  clear();
+  const start = new Date();
+  // 7 days
+  const end = Interval.after(start, 86400 * 1000 * DAYS)
+    .end.toUTC()
+    .toISO();
+  return clause.And(
+    clause.GreaterEq("start_time", start.toISOString()),
+    clause.LessEq("start_time", end),
+  );
+};
+
+function getCompleteClause(id: ID) {
+  return clause.And(clause.Eq("user_id", id), getClause());
+}
+
+const getNewLoader = (context: boolean = true) => {
+  return new QueryLoaderFactory({
+    groupCol: "user_id",
+    ...FakeEvent.loaderOptions(),
+    clause: getClause(),
+    sortColumn: "start_time asc",
+  }).createLoader(context ? ctx : undefined);
+};
+
+const getConfigurableLoader = (
+  context: boolean,
+  options: EdgeQueryableDataOptions,
+) => {
+  return new QueryLoaderFactory({
+    groupCol: "user_id",
+    ...FakeEvent.loaderOptions(),
+    clause: getClause(),
+    sortColumn: "start_time asc",
+  }).createConfigurableLoader(options, context ? ctx : undefined);
+};
+
+const getNonGroupableLoader = (id: ID, context: boolean = true) => {
+  return new QueryLoaderFactory({
+    ...FakeEvent.loaderOptions(),
+    clause: getCompleteClause(id),
+    sortColumn: "start_time asc",
+  }).createLoader(context ? ctx : undefined);
+};
+
+describe("postgres", () => {
+  beforeAll(async () => {
+    setLogLevels(["query", "error"]);
+    ml.mock();
+
+    tdb = await setupTempDB();
+  });
+
+  beforeEach(() => {
+    // reset context for each test
+    ctx = new TestContext();
+  });
+
+  afterEach(() => {
+    ml.clear();
+  });
+
+  afterAll(async () => {
+    ml.restore();
+    await tdb.afterAll();
+  });
+  commonTests();
+});
+
+describe("sqlite", () => {
+  setupSqlite(`sqlite:///query_loader.db`, tempDBTables);
+
+  beforeAll(async () => {
+    setLogLevels(["query", "error"]);
+    ml.mock();
+  });
+
+  beforeEach(async () => {
+    // reset context for each test
+    ctx = new TestContext();
+    // create once
+    await createEdges();
+  });
+
+  afterEach(() => {
+    ml.clear();
+  });
+
+  afterAll(async () => {
+    ml.restore();
+  });
+  commonTests();
+});
+
+// index_loader.test.ts tests a lof of things that this tests so we don't test every path here
+// just the "complex" ones
+function commonTests() {
+  describe("groupCol passed", () => {
+    test("single id. with context", async () => {
+      await verifySingleIDWithContextCacheHit((id) => getNewLoader());
+    });
+
+    test("single id. without context", async () => {
+      await verifySingleIDWithoutContextCacheHit((id) => getNewLoader(false));
+    });
+
+    test("multi-ids. with context", async () => {
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(true, opts),
+        (ids) => {
+          expect(ml.logs.length).toBe(1);
+          expect(ml.logs[0].query).toMatch(/^SELECT * /);
+          expect(ml.logs[0].values.length).toBe(ids.length + 2);
+          // not testing actual values for timestamp here because time has probably advanced since test ran
+          expect(ml.logs[0].values.slice(0, ids.length)).toEqual(ids);
+        },
+        verifyGroupedCacheHit,
+      );
+    });
+
+    test("multi-ids. without context", async () => {
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(false, opts),
+        verifyMultiCountQueryCacheMiss,
+        verifyMultiCountQueryCacheMiss,
+      );
+    });
+
+    test("multi-ids. with context, offset", async () => {
+      await testMultiQueryDataOffset((options) =>
+        getConfigurableLoader(true, options),
+      );
+    });
+
+    test("multi-ids. without context, offset", async () => {
+      await testMultiQueryDataOffset((options) =>
+        getConfigurableLoader(false, options),
+      );
+    });
+
+    test("multi-ids. with context different limits", async () => {
+      let data = await createData();
+
+      // initial. default limit
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(true, opts),
+        (ids) => {
+          expect(ml.logs.length).toBe(1);
+          expect(ml.logs[0].query).toMatch(/^SELECT * /);
+          //        expect(ml.logs[0].values).toEqual(ids);
+          expect(ml.logs[0].values.length).toBe(ids.length + 2);
+          // not testing actual values for timestamp here because time has probably advanced since test ran
+          expect(ml.logs[0].values.slice(0, ids.length)).toEqual(ids);
+        },
+        verifyGroupedCacheHit,
+        undefined,
+        data,
+      );
+
+      // query again with same data and same limit and it should all be cache hits
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(true, opts),
+        verifyGroupedCacheHit,
+        verifyGroupedCacheHit,
+        undefined,
+        data,
+      );
+
+      // change slice e.g. first N and now we hit the db again
+
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(true, opts),
+        (ids) => {
+          expect(ml.logs.length).toBe(1);
+          expect(ml.logs[0].query).toMatch(/^SELECT * /);
+          //        expect(ml.logs[0].values).toEqual(ids);
+          expect(ml.logs[0].values.length).toBe(ids.length + 2);
+          // not testing actual values for timestamp here because time has probably advanced since test ran
+          expect(ml.logs[0].values.slice(0, ids.length)).toEqual(ids);
+        },
+        verifyGroupedCacheHit,
+        3,
+        data,
+      );
+
+      // query for first 3 again and all hits
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(true, opts),
+        verifyGroupedCacheHit,
+        verifyGroupedCacheHit,
+        3,
+        data,
+      );
+
+      // change slice e.g. first N and now we hit the db again
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(true, opts),
+        // TODO move this intoa function
+        (ids) => {
+          expect(ml.logs.length).toBe(1);
+          expect(ml.logs[0].query).toMatch(/^SELECT * /);
+          //        expect(ml.logs[0].values).toEqual(ids);
+          expect(ml.logs[0].values.length).toBe(ids.length + 2);
+          // not testing actual values for timestamp here because time has probably advanced since test ran
+          expect(ml.logs[0].values.slice(0, ids.length)).toEqual(ids);
+        },
+        verifyGroupedCacheHit,
+        2,
+        data,
+      );
+    });
+
+    test("multi-ids. with no context different limits", async () => {
+      let data = await createData();
+
+      // initial. default limit
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(false, opts),
+        verifyMultiCountQueryCacheMiss,
+        verifyMultiCountQueryCacheMiss,
+        undefined,
+        data,
+      );
+
+      // // query again with same data and same limit and still we refetch it all
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(false, opts),
+        verifyMultiCountQueryCacheMiss,
+        verifyMultiCountQueryCacheMiss,
+        undefined,
+        data,
+      );
+
+      // change slice e.g. first N and now we hit the db again
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(false, opts),
+        verifyMultiCountQueryCacheMiss,
+        verifyMultiCountQueryCacheMiss,
+        3,
+        data,
+      );
+
+      // refetch for 3. hit db again
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(false, opts),
+        verifyMultiCountQueryCacheMiss,
+        verifyMultiCountQueryCacheMiss,
+        3,
+        data,
+      );
+
+      // change slice e.g. first N and now we hit the db again
+      await testMultiQueryDataAvail(
+        (opts) => getConfigurableLoader(false, opts),
+        verifyMultiCountQueryCacheMiss,
+        verifyMultiCountQueryCacheMiss,
+        3,
+        data,
+      );
+    });
+  });
+
+  describe("clause only", () => {
+    // single
+    // so this doesn't actually make sense as a loader because the id is part of the query
+    // the reason to support this is for EntQuery and connection support
+    // also in case the query is repeated within the same request but that's probably not that likely
+    test("single id. with context", async () => {
+      const [user, events] = await verifySingleIDWithContextCacheHit((id) =>
+        getNonGroupableLoader(id),
+      );
+
+      ml.clear();
+      // different loader hits the db again
+      // TODO would be nice to somehow avoid this by using the same key/dataloader
+      const loader2 = getNonGroupableLoader(user.id);
+      const edges = await loader2.load(user.id);
+      verifyUserToEventsRawData(edges, events);
+      verifyMultiCountQueryCacheMiss([user.id]);
+
+      // even with different user, same result since id is baked into query
+      const user2 = await createTestUser();
+      const edges2 = await loader2.load(user2.id);
+      verifyUserToEventsRawData(edges2, events);
+    });
+
+    test("single id. without context", async () => {
+      await verifySingleIDWithoutContextCacheHit((id) =>
+        getNonGroupableLoader(id, false),
+      );
+    });
+
+    test("multi-ids", async () => {
+      const data = await createData();
+      let { m, ids, users } = data;
+      ml.clear();
+
+      const edges = await Promise.all(
+        ids.map(async (id) => {
+          // have to use different loader for each to get results
+          const loader = getNonGroupableLoader(id);
+          return await loader.load(id);
+        }),
+      );
+      ml.verifyNoErrors();
+
+      // hits db for each query
+      verifyMultiCountQueryCacheMiss(ids);
+      // data is correct
+      verifyGroupedData(ids, users, edges, m);
+    });
+
+    // multi-ids. have to use different loaders, just fetching at same time
+  });
+
+  async function verifySingleIDWithContextCacheHit(
+    loaderFn: (id: ID) => Loader<ID, Data[]>,
+  ): Promise<[FakeUser, FakeEvent[]]> {
+    const [user, events] = await createAllEvents({
+      howMany: HOW_MANY,
+      interval: INTERVAL,
+    });
+    // create another one just to make sure we're doing some filtering
+    await createAllEvents({ howMany: 5, interval: 100 });
+
+    ml.clear();
+    const loader = loaderFn(user.id);
+    //    const loader = getNewLoader();
+    const edges = await loader.load(user.id);
+
+    // we get 7 back because we're just looking at the next week's events
+    expect(edges.length).toBe(DAYS);
+    verifyUserToEventsRawData(edges, events);
+    verifyMultiCountQueryCacheMiss([user.id]);
+
+    ml.clear();
+    const edges2 = await loader.load(user.id);
+    expect(edges).toStrictEqual(edges2);
+
+    verifyGroupedCacheHit([user.id]);
+
+    return [user, events];
+  }
+
+  async function verifySingleIDWithoutContextCacheHit(
+    loaderFn: (id: ID) => Loader<ID, Data[]>,
+  ) {
+    const [user, events] = await createAllEvents({
+      howMany: HOW_MANY,
+      // every 24 hours
+      interval: INTERVAL,
+    });
+    // create another one just to make sure we're doing some filtering
+    await createAllEvents({ howMany: 5, interval: 100 });
+
+    ml.clear();
+    const loader = loaderFn(user.id);
+    const edges = await loader.load(user.id);
+
+    // we get 7 back because we're just looking at the next week's events
+    expect(edges.length).toBe(DAYS);
+    verifyUserToEventsRawData(edges, events);
+    verifyMultiCountQueryCacheMiss([user.id]);
+
+    ml.clear();
+    const edges2 = await loader.load(user.id);
+    expect(edges).toStrictEqual(edges2);
+
+    verifyMultiCountQueryCacheMiss([user.id]);
+  }
+
+  function verifyUserToEventsRawData(edges: Data[], events: FakeEvent[]) {
+    const expEvents = events.slice(0, DAYS);
+    expect(edges.length).toBe(expEvents.length);
+
+    for (let i = 0; i < edges.length; i++) {
+      const edge = edges[i];
+      const expEdge = events[i].data;
+      // both raw from db so no conversion needed
+      expect(edge, `${i}th index`).toMatchObject(expEdge);
+    }
+  }
+
+  function verifyMultiCountQueryCacheMiss(ids: ID[], slice?: number) {
+    expect(ml.logs.length).toBe(ids.length);
+    ml.logs.forEach((log, idx) => {
+      const expQuery = buildQuery({
+        tableName: "fake_events",
+        fields: FakeEvent.loaderOptions().fields,
+        clause: getCompleteClause(ids[idx]),
+        orderby: "start_time asc",
+        limit: slice || DefaultLimit,
+      });
+      // not testing actual values for timestamp here because time has probably advanced since test ran
+      expect(log.query).toEqual(expQuery);
+      expect(log.values.length).toBe(3);
+      expect(log.values[0]).toEqual(ids[idx]);
+    });
+  }
+
+  function verifyGroupedCacheHit(ids: ID[]) {
+    ml.verifyNoErrors();
+    expect(ml.logs.length).toBe(ids.length);
+    // cache hit for each id
+    ml.logs.forEach((log, idx) => {
+      expect(log).toStrictEqual({
+        "dataloader-cache-hit": ids[idx],
+        "tableName": "fake_events",
+      });
+    });
+  }
+
+  interface createdData {
+    m: Map<ID, FakeEvent[]>;
+    ids: ID[];
+    users: FakeUser[];
+  }
+
+  async function createData(): Promise<createdData> {
+    const m = new Map<ID, FakeEvent[]>();
+    const ids: ID[] = [];
+    const users: FakeUser[] = [];
+
+    const date = new Date();
+    const inputs: Partial<EventCreateInput>[] = [];
+    for (let i = 0; i < HOW_MANY; i++) {
+      // we only care about startTime here and that's the sortCol
+      advanceBy(INTERVAL);
+      inputs.push({
+        startTime: new Date(),
+      });
+    }
+
+    await Promise.all(
+      [1, 2, 3, 4, 5].map(async (count, idx) => {
+        let [user, events] = await createAllEvents({
+          howMany: HOW_MANY,
+          // don't advance here...
+          interval: 0,
+          // advancing handled here
+          eventInputs: inputs,
+        });
+
+        m.set(user.id, events);
+        ids[idx] = user.id;
+        users[idx] = user;
+      }),
+    );
+    return { m, ids, users };
+  }
+
+  async function testMultiQueryDataAvail(
+    loaderFn: (opts: EdgeQueryableDataOptions) => Loader<ID, Data[]>,
+    verifyPostFirstQuery: (ids: ID[], slice?: number) => void,
+    verifyPostSecondQuery: (ids: ID[], slice?: number) => void,
+    slice?: number,
+    data?: createdData,
+  ) {
+    if (!data) {
+      data = await createData();
+    }
+    let { m, ids, users } = data;
+
+    // clear post creation
+    ml.clear();
+
+    // TODO this needs to be done prior to the JS event loop
+    // need to make this work for scenarios where the loader is created in same loop
+    const loader = loaderFn({
+      limit: slice,
+    });
+    const edges = await Promise.all(ids.map(async (id) => loader.load(id)));
+    ml.verifyNoErrors();
+
+    verifyGroupedData(ids, users, edges, m, slice);
+
+    verifyPostFirstQuery(ids, slice);
+
+    ml.clear();
+
+    // reload data
+    const edges2 = await Promise.all(ids.map(async (id) => loader.load(id)));
+
+    verifyGroupedData(ids, users, edges2, m, slice);
+    expect(edges).toStrictEqual(edges2);
+
+    verifyPostSecondQuery(ids, slice);
+  }
+
+  function verifyGroupedData(
+    ids: ID[],
+    users: FakeUser[],
+    edges: Data[][],
+    m: Map<ID, FakeEvent[]>,
+    slice?: number,
+  ) {
+    for (let i = 0; i < ids.length; i++) {
+      const user = users[i];
+      let events = m.get(user.id) || [];
+      events = events.slice(0, DAYS);
+      if (slice) {
+        events = events.slice(0, slice);
+      }
+
+      expect(
+        edges[i].length,
+        `count for idx ${i} for id ${ids[i]} was not as expected`,
+      ).toBe(events.length);
+
+      // verify the edges are as expected
+      verifyUserToEventsRawData(edges[i], events);
+    }
+  }
+
+  async function testMultiQueryDataOffset(
+    loaderFn: (opts: EdgeQueryableDataOptions) => Loader<ID, Data[]>,
+  ) {
+    const { m, ids, users } = await createData();
+
+    // clear post creation
+    ml.clear();
+
+    const edges = await Promise.all(
+      ids.map(async (id) => {
+        const events = m.get(id) || [];
+        const options = {
+          // how an offset query works
+          clause: clause.Greater(
+            "start_time",
+            events[0].startTime.toISOString(),
+          ),
+          limit: 1,
+        };
+
+        const loader = loaderFn(options);
+        return loader.load(id);
+      }),
+    );
+    ml.verifyNoErrors();
+
+    // this doesn't exist here since the id count is different
+    // TODO we should change that???
+    // we get one edge for each that returned (other than the one with just one row)
+    for (let i = 0; i < ids.length; i++) {
+      let expEvents: FakeEvent[] = [];
+      const user = users[i];
+
+      expEvents = [(m.get(user.id) || [])[1]];
+      expect(
+        edges[i].length,
+        `count for idx ${i} for id ${ids[i]} was not as expected`,
+        // 1 row returned for everything but first one
+      ).toBe(expEvents.length);
+
+      // verify the edges are as expected
+      // just the one (if result exists)
+      verifyUserToEventsRawData(edges[i], expEvents);
+    }
+    verifyMultiCountQueryOffset(ids, m);
+
+    ml.clear();
+
+    // reload data
+    const edges2 = await Promise.all(
+      ids.map(async (id) => {
+        const events = m.get(id) || [];
+        const options = {
+          clause: clause.Greater(
+            "start_time",
+            events[0].startTime.toISOString(),
+          ),
+          limit: 1,
+        };
+
+        const loader = loaderFn(options);
+        return loader.load(id);
+      }),
+    );
+
+    // query again, same data
+    // if context, we hit local cache. otherwise, hit db
+    expect(edges).toStrictEqual(edges2);
+    verifyMultiCountQueryOffset(ids, m);
+  }
+
+  function verifyMultiCountQueryOffset(ids: ID[], m: Map<ID, FakeEvent[]>) {
+    expect(ml.logs.length).toBe(ids.length);
+    ml.logs.forEach((log, idx) => {
+      let events = m.get(ids[idx]) || [];
+      const fields = FakeEvent.loaderOptions().fields;
+
+      const cls = clause.And(
+        getCompleteClause(ids[idx]),
+        clause.Greater("start_time", events[0].startTime.toISOString()),
+      );
+
+      const expQuery = buildQuery({
+        tableName: "fake_events",
+        fields: fields,
+        clause: cls,
+        orderby: "start_time asc",
+        limit: 1,
+      });
+      expect(log.query).toEqual(expQuery);
+      expect(log.values[0]).toEqual(ids[idx]);
+      //      console.debug(log.values);
+      // not testing the rest because difficult
+    });
+  }
+}

--- a/ts/src/core/loaders/query_loader.ts
+++ b/ts/src/core/loaders/query_loader.ts
@@ -220,7 +220,6 @@ export class QueryLoaderFactory<K extends any>
   name: string;
   constructor(private options: QueryOptions) {
     if (options.groupCol) {
-      // TODO tableName?
       this.name = `queryLoader:${options.tableName}:${options.groupCol}`;
     } else if (options.clause) {
       this.name = `queryLoader:${
@@ -249,11 +248,7 @@ export class QueryLoaderFactory<K extends any>
       return new QueryDirectLoader(this.options, options);
     }
 
-    // todo tableName
-    // we create a loader which can combine first X queries in the same fetch
-    //        const key = `indexLoader:limit:${options.limit}:orderby:${options.orderby}`;
     const key = `${this.name}:limit:${options.limit}:orderby:${options.orderby}`;
-    //    console.debug(key);
     return getCustomLoader(
       key,
       () => new QueryLoader(this.options, context, options),

--- a/ts/src/core/loaders/query_loader.ts
+++ b/ts/src/core/loaders/query_loader.ts
@@ -108,7 +108,7 @@ function createLoader<K extends any>(
       values: keys,
       orderby: getOrderBy(sortCol, queryOptions?.orderby),
       limit: queryOptions?.limit || DefaultLimit,
-      fkeyColumn: col,
+      groupColumn: col,
       clause: extraClause,
     });
 

--- a/ts/src/core/loaders/query_loader.ts
+++ b/ts/src/core/loaders/query_loader.ts
@@ -1,0 +1,263 @@
+import DataLoader from "dataloader";
+import {
+  Context,
+  ID,
+  EdgeQueryableDataOptions,
+  Loader,
+  LoaderFactory,
+  Data,
+  PrimableLoader,
+} from "../base";
+import {
+  DefaultLimit,
+  performRawQuery,
+  buildGroupQuery,
+  loadRows,
+} from "../ent";
+import * as clause from "../clause";
+import { logEnabled } from "../logger";
+import { cacheMap, getCustomLoader, getLoader } from "./loader";
+import memoizee from "memoizee";
+import { ObjectLoaderFactory } from "./object_loader";
+
+function getOrderBy(sortCol: string, orderby?: string) {
+  let sortColLower = sortCol.toLowerCase();
+  let orderbyDirection = " DESC";
+  if (sortColLower.endsWith("asc") || sortCol.endsWith("desc")) {
+    orderbyDirection = "";
+  }
+  return orderby || `${sortCol}${orderbyDirection}`;
+}
+
+async function simpleCase<K extends any>(
+  options: QueryOptions,
+  id: K,
+  queryOptions?: EdgeQueryableDataOptions,
+) {
+  let cls: clause.Clause;
+  if (options.groupCol) {
+    cls = clause.Eq(options.groupCol, id);
+    if (options.clause) {
+      cls = clause.And(cls, options.clause);
+    }
+  } else if (options.clause) {
+    cls = options.clause;
+  } else {
+    throw new Error(`need options.groupCol or options.clause`);
+  }
+  if (queryOptions?.clause) {
+    cls = clause.And(cls, queryOptions.clause);
+  }
+
+  let sortCol = options.sortColumn || "created_at";
+
+  return await loadRows({
+    ...options,
+    clause: cls,
+    orderby: getOrderBy(sortCol, queryOptions?.orderby),
+    limit: queryOptions?.limit || DefaultLimit,
+  });
+}
+
+function createLoader<K extends any>(
+  options: QueryOptions,
+  queryOptions?: EdgeQueryableDataOptions,
+): DataLoader<K, Data[]> {
+  let sortCol = options.sortColumn || "created_at";
+
+  const loaderOptions: DataLoader.Options<K, Data[]> = {};
+
+  // if query logging is enabled, we should log what's happening with loader
+  if (logEnabled("query")) {
+    loaderOptions.cacheMap = new cacheMap(options);
+  }
+
+  return new DataLoader(async (keys: K[]) => {
+    if (!keys.length) {
+      return [];
+    }
+
+    // keep query simple if we're only fetching for one id
+    // or can't group because no groupCol...
+    if (keys.length == 1 || !options.groupCol) {
+      const rows = await simpleCase(options, keys[0], queryOptions);
+      return [rows];
+    }
+
+    let m = new Map<K, number>();
+    let result: Data[][] = [];
+    for (let i = 0; i < keys.length; i++) {
+      result.push([]);
+      // store the index....
+      m.set(keys[i], i);
+    }
+
+    const col = options.groupCol;
+    let extraClause: clause.Clause | undefined;
+    if (options.clause && queryOptions?.clause) {
+      extraClause = clause.And(options.clause, queryOptions.clause);
+    } else if (options.clause) {
+      extraClause = options.clause;
+    } else if (queryOptions?.clause) {
+      extraClause = queryOptions.clause;
+    }
+
+    const [query, cls2] = buildGroupQuery({
+      tableName: options.tableName,
+      fields: options.fields,
+      values: keys,
+      orderby: getOrderBy(sortCol, queryOptions?.orderby),
+      limit: queryOptions?.limit || DefaultLimit,
+      fkeyColumn: col,
+      clause: extraClause,
+    });
+
+    const rows = await performRawQuery(query, cls2.values(), cls2.logValues());
+    for (const row of rows) {
+      const srcID = row[col];
+      const idx = m.get(srcID);
+      delete row.row_num;
+      if (idx === undefined) {
+        throw new Error(
+          `malformed query. got ${srcID} back but didn't query for it`,
+        );
+      }
+      result[idx].push(row);
+    }
+    return result;
+  }, loaderOptions);
+}
+
+export class QueryDirectLoader<K extends any> implements Loader<K, Data[]> {
+  constructor(
+    private options: QueryOptions,
+    private queryOptions?: EdgeQueryableDataOptions,
+  ) {}
+
+  async load(id: K): Promise<Data[]> {
+    return simpleCase(this.options, id, this.queryOptions);
+  }
+
+  clearAll() {}
+}
+
+export class QueryLoader<K extends any> implements Loader<K, Data[]> {
+  private loader: DataLoader<K, Data[]> | undefined;
+  private primedLoaders:
+    | Map<string, PrimableLoader<any, Data | null>>
+    | undefined;
+  private memoizedInitPrime: () => void;
+  constructor(
+    private options: QueryOptions,
+    public context?: Context,
+    private queryOptions?: EdgeQueryableDataOptions,
+  ) {
+    if (context) {
+      this.loader = createLoader(options, queryOptions);
+    }
+    this.memoizedInitPrime = memoizee(this.initPrime.bind(this));
+  }
+
+  private initPrime() {
+    if (!this.context || !this.options?.toPrime) {
+      return;
+    }
+    let primedLoaders = new Map();
+    this.options.toPrime.forEach((prime) => {
+      const l2 = prime.createLoader(this.context);
+      if ((l2 as PrimableLoader<any, Data | null>).prime === undefined) {
+        return;
+      }
+      primedLoaders.set(prime.options.key, l2);
+    });
+    this.primedLoaders = primedLoaders;
+  }
+
+  async load(id: K): Promise<Data[]> {
+    if (this.loader) {
+      this.memoizedInitPrime();
+      const rows = await this.loader.load(id);
+      if (this.primedLoaders) {
+        for (const row of rows) {
+          for (const [key, loader] of this.primedLoaders) {
+            const value = row[key];
+            if (value !== undefined) {
+              loader.prime(row);
+            }
+          }
+        }
+      }
+      return rows;
+    }
+
+    return simpleCase(this.options, id, this.queryOptions);
+  }
+
+  clearAll() {
+    this.loader && this.loader.clearAll();
+  }
+}
+
+interface QueryOptions {
+  fields: string[];
+  tableName: string; // or function for assoc_edge. come back to it
+  // if provided, we'll group queries to the database via this key and this will be the unique id we're querying for
+  // using window functions or not
+  groupCol?: string;
+  // will be combined with groupCol to make a simple or complex query
+  // if no groupCol, this is required
+  // if no clause and groupCol, we'll just use groupCol to make the query
+  clause?: clause.Clause;
+  sortColumn?: string; // order by this column
+
+  // if provided, will be used to prime data in this object...
+  toPrime?: ObjectLoaderFactory<ID>[];
+}
+
+export class QueryLoaderFactory<K extends any>
+  implements LoaderFactory<K, Data[]>
+{
+  name: string;
+  constructor(private options: QueryOptions) {
+    if (options.groupCol) {
+      // TODO tableName?
+      this.name = `queryLoader:${options.tableName}:${options.groupCol}`;
+    } else if (options.clause) {
+      this.name = `queryLoader:${
+        options.tableName
+      }:${options.clause.instanceKey()}`;
+    } else {
+      throw new Error(
+        `must pass at least one of groupCol and clause to QueryLoaderFactory`,
+      );
+    }
+  }
+
+  createLoader(context?: Context) {
+    return getLoader(
+      this,
+      () => new QueryLoader(this.options, context),
+      context,
+    );
+  }
+
+  createConfigurableLoader(
+    options: EdgeQueryableDataOptions,
+    context?: Context,
+  ) {
+    if (options?.clause || !context) {
+      return new QueryDirectLoader(this.options, options);
+    }
+
+    // todo tableName
+    // we create a loader which can combine first X queries in the same fetch
+    //        const key = `indexLoader:limit:${options.limit}:orderby:${options.orderby}`;
+    const key = `${this.name}:limit:${options.limit}:orderby:${options.orderby}`;
+    //    console.debug(key);
+    return getCustomLoader(
+      key,
+      () => new QueryLoader(this.options, context, options),
+      context,
+    );
+  }
+}

--- a/ts/src/core/loaders/raw_count_loader.test.ts
+++ b/ts/src/core/loaders/raw_count_loader.test.ts
@@ -23,8 +23,8 @@ const getNewLoader = (context: boolean = true) => {
   return new RawCountLoader(
     {
       tableName: "fake_contacts",
+      groupCol: "user_id",
     },
-    "user_id",
     context ? new TestContext() : undefined,
   );
 };
@@ -236,7 +236,7 @@ function commonTests() {
 }
 
 async function testMultiQueryDataAvail(
-  loaderFn: () => RawCountLoader,
+  loaderFn: () => RawCountLoader<ID>,
   verifyPostFirstQuery: (ids: ID[]) => void,
   verifyPostSecondQuery: (ids: ID[]) => void,
 ) {
@@ -281,7 +281,7 @@ async function testMultiQueryDataAvail(
 }
 
 async function testMultiQueryNoData(
-  loaderFn: () => RawCountLoader,
+  loaderFn: () => RawCountLoader<ID>,
   verifyPostFirstQuery: (ids: ID[]) => void,
   verifyPostSecondQuery: (ids: ID[]) => void,
 ) {

--- a/ts/src/core/loaders/raw_count_loader.test.ts
+++ b/ts/src/core/loaders/raw_count_loader.test.ts
@@ -6,18 +6,18 @@ import { setLogLevels } from "../logger";
 import { MockLogs } from "../../testutils/mock_log";
 import { ID } from "../base";
 import { buildQuery } from "../ent";
-
 import * as clause from "../clause";
-
 import { setupSqlite, TempDB } from "../../testutils/db/test_db";
-import { FakeContact } from "../../testutils/fake_data/index";
+import {
+  FakeContact,
+  getCompleteClause,
+} from "../../testutils/fake_data/index";
 import {
   createAllContacts,
   createAllEvents,
   setupTempDB,
   tempDBTables,
 } from "../../testutils/fake_data/test_helpers";
-import { Interval } from "luxon";
 import { clear } from "jest-date-mock";
 
 const ml = new MockLogs();
@@ -247,24 +247,6 @@ function commonTests() {
     // every 24 hours
     const INTERVAL = 24 * 60 * 60 * 1000;
 
-    const getClause = () => {
-      // get events starting within the next week
-
-      clear();
-      const start = new Date();
-      // 7 days
-      const end = Interval.after(start, 86400 * 1000 * DAYS)
-        .end.toUTC()
-        .toISO();
-      return clause.And(
-        clause.GreaterEq("start_time", start.toISOString()),
-        clause.LessEq("start_time", end),
-      );
-    };
-
-    function getCompleteClause(id: ID) {
-      return clause.And(clause.Eq("user_id", id), getClause());
-    }
     const getNonGroupableLoader = (id: ID, context: boolean = true) => {
       return new RawCountLoader(
         {

--- a/ts/src/core/loaders/raw_count_loader.ts
+++ b/ts/src/core/loaders/raw_count_loader.ts
@@ -132,11 +132,28 @@ export class RawCountLoader<K extends any> implements Loader<K, number> {
 
 export class RawCountLoaderFactory implements LoaderFactory<ID, number> {
   name: string;
-  constructor(private options: QueryCountOptions) {
+  private options: QueryCountOptions;
+  constructor(options: SelectBaseDataOptions, col: string);
+  constructor(options: QueryCountOptions);
+  constructor(
+    options: SelectBaseDataOptions | QueryCountOptions,
+    col?: string,
+  ) {
+    if (typeof col === "string") {
+      // old API
+      this.options = {
+        ...options,
+        groupCol: col,
+      };
+    } else {
+      this.options = options;
+    }
     if (this.options.groupCol) {
-      this.name = `${options.tableName}:${this.options.groupCol}`;
+      this.name = `${this.options.tableName}:${this.options.groupCol}`;
     } else if (this.options.clause) {
-      this.name = `${options.tableName}:${this.options.clause.instanceKey()}`;
+      this.name = `${
+        this.options.tableName
+      }:${this.options.clause.instanceKey()}`;
     } else {
       throw new Error(
         `must pass at least one of groupCol and clause to QueryLoaderFactory`,

--- a/ts/src/core/loaders/raw_count_loader.ts
+++ b/ts/src/core/loaders/raw_count_loader.ts
@@ -23,7 +23,11 @@ interface QueryCountOptions {
   clause?: clause.Clause;
 }
 
-async function simpleCase<K extends any>(options: QueryCountOptions, key: K) {
+async function simpleCase<K extends any>(
+  options: QueryCountOptions,
+  key: K,
+  context?: Context,
+) {
   let cls: clause.Clause;
   if (options.groupCol && options.clause) {
     cls = clause.And(clause.Eq(options.groupCol, key), options.clause);
@@ -40,6 +44,7 @@ async function simpleCase<K extends any>(options: QueryCountOptions, key: K) {
     // sqlite needs as count otherwise it returns count(1)
     fields: ["count(1) as count"],
     clause: cls,
+    context,
   });
   return [parseInt(row?.count, 10) || 0];
 }
@@ -116,7 +121,7 @@ export class RawCountLoader<K extends any> implements Loader<K, number> {
       return await this.loader.load(id);
     }
 
-    const rows = await simpleCase(this.options, id);
+    const rows = await simpleCase(this.options, id, this.context);
     return rows[0];
   }
 

--- a/ts/src/core/logger.ts
+++ b/ts/src/core/logger.ts
@@ -1,3 +1,5 @@
+import { SqliteError } from "better-sqlite3";
+
 type logType = "query" | "warn" | "info" | "error" | "debug";
 var m = {
   query: "log",
@@ -21,6 +23,10 @@ export function clearLogLevels() {
 
 export function log(level: logType, msg: any) {
   if (logLevels.has(level)) {
+    if (level == "error" && msg instanceof SqliteError) {
+      console.error(msg.message);
+      return;
+    }
     console[m[level]](msg);
   }
 }

--- a/ts/src/core/query/assoc_query_sqlite.test.ts
+++ b/ts/src/core/query/assoc_query_sqlite.test.ts
@@ -17,7 +17,8 @@ commonTests({
 });
 
 describe("custom assoc", () => {
-  setupSqlite(`sqlite:///assoc_query.db`, tempDBTables);
+  // DB.getInstance is broken. so we need the same assoc instance to be used
+  //  setupSqlite(`sqlite:///assoc_query_sqlite.db`, tempDBTables);
 
   // TODO there's a weird dependency with commonTest above where commenting that out breaks this...
   assocTests();

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -1,0 +1,101 @@
+import { MockLogs } from "../../testutils/mock_log";
+import {
+  FakeEvent,
+  FakeUser,
+  UserToEventsInNextWeekQuery,
+} from "../../testutils/fake_data";
+import {
+  createAllEvents,
+  setupTempDB,
+} from "../../testutils/fake_data/test_helpers";
+import { setLogLevels } from "../logger";
+import { TempDB } from "../../testutils/db/test_db";
+import { buildQuery } from "../ent";
+import * as clause from "../clause";
+
+const INTERVAL = 24 * 60 * 60 * 1000;
+
+let user: FakeUser;
+let events: FakeEvent[];
+let ml = new MockLogs();
+let tdb: TempDB;
+
+beforeAll(async () => {
+  setLogLevels(["query", "error"]);
+  ml.mock();
+
+  tdb = await setupTempDB();
+  [user, events] = await createAllEvents({
+    howMany: 10,
+    interval: INTERVAL,
+  });
+});
+
+beforeEach(() => {
+  ml.clear();
+});
+
+afterAll(async () => {
+  ml.restore();
+  await tdb.afterAll();
+});
+
+const getQuery = () => {
+  return new UserToEventsInNextWeekQuery(user.viewer, user);
+};
+
+// test just to confirm that simple entquery things work
+test("rawCount", async () => {
+  const q = getQuery();
+
+  const count = await q.queryRawCount();
+  expect(count).toBe(7);
+  expect(ml.logs.length).toBe(1);
+});
+
+test("ents", async () => {
+  const q = getQuery();
+
+  const ents = await q.queryEnts();
+  expect(ents.length).toBe(7);
+  expect(ml.logs.length).toBe(1);
+});
+
+test("first N", async () => {
+  const q = getQuery();
+
+  const ents = await q.first(2).queryEnts();
+  expect(ents.length).toBe(2);
+  expect(ml.logs.length).toBe(1);
+});
+
+test("first N. after", async () => {
+  const q = getQuery();
+
+  const edges = await q.queryEdges();
+  expect(edges.length).toBe(7);
+  expect(ml.logs.length).toBe(1);
+
+  ml.clear();
+
+  const cursor = q.getCursor(edges[2]);
+  const q2 = getQuery();
+  const ents = await q2.first(2, cursor).queryEnts();
+  expect(ents.length).toBe(2);
+  expect(ents[0].id).toBe(edges[3].id);
+  expect(ml.logs.length).toBe(1);
+
+  const query = buildQuery({
+    ...FakeEvent.loaderOptions(),
+    orderby: "start_time DESC",
+    limit: 3,
+    clause: clause.And(
+      clause.Eq("user_id", user.id),
+      clause.GreaterEq("start_time", 1),
+      clause.LessEq("start_time", 2),
+      // the cursor check
+      clause.Less("start_time", 4),
+    ),
+  });
+  expect(query).toEqual(ml.logs[0].query);
+});

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -130,6 +130,9 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
     const limit = this.options.limit + 1;
 
     options.limit = limit;
+    // todo may not be desc
+    // and if asc
+    // clause below should switch to greater...
     options.orderby = `${this.sortCol} DESC`;
     // we sort by most recent first
     // so when paging, we fetch afterCursor X

--- a/ts/src/core/query/shared_test.ts
+++ b/ts/src/core/query/shared_test.ts
@@ -263,12 +263,10 @@ export const commonTests = <TData extends Data>(opts: options<TData>) => {
   });
 
   beforeEach(async () => {
-    //    console.log("beforeEach");
-    // TODO figure out why this failed in the absence of this and have it fail loudly...
-
-    if (!opts.livePostgresDB) {
-      await createEdges();
+    if (opts.livePostgresDB) {
+      return;
     }
+    await createEdges();
   });
 
   afterAll(async () => {

--- a/ts/src/graphql/graphql.ts
+++ b/ts/src/graphql/graphql.ts
@@ -708,3 +708,5 @@ const gqlFileUpload: CustomType = {
 };
 
 export { gqlFileUpload };
+
+//const gqlConnection:

--- a/ts/src/graphql/graphql.ts
+++ b/ts/src/graphql/graphql.ts
@@ -708,5 +708,3 @@ const gqlFileUpload: CustomType = {
 };
 
 export { gqlFileUpload };
-
-//const gqlConnection:

--- a/ts/src/testutils/db/test_db.ts
+++ b/ts/src/testutils/db/test_db.ts
@@ -371,7 +371,7 @@ export class TempDB {
 
   async afterAll() {
     if (this.dialect === Dialect.SQLite) {
-      await this.sqlite.close();
+      this.sqlite.close();
       return;
     }
 

--- a/ts/src/testutils/fake_data/fake_contact.ts
+++ b/ts/src/testutils/fake_data/fake_contact.ts
@@ -17,6 +17,7 @@ import { convertDate } from "../../core/convert";
 
 export class FakeContact implements Ent {
   readonly id: ID;
+  readonly data: Data;
   readonly nodeType = NodeType.FakeContact;
   readonly createdAt: Date;
   readonly updatedAt: Date;
@@ -30,6 +31,7 @@ export class FakeContact implements Ent {
   };
 
   constructor(public viewer: Viewer, data: Data) {
+    this.data = data;
     this.id = data.id;
     this.createdAt = convertDate(data.created_at);
     this.updatedAt = convertDate(data.updated_at);

--- a/ts/src/testutils/fake_data/fake_event.ts
+++ b/ts/src/testutils/fake_data/fake_event.ts
@@ -63,10 +63,6 @@ export class FakeEvent implements Ent {
     ];
   }
 
-  // let's do events in the last day...
-  // and then we query for multiple ids
-  // vs not
-
   static getTestTable() {
     return table(
       "fake_events",

--- a/ts/src/testutils/fake_data/fake_event.ts
+++ b/ts/src/testutils/fake_data/fake_event.ts
@@ -23,6 +23,7 @@ import { convertDate, convertNullableDate } from "../../core/convert";
 
 export class FakeEvent implements Ent {
   readonly id: ID;
+  readonly data: Data;
   readonly nodeType = NodeType.FakeEvent;
   readonly createdAt: Date;
   readonly updatedAt: Date;
@@ -36,6 +37,7 @@ export class FakeEvent implements Ent {
   privacyPolicy: PrivacyPolicy = AlwaysAllowPrivacyPolicy;
 
   constructor(public viewer: Viewer, data: Data) {
+    this.data = data;
     this.id = data.id;
     this.createdAt = convertDate(data.created_at);
     this.updatedAt = convertDate(data.updated_at);
@@ -61,12 +63,17 @@ export class FakeEvent implements Ent {
     ];
   }
 
+  // let's do events in the last day...
+  // and then we query for multiple ids
+  // vs not
+
   static getTestTable() {
     return table(
       "fake_events",
       uuid("id", { primaryKey: true }),
       timestamptz("created_at"),
       timestamptz("updated_at"),
+      // TODO index:true
       timestamptz("start_time"),
       timestamptz("end_time", { nullable: true }),
       text("location"),
@@ -105,6 +112,7 @@ export class FakeEventSchema
   fields: Field[] = [
     TimestampType({
       name: "startTime",
+      index: true,
     }),
     TimestampType({
       name: "endTime",

--- a/ts/src/testutils/fake_data/fake_user.ts
+++ b/ts/src/testutils/fake_data/fake_user.ts
@@ -39,6 +39,7 @@ export class ViewerWithAccessToken extends IDViewer {
 
 export class FakeUser implements Ent {
   readonly id: ID;
+  readonly data: Data;
   readonly nodeType = NodeType.FakeUser;
   readonly createdAt: Date;
   readonly updatedAt: Date;
@@ -72,6 +73,7 @@ export class FakeUser implements Ent {
   };
 
   constructor(public viewer: Viewer, data: Data) {
+    this.data = data;
     this.id = data.id;
     this.createdAt = convertDate(data.created_at);
     this.updatedAt = convertDate(data.updated_at);

--- a/ts/src/testutils/fake_data/test_helpers.ts
+++ b/ts/src/testutils/fake_data/test_helpers.ts
@@ -24,7 +24,6 @@ import {
 } from ".";
 import { EventCreateInput, FakeEvent, getEventBuilder } from "./fake_event";
 import { NodeType } from "./const";
-import { convertDate } from "../../core/convert";
 
 export function getContactInput(
   user: FakeUser,

--- a/ts/src/testutils/fake_data/test_helpers.ts
+++ b/ts/src/testutils/fake_data/test_helpers.ts
@@ -1,5 +1,5 @@
 import { fail } from "assert";
-import { advanceBy, advanceTo } from "jest-date-mock";
+import { advanceBy, advanceTo, clear } from "jest-date-mock";
 import { IDViewer, LoggedOutViewer } from "../../core/viewer";
 import { Data } from "../../core/base";
 import { AssocEdge, loadEdgeData } from "../../core/ent";
@@ -24,6 +24,7 @@ import {
 } from ".";
 import { EventCreateInput, FakeEvent, getEventBuilder } from "./fake_event";
 import { NodeType } from "./const";
+import { MockDate } from "./../mock_date";
 
 export function getContactInput(
   user: FakeUser,
@@ -272,6 +273,10 @@ export async function createAllEvents(
 
   let arr = new Array(opts.howMany);
   arr.fill(1);
+
+  // start at date in case something else has used a date already
+  advanceTo(MockDate.getDate());
+
   const events = await Promise.all(
     arr.map(async (v, idx: number) => {
       // just to make times deterministic so that tests can consistently work

--- a/ts/src/testutils/fake_data/user_query.ts
+++ b/ts/src/testutils/fake_data/user_query.ts
@@ -1,6 +1,7 @@
 import { Ent, ID, Viewer } from "../../core/base";
 import { CustomEdgeQueryBase } from "../../core/query/custom_query";
 import { AssocEdge } from "../../core/ent";
+import * as clause from "../../core/clause";
 import {
   AssocEdgeQueryBase,
   EdgeQuerySource,
@@ -21,6 +22,10 @@ import { AssocEdgeCountLoaderFactory } from "../../core/loaders/assoc_count_load
 import { AssocEdgeLoaderFactory } from "../../core/loaders/assoc_edge_loader";
 import { IndexLoaderFactory } from "../../core/loaders/index_loader";
 import { contactLoader } from "./fake_contact";
+import { clear } from "jest-date-mock";
+import { Interval } from "luxon";
+import { QueryLoaderFactory } from "../../core/loaders/query_loader";
+import { MockDate } from "./../mock_date";
 
 export class UserToContactsQuery extends AssocEdgeQueryBase<
   FakeUser,
@@ -326,5 +331,57 @@ export class UserToHostedEventsQuery extends AssocEdgeQueryBase<
   }
   queryMaybe(): EventToMaybeQuery {
     return EventToDeclinedQuery.query(this.viewer, this);
+  }
+}
+
+export const getNextWeekClause = () => {
+  // get events starting within the next week
+
+  clear();
+  const start = MockDate.getDate();
+  // 7 days
+  const end = Interval.after(start, 86400 * 1000 * 7)
+    .end.toUTC()
+    .toISO();
+
+  return clause.And(
+    clause.GreaterEq("start_time", start.toISOString()),
+    clause.LessEq("start_time", end),
+  );
+};
+
+export const userToEventsInNextWeekCountLoaderFactory =
+  new RawCountLoaderFactory({
+    ...FakeEvent.loaderOptions(),
+    groupCol: "user_id",
+    clause: getNextWeekClause(),
+  });
+
+export const userToEventsInNextWeekDataLoaderFactory = new QueryLoaderFactory({
+  ...FakeEvent.loaderOptions(),
+  groupCol: "user_id",
+  clause: getNextWeekClause(),
+  toPrime: [contactLoader],
+  sortColumn: "start_time",
+});
+
+export class UserToEventsInNextWeekQuery extends CustomEdgeQueryBase<FakeEvent> {
+  constructor(viewer: Viewer, src: ID | FakeUser) {
+    super(viewer, {
+      src,
+      // we want to reuse this and not create a new one every time...
+      countLoaderFactory: userToEventsInNextWeekCountLoaderFactory,
+      dataLoaderFactory: userToEventsInNextWeekDataLoaderFactory,
+      options: FakeEvent.loaderOptions(),
+      // hmm TODO shouldn't need to write this twice...
+      sortColumn: "start_time",
+    });
+  }
+
+  static query(
+    viewer: Viewer,
+    src: FakeUser | ID,
+  ): UserToEventsInNextWeekQuery {
+    return new UserToEventsInNextWeekQuery(viewer, src);
   }
 }

--- a/ts/src/testutils/fake_data/user_query.ts
+++ b/ts/src/testutils/fake_data/user_query.ts
@@ -45,10 +45,10 @@ export class UserToContactsQuery extends AssocEdgeQueryBase<
   }
 }
 
-export const userToContactsCountLoaderFactory = new RawCountLoaderFactory(
-  FakeContact.loaderOptions(),
-  "user_id",
-);
+export const userToContactsCountLoaderFactory = new RawCountLoaderFactory({
+  ...FakeContact.loaderOptions(),
+  groupCol: "user_id",
+});
 export const userToContactsDataLoaderFactory = new IndexLoaderFactory(
   FakeContact.loaderOptions(),
   "user_id",

--- a/ts/src/testutils/fake_data/user_query.ts
+++ b/ts/src/testutils/fake_data/user_query.ts
@@ -334,7 +334,7 @@ export class UserToHostedEventsQuery extends AssocEdgeQueryBase<
   }
 }
 
-export const getNextWeekClause = () => {
+export const getNextWeekClause = (): clause.Clause => {
   // get events starting within the next week
 
   clear();
@@ -349,6 +349,10 @@ export const getNextWeekClause = () => {
     clause.LessEq("start_time", end),
   );
 };
+
+export function getCompleteClause(id: ID): clause.Clause {
+  return clause.And(clause.Eq("user_id", id), getNextWeekClause());
+}
 
 export const userToEventsInNextWeekCountLoaderFactory =
   new RawCountLoaderFactory({

--- a/ts/src/testutils/mock_date.ts
+++ b/ts/src/testutils/mock_date.ts
@@ -1,0 +1,10 @@
+export class MockDate {
+  private static date: Date | undefined;
+  // this exists so that we can reuse the same date across different places in tests
+  static getDate(): Date {
+    if (this.date === undefined) {
+      this.date = new Date();
+    }
+    return this.date;
+  }
+}


### PR DESCRIPTION
make it so that we can use custom queries as entquery 

kind of a followup to https://github.com/lolopinto/ent/pull/390

now, defining custom query clause and you get entquery with pagination etc 

next, ability to add a decorator and have a graphql connection exposed so that it's as first class a citizen as the ones exposed by the framework based on the schema

This refactors IndexLoader into QueryLoader which is more flexible to support the base cases we previously supported e.g.
* indexed field (what we already support)
* indexed field and extraClause (new). an s
* just clause for super custom cases. this won't be grouped into the same query but will still work for entquery etc