### PR TITLE
Update dockerfile

### DIFF
--- a/examples/ent-rsvp/backend/Dockerfile
+++ b/examples/ent-rsvp/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:0.0.8
+FROM ghcr.io/lolopinto/ent:0.0.17
 
 WORKDIR /app
 

--- a/examples/ent-rsvp/backend/develop.Dockerfile
+++ b/examples/ent-rsvp/backend/develop.Dockerfile
@@ -2,6 +2,6 @@ FROM ghcr.io/lolopinto/ent:0.0.17
 
 WORKDIR /app
 
-COPY . /app
+COPY . .
 
 CMD ["node", "dist/graphql/index.js"]

--- a/examples/ent-rsvp/backend/develop.Dockerfile
+++ b/examples/ent-rsvp/backend/develop.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:0.0.11
+FROM ghcr.io/lolopinto/ent:0.0.17
 
 WORKDIR /app
 

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "compile": "rm -rf dist && ./node_modules/.bin/ent-custom-compiler",
     "start": "docker-compose -f docker-compose.dev.yml up --build",
+    "init": "docker-compose -f docker-compose.dev.yml run --rm app npm install",
     "codegen": "docker-compose -f docker-compose.dev.yml run --rm app tsent codegen",
     "upgrade": "docker-compose -f docker-compose.dev.yml run --rm app tsent upgrade",
     "start-fast": "npm run compile && node dist/graphql/index.js"

--- a/examples/simple/Dockerfile
+++ b/examples/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM lolopinto/ent:0.0.1
+FROM lolopinto/ent:0.0.17
 
 # TODO this needs to be tested for "production"
 # works locally when run here but needs to be tested in hostile environments

--- a/examples/simple/develop.Dockerfile
+++ b/examples/simple/develop.Dockerfile
@@ -2,6 +2,6 @@ FROM ghcr.io/lolopinto/ent:0.0.17
 
 WORKDIR /app
 
-COPY . /app
+COPY . .
 
 CMD ["node", "dist/graphql/index.js"]

--- a/examples/simple/develop.Dockerfile
+++ b/examples/simple/develop.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:0.0.11
+FROM ghcr.io/lolopinto/ent:0.0.17
 
 WORKDIR /app
 

--- a/examples/simple/docker-compose.dev.yml
+++ b/examples/simple/docker-compose.dev.yml
@@ -5,8 +5,6 @@ services:
     build: 
       context: .
       dockerfile: develop.Dockerfile
-      args:
-        - GITHUB_TOKEN=${GITHUB_TOKEN}
     container_name: example_app
     ports: 
       - 4000:4000
@@ -15,5 +13,4 @@ services:
       - .:/app:rw,delegated
     environment:
       - DB_CONNECTION_STRING=postgres://ola:@host.docker.internal/tsent_test
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
 

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "simple",
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
@@ -12,7 +13,7 @@
         "@snowtop/snowtop-passport": "^0.0.1",
         "@snowtop/snowtop-password": "^0.0.1",
         "@snowtop/snowtop-phonenumber": "^0.0.1",
-        "@snowtop/snowtop-ts": "^0.0.4",
+        "@snowtop/snowtop-ts": "^0.0.5",
         "@types/express-session": "^1.17.3",
         "@types/graphql-upload": "^8.0.4",
         "@types/luxon": "^1.26.5",
@@ -977,9 +978,9 @@
       }
     },
     "node_modules/@snowtop/snowtop-ts": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@snowtop/snowtop-ts/-/snowtop-ts-0.0.4.tgz",
-      "integrity": "sha512-BgZm6GrnCMAmCyyYvSyqRnk5L50pDrgidkZ1fiXP48M5FK9pWaibE4uQ+jcqogDepz69lWlCnpyVZOW9pBgDVw==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@snowtop/snowtop-ts/-/snowtop-ts-0.0.5.tgz",
+      "integrity": "sha512-wNS6WjGKYtNDbwoWanxbPfhJO5nW0gtezsQcr9K/mDaOtqYY2S5ROE9NgpS/dgQivGJoZW6tY96hWlNG6I4ysw==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "better-sqlite3": "^7.4.1",
@@ -9683,9 +9684,9 @@
       }
     },
     "@snowtop/snowtop-ts": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@snowtop/snowtop-ts/-/snowtop-ts-0.0.4.tgz",
