### PR TITLE
update custom_compiler to always return something

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
now that we use

```ts
import type { RunResult, Database as SqliteDatabase } from "better-sqlite3";

``` 

in core/db.ts

"better-sqlite3" doesn't exist when compiling dependencies leading to an error. we shouldn't have an error here since undefined is valid