### PR TITLE
add debug flag to log the files being changed

### DIFF
--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -4,15 +4,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/lolopinto/ent/internal/file"
 	"github.com/lolopinto/ent/internal/schema"
 	"github.com/lolopinto/ent/internal/syncerr"
 )
-
-// Processor stores the parsed data needed for codegen
-type Processor struct {
-	Schema   *schema.Schema
-	CodePath *CodePath
-}
 
 type option struct {
 	disablePrompts bool
@@ -24,6 +19,13 @@ func DisablePrompts() Option {
 	return func(opt *option) {
 		opt.disablePrompts = true
 	}
+}
+
+// Processor stores the parsed data needed for codegen
+type Processor struct {
+	Schema    *schema.Schema
+	CodePath  *CodePath
+	debugMode bool
 }
 
 func (cp *Processor) Run(steps []Step, step string, options ...Option) error {
@@ -110,16 +112,19 @@ type StepWithPreProcess interface {
 	PreProcessData(data *Processor) error
 }
 
-func NewCodegenProcessor(schema *schema.Schema, configPath, modulePath string) (*Processor, error) {
+func NewCodegenProcessor(schema *schema.Schema, configPath, modulePath string, debugMode bool) (*Processor, error) {
 	codePathInfo, err := NewCodePath(configPath, modulePath)
 	if err != nil {
 		return nil, err
 	}
 
 	data := &Processor{
-		Schema:   schema,
-		CodePath: codePathInfo,
+		Schema:    schema,
+		CodePath:  codePathInfo,
+		debugMode: debugMode,
 	}
 
+	// if in debug mode can log things
+	file.SetGlobalLogStatus(debugMode)
 	return data, nil
 }

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -43,6 +43,7 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 	if s.db == nil {
 		return errors.New("weirdness. dbSchema is nil when it shouldn't be")
 	}
+	fmt.Println("updating db...")
 	return s.db.makeDBChanges()
 }
 

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -435,6 +435,8 @@ func (p *TSStep) ProcessData(processor *codegen.Processor) error {
 		return errors.New("weirdness. graphqlSchema is nil when it shouldn't be")
 	}
 
+	fmt.Println("generating graphql code...")
+
 	steps := []step{
 		writeGraphQLTypesStep{},
 		writeNodeQueryStep{},

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -35,6 +35,7 @@ func (s *Step) Name() string {
 var nodeType = regexp.MustCompile(`(\w+)Type`)
 
 func (s *Step) ProcessData(processor *codegen.Processor) error {
+	fmt.Println("generating ent code...")
 	var wg sync.WaitGroup
 	wg.Add(len(processor.Schema.Nodes))
 	var serr syncerr.Error

--- a/tsent/cmd/codegen.go
+++ b/tsent/cmd/codegen.go
@@ -14,7 +14,8 @@ import (
 )
 
 type codegenArgs struct {
-	step string
+	step  string
+	debug bool
 }
 
 var codegenInfo codegenArgs
@@ -50,7 +51,7 @@ var codegenCmd = &cobra.Command{
 
 		// module path empty because not go
 		// same as ParseSchemaFromTSDir. default to schema. we want a flag here eventually
-		processor, err := codegen.NewCodegenProcessor(schema, "src/schema", "")
+		processor, err := codegen.NewCodegenProcessor(schema, "src/schema", "", codegenInfo.debug)
 		if err != nil {
 			return err
 		}

--- a/tsent/cmd/root.go
+++ b/tsent/cmd/root.go
@@ -24,6 +24,7 @@ func init() {
 	rootCmd.AddCommand(alembicCmd)
 
 	codegenCmd.Flags().StringVarP(&codegenInfo.step, "step", "s", "", "limit to only run a particular step e.g. db, graphql, codegen")
+	codegenCmd.Flags().BoolVar(&codegenInfo.debug, "debug", false, "debug mode. add debug information to codegen e.g. files written etc")
 }
 
 func Execute() {


### PR DESCRIPTION
and when the debug flag isn't passed (default behavior), we only log high level information as to what's happening

now that https://github.com/lolopinto/ent/pull/410 exists, we need what's being logged to be high level information so that if there's a prompt, it's not drowned in the sea of files being chnaged

over time, this will need to be updated but works fine for now.