### PR TITLE
Update language for primary key constraints

### DIFF
--- a/docs/docs/ent-schema/constraints.mdx
+++ b/docs/docs/ent-schema/constraints.mdx
@@ -42,7 +42,7 @@ import SqliteGuestsUniqueSrc from "./sqlite_guests_unique_constraint.txt";
 
 ## primary key constraint
 
-The easiest way to add a unique constraint on a single column is to use the [primaryKey modifier](/docs/ent-schema/fields#primarykey) on the field.
+The easiest way to add a primary key constraint on a single column is to use the [primaryKey modifier](/docs/ent-schema/fields#primarykey) on the field.
 
 To add a multi-column constraint:
 


### PR DESCRIPTION
The exact copy was used in the unique constraint paragraph above and it was confusing initially to understand how these were different.