### PR TITLE
when there's no db changes, no need to call into auto_schema a second time

### DIFF
--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -34,10 +34,15 @@ func DisableFormat() Option {
 
 // Processor stores the parsed data needed for codegen
 type Processor struct {
-	Schema    *schema.Schema
-	Config    *Config
-	debugMode bool
-	opt       *option
+	Schema      *schema.Schema
+	Config      *Config
+	debugMode   bool
+	opt         *option
+	noDBChanges bool
+}
+
+func (p *Processor) NoDBChanges() bool {
+	return p.noDBChanges
 }
 
 func (p *Processor) Run(steps []Step, step string, options ...Option) error {

--- a/internal/codegen/prompts.go
+++ b/internal/codegen/prompts.go
@@ -83,6 +83,11 @@ func checkAndHandlePrompts(p *Processor) error {
 		return err
 	}
 
+	if len(m) == 0 {
+		// we know there's no db changes so we should flag this so that we don't call into python in the future to try and make changes
+		p.noDBChanges = true
+	}
+
 	prompts, err := getPrompts(p.Schema, m)
 	if err != nil {
 		return err

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -43,6 +43,9 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 	if s.db == nil {
 		return errors.New("weirdness. dbSchema is nil when it shouldn't be")
 	}
+	if processor.NoDBChanges() {
+		return nil
+	}
 	fmt.Println("updating db...")
 	return s.db.makeDBChanges()
 }


### PR DESCRIPTION
both paths are running the same code
https://github.com/lolopinto/ent/blob/main/python/auto_schema/auto_schema/runner.py#L185
https://github.com/lolopinto/ent/blob/main/python/auto_schema/auto_schema/runner.py#L258

so no reason to call this twice.

we just keep a flag in golang that we check and avoid the overhead a second time

way simpler than options presented at https://github.com/lolopinto/ent/issues/453