-      "integrity": "sha512-BgZm6GrnCMAmCyyYvSyqRnk5L50pDrgidkZ1fiXP48M5FK9pWaibE4uQ+jcqogDepz69lWlCnpyVZOW9pBgDVw==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@snowtop/snowtop-ts/-/snowtop-ts-0.0.5.tgz",
+      "integrity": "sha512-wNS6WjGKYtNDbwoWanxbPfhJO5nW0gtezsQcr9K/mDaOtqYY2S5ROE9NgpS/dgQivGJoZW6tY96hWlNG6I4ysw==",
       "requires": {
         "@types/node": "^15.0.2",
         "better-sqlite3": "^7.4.1",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -10,7 +10,9 @@
     "test": "jest",
     "compile": "rm -rf dist && ./node_modules/.bin/ent-custom-compiler",
     "start": "docker-compose -f docker-compose.dev.yml up --build",
+    "init": "docker-compose -f docker-compose.dev.yml run --rm app npm install",
     "codegen": "docker-compose -f docker-compose.dev.yml run --rm app tsent codegen",
+    "upgrade": "docker-compose -f docker-compose.dev.yml run --rm app tsent upgrade",
     "start-fast": "npm run compile && node dist/graphql/index.js"
   },
   "author": "",
@@ -34,7 +36,7 @@
     "@snowtop/snowtop-passport": "^0.0.1",
     "@snowtop/snowtop-password": "^0.0.1",
     "@snowtop/snowtop-phonenumber": "^0.0.1",
-    "@snowtop/snowtop-ts": "^0.0.4",
+    "@snowtop/snowtop-ts": "^0.0.5",
     "@types/express-session": "^1.17.3",
     "@types/graphql-upload": "^8.0.4",
     "@types/luxon": "^1.26.5",

--- a/examples/todo-sqlite/Dockerfile
+++ b/examples/todo-sqlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM lolopinto/ent:0.0.1
+FROM lolopinto/ent:0.0.17
 
 # TODO this needs to be tested for "production"
 # works locally when run here but needs to be tested in hostile environments

--- a/examples/todo-sqlite/develop.Dockerfile
+++ b/examples/todo-sqlite/develop.Dockerfile
@@ -2,6 +2,6 @@ FROM ghcr.io/lolopinto/ent:0.0.17
 
 WORKDIR /app
 
-COPY . /app
+COPY . .
 
 CMD ["node", "dist/graphql/index.js"]

--- a/examples/todo-sqlite/develop.Dockerfile
+++ b/examples/todo-sqlite/develop.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:0.0.11
+FROM ghcr.io/lolopinto/ent:0.0.17
 
 WORKDIR /app
 

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -7,10 +7,11 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "jest",
     "compile": "rm -rf dist && ./node_modules/.bin/ent-custom-compiler",
     "start": "docker-compose -f docker-compose.dev.yml up --build",
+    "init": "docker-compose -f docker-compose.dev.yml run --rm app npm install",
     "codegen": "docker-compose -f docker-compose.dev.yml run --rm app tsent codegen",
+    "upgrade": "docker-compose -f docker-compose.dev.yml run --rm app tsent upgrade",
     "start-fast": "npm run compile && node dist/graphql/index.js"
   },
   "author": "",

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -2,13 +2,13 @@
 ARG ARCH=
 FROM ${ARCH}python:3.8.11-buster 
 
-# Install node prereqs, nodejs and yarn
-# Ref: https://deb.nodesource.com/setup_14.x
-# Ref: https://yarnpkg.com/en/docs/install
-
 # gotten from https://github.com/nikolaik/docker-python-nodejs/blob/master/Dockerfile
+
+# Install node prereqs, nodejs and yarn
+# Ref: https://deb.nodesource.com/setup_16.x
+# Ref: https://yarnpkg.com/en/docs/install
 RUN \
-  echo "deb https://deb.nodesource.com/node_14.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_16.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -1,5 +1,27 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs16
+#FROM nikolaik/python-nodejs:python3.8-nodejs16
+# buster supports 6.4
+ARG ARCH=
+FROM ${ARCH}python:3.8.11-buster 
 
