### PR TITLE
smaller docker images

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-      - '**.go'
+      - 'ent/**.go'
+      - 'internal/**.go'
       - ts/src/**
       - .github/workflows/go_ci.yml
 

--- a/.github/workflows/new_docker_image.yml
+++ b/.github/workflows/new_docker_image.yml
@@ -31,7 +31,7 @@ jobs:
       uses: docker/setup-qemu-action@v1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
       uses: actions/cache@v2
@@ -53,4 +53,3 @@ jobs:
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-        

--- a/.github/workflows/new_docker_image.yml
+++ b/.github/workflows/new_docker_image.yml
@@ -33,14 +33,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
     - name: docker login
       env:
         DOCKER_TOKEN: ${{secrets.DOCKER_TOKEN}}
@@ -49,7 +41,3 @@ jobs:
     - name: build the image
       run: cd release_image && go run .
 
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/new_docker_image.yml
+++ b/.github/workflows/new_docker_image.yml
@@ -33,13 +33,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@master
 
-    # - name: Cache Docker layers
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: /tmp/.buildx-cache
-    #     key: ${{ runner.os }}-buildx-${{ github.sha }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-buildx-
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
 
     - name: docker login
       env:
@@ -49,7 +49,7 @@ jobs:
     - name: build the image
       run: cd release_image && go run .
 
-    # - name: Move cache
-    #   run: |
-    #     rm -rf /tmp/.buildx-cache
-    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/new_docker_image.yml
+++ b/.github/workflows/new_docker_image.yml
@@ -33,6 +33,14 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
     - name: docker login
       env:
         DOCKER_TOKEN: ${{secrets.DOCKER_TOKEN}}
@@ -41,3 +49,8 @@ jobs:
     - name: build the image
       run: cd release_image && go run .
 
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        

--- a/.github/workflows/new_docker_image.yml
+++ b/.github/workflows/new_docker_image.yml
@@ -31,7 +31,7 @@ jobs:
       uses: docker/setup-qemu-action@v1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@master
+      uses: docker/setup-buildx-action@v1
 
     - name: docker login
       env:

--- a/.github/workflows/new_docker_image.yml
+++ b/.github/workflows/new_docker_image.yml
@@ -33,13 +33,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-
 
     - name: docker login
       env:
@@ -49,7 +49,7 @@ jobs:
     - name: build the image
       run: cd release_image && go run .
 
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -17,18 +17,23 @@ import (
 )
 
 // next tag
-const TAG = "0.0.19"
+const TAG = "0.0.20-test"
 
 // if current node gets latest tag...
 const CURRENT_NODE_VERSION = 16
 const REPO = "ghcr.io/lolopinto/ent"
 
-const UPDATE_LATEST = true
+const UPDATE_LATEST = false
 
-var NODE_VERSIONS = []dockerfileData{
-	{14, 6},
-	{15, 7},
-	{16, 7},
+var NODE_VERSIONS = []int{
+	14,
+	15,
+	16,
+}
+
+var SUFFIXES = []string{
+	"dev",
+	"slim",
 }
 
 // can change platforms here to test locally
@@ -39,14 +44,20 @@ var PLATFORMS = []string{
 
 func main() {
 	var wg sync.WaitGroup
-	wg.Add(len(NODE_VERSIONS))
+	wg.Add(len(NODE_VERSIONS) * len(SUFFIXES))
 	errs := make([]error, len(NODE_VERSIONS))
 	for i := range NODE_VERSIONS {
-		go func(i int) {
-			defer wg.Done()
-			v := NODE_VERSIONS[i]
-			errs[i] = <-run(v.NODE_VERSION, v.NPM_VERSION)
-		}(i)
+		for j := range SUFFIXES {
+			go func(i, j int) {
+				defer wg.Done()
+				v := NODE_VERSIONS[i]
+				suffix := SUFFIXES[j]
+				errs[i] = <-run(dockerfileData{
+					NodeVersion: v,
+					Suffix:      suffix,
+				})
+			}(i, j)
+		}
 	}
 	wg.Wait()
 
@@ -56,15 +67,19 @@ func main() {
 }
 
 type dockerfileData struct {
-	NODE_VERSION int
-	NPM_VERSION  int
+	NodeVersion int
+	Suffix      string
+}
+
+func (d *dockerfileData) Development() bool {
+	return d.Suffix == "dev"
 }
 
 func createDockerfile(path string, d dockerfileData) error {
 	imps := tsimport.NewImports()
 
 	return file.Write((&file.TemplatedBasedFileWriter{
-		Data:              d,
+		Data:              &d,
 		CreateDirIfNeeded: true,
 		AbsPathToTemplate: util.GetAbsolutePath("../ts/Dockerfile.tmpl"),
 		TemplateName:      "Dockerfile.tmpl",
@@ -74,18 +89,18 @@ func createDockerfile(path string, d dockerfileData) error {
 	}))
 }
 
-func getTags(node int) []string {
+func getTags(d dockerfileData) []string {
 	ret := []string{
-		fmt.Sprintf("%s:%s-nodejs-%d", REPO, TAG, node),
+		fmt.Sprintf("%s:%s-nodejs-%d-%s", REPO, TAG, d.NodeVersion, d.Suffix),
 	}
-	if node == CURRENT_NODE_VERSION && UPDATE_LATEST {
+	if d.NodeVersion == CURRENT_NODE_VERSION && UPDATE_LATEST {
 		ret = append(ret, fmt.Sprintf("%s:latest", REPO))
 	}
 	return ret
 }
 
-func getCommandArgs(node int, builder string) []string {
-	tags := getTags(node)
+func getCommandArgs(d dockerfileData, builder string) []string {
+	tags := getTags(d)
 	ret := []string{
 		"buildx",
 		"build",
@@ -93,6 +108,10 @@ func getCommandArgs(node int, builder string) []string {
 		builder,
 		"--platform",
 		strings.Join(PLATFORMS, ","),
+		"--cache-from",
+		"type=local,src=/tmp/.buildx-cache",
+		"--cache-to",
+		"type=local,mode=max,dest=/tmp/.buildx-cache-new",
 	}
 
 	for _, tag := range tags {
@@ -104,23 +123,31 @@ func getCommandArgs(node int, builder string) []string {
 	return ret
 }
 
-func run(node, npm int) <-chan error {
+func run(d dockerfileData) <-chan error {
 	c := make(chan error)
 	go func() {
-		dir := fmt.Sprintf("node_%d", node)
-		err := os.Mkdir(dir, os.ModePerm)
-		if err != nil {
-			c <- errors.Wrap(err, "error creating directory")
-			return
+		dir := fmt.Sprintf("node_%d_%s", d.NodeVersion, d.Suffix)
+		info, err := os.Stat(dir)
+		if err == nil {
+			if !info.IsDir() {
+				c <- errors.Wrapf(err, "path %s exists and is not a directory", dir)
+			}
+		} else if os.IsNotExist(err) {
+			// only create if directory exists
+			err := os.Mkdir(dir, os.ModePerm)
+			if err != nil {
+				c <- errors.Wrap(err, "error creating directory")
+				return
+			}
+		} else {
+			c <- errors.Wrap(err, "unexpected error")
 		}
 
 		defer os.RemoveAll(dir)
 		dockerfile := path.Join(dir, "Dockerfile")
 
-		err = createDockerfile(dockerfile, dockerfileData{
-			NODE_VERSION: node,
-			NPM_VERSION:  npm,
-		})
+		err = createDockerfile(dockerfile, d)
+
 		if err != nil {
 			c <- errors.Wrap(err, "error creating docker file")
 			return
@@ -138,7 +165,7 @@ func run(node, npm int) <-chan error {
 		builder := strings.TrimSpace(out.String())
 
 		// build image
-		cmd := exec.Command("docker", getCommandArgs(node, builder)...)
+		cmd := exec.Command("docker", getCommandArgs(d, builder)...)
 		cmd.Dir = dir
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // next tag
-const TAG = "0.0.20-test"
+const TAG = "0.0.20-test2"
 
 // if current node gets latest tag...
 const CURRENT_NODE_VERSION = 16
@@ -26,8 +26,8 @@ const REPO = "ghcr.io/lolopinto/ent"
 const UPDATE_LATEST = false
 
 var NODE_VERSIONS = []int{
-	14,
-	15,
+	// 14,
+	// 15,
 	16,
 }
 
@@ -45,14 +45,14 @@ var PLATFORMS = []string{
 func main() {
 	var wg sync.WaitGroup
 	wg.Add(len(NODE_VERSIONS) * len(SUFFIXES))
-	errs := make([]error, len(NODE_VERSIONS))
+	errs := make([]error, len(NODE_VERSIONS)*len(SUFFIXES))
 	for i := range NODE_VERSIONS {
 		for j := range SUFFIXES {
 			go func(i, j int) {
 				defer wg.Done()
 				v := NODE_VERSIONS[i]
 				suffix := SUFFIXES[j]
-				errs[i] = <-run(dockerfileData{
+				errs[i*len(SUFFIXES)+j] = <-run(dockerfileData{
 					NodeVersion: v,
 					Suffix:      suffix,
 				})
@@ -108,10 +108,10 @@ func getCommandArgs(d dockerfileData, builder string) []string {
 		builder,
 		"--platform",
 		strings.Join(PLATFORMS, ","),
-		"--cache-from",
-		"type=local,src=/tmp/.buildx-cache",
-		"--cache-to",
-		"type=local,mode=max,dest=/tmp/.buildx-cache-new",
+		// "--cache-from",
+		// "type=local,src=/tmp/.buildx-cache",
+		// "--cache-to",
+		// "type=local,mode=max,dest=/tmp/.buildx-cache-new",
 	}
 
 	for _, tag := range tags {

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -26,8 +26,8 @@ const REPO = "ghcr.io/lolopinto/ent"
 const UPDATE_LATEST = true
 
 var NODE_VERSIONS = []int{
-	// 14,
-	// 15,
+	14,
+	15,
 	16,
 }
 
@@ -41,7 +41,7 @@ var SUFFIXES = []string{
 
 // can change platforms here to test locally
 var PLATFORMS = []string{
-	//	"linux/amd64",
+	"linux/amd64",
 	"linux/arm64",
 }
 
@@ -100,7 +100,8 @@ func getTags(d dockerfileData) []string {
 	ret := []string{
 		fmt.Sprintf("%s:%s-nodejs-%d-%s", REPO, TAG, d.NodeVersion, d.Suffix),
 	}
-	if d.NodeVersion == CURRENT_NODE_VERSION && UPDATE_LATEST {
+	// current node development gets latest since it should have full ish
+	if d.NodeVersion == CURRENT_NODE_VERSION && UPDATE_LATEST && d.Development() {
 		ret = append(ret, fmt.Sprintf("%s:latest", REPO))
 	}
 	return ret

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -26,8 +26,8 @@ const REPO = "ghcr.io/lolopinto/ent"
 const UPDATE_LATEST = true
 
 var NODE_VERSIONS = []int{
-	14,
-	15,
+	// 14,
+	// 15,
 	16,
 }
 
@@ -41,7 +41,7 @@ var SUFFIXES = []string{
 
 // can change platforms here to test locally
 var PLATFORMS = []string{
-	"linux/amd64",
+	//	"linux/amd64",
 	"linux/arm64",
 }
 

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // next tag
-const TAG = "0.0.20-test2"
+const TAG = "0.0.20"
 
 // if current node gets latest tag...
 const CURRENT_NODE_VERSION = 16

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -1,20 +1,26 @@
+ARG GOLANG_VERSION=v0.0.19
+ARG AUTO_SCHEMA_VERSION=0.0.7
+
 # get and install tsent
 FROM golang:1.16.5-buster As golang-image
+ARG GOLANG_VERSION
 ENV GOPATH=$HOME/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOPATH/bin
-RUN go install github.com/lolopinto/ent/tsent@v0.0.19
+RUN go install github.com/lolopinto/ent/tsent@$GOLANG_VERSION
 
 # get and install auto_schema
 FROM python:3.8.11-buster AS python-image
+ARG AUTO_SCHEMA_VERSION
 RUN python -m venv /opt/venv
 # Make sure we use the virtualenv
 ENV PATH /opt/venv/bin:$PATH
 
-RUN python3 -m pip install auto_schema==0.0.7
+RUN python3 -m pip install auto_schema==$AUTO_SCHEMA_VERSION
 
 # final image needs to be python-based to have auto-schema work
 FROM python:3.8.11-slim AS final-image
+ARG GOLANG_VERSION
 
 ENV PATH /opt/venv/bin:$PATH
 ENV PATH /go/bin:$PATH
@@ -47,6 +53,7 @@ RUN npm install --save-dev tsconfig-paths
 
 COPY --from=golang-image /go/bin/tsent /go/bin/tsent
 COPY --from=python-image /opt/venv /opt/venv
+COPY --from=golang-image /go/pkg/mod/github.com/lolopinto/ent@$GOLANG_VERSION /go/pkg/mod/github.com/lolopinto/ent@$GOLANG_VERSION
 
 CMD ["node"]
 

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -1,58 +1,51 @@
-#FROM nikolaik/python-nodejs:python3.8-nodejs16
-ARG ARCH=
-FROM ${ARCH}python:3.8.11-buster 
+# get and install tsent
+FROM golang:1.16.5-buster As golang-image
+ENV GOPATH=$HOME/go
+ENV GOBIN $GOPATH/bin
+ENV PATH $PATH:$GOPATH/bin
+RUN go install github.com/lolopinto/ent/tsent@v0.0.19
 
-# gotten from https://github.com/nikolaik/docker-python-nodejs/blob/master/Dockerfile
+# get and install auto_schema
+FROM python:3.8.11-buster AS python-image
+RUN python -m venv /opt/venv
+# Make sure we use the virtualenv
+ENV PATH /opt/venv/bin:$PATH
 
-# Install node prereqs, nodejs and yarn
-# Ref: https://deb.nodesource.com/setup_16.x
-# Ref: https://yarnpkg.com/en/docs/install
+RUN python3 -m pip install auto_schema==0.0.7
+
+# final image needs to be python-based to have auto-schema work
+FROM python:3.8.11-slim AS final-image
+COPY --from=golang-image /go/bin/tsent /go/bin/tsent
+COPY --from=python-image /opt/venv /opt/venv
+
+ENV PATH /opt/venv/bin:$PATH
+ENV PATH /go/bin:$PATH
+
+# this is associating this image with this repo
+LABEL org.opencontainers.image.source https://github.com/lolopinto/ent
+
+# install node and dependencies
 RUN \
+  apt-get update && \
+  # wget and gnupg are dependencies needed below
+  apt-get install -yqq wget gnupg && \
   echo "deb https://deb.nodesource.com/node_16.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   apt-get update && \
   apt-get install -yqq nodejs yarn && \
-  pip install -U pip && pip install pipenv 
+  apt-get autoremove wget -yqq && \
+  rm -rf /var/lib/apt/lists/*
 
-RUN  npm i -g npm@^7 
-RUN  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && ln -s /root/.poetry/bin/poetry /usr/local/bin 
-RUN  rm -rf /var/lib/apt/lists/*
+# these next ones are not included in slim variants
 
-ARG TARGETARCH
-# this is associating this image with this repo
-LABEL org.opencontainers.image.source https://github.com/lolopinto/ent
+RUN apt update && apt --assume-yes install zsh && \
+  rm -rf /var/lib/apt/lists/*
+RUN npm install -g typescript prettier ts-node
 
-RUN apt update && apt --assume-yes install zsh
-
-# install auto_schema
-RUN python3 -m pip install auto_schema==0.0.7
-
-# get go
-RUN wget https://storage.googleapis.com/golang/go1.16.5.linux-$TARGETARCH.tar.gz
-
-RUN tar -C /usr/local -xzf go1.16.5.linux-$TARGETARCH.tar.gz
-
-ENV PATH $PATH:/usr/local/go/bin
-
-# default path but make it explicit
-ENV GOPATH=$HOME/go
-ENV GOBIN $GOPATH/bin
-ENV PATH $PATH:$GOPATH/bin
-
-RUN go install github.com/lolopinto/ent/tsent@v0.0.19
-
-# first 3 need to move from ts/package.json
-# maybe typescript?
-RUN npm install -g ts-node prettier typescript
-# this needs to be local apparently
 WORKDIR /app
 RUN npm install --save-dev tsconfig-paths 
 
 CMD ["node"]
 
-# TODO eventually need a production Dockerfile that's lighter than this...
-# don't need ts-node, prettier, tsconfig-paths for example
-
-# still need go, python and node tho because of CLI and db 

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -15,8 +15,6 @@ RUN python3 -m pip install auto_schema==0.0.7
 
 # final image needs to be python-based to have auto-schema work
 FROM python:3.8.11-slim AS final-image
-COPY --from=golang-image /go/bin/tsent /go/bin/tsent
-COPY --from=python-image /opt/venv /opt/venv
 
 ENV PATH /opt/venv/bin:$PATH
 ENV PATH /go/bin:$PATH
@@ -46,6 +44,9 @@ RUN npm install -g typescript prettier ts-node
 
 WORKDIR /app
 RUN npm install --save-dev tsconfig-paths 
+
+COPY --from=golang-image /go/bin/tsent /go/bin/tsent
+COPY --from=python-image /opt/venv /opt/venv
 
 CMD ["node"]
 

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -1,5 +1,6 @@
 ARG GOLANG_VERSION=v0.0.19
 ARG AUTO_SCHEMA_VERSION=0.0.7
+ARG NODE_VERSION=16
 
 # get and install tsent
 FROM golang:1.16.5-buster As golang-image
@@ -21,6 +22,7 @@ RUN python3 -m pip install auto_schema==$AUTO_SCHEMA_VERSION
 # final image needs to be python-based to have auto-schema work
 FROM python:3.8.11-slim AS final-image
 ARG GOLANG_VERSION
+ARG NODE_VERSION
 
 ENV PATH /opt/venv/bin:$PATH
 ENV PATH /go/bin:$PATH
@@ -33,7 +35,7 @@ RUN \
   apt-get update && \
   # wget and gnupg are dependencies needed below
   apt-get install -yqq wget gnupg && \
-  echo "deb https://deb.nodesource.com/node_16.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_$NODE_VERSION.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -34,7 +34,8 @@ LABEL org.opencontainers.image.source https://github.com/lolopinto/ent
 RUN \
   apt-get update && \
   # wget and gnupg are dependencies needed below
-  apt-get install -yqq wget gnupg && \
+  # libpq-dev for libpq
+  apt-get install -yqq wget gnupg libpq-dev && \
   echo "deb https://deb.nodesource.com/node_$NODE_VERSION.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \

--- a/ts/Dockerfile.tmpl
+++ b/ts/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # get and install tsent
-FROM golang:1.16.5-buster As golang-image
+FROM golang:1.16.5-buster AS golang-image
 ENV GOPATH=$HOME/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOPATH/bin

--- a/ts/Dockerfile.tmpl
+++ b/ts/Dockerfile.tmpl
@@ -1,58 +1,54 @@
-#FROM nikolaik/python-nodejs:python3.8-nodejs16
-ARG ARCH=
-FROM ${ARCH}python:3.8.11-buster 
+# get and install tsent
+FROM golang:1.16.5-buster As golang-image
+ENV GOPATH=$HOME/go
+ENV GOBIN $GOPATH/bin
+ENV PATH $PATH:$GOPATH/bin
+RUN go install github.com/lolopinto/ent/tsent@v0.0.19
 
-# gotten from https://github.com/nikolaik/docker-python-nodejs/blob/master/Dockerfile
+# get and install auto_schema
+FROM python:3.8.11-buster AS python-image
+RUN python -m venv /opt/venv
+# Make sure we use the virtualenv
+ENV PATH /opt/venv/bin:$PATH
 
-# Install node prereqs, nodejs and yarn
-# Ref: https://deb.nodesource.com/setup_16.x
-# Ref: https://yarnpkg.com/en/docs/install
+RUN python3 -m pip install auto_schema==0.0.7
+
+# final image needs to be python-based to have auto-schema work
+FROM python:3.8.11-slim AS final-image
+COPY --from=golang-image /go/bin/tsent /go/bin/tsent
+COPY --from=python-image /opt/venv /opt/venv
+
+ENV PATH /opt/venv/bin:$PATH
+ENV PATH /go/bin:$PATH
+
+# this is associating this image with this repo
+LABEL org.opencontainers.image.source https://github.com/lolopinto/ent
+
+# install node and dependencies
 RUN \
-  echo "deb https://deb.nodesource.com/node_{{.NODE_VERSION}}.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  # wget and gnupg are dependencies needed below
+  apt-get install -yqq wget gnupg && \
+  echo "deb https://deb.nodesource.com/node_{{.NodeVersion}}.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   apt-get update && \
   apt-get install -yqq nodejs yarn && \
-  pip install -U pip && pip install pipenv 
+  apt-get autoremove wget -yqq && \
+  rm -rf /var/lib/apt/lists/*
 
-RUN  npm i -g npm@^{{.NPM_VERSION}}
-RUN  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && ln -s /root/.poetry/bin/poetry /usr/local/bin 
-RUN  rm -rf /var/lib/apt/lists/*
+{{ if .Development -}}
 
-ARG TARGETARCH
-# this is associating this image with this repo
-LABEL org.opencontainers.image.source https://github.com/lolopinto/ent
+RUN apt update && apt --assume-yes install zsh && \
+  rm -rf /var/lib/apt/lists/*
 
-RUN apt update && apt --assume-yes install zsh
+RUN npm install -g typescript prettier ts-node
 
-# install auto_schema
-RUN python3 -m pip install auto_schema==0.0.7
-
-# get go
-RUN wget https://storage.googleapis.com/golang/go1.16.5.linux-$TARGETARCH.tar.gz
-
-RUN tar -C /usr/local -xzf go1.16.5.linux-$TARGETARCH.tar.gz
-
-ENV PATH $PATH:/usr/local/go/bin
-
-# default path but make it explicit
-ENV GOPATH=$HOME/go
-ENV GOBIN $GOPATH/bin
-ENV PATH $PATH:$GOPATH/bin
-
-RUN go install github.com/lolopinto/ent/tsent@v0.0.19
-
-# first 3 need to move from ts/package.json
-# maybe typescript?
-RUN npm install -g ts-node prettier typescript
-# this needs to be local apparently
 WORKDIR /app
 RUN npm install --save-dev tsconfig-paths 
 
+{{ end -}}
+
 CMD ["node"]
 
-# TODO eventually need a production Dockerfile that's lighter than this...
-# don't need ts-node, prettier, tsconfig-paths for example
-
-# still need go, python and node tho because of CLI and db 

--- a/ts/Dockerfile.tmpl
+++ b/ts/Dockerfile.tmpl
@@ -3,7 +3,7 @@ FROM golang:1.16.5-buster AS golang-image
 ENV GOPATH=$HOME/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOPATH/bin
-RUN go install github.com/lolopinto/ent/tsent@v0.0.19
+RUN go install github.com/lolopinto/ent/tsent@{{.TsentVersion}}
 
 # get and install auto_schema
 FROM python:3.8.11-buster AS python-image
@@ -11,7 +11,7 @@ RUN python -m venv /opt/venv
 # Make sure we use the virtualenv
 ENV PATH /opt/venv/bin:$PATH
 
-RUN python3 -m pip install auto_schema==0.0.7
+RUN python3 -m pip install auto_schema=={{.AutoSchemaVersion}}
 
 # final image needs to be python-based to have auto-schema work
 FROM python:3.8.11-slim AS final-image

--- a/ts/Dockerfile.tmpl
+++ b/ts/Dockerfile.tmpl
@@ -1,22 +1,25 @@
+ARG GOLANG_VERSION={{.TsentVersion}}
+ARG AUTO_SCHEMA_VERSION={{.AutoSchemaVersion}}
+
 # get and install tsent
 FROM golang:1.16.5-buster AS golang-image
+ARG GOLANG_VERSION
 ENV GOPATH=$HOME/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOPATH/bin
-RUN go install github.com/lolopinto/ent/tsent@{{.TsentVersion}}
+RUN go install github.com/lolopinto/ent/tsent@$GOLANG_VERSION
 
 # get and install auto_schema
 FROM python:3.8.11-buster AS python-image
+ARG AUTO_SCHEMA_VERSION
 RUN python -m venv /opt/venv
 # Make sure we use the virtualenv
 ENV PATH /opt/venv/bin:$PATH
 
-RUN python3 -m pip install auto_schema=={{.AutoSchemaVersion}}
+RUN python3 -m pip install auto_schema==$AUTO_SCHEMA_VERSION
 
 # final image needs to be python-based to have auto-schema work
 FROM python:3.8.11-slim AS final-image
-COPY --from=golang-image /go/bin/tsent /go/bin/tsent
-COPY --from=python-image /opt/venv /opt/venv
 
 ENV PATH /opt/venv/bin:$PATH
 ENV PATH /go/bin:$PATH
@@ -49,6 +52,10 @@ WORKDIR /app
 RUN npm install --save-dev tsconfig-paths 
 
 {{ end -}}
+
+COPY --from=golang-image /go/bin/tsent /go/bin/tsent
+COPY --from=python-image /opt/venv /opt/venv
+COPY --from=golang-image /go/pkg/mod/github.com/lolopinto/ent@$GOLANG_VERSION /go/pkg/mod/github.com/lolopinto/ent@$GOLANG_VERSION
 
 CMD ["node"]
 

--- a/ts/Dockerfile.tmpl
+++ b/ts/Dockerfile.tmpl
@@ -34,7 +34,8 @@ LABEL org.opencontainers.image.source https://github.com/lolopinto/ent
 RUN \
   apt-get update && \
   # wget and gnupg are dependencies needed below
-  apt-get install -yqq wget gnupg && \
+  # libpq-dev for libpq
+  apt-get install -yqq wget gnupg libpq-dev && \
   echo "deb https://deb.nodesource.com/node_$NODE_VERSION.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \

--- a/ts/Dockerfile.tmpl
+++ b/ts/Dockerfile.tmpl
@@ -1,5 +1,6 @@
 ARG GOLANG_VERSION={{.TsentVersion}}
 ARG AUTO_SCHEMA_VERSION={{.AutoSchemaVersion}}
+ARG NODE_VERSION={{.NodeVersion}}
 
 # get and install tsent
 FROM golang:1.16.5-buster AS golang-image
@@ -20,6 +21,8 @@ RUN python3 -m pip install auto_schema==$AUTO_SCHEMA_VERSION
 
 # final image needs to be python-based to have auto-schema work
 FROM python:3.8.11-slim AS final-image
+ARG GOLANG_VERSION
+ARG NODE_VERSION
 
 ENV PATH /opt/venv/bin:$PATH
 ENV PATH /go/bin:$PATH
@@ -32,7 +35,7 @@ RUN \
   apt-get update && \
   # wget and gnupg are dependencies needed below
   apt-get install -yqq wget gnupg && \
-  echo "deb https://deb.nodesource.com/node_{{.NodeVersion}}.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_$NODE_VERSION.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/ts/RELEASING.MD
+++ b/ts/RELEASING.MD
@@ -6,7 +6,7 @@ To update the Docker image, following steps are needed:
 
 * Update `TAG` const in  `release_image/main.go` by bumping e.g. from `0.0.17` to `0.0.18` 
 * Update `AUTO_SCHEMA_VERSION` in `release_image/main.go` const for new `auto_schema` version or `TSENT_VERSION` const for new golang `tsent` release version
-* Also update `Dockerfile` so that Dockerfile is up to date.
+* Also update `GOLANG_VERSION`, or `AUTO_SCHEMA_VERSION` or `NODE_VERSION` args at the top of `Dockerfile` so that is up to date.
 
 To update locally, we're high level following [these steps](https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/pushing-and-pulling-docker-images#authenticating-to-github-container-registry):
 
@@ -19,6 +19,6 @@ We use [buildx](https://docs.docker.com/buildx/working-with-buildx/#build-multi-
 
 If just testing, don't use `latest` tag above.
 
-Currently, can't get the multi-arch image to be built on an M1 mac so needs to be built on an intel mac. 
+Currently, can't get the multi-arch image to be built on an M1 mac so needs to be built on an intel mac.
 
-PS: To figure out what the new version/tag should be, current version can be found at https://github.com/users/lolopinto/packages/container/package/ent.
+PS: To figure out what the new version/tag should be, current version can be found [here](https://github.com/users/lolopinto/packages/container/package/ent).

--- a/ts/RELEASING.MD
+++ b/ts/RELEASING.MD
@@ -4,8 +4,8 @@ We use a Github Action to release a new docker image anytime anything relevant c
 
 To update the Docker image, following steps are needed:
 
-* update `ts/Dockerfile.tmpl`for new `auto_schema` version or golang `tsent` release version
 * Update `TAG` const in  `release_image/main.go` by bumping e.g. from `0.0.17` to `0.0.18` 
+* Update `AUTO_SCHEMA_VERSION` in `release_image/main.go` const for new `auto_schema` version or `TSENT_VERSION` const for new golang `tsent` release version
 * Also update `Dockerfile` so that Dockerfile is up to date.
 
 To update locally, we're high level following [these steps](https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/pushing-and-pulling-docker-images#authenticating-to-github-container-registry):


### PR DESCRIPTION
* use multi-stage builds and remove cruft we don't need

there's now 6 images per release:
* node 14 dev (has dependencies for codegen e.g. prettier, tsconfig-paths, typescript, /bin/zsh for better shell)
* node 14 slim (without the above, we still have tsent and auto_schema for database upgrades)
* node 15 dev
* node 15 slim
* node 16 dev
* node 16 slim

if tsent and auto_schema aren't needed, nodejs images from docker can be used directly

add caching to github action by outputting to registry 

libpq-dev needed for https://www.psycopg.org/docs/install.html

here's what sizes look like now:

```
% docker image ls | grep ghcr.io/lolopinto/ent  | grep -v "<none>"
ghcr.io/lolopinto/ent                                             0.0.20-nodejs-16-slim        a138f0ac48cf   About an hour ago   308MB
ghcr.io/lolopinto/ent                                             0.0.20-nodejs-16-dev         630c2bb2f8e3   2 hours ago         431MB
ghcr.io/lolopinto/ent                                             0.0.19-nodejs-16             17838dda3004   2 weeks ago         1.87GB
```

can still make them even smaller but this will do for now