### PR TITLE
move parsing custom graphql data into preprocess step.

### DIFF
--- a/gent/cmd/codegen.go
+++ b/gent/cmd/codegen.go
@@ -51,7 +51,7 @@ func parseSchemasAndGenerate(codePathInfo *codegen.CodePath, specificConfig, ste
 		return nil
 	}
 
-	processor := &codegen.CodegenProcessor{
+	processor := &codegen.Processor{
 		Schema:   schema,
 		CodePath: codePathInfo,
 	}

--- a/internal/code/codegen_plugin.go
+++ b/internal/code/codegen_plugin.go
@@ -30,7 +30,7 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 			}
 
 			for _, action := range nodeData.ActionInfo.Actions {
-				if err := writeActionFile(nodeData, action, data.CodePath); err != nil {
+				if err := writeActionFile(nodeData, action, processor.CodePath); err != nil {
 					return err
 				}
 			}

--- a/internal/code/codegen_plugin.go
+++ b/internal/code/codegen_plugin.go
@@ -11,21 +11,21 @@ func (s *Step) Name() string {
 	return "codegen"
 }
 
-func (s *Step) ProcessData(data *codegen.CodegenProcessor) error {
-	for _, info := range data.Schema.Nodes {
+func (s *Step) ProcessData(processor *codegen.Processor) error {
+	for _, info := range processor.Schema.Nodes {
 		if !info.ShouldCodegen {
 			continue
 		}
 		nodeData := info.NodeData
 		//fmt.Println(specificConfig, structName)
 		if len(nodeData.PackageName) > 0 {
-			if err := writeModelFile(nodeData, data.CodePath); err != nil {
+			if err := writeModelFile(nodeData, processor.CodePath); err != nil {
 				return err
 			}
 			if err := writePrivacyFile(nodeData); err != nil {
 				return err
 			}
-			if err := writeMutationBuilderFile(nodeData, data.CodePath); err != nil {
+			if err := writeMutationBuilderFile(nodeData, processor.CodePath); err != nil {
 				return err
 			}
 

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -9,8 +9,6 @@ import (
 )
 
 // Processor stores the parsed data needed for codegen
-// this needs a new name
-// Processor?
 type Processor struct {
 	Schema   *schema.Schema
 	CodePath *CodePath

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -6,10 +6,10 @@ import (
 	"github.com/lolopinto/ent/internal/schema"
 )
 
-// CodegenProcessor stores the parsed data needed for codegen
+// Processor stores the parsed data needed for codegen
 // this needs a new name
-// CodegenProcessor?
-type CodegenProcessor struct {
+// Processor?
+type Processor struct {
 	Schema   *schema.Schema
 	CodePath *CodePath
 }
@@ -26,7 +26,7 @@ func DisablePrompts() Option {
 	}
 }
 
-func (cp *CodegenProcessor) Run(steps []Step, step string, options ...Option) error {
+func (cp *Processor) Run(steps []Step, step string, options ...Option) error {
 	opt := &option{}
 	for _, o := range options {
 		o(opt)
@@ -82,23 +82,23 @@ func (cp *CodegenProcessor) Run(steps []Step, step string, options ...Option) er
 // e.g. db/ graphql/code etc
 type Step interface {
 	Name() string
-	ProcessData(data *CodegenProcessor) error
+	ProcessData(data *Processor) error
 }
 
 type StepWithPreProcess interface {
 	Step
 	// any pre-process steps can be done here
 	// this is where things like user input and other
-	PreProcessData(data *CodegenProcessor) error
+	PreProcessData(data *Processor) error
 }
 
-func NewCodegenProcessor(schema *schema.Schema, configPath, modulePath string) (*CodegenProcessor, error) {
+func NewCodegenProcessor(schema *schema.Schema, configPath, modulePath string) (*Processor, error) {
 	codePathInfo, err := NewCodePath(configPath, modulePath)
 	if err != nil {
 		return nil, err
 	}
 
-	data := &CodegenProcessor{
+	data := &Processor{
 		Schema:   schema,
 		CodePath: codePathInfo,
 	}

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -31,15 +31,15 @@ func (s *Step) Name() string {
 	return "db"
 }
 
-func (s *Step) PreProcessData(data *codegen.CodegenProcessor) error {
+func (s *Step) PreProcessData(processor *codegen.Processor) error {
 	// generate python schema file and then make changes to underlying db
-	db := newDBSchema(data.Schema, data.CodePath.GetRootPathToConfigs())
+	db := newDBSchema(processor.Schema, processor.CodePath.GetRootPathToConfigs())
 	s.db = db
 
 	return db.processSchema()
 }
 
-func (s *Step) ProcessData(data *codegen.CodegenProcessor) error {
+func (s *Step) ProcessData(processor *codegen.Processor) error {
 	if s.db == nil {
 		return errors.New("weirdness. dbSchema is nil when it shouldn't be")
 	}

--- a/internal/graphql/custom_functions_test.go
+++ b/internal/graphql/custom_functions_test.go
@@ -615,7 +615,7 @@ func parse(t *testing.T, code, dirPath, packagePath string, nodes []string) {
 		"github.com/lolopinto/ent/internal/graphql/"+basePath+"/graphql",
 	)
 	require.Nil(t, err)
-	s := newGraphQLSchema(&codegen.CodegenProcessor{
+	s := newGraphQLSchema(&codegen.Processor{
 		CodePath: codepath,
 		Schema:   &schema.Schema{},
 	})

--- a/internal/graphql/custom_ts_test.go
+++ b/internal/graphql/custom_ts_test.go
@@ -46,7 +46,7 @@ func TestCustomMutation(t *testing.T) {
 	require.NoError(t, err)
 
 	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
-	data := &codegen.CodegenProcessor{
+	data := &codegen.Processor{
 		Schema:   schema,
 		CodePath: getCodePath(t, dirPath),
 	}
@@ -193,7 +193,7 @@ func TestCustomQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
-	data := &codegen.CodegenProcessor{
+	data := &codegen.Processor{
 		Schema:   schema,
 		CodePath: getCodePath(t, dirPath),
 	}
@@ -325,7 +325,7 @@ func TestCustomListQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
-	data := &codegen.CodegenProcessor{
+	data := &codegen.Processor{
 		Schema:   schema,
 		CodePath: getCodePath(t, dirPath),
 	}
@@ -506,7 +506,7 @@ func TestCustomQueryReferencesExistingObject(t *testing.T) {
 	require.NoError(t, err)
 
 	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
-	data := &codegen.CodegenProcessor{
+	data := &codegen.Processor{
 		Schema:   schema,
 		CodePath: getCodePath(t, dirPath),
 	}
@@ -635,7 +635,7 @@ func TestCustomUploadType(t *testing.T) {
 	require.NoError(t, err)
 
 	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
-	data := &codegen.CodegenProcessor{
+	data := &codegen.Processor{
 		Schema:   schema,
 		CodePath: getCodePath(t, dirPath),
 	}

--- a/internal/graphql/ent_graphql_server_plugin.go
+++ b/internal/graphql/ent_graphql_server_plugin.go
@@ -55,7 +55,7 @@ type ServerBuild struct {
 	ResolverPackageName string
 }
 
-func newGraphQLServerPlugin(data *intcodegen.CodegenProcessor) plugin.Plugin {
+func newGraphQLServerPlugin(data *intcodegen.Processor) plugin.Plugin {
 	return &entGraphQLServerPlugin{
 		codePath: data.CodePath,
 	}

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -69,10 +69,10 @@ type CustomField struct {
 // 	customField
 // }
 
-// func (f *CustomField) UnmarshalJSON(processor []byte) error {
+// func (f *CustomField) UnmarshalJSON(data []byte) error {
 // 	var cf *customField
 
-// 	err := json.Unmarshal(processor, &cf)
+// 	err := json.Unmarshal(data, &cf)
 // 	if err != nil {
 // 		return err
 // 	}
@@ -424,9 +424,9 @@ func (p *TSStep) PreProcessData(processor *codegen.Processor) error {
 
 func (p *TSStep) ProcessData(processor *codegen.Processor) error {
 	// these all need to be done after
-	// 1a/ build processor (actions and nodes)
+	// 1a/ build data (actions and nodes)
 	// 1b/ parse custom files
-	// 2/ inject any custom processor in there
+	// 2/ inject any custom data in there
 	// 3/ write node files first then action files since there's a dependency...
 	// 4/ write query/mutation/schema file
 	// schema file depends on query/mutation so not quite worth the complication of breaking those 2 up

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -68,10 +68,10 @@ type CustomField struct {
 // 	customField
 // }
 
-// func (f *CustomField) UnmarshalJSON(data []byte) error {
+// func (f *CustomField) UnmarshalJSON(processor []byte) error {
 // 	var cf *customField
 
-// 	err := json.Unmarshal(data, &cf)
+// 	err := json.Unmarshal(processor, &cf)
 // 	if err != nil {
 // 		return err
 // 	}
@@ -243,12 +243,12 @@ const NullableContentsAndList NullableItem = "contentsAndList"
 const NullableTrue NullableItem = "true"
 
 type step interface {
-	process(data *codegen.CodegenProcessor, s *gqlSchema) error
+	process(processor *codegen.Processor, s *gqlSchema) error
 }
 
 type writeGraphQLTypesStep struct{}
 
-func (st writeGraphQLTypesStep) process(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func (st writeGraphQLTypesStep) process(processor *codegen.Processor, s *gqlSchema) error {
 	var wg sync.WaitGroup
 	var serr syncerr.Error
 
@@ -295,7 +295,7 @@ func (st writeGraphQLTypesStep) process(data *codegen.CodegenProcessor, s *gqlSc
 					go func(idx int) {
 						defer wg2.Done()
 						conn := node.connections[idx]
-						if err := writeConnectionFile(data, s, conn); err != nil {
+						if err := writeConnectionFile(processor, s, conn); err != nil {
 							serr.Append((err))
 						}
 					}(idx)
@@ -332,7 +332,7 @@ func (st writeGraphQLTypesStep) process(data *codegen.CodegenProcessor, s *gqlSc
 					go func(idx int) {
 						defer wg2.Done()
 						conn := node.connections[idx]
-						if err := writeConnectionFile(data, s, conn); err != nil {
+						if err := writeConnectionFile(processor, s, conn); err != nil {
 							serr.Append((err))
 						}
 					}(idx)
@@ -349,30 +349,30 @@ func (st writeGraphQLTypesStep) process(data *codegen.CodegenProcessor, s *gqlSc
 
 type writeQueryStep struct{}
 
-func (st writeQueryStep) process(data *codegen.CodegenProcessor, s *gqlSchema) error {
-	return writeQueryFile(data, s)
+func (st writeQueryStep) process(processor *codegen.Processor, s *gqlSchema) error {
+	return writeQueryFile(processor, s)
 }
 
 type writeMutationStep struct{}
 
-func (st writeMutationStep) process(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func (st writeMutationStep) process(processor *codegen.Processor, s *gqlSchema) error {
 	if s.hasMutations {
-		return writeMutationFile(data, s)
+		return writeMutationFile(processor, s)
 	}
 	return nil
 }
 
 type writeNodeQueryStep struct{}
 
-func (st writeNodeQueryStep) process(data *codegen.CodegenProcessor, s *gqlSchema) error {
-	return writeNodeQueryFile(data, s)
+func (st writeNodeQueryStep) process(processor *codegen.Processor, s *gqlSchema) error {
+	return writeNodeQueryFile(processor, s)
 }
 
 type writeInternalIndexStep struct {
 }
 
-func (st writeInternalIndexStep) process(data *codegen.CodegenProcessor, s *gqlSchema) error {
-	if err := writeInternalGQLResolversFile(s, data.CodePath); err != nil {
+func (st writeInternalIndexStep) process(processor *codegen.Processor, s *gqlSchema) error {
+	if err := writeInternalGQLResolversFile(s, processor.CodePath); err != nil {
 		return err
 	}
 	return writeGQLResolversIndexFile()
@@ -380,47 +380,47 @@ func (st writeInternalIndexStep) process(data *codegen.CodegenProcessor, s *gqlS
 
 type generateGQLSchemaStep struct{}
 
-func (st generateGQLSchemaStep) process(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func (st generateGQLSchemaStep) process(processor *codegen.Processor, s *gqlSchema) error {
 	return generateSchemaFile(s.hasMutations)
 }
 
 type writeSchemaStep struct{}
 
-func (st writeSchemaStep) process(data *codegen.CodegenProcessor, s *gqlSchema) error {
-	return writeTSSchemaFile(data, s)
+func (st writeSchemaStep) process(processor *codegen.Processor, s *gqlSchema) error {
+	return writeTSSchemaFile(processor, s)
 }
 
 type writeIndexStep struct{}
 
-func (st writeIndexStep) process(data *codegen.CodegenProcessor, s *gqlSchema) error {
-	return writeTSIndexFile(data, s)
+func (st writeIndexStep) process(processor *codegen.Processor, s *gqlSchema) error {
+	return writeTSIndexFile(processor, s)
 }
 
-func buildSchema(data *codegen.CodegenProcessor, fromTest bool) (*gqlSchema, error) {
-	cd, s := <-parseCustomData(data, fromTest), <-buildGQLSchema(data)
+func buildSchema(processor *codegen.Processor, fromTest bool) (*gqlSchema, error) {
+	cd, s := <-parseCustomData(processor, fromTest), <-buildGQLSchema(processor)
 	if cd.Error != nil {
 		return nil, cd.Error
 	}
 	// put this here after the fact
 	s.customData = cd
 
-	if err := processCustomData(data, s); err != nil {
+	if err := processCustomData(processor, s); err != nil {
 		return nil, err
 	}
 
 	return s, nil
 }
 
-func (p *TSStep) ProcessData(data *codegen.CodegenProcessor) error {
+func (p *TSStep) ProcessData(processor *codegen.Processor) error {
 	// these all need to be done after
-	// 1a/ build data (actions and nodes)
+	// 1a/ build processor (actions and nodes)
 	// 1b/ parse custom files
-	// 2/ inject any custom data in there
+	// 2/ inject any custom processor in there
 	// 3/ write node files first then action files since there's a dependency...
 	// 4/ write query/mutation/schema file
 	// schema file depends on query/mutation so not quite worth the complication of breaking those 2 up
 
-	s, err := buildSchema(data, false)
+	s, err := buildSchema(processor, false)
 	if err != nil {
 		return err
 	}
@@ -437,7 +437,7 @@ func (p *TSStep) ProcessData(data *codegen.CodegenProcessor) error {
 	}
 
 	for _, st := range steps {
-		if err := st.process(data, s); err != nil {
+		if err := st.process(processor, s); err != nil {
 			return err
 		}
 	}
@@ -487,7 +487,7 @@ func getTSIndexFilePath() string {
 }
 
 func getTempSchemaFilePath() string {
-	return fmt.Sprintf("src/graphql/gen_schema.ts")
+	return "src/graphql/gen_schema.ts"
 }
 
 func getSchemaFilePath() string {
@@ -519,7 +519,7 @@ func getFilePathForCustomQuery(name string) string {
 	return fmt.Sprintf("src/graphql/resolvers/generated/%s_query_type.ts", strcase.ToSnake(name))
 }
 
-func parseCustomData(data *codegen.CodegenProcessor, fromTest bool) chan *customData {
+func parseCustomData(processor *codegen.Processor, fromTest bool) chan *customData {
 	var res = make(chan *customData)
 	go func() {
 		var cd customData
@@ -527,8 +527,8 @@ func parseCustomData(data *codegen.CodegenProcessor, fromTest bool) chan *custom
 
 		var buf bytes.Buffer
 		var out bytes.Buffer
-		for key := range data.Schema.Nodes {
-			info := data.Schema.Nodes[key]
+		for key := range processor.Schema.Nodes {
+			info := processor.Schema.Nodes[key]
 			nodeData := info.NodeData
 
 			buf.WriteString(nodeData.Node)
@@ -557,15 +557,15 @@ func parseCustomData(data *codegen.CodegenProcessor, fromTest bool) chan *custom
 				testingutils.DefaultCompilerOptions(),
 				scriptPath,
 				"--path",
-				filepath.Join(data.CodePath.GetAbsPathToRoot(), "src"),
+				filepath.Join(processor.CodePath.GetAbsPathToRoot(), "src"),
 			}
 		} else {
 			cmdArgs = append(
-				cmd.GetArgsForScript(data.CodePath.GetAbsPathToRoot()),
+				cmd.GetArgsForScript(processor.CodePath.GetAbsPathToRoot()),
 				scriptPath,
 				"--path",
 				// TODO this should be a configuration option to indicate where the code root is
-				filepath.Join(data.CodePath.GetAbsPathToRoot(), "src"),
+				filepath.Join(processor.CodePath.GetAbsPathToRoot(), "src"),
 			)
 			cmdName = "ts-node-script"
 		}
@@ -588,7 +588,7 @@ func parseCustomData(data *codegen.CodegenProcessor, fromTest bool) chan *custom
 
 		if err := json.Unmarshal(out.Bytes(), &cd); err != nil {
 			spew.Dump((out.Bytes()))
-			err = errors.Wrap(err, "error unmarshalling custom data")
+			err = errors.Wrap(err, "error unmarshalling custom processor")
 			cd.Error = err
 		}
 		res <- &cd
@@ -596,22 +596,22 @@ func parseCustomData(data *codegen.CodegenProcessor, fromTest bool) chan *custom
 	return res
 }
 
-func processCustomData(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func processCustomData(processor *codegen.Processor, s *gqlSchema) error {
 	cd := s.customData
 	// TODO remove this
 	if len(cd.Args) > 0 {
 		return errors.New("TOOD: need to process args. doesn't work at the moment")
 	}
 
-	if err := processCustomFields(data, cd, s); err != nil {
+	if err := processCustomFields(processor, cd, s); err != nil {
 		return err
 	}
 
-	if err := processCustomMutations(data, cd, s); err != nil {
+	if err := processCustomMutations(processor, cd, s); err != nil {
 		return err
 	}
 
-	if err := processCustomQueries(data, cd, s); err != nil {
+	if err := processCustomQueries(processor, cd, s); err != nil {
 		return err
 	}
 
@@ -630,7 +630,7 @@ type gqlobjectData struct {
 	Package      *codegen.ImportPackage
 }
 
-func (obj gqlobjectData) DefaultImports() []*fileImport {
+func (obj *gqlobjectData) DefaultImports() []*fileImport {
 	var result []*fileImport
 	for _, node := range obj.GQLNodes {
 		result = append(result, node.DefaultImports...)
@@ -638,7 +638,7 @@ func (obj gqlobjectData) DefaultImports() []*fileImport {
 	return result
 }
 
-func (obj gqlobjectData) Imports() []*fileImport {
+func (obj *gqlobjectData) Imports() []*fileImport {
 	var result []*fileImport
 	for _, node := range obj.GQLNodes {
 		result = append(result, node.Imports...)
@@ -657,7 +657,7 @@ func (obj gqlobjectData) Imports() []*fileImport {
 	return result
 }
 
-func (obj gqlobjectData) TSInterfaces() []*interfaceType {
+func (obj *gqlobjectData) TSInterfaces() []*interfaceType {
 	var result []*interfaceType
 	for _, node := range obj.GQLNodes {
 		result = append(result, node.TSInterfaces...)
@@ -665,7 +665,7 @@ func (obj gqlobjectData) TSInterfaces() []*interfaceType {
 	return result
 }
 
-func (obj gqlobjectData) ForeignImport(name string) bool {
+func (obj *gqlobjectData) ForeignImport(name string) bool {
 	if !obj.initMap {
 		obj.m = make(map[string]bool)
 
@@ -779,7 +779,7 @@ type gqlConnection struct {
 	Package  *codegen.ImportPackage
 }
 
-func getGqlConnection(packageName string, edge edge.ConnectionEdge, data *codegen.CodegenProcessor) *gqlConnection {
+func getGqlConnection(packageName string, edge edge.ConnectionEdge, processor *codegen.Processor) *gqlConnection {
 	nodeType := fmt.Sprintf("%sType", edge.GetNodeInfo().Node)
 
 	var edgeImpPath string
@@ -803,11 +803,11 @@ func getGqlConnection(packageName string, edge edge.ConnectionEdge, data *codege
 				Type:       edge.TsEdgeQueryEdgeName(),
 			},
 		},
-		Package: data.CodePath.GetImportPackage(),
+		Package: processor.CodePath.GetImportPackage(),
 	}
 }
 
-func buildGQLSchema(data *codegen.CodegenProcessor) chan *gqlSchema {
+func buildGQLSchema(processor *codegen.Processor) chan *gqlSchema {
 	var result = make(chan *gqlSchema)
 	go func() {
 		var hasMutations bool
@@ -816,14 +816,14 @@ func buildGQLSchema(data *codegen.CodegenProcessor) chan *gqlSchema {
 		edgeNames := make(map[string]bool)
 		var wg sync.WaitGroup
 		var m sync.Mutex
-		wg.Add(len(data.Schema.Nodes))
-		wg.Add(len(data.Schema.Enums))
+		wg.Add(len(processor.Schema.Nodes))
+		wg.Add(len(processor.Schema.Enums))
 
-		for key := range data.Schema.Enums {
+		for key := range processor.Schema.Enums {
 			go func(key string) {
 				defer wg.Done()
 
-				enumType := data.Schema.Enums[key].GQLEnum
+				enumType := processor.Schema.Enums[key].GQLEnum
 
 				m.Lock()
 				defer m.Unlock()
@@ -836,12 +836,12 @@ func buildGQLSchema(data *codegen.CodegenProcessor) chan *gqlSchema {
 				}
 			}(key)
 		}
-		nodeMap := data.Schema.Nodes
-		for key := range data.Schema.Nodes {
+		nodeMap := processor.Schema.Nodes
+		for key := range processor.Schema.Nodes {
 			go func(key string) {
 				defer wg.Done()
 
-				info := data.Schema.Nodes[key]
+				info := processor.Schema.Nodes[key]
 				nodeData := info.NodeData
 
 				// nothing to do here
@@ -855,7 +855,7 @@ func buildGQLSchema(data *codegen.CodegenProcessor) chan *gqlSchema {
 						Node:         nodeData.Node,
 						NodeInstance: nodeData.NodeInstance,
 						GQLNodes:     []*objectType{buildNodeForObject(nodeMap, nodeData)},
-						Package:      data.CodePath.GetImportPackage(),
+						Package:      processor.CodePath.GetImportPackage(),
 					},
 					FilePath: getFilePathForNode(nodeData),
 				}
@@ -881,7 +881,7 @@ func buildGQLSchema(data *codegen.CodegenProcessor) chan *gqlSchema {
 								GQLNodes:     buildActionNodes(nodeData, action, actionPrefix),
 								Enums:        buildActionEnums(nodeData, action),
 								FieldConfig:  fieldCfg,
-								Package:      data.CodePath.GetImportPackage(),
+								Package:      processor.CodePath.GetImportPackage(),
 							},
 							FilePath: getFilePathForAction(nodeData, action),
 						}
@@ -895,7 +895,7 @@ func buildGQLSchema(data *codegen.CodegenProcessor) chan *gqlSchema {
 						if nodeMap.HideFromGraphQL(edge) {
 							continue
 						}
-						conn := getGqlConnection(nodeData.PackageName, edge, data)
+						conn := getGqlConnection(nodeData.PackageName, edge, processor)
 						obj.connections = append(obj.connections, conn)
 					}
 				}
@@ -1143,7 +1143,7 @@ func (n *connectionBaseObj) ForeignImport(name string) bool {
 	return true
 }
 
-func writeConnectionFile(data *codegen.CodegenProcessor, s *gqlSchema, conn *gqlConnection) error {
+func writeConnectionFile(processor *codegen.Processor, s *gqlSchema, conn *gqlConnection) error {
 	imps := tsimport.NewImports()
 	return file.Write((&file.TemplatedBasedFileWriter{
 		Data: struct {
@@ -1155,7 +1155,7 @@ func writeConnectionFile(data *codegen.CodegenProcessor, s *gqlSchema, conn *gql
 			conn,
 			s.customEdges[conn.Edge.TsEdgeQueryEdgeName()],
 			&connectionBaseObj{},
-			data.CodePath.GetImportPackage(),
+			processor.CodePath.GetImportPackage(),
 		},
 		CreateDirIfNeeded: true,
 		AbsPathToTemplate: util.GetAbsolutePath("ts_templates/connection.tmpl"),
@@ -2107,7 +2107,7 @@ type gqlRootData struct {
 	Node       string
 }
 
-func getQueryData(data *codegen.CodegenProcessor, s *gqlSchema) []rootField {
+func getQueryData(processor *codegen.Processor, s *gqlSchema) []rootField {
 	// add node query
 	results := []rootField{
 		{
@@ -2136,11 +2136,11 @@ func getQueryData(data *codegen.CodegenProcessor, s *gqlSchema) []rootField {
 	return results
 }
 
-func getMutationData(data *codegen.CodegenProcessor, s *gqlSchema) []rootField {
+func getMutationData(processor *codegen.Processor, s *gqlSchema) []rootField {
 	var results []rootField
-	for key := range data.Schema.Nodes {
+	for key := range processor.Schema.Nodes {
 
-		nodeData := data.Schema.Nodes[key].NodeData
+		nodeData := processor.Schema.Nodes[key].NodeData
 		if nodeData.HideFromGraphQL {
 			continue
 		}
@@ -2176,11 +2176,11 @@ func getMutationData(data *codegen.CodegenProcessor, s *gqlSchema) []rootField {
 	return results
 }
 
-func writeQueryFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func writeQueryFile(processor *codegen.Processor, s *gqlSchema) error {
 	imps := tsimport.NewImports()
 	return file.Write((&file.TemplatedBasedFileWriter{
 		Data: gqlRootData{
-			RootFields: getQueryData(data, s),
+			RootFields: getQueryData(processor, s),
 			Type:       "QueryType",
 			Node:       "Query",
 		},
@@ -2194,11 +2194,11 @@ func writeQueryFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
 	}))
 }
 
-func writeMutationFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func writeMutationFile(processor *codegen.Processor, s *gqlSchema) error {
 	imps := tsimport.NewImports()
 	return file.Write((&file.TemplatedBasedFileWriter{
 		Data: gqlRootData{
-			RootFields: getMutationData(data, s),
+			RootFields: getMutationData(processor, s),
 			Type:       "MutationType",
 			Node:       "Mutation",
 		},
@@ -2212,7 +2212,7 @@ func writeMutationFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
 	}))
 }
 
-func buildNodeFieldConfig(data *codegen.CodegenProcessor, s *gqlSchema) *fieldConfig {
+func buildNodeFieldConfig(processsor *codegen.Processor, s *gqlSchema) *fieldConfig {
 	return &fieldConfig{
 		Exported: true,
 		Name:     "NodeQueryType",
@@ -2247,7 +2247,7 @@ func (n *nodeBaseObj) ForeignImport(name string) bool {
 	return true
 }
 
-func writeNodeQueryFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func writeNodeQueryFile(processor *codegen.Processor, s *gqlSchema) error {
 	imps := tsimport.NewImports()
 	return file.Write(&file.TemplatedBasedFileWriter{
 		Data: struct {
@@ -2255,9 +2255,9 @@ func writeNodeQueryFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
 			BaseObj     *nodeBaseObj
 			Package     *codegen.ImportPackage
 		}{
-			buildNodeFieldConfig(data, s),
+			buildNodeFieldConfig(processor, s),
 			&nodeBaseObj{},
-			data.CodePath.GetImportPackage(),
+			processor.CodePath.GetImportPackage(),
 		},
 		CreateDirIfNeeded: true,
 		AbsPathToTemplate: util.GetAbsolutePath("ts_templates/node.tmpl"),
@@ -2275,7 +2275,7 @@ func writeNodeQueryFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
 	}, file.WriteOnce())
 }
 
-func writeTSSchemaFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func writeTSSchemaFile(processor *codegen.Processor, s *gqlSchema) error {
 	imps := tsimport.NewImports()
 	return file.Write((&file.TemplatedBasedFileWriter{
 		Data: struct {
@@ -2300,7 +2300,7 @@ func writeTSSchemaFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
 	}))
 }
 
-func writeTSIndexFile(data *codegen.CodegenProcessor, s *gqlSchema) error {
+func writeTSIndexFile(processor *codegen.Processor, s *gqlSchema) error {
 	imps := tsimport.NewImports()
 	return file.Write((&file.TemplatedBasedFileWriter{
 		Data: struct {

--- a/internal/graphql/graphql_schema.go
+++ b/internal/graphql/graphql_schema.go
@@ -50,8 +50,8 @@ var sortedGQLlSteps = []gqlStep{
 	"generate_code",
 }
 
-func (p *Step) ProcessData(data *codegen.CodegenProcessor) error {
-	graphql := newGraphQLSchema(data)
+func (p *Step) ProcessData(processor *codegen.Processor) error {
+	graphql := newGraphQLSchema(processor)
 	graphql.generateSchema()
 
 	// right now it all panics but we have to change that lol
@@ -63,7 +63,7 @@ var _ codegen.Step = &Step{}
 var defaultGraphQLFolder = "graphql"
 
 type graphQLSchema struct {
-	config                *codegen.CodegenProcessor
+	config                *codegen.Processor
 	Types                 map[string]*graphQLSchemaInfo
 	sortedTypes           []*graphQLSchemaInfo
 	pathsToGraphQLObjects map[string]string
@@ -84,7 +84,7 @@ type graphQLSchema struct {
 	disableServerGO bool
 }
 
-func newGraphQLSchema(data *codegen.CodegenProcessor) *graphQLSchema {
+func newGraphQLSchema(processor *codegen.Processor) *graphQLSchema {
 	types := make(map[string]*graphQLSchemaInfo)
 	// TODO this is initially going to be just the ents but will eventually be used for
 	// config.TypeMapEntry in buildYmlConfig as it gets more complicated and we add other objects
@@ -93,7 +93,7 @@ func newGraphQLSchema(data *codegen.CodegenProcessor) *graphQLSchema {
 	mutationCustomImpls := make(map[string]*customFunction)
 
 	schema := &graphQLSchema{
-		config:                data,
+		config:                processor,
 		Types:                 types,
 		pathsToGraphQLObjects: pathsToGraphQLObjects,
 		mutationCustomImpls:   mutationCustomImpls,
@@ -101,12 +101,12 @@ func newGraphQLSchema(data *codegen.CodegenProcessor) *graphQLSchema {
 
 		// parsing custom ent code
 		customEntParser: &schemaparser.ConfigSchemaParser{
-			AbsRootPath: data.CodePath.GetAbsPathToModels(),
+			AbsRootPath: processor.CodePath.GetAbsPathToModels(),
 		},
 
 		// parsing top level functions
 		topLevelParser: &schemaparser.ConfigSchemaParser{
-			AbsRootPath: data.CodePath.GetAbsPathToGraphQL() + "...",
+			AbsRootPath: processor.CodePath.GetAbsPathToGraphQL() + "...",
 			// for default generated files, don't parse them and treat them as basically empty files
 			// errors in there shouldn't affect this process since if everything succeeds now, we are fine
 			FilesToIgnore: defaultGraphQLFiles,

--- a/internal/graphql/graphql_schema_test.go
+++ b/internal/graphql/graphql_schema_test.go
@@ -110,7 +110,7 @@ type TodoConfig struct {
 	}
 	`
 
-	s := newGraphQLSchema(&codegen.CodegenProcessor{
+	s := newGraphQLSchema(&codegen.Processor{
 		Schema: parseSchema(t, sources, "GraphQLOtherIDWithNoEdge"),
 		// TODO fix this. shouldn't need to be manual...
 		CodePath: getCodePath(t, "../testdata/models/configs"),
@@ -141,7 +141,7 @@ type HiddenObjConfig struct {
 	}
 	`
 
-	s := newGraphQLSchema(&codegen.CodegenProcessor{
+	s := newGraphQLSchema(&codegen.Processor{
 		Schema:   parseSchema(t, sources, "GraphQLHiddenObj"),
 		CodePath: getCodePath(t, ""),
 	})
@@ -268,7 +268,7 @@ func (account *Account) GetFoo(baz int) string {
 	return "foo"
 }`
 
-	s := newGraphQLSchema(&codegen.CodegenProcessor{
+	s := newGraphQLSchema(&codegen.Processor{
 		// don't need real values here since we're not testing this
 		// can do lazy schema for now since we're not testing the loaded schema path
 		// probably fragile and needs to change
@@ -454,7 +454,7 @@ func getTestGraphQLFieldFromTemplate(typeName, fieldName string, schema *graphQL
 }
 
 func getTestGraphQLSchema(t *testing.T) *graphQLSchema {
-	data := &codegen.CodegenProcessor{
+	data := &codegen.Processor{
 		Schema: getParsedTestSchema(t),
 		// TODO fix this. shouldn't need to be manual...
 		CodePath: getCodePath(t, "../testdata/models/configs"),

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -23,9 +23,9 @@ import (
 )
 
 type Step struct {
-	m        sync.Mutex
-	nodeType []enum.Data
-	edgeType []enum.Data
+	m         sync.Mutex
+	nodeTypes []enum.Data
+	edgeTypes []enum.Data
 }
 
 func (s *Step) Name() string {
@@ -159,15 +159,15 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 		return err
 	}
 	// sort data so that the enum is stable
-	sort.Slice(s.nodeType, func(i, j int) bool {
-		return s.nodeType[i].Name < s.nodeType[j].Name
+	sort.Slice(s.nodeTypes, func(i, j int) bool {
+		return s.nodeTypes[i].Name < s.nodeTypes[j].Name
 	})
-	sort.Slice(s.edgeType, func(i, j int) bool {
-		return s.edgeType[i].Name < s.edgeType[j].Name
+	sort.Slice(s.edgeTypes, func(i, j int) bool {
+		return s.edgeTypes[i].Name < s.edgeTypes[j].Name
 	})
 	funcs := []func() error{
 		func() error {
-			return writeConstFile(s.nodeType, s.edgeType)
+			return writeConstFile(s.nodeTypes, s.edgeTypes)
 		},
 		func() error {
 			return writeInternalEntFile(processor.Schema, processor.CodePath)
@@ -176,7 +176,7 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 			return writeEntIndexFile()
 		},
 		func() error {
-			return writeLoadAnyFile(s.nodeType, processor.CodePath)
+			return writeLoadAnyFile(s.nodeTypes, processor.CodePath)
 		},
 	}
 
@@ -191,7 +191,7 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 func (s *Step) addNodeType(name, value, comment string, nodeData *schema.NodeData) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	s.nodeType = append(s.nodeType, enum.Data{
+	s.nodeTypes = append(s.nodeTypes, enum.Data{
 		Name:    name,
 		Value:   value,
 		Comment: comment,
@@ -201,7 +201,7 @@ func (s *Step) addNodeType(name, value, comment string, nodeData *schema.NodeDat
 func (s *Step) addEdgeType(name, value, comment string) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	s.edgeType = append(s.edgeType, enum.Data{
+	s.edgeTypes = append(s.edgeTypes, enum.Data{
 		Name:    name,
 		Value:   value,
 		Comment: comment,
@@ -227,7 +227,6 @@ func (s *Step) accumulateConsts(nodeData *schema.NodeData) error {
 				comment := strings.ReplaceAll(constant.Comment, constant.ConstName, match[1])
 
 				s.addNodeType(match[1], constant.ConstValue, comment, nodeData)
-				break
 
 			case "EdgeType":
 				constName, err := edge.TsEdgeConst(constant.ConstName)
@@ -237,7 +236,6 @@ func (s *Step) accumulateConsts(nodeData *schema.NodeData) error {
 				comment := strings.ReplaceAll(constant.Comment, constant.ConstName, constName)
 
 				s.addEdgeType(constName, constant.ConstValue, comment)
-				break
 			}
 		}
 	}
@@ -319,11 +317,11 @@ func getImportPathForBaseQueryFile(packageName string) string {
 }
 
 func getFilePathForConstFile() string {
-	return fmt.Sprintf("src/ent/const.ts")
+	return "src/ent/const.ts"
 }
 
 func getFilePathForLoadAnyFile() string {
-	return fmt.Sprintf("src/ent/loadAny.ts")
+	return "src/ent/loadAny.ts"
 }
 
 func getFilePathForBuilderFile(nodeData *schema.NodeData) string {


### PR DESCRIPTION
probably faster and more importantly, we find any errors before we start making changes

plus  rename codegen.CodegenProcessor to Processor
    
looks better. still not clear this is the correct name

and parallelize pre-processing 

builds on top of https://github.com/lolopinto/ent/pull/410