+# Install node prereqs, nodejs and yarn
+# Ref: https://deb.nodesource.com/setup_14.x
+# Ref: https://yarnpkg.com/en/docs/install
+
+RUN \
+  echo "deb https://deb.nodesource.com/node_14.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
+  wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  apt-get update && \
+  apt-get install -yqq nodejs yarn && \
+  pip install -U pip && pip install pipenv 
+
+RUN  npm i -g npm@^7 
+#RUN  npm i -g yarn
+RUN  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && ln -s /root/.poetry/bin/poetry /usr/local/bin 
+RUN  rm -rf /var/lib/apt/lists/*
+
+ARG TARGETARCH
 # this is associating this image with this repo
 LABEL org.opencontainers.image.source https://github.com/lolopinto/ent
 
@@ -9,9 +31,9 @@ RUN apt update && apt --assume-yes install zsh
 RUN python3 -m pip install auto_schema==0.0.7
 
 # get go
-RUN wget https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz
+RUN wget https://storage.googleapis.com/golang/go1.16.5.linux-$TARGETARCH.tar.gz
 
-RUN tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.16.5.linux-$TARGETARCH.tar.gz
 
 ENV PATH $PATH:/usr/local/go/bin
 
@@ -20,7 +42,7 @@ ENV GOPATH=$HOME/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOPATH/bin
 
-RUN go install github.com/lolopinto/ent/tsent@v0.0.17
+RUN go install github.com/lolopinto/ent/tsent@v0.0.18
 
 # first 3 need to move from ts/package.json
 # maybe typescript?

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -1,5 +1,4 @@
 #FROM nikolaik/python-nodejs:python3.8-nodejs16
-# buster supports 6.4
 ARG ARCH=
 FROM ${ARCH}python:3.8.11-buster 
 
@@ -7,6 +6,7 @@ FROM ${ARCH}python:3.8.11-buster
 # Ref: https://deb.nodesource.com/setup_14.x
 # Ref: https://yarnpkg.com/en/docs/install
 
+# gotten from https://github.com/nikolaik/docker-python-nodejs/blob/master/Dockerfile
 RUN \
   echo "deb https://deb.nodesource.com/node_14.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
@@ -17,7 +17,6 @@ RUN \
   pip install -U pip && pip install pipenv 
 
 RUN  npm i -g npm@^7 
-#RUN  npm i -g yarn
 RUN  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && ln -s /root/.poetry/bin/poetry /usr/local/bin 
 RUN  rm -rf /var/lib/apt/lists/*
 

--- a/ts/RELEASING.MD
+++ b/ts/RELEASING.MD
@@ -3,12 +3,12 @@ Steps to update docker image:
 
 high level following [these steps](https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/pushing-and-pulling-docker-images#authenticating-to-github-container-registry):
 
-* `echo "{TOKEN}" | docker login ghcr.io -u USERNAME --password-stdin`
-* `docker build --no-cache -t ent .`
-* `docker tag ent ghcr.io/lolopinto/ent:(tag)`
-* `docker tag ent ghcr.io/lolopinto/ent:latest`
+We use [buildx](https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images) to build a multi-arch image
 
-* `docker push ghcr.io/lolopinto/ent` for latest
-* `docker push ghcr.io/lolopinto/ent:(tag)`
+* `echo "{TOKEN}" | docker login ghcr.io -u USERNAME --password-stdin`
+* `docker buildx create --use` to create a new builder
+* `docker buildx build --platform linux/arm64,linux/amd64 --tag ghcr.io/lolopinto/ent:(tag) --tag ghcr.io/lolopinto/ent:latest --push .` to build and push new image
+
+Currently, can't get the multi-arch image to be built on an M1 mac so needs to be built on an intel mac. 
 
 PS: To figure out what the new version/tag should be, current version can be found at https://github.com/users/lolopinto/packages/container/package/ent.


### PR DESCRIPTION
update dockerfile for https://github.com/lolopinto/ent/releases/tag/v0.0.18

supports multi-arch images that work on both linux/amd64 (intel macs) and linux/arm64 (apple silicon macs)

moved from nikolaik/python-nodejs:python3.8-nodejs16 to building image locally since the architecture wasn't working using that. 

Use `docker buildx` to build