### PR TITLE
two changes to Field APIs

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -2290,7 +2290,7 @@ function commonTests() {
     });
   });
 
-  test.only("defaultValueOnCreate", async () => {
+  test("defaultValueOnCreate", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
       new UserSchema(),

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -189,7 +189,10 @@ class ContactSchema extends BaseEntSchema {
   fields: Field[] = [
     StringType({ name: "FirstName" }),
     StringType({ name: "LastName" }),
-    StringType({ name: "UserID" }),
+    StringType({
+      name: "UserID",
+      defaultValueOnCreate: (builder) => builder.viewer.viewerID,
+    }),
   ];
   ent = Contact;
 }
@@ -2285,6 +2288,48 @@ function commonTests() {
       // get the last two. Snow replaced with **** since sensitive
       expect(lastLog.values.slice(3)).toStrictEqual(["Jon", "****"]);
     });
+  });
+
+  test.only("defaultValueOnCreate", async () => {
+    const builder = new SimpleBuilder(
+      new LoggedOutViewer(),
+      new UserSchema(),
+      new Map([
+        ["FirstName", "Jon"],
+        ["LastName", "Snow"],
+      ]),
+    );
+    await builder.saveX();
+    const user = await builder.editedEntX();
+
+    const builder2 = new SimpleBuilder(
+      new IDViewer(user.id),
+      new ContactSchema(),
+      new Map([
+        ["FirstName", "Jon"],
+        ["LastName", "Snow"],
+      ]),
+    );
+
+    await builder2.saveX();
+    const contact = await builder2.editedEntX();
+    expect(contact.data.user_id).toEqual(user.id);
+
+    const builder3 = new SimpleBuilder(
+      new LoggedOutViewer(),
+      new ContactSchema(),
+      new Map([
+        ["FirstName", "Jon"],
+        ["LastName", "Snow"],
+      ]),
+    );
+    // logged out viewer with null viewer throws since it's still required
+    try {
+      await builder3.saveX();
+      fail("should have thrown");
+    } catch (e) {
+      expect(e.message).toBe("required field UserID not set");
+    }
   });
 }
 const getLoggedInBuilder = () => {

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -197,6 +197,18 @@ class ContactSchema extends BaseEntSchema {
   ent = Contact;
 }
 
+class ContactSchema2 extends BaseEntSchema {
+  fields: Field[] = [
+    StringType({ name: "FirstName" }),
+    StringType({ name: "LastName" }),
+    StringType({
+      name: "UserID",
+      defaultToViewerOnCreate: true,
+    }),
+  ];
+  ent = Contact;
+}
+
 class CustomUser implements Ent {
   id: ID;
   accountID: string;
@@ -2318,6 +2330,48 @@ function commonTests() {
     const builder3 = new SimpleBuilder(
       new LoggedOutViewer(),
       new ContactSchema(),
+      new Map([
+        ["FirstName", "Jon"],
+        ["LastName", "Snow"],
+      ]),
+    );
+    // logged out viewer with null viewer throws since it's still required
+    try {
+      await builder3.saveX();
+      fail("should have thrown");
+    } catch (e) {
+      expect(e.message).toBe("required field UserID not set");
+    }
+  });
+
+  test("defaultToViewerOnCreate", async () => {
+    const builder = new SimpleBuilder(
+      new LoggedOutViewer(),
+      new UserSchema(),
+      new Map([
+        ["FirstName", "Jon"],
+        ["LastName", "Snow"],
+      ]),
+    );
+    await builder.saveX();
+    const user = await builder.editedEntX();
+
+    const builder2 = new SimpleBuilder(
+      new IDViewer(user.id),
+      new ContactSchema2(),
+      new Map([
+        ["FirstName", "Jon"],
+        ["LastName", "Snow"],
+      ]),
+    );
+
+    await builder2.saveX();
+    const contact = await builder2.editedEntX();
+    expect(contact.data.user_id).toEqual(user.id);
+
+    const builder3 = new SimpleBuilder(
+      new LoggedOutViewer(),
+      new ContactSchema2(),
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -413,7 +413,7 @@ export class Orchestrator<T extends Ent> {
       promises.push(this.triggers(triggerPromises));
     }
 
-    promises.push(this.validateFields());
+    promises.push(this.validateFields(builder, action));
 
     let validators = action?.validators || [];
     if (validators) {
@@ -461,7 +461,10 @@ export class Orchestrator<T extends Ent> {
     return (val as Builder<T>).placeholderID !== undefined;
   }
 
-  private async validateFields(): Promise<void> {
+  private async validateFields(
+    builder: Builder<T>,
+    action?: Action<T> | undefined,
+  ): Promise<void> {
     // existing ent required for edit or delete operations
     switch (this.options.operation) {
       case WriteOperation.Delete:
@@ -480,6 +483,10 @@ export class Orchestrator<T extends Ent> {
     let data = {};
     let logValues = {};
     const schemaFields = getFields(this.options.schema);
+    let input: Data = {};
+    if (action !== undefined) {
+      input = action.getInput();
+    }
     for (const [fieldName, field] of schemaFields) {
       let value = editedFields.get(fieldName);
       let dbKey = field.storageKey || snakeCase(field.name);
@@ -489,14 +496,14 @@ export class Orchestrator<T extends Ent> {
           field.defaultValueOnCreate &&
           this.options.operation === WriteOperation.Insert
         ) {
-          value = field.defaultValueOnCreate();
+          value = field.defaultValueOnCreate(builder, input);
         }
 
         if (
           field.defaultValueOnEdit &&
           this.options.operation === WriteOperation.Edit
         ) {
-          value = field.defaultValueOnEdit();
+          value = field.defaultValueOnEdit(builder, input);
           // TODO special case this if this is the onlything changing and don't do the write.
         }
       }

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -492,11 +492,18 @@ export class Orchestrator<T extends Ent> {
       let dbKey = field.storageKey || snakeCase(field.name);
 
       if (value === undefined) {
-        if (
-          field.defaultValueOnCreate &&
-          this.options.operation === WriteOperation.Insert
-        ) {
-          value = field.defaultValueOnCreate(builder, input);
+        if (this.options.operation === WriteOperation.Insert) {
+          if (field.defaultToViewerOnCreate && field.defaultValueOnCreate) {
+            throw new Error(
+              `cannot set both defaultToViewerOnCreate and defaultValueOnCreate`,
+            );
+          }
+          if (field.defaultToViewerOnCreate) {
+            value = builder.viewer.viewerID;
+          }
+          if (field.defaultValueOnCreate) {
+            value = field.defaultValueOnCreate(builder, input);
+          }
         }
 
         if (

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -219,6 +219,9 @@ export interface FieldOptions {
   // must have a defaultValueOnCreate() field if set
   disableUserEditable?: boolean;
   defaultValueOnCreate?(builder: Builder<Ent>, input: Data): any;
+  // shorthand for defaultValueOnCreate: (builder)=>builder.viewer.viewerID;
+  // exists for common scenario to set a field to the logged in viewerID.
+  defaultToViewerOnCreate?: boolean;
   defaultValueOnEdit?(builder: Builder<Ent>, input: Data): any;
   // this is very specific.
   // maybe there's a better way to indicate this

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -1,3 +1,6 @@
+import { Data, Ent } from "../core/base";
+import { Builder } from "../action/action";
+
 // Schema is the base for every schema in typescript
 export default interface Schema {
   // schema has list of fields that are unique to each node
@@ -215,8 +218,8 @@ export interface FieldOptions {
   // indicates that this can't be edited by the user
   // must have a defaultValueOnCreate() field if set
   disableUserEditable?: boolean;
-  defaultValueOnCreate?(): any;
-  defaultValueOnEdit?(): any;
+  defaultValueOnCreate?(builder: Builder<Ent>, input: Data): any;
+  defaultValueOnEdit?(builder: Builder<Ent>, input: Data): any;
   // this is very specific.
   // maybe there's a better way to indicate this
   // we sometimes have actionOnlyFields when an action creates a child object and we want to skip


### PR DESCRIPTION
* change `defaultValueOnCreate` to take builder and input so that it can be used to default to viewer or something else
* add `defaultToViewerOnCreate` for hte common use case which inspired these changes 

for https://github.com/lolopinto/ent/issues/435

