### PR TITLE
Fix codegen

### DIFF
--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -14,8 +14,11 @@ import (
 )
 
 type option struct {
-	disablePrompts bool
-	disableFormat  bool
+	disablePrompts       bool
+	disableFormat        bool
+	disableCustomGraphQL bool
+	fromTest             bool
+	disableSchemaGQL     bool
 }
 
 type Option func(*option)
@@ -32,6 +35,24 @@ func DisableFormat() Option {
 	}
 }
 
+func DisableCustomGraphQL() Option {
+	return func(opt *option) {
+		opt.disableCustomGraphQL = true
+	}
+}
+
+func FromTest() Option {
+	return func(opt *option) {
+		opt.fromTest = true
+	}
+}
+
+func DisableSchemaGQL() Option {
+	return func(opt *option) {
+		opt.disableSchemaGQL = true
+	}
+}
+
 // Processor stores the parsed data needed for codegen
 type Processor struct {
 	Schema      *schema.Schema
@@ -43,6 +64,18 @@ type Processor struct {
 
 func (p *Processor) NoDBChanges() bool {
 	return p.noDBChanges
+}
+
+func (p *Processor) DisableCustomGraphQL() bool {
+	return p.opt.disableCustomGraphQL
+}
+
+func (p *Processor) FromTest() bool {
+	return p.opt.fromTest
+}
+
+func (p *Processor) DisableSchemaGQL() bool {
+	return p.opt.disableSchemaGQL
 }
 
 func (p *Processor) Run(steps []Step, step string, options ...Option) error {

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -67,14 +67,23 @@ func (p *Processor) NoDBChanges() bool {
 }
 
 func (p *Processor) DisableCustomGraphQL() bool {
+	if p.opt == nil {
+		return false
+	}
 	return p.opt.disableCustomGraphQL
 }
 
 func (p *Processor) FromTest() bool {
+	if p.opt == nil {
+		return false
+	}
 	return p.opt.fromTest
 }
 
 func (p *Processor) DisableSchemaGQL() bool {
+	if p.opt == nil {
+		return false
+	}
 	return p.opt.disableSchemaGQL
 }
 
@@ -160,7 +169,7 @@ func (p *Processor) FormatTS() error {
 }
 
 func postProcess(p *Processor) error {
-	if p.opt.disableFormat {
+	if p.opt != nil && p.opt.disableFormat {
 		return nil
 	}
 	return p.FormatTS()

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -79,11 +79,9 @@ func (p *Processor) DisableSchemaGQL() bool {
 }
 
 func (p *Processor) Run(steps []Step, step string, options ...Option) error {
-	opt := &option{}
 	for _, o := range options {
-		o(opt)
+		o(p.opt)
 	}
-	p.opt = opt
 
 	if step != "" {
 		for _, s := range steps {
@@ -128,7 +126,7 @@ func (p *Processor) Run(steps []Step, step string, options ...Option) error {
 		}
 	}
 
-	if !opt.disablePrompts {
+	if !p.opt.disablePrompts {
 		if err := runAndLog(p, checkAndHandlePrompts, func(d time.Duration) {
 			fmt.Printf("check and handle prompts step took %v \n", d)
 		}); err != nil {
@@ -204,6 +202,7 @@ func NewCodegenProcessor(schema *schema.Schema, configPath, modulePath string, d
 		Schema:    schema,
 		Config:    cfg,
 		debugMode: debugMode,
+		opt:       &option{},
 	}
 
 	// if in debug mode can log things

--- a/internal/graphql/custom_ts.go
+++ b/internal/graphql/custom_ts.go
@@ -672,11 +672,11 @@ func buildObjectType(processor *codegen.Processor, cd *customData, s *gqlSchema,
 }
 
 func getRelativeImportPath(processor *codegen.Processor, basepath, targetpath string) (string, error) {
+	// we get absolute paths now
 	// BONUS: instead of this, we should use the nice paths in tsconfig...
-	absPath := filepath.Join(processor.Config.GetAbsPathToRoot(), basepath)
 
 	// need to do any relative imports from the directory not from the file itself
-	dir := filepath.Dir(absPath)
+	dir := filepath.Dir(basepath)
 	rel, err := filepath.Rel(dir, targetpath)
 	if err != nil {
 		return "", err

--- a/internal/graphql/custom_ts.go
+++ b/internal/graphql/custom_ts.go
@@ -17,7 +17,7 @@ import (
 
 type processCustomRoot interface {
 	process(processor *codegen.Processor, cd *customData, s *gqlSchema) error
-	getFilePath(string) string
+	getFilePath(*codegen.Processor, string) string
 	getArgObject(cd *customData, arg CustomItem) *CustomObject
 	getFields(cd *customData) []CustomField
 	buildFieldConfig(processor *codegen.Processor, cd *customData, s *gqlSchema, field CustomField) (*fieldConfig, error)
@@ -41,8 +41,8 @@ func (cm *customMutationsProcesser) process(processor *codegen.Processor, cd *cu
 	return nil
 }
 
-func (cm *customMutationsProcesser) getFilePath(gqlName string) string {
-	return getFilePathForCustomMutation(gqlName)
+func (cm *customMutationsProcesser) getFilePath(p *codegen.Processor, gqlName string) string {
+	return getFilePathForCustomMutation(p.Config, gqlName)
 }
 
 func (cm *customMutationsProcesser) getArgObject(cd *customData, arg CustomItem) *CustomObject {
@@ -56,7 +56,7 @@ func (cm *customMutationsProcesser) getFields(cd *customData) []CustomField {
 func (cm *customMutationsProcesser) buildFieldConfig(processor *codegen.Processor, cd *customData, s *gqlSchema, field CustomField) (*fieldConfig, error) {
 	b := &mutationFieldConfigBuilder{
 		field:    field,
-		filePath: cm.getFilePath(field.GraphQLName),
+		filePath: cm.getFilePath(processor, field.GraphQLName),
 		cd:       cd,
 	}
 
@@ -81,8 +81,8 @@ func (cq *customQueriesProcesser) process(processor *codegen.Processor, cd *cust
 	return err
 }
 
-func (cq *customQueriesProcesser) getFilePath(gqlName string) string {
-	return getFilePathForCustomQuery(gqlName)
+func (cq *customQueriesProcesser) getFilePath(processor *codegen.Processor, gqlName string) string {
+	return getFilePathForCustomQuery(processor.Config, gqlName)
 }
 
 func (cq *customQueriesProcesser) getArgObject(cd *customData, arg CustomItem) *CustomObject {
@@ -96,7 +96,7 @@ func (cq *customQueriesProcesser) getFields(cd *customData) []CustomField {
 func (cq *customQueriesProcesser) buildFieldConfig(processor *codegen.Processor, cd *customData, s *gqlSchema, field CustomField) (*fieldConfig, error) {
 	b := &queryFieldConfigBuilder{
 		field,
-		cq.getFilePath(field.GraphQLName),
+		cq.getFilePath(processor, field.GraphQLName),
 	}
 	return b.build(processor, cd, s, field)
 }
@@ -122,7 +122,7 @@ func processFields(processor *codegen.Processor, cd *customData, s *gqlSchema, c
 		var objTypes []*objectType
 
 		// TODO we want an option for namespace for folders but for now ignore
-		filePath := cr.getFilePath(field.GraphQLName)
+		filePath := cr.getFilePath(processor, field.GraphQLName)
 
 		// let's try and make this generic enough to work for input type and standard args...
 		// and have graphql complain if not valid types at the end here

--- a/internal/graphql/custom_ts_test.go
+++ b/internal/graphql/custom_ts_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/lolopinto/ent/internal/codegen"
@@ -113,7 +114,7 @@ func TestCustomMutation(t *testing.T) {
 	assert.Len(t, gqlNode.connections, 0)
 	assert.Len(t, gqlNode.Dependents, 0)
 	assert.Equal(t, gqlNode.Field, &item)
-	assert.Equal(t, gqlNode.FilePath, "src/graphql/mutations/generated/email_available_type.ts")
+	assert.True(t, strings.HasSuffix(gqlNode.FilePath, "src/graphql/mutations/generated/email_available_type.ts"))
 
 	objData := gqlNode.ObjData
 	require.NotNil(t, objData)
@@ -260,7 +261,7 @@ func TestCustomQuery(t *testing.T) {
 	assert.Len(t, gqlNode.connections, 0)
 	assert.Len(t, gqlNode.Dependents, 0)
 	assert.Equal(t, gqlNode.Field, &item)
-	assert.Equal(t, gqlNode.FilePath, "src/graphql/resolvers/generated/email_available_query_type.ts")
+	assert.True(t, strings.HasSuffix(gqlNode.FilePath, "src/graphql/resolvers/generated/email_available_query_type.ts"))
 
 	objData := gqlNode.ObjData
 	require.NotNil(t, objData)
@@ -393,7 +394,7 @@ func TestCustomListQuery(t *testing.T) {
 	assert.Len(t, gqlNode.connections, 0)
 	assert.Len(t, gqlNode.Dependents, 0)
 	assert.Equal(t, gqlNode.Field, &item)
-	assert.Equal(t, gqlNode.FilePath, "src/graphql/resolvers/generated/emails_available_query_type.ts")
+	assert.True(t, strings.HasSuffix(gqlNode.FilePath, "src/graphql/resolvers/generated/emails_available_query_type.ts"))
 
 	objData := gqlNode.ObjData
 	require.NotNil(t, objData)
@@ -574,7 +575,7 @@ func TestCustomQueryReferencesExistingObject(t *testing.T) {
 	assert.Len(t, gqlNode.connections, 0)
 	assert.Len(t, gqlNode.Dependents, 0)
 	assert.Equal(t, gqlNode.Field, &item)
-	assert.Equal(t, gqlNode.FilePath, "src/graphql/resolvers/generated/username_query_type.ts")
+	assert.True(t, strings.HasSuffix(gqlNode.FilePath, "src/graphql/resolvers/generated/username_query_type.ts"))
 
 	objData := gqlNode.ObjData
 	require.NotNil(t, objData)
@@ -703,7 +704,7 @@ func TestCustomUploadType(t *testing.T) {
 	assert.Len(t, gqlNode.connections, 0)
 	assert.Len(t, gqlNode.Dependents, 0)
 	assert.Equal(t, gqlNode.Field, &item)
-	assert.Equal(t, gqlNode.FilePath, "src/graphql/mutations/generated/profile_pic_upload_type.ts")
+	assert.True(t, strings.HasSuffix(gqlNode.FilePath, "src/graphql/mutations/generated/profile_pic_upload_type.ts"))
 
 	objData := gqlNode.ObjData
 	require.NotNil(t, objData)

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -292,23 +292,32 @@ func (p *TSStep) writeBaseFiles(processor *codegen.Processor, s *gqlSchema) erro
 			return writeFile(node)
 		})
 
-		for _, dependentNode := range node.Dependents {
-			funcs = append(funcs, func() error {
-				return writeFile(dependentNode)
-			})
+		for idx := range node.Dependents {
+			func(idx int) {
+				dependentNode := node.Dependents[idx]
+				funcs = append(funcs, func() error {
+					return writeFile(dependentNode)
+				})
+			}(idx)
 		}
 
-		for _, conn := range node.connections {
-			funcs = append(funcs, func() error {
-				return writeConnectionFile(processor, s, conn)
-			})
+		for idx := range node.connections {
+			func(idx int) {
+				conn := node.connections[idx]
+				funcs = append(funcs, func() error {
+					return writeConnectionFile(processor, s, conn)
+				})
+			}(idx)
 		}
 	}
 
-	for _, enum := range s.enums {
-		funcs = append(funcs, func() error {
-			return writeEnumFile(enum)
-		})
+	for idx := range s.enums {
+		func(idx string) {
+			enum := s.enums[idx]
+			funcs = append(funcs, func() error {
+				return writeEnumFile(enum)
+			})
+		}(idx)
 	}
 
 	for _, node := range s.nodes {

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -248,7 +248,6 @@ type writeFileFn func() error
 type writeFileFnList []writeFileFn
 
 func buildSchema(processor *codegen.Processor, fromTest bool) (*gqlSchema, error) {
-	spew.Dump(fromTest)
 	cd, s := <-parseCustomData(processor, fromTest), <-buildGQLSchema(processor)
 	if cd.Error != nil {
 		return nil, cd.Error
@@ -299,31 +298,25 @@ func (p *TSStep) writeBaseFiles(processor *codegen.Processor, s *gqlSchema) erro
 		})
 
 		for idx := range node.Dependents {
-			func(idx int) {
-				dependentNode := node.Dependents[idx]
-				funcs = append(funcs, func() error {
-					return writeFile(dependentNode)
-				})
-			}(idx)
+			dependentNode := node.Dependents[idx]
+			funcs = append(funcs, func() error {
+				return writeFile(dependentNode)
+			})
 		}
 
 		for idx := range node.connections {
-			func(idx int) {
-				conn := node.connections[idx]
-				funcs = append(funcs, func() error {
-					return writeConnectionFile(processor, s, conn)
-				})
-			}(idx)
+			conn := node.connections[idx]
+			funcs = append(funcs, func() error {
+				return writeConnectionFile(processor, s, conn)
+			})
 		}
 	}
 
 	for idx := range s.enums {
-		func(idx string) {
-			enum := s.enums[idx]
-			funcs = append(funcs, func() error {
-				return writeEnumFile(enum)
-			})
-		}(idx)
+		enum := s.enums[idx]
+		funcs = append(funcs, func() error {
+			return writeEnumFile(enum)
+		})
 	}
 
 	for _, node := range s.nodes {

--- a/internal/graphql/ts_templates/schema.tmpl
+++ b/internal/graphql/ts_templates/schema.tmpl
@@ -6,7 +6,7 @@
 {{ end -}}
 
 {{range $typ := .AllTypes -}}
-  {{reserveImport $typ.Path $typ.Type}}
+  {{reserveImport $typ.ImportPath $typ.Type}}
 {{ end -}} 
 
 export default new {{useImport "GraphQLSchema"}}({

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -81,14 +81,17 @@ func (s *Step) processActions(processor *codegen.Processor, nodeData *schema.Nod
 		return writeBuilderFile(nodeData, processor.Config)
 	})
 
-	for _, action := range nodeData.ActionInfo.Actions {
-		ret = append(ret, func() error {
-			return writeBaseActionFile(nodeData, processor.Config, action)
-		})
+	for idx := range nodeData.ActionInfo.Actions {
+		func(idx int) {
+			action := nodeData.ActionInfo.Actions[idx]
+			ret = append(ret, func() error {
+				return writeBaseActionFile(nodeData, processor.Config, action)
+			})
 
-		ret = append(ret, func() error {
-			return writeActionFile(nodeData, processor.Config, action)
-		})
+			ret = append(ret, func() error {
+				return writeActionFile(nodeData, processor.Config, action)
+			})
+		}(idx)
 	}
 	return ret
 }
@@ -102,18 +105,25 @@ func (s *Step) processEdges(processor *codegen.Processor, nodeData *schema.NodeD
 		return writeBaseQueryFile(processor.Schema, nodeData, processor.Config)
 	})
 
-	for _, edge := range nodeData.EdgeInfo.Associations {
-		ret = append(ret, func() error {
-			return writeAssocEdgeQueryFile(processor.Schema, nodeData, edge, processor.Config)
-		})
+	for idx := range nodeData.EdgeInfo.Associations {
+		func(idx int) {
+			edge := nodeData.EdgeInfo.Associations[idx]
+			ret = append(ret, func() error {
+				return writeAssocEdgeQueryFile(processor.Schema, nodeData, edge, processor.Config)
+			})
+		}(idx)
 	}
 
 	// edges with IndexLoaderFactory
 	edges := nodeData.EdgeInfo.GetEdgesForIndexLoader()
-	for _, edge := range edges {
-		ret = append(ret, func() error {
-			return writeCustomEdgeQueryFile(processor.Schema, nodeData, edge, processor.Config)
-		})
+	for idx := range edges {
+		func(idx int) {
+			edge := edges[idx]
+			ret = append(ret, func() error {
+				return writeCustomEdgeQueryFile(processor.Schema, nodeData, edge, processor.Config)
+			})
+
+		}(idx)
 	}
 	return ret
 }

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -137,7 +137,6 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 		funcs = append(funcs, s.processNode(processor, info, &serr)...)
 	}
 
-	//	wg.Add(len(processor.Schema.Enums))
 	for _, info := range processor.Schema.Enums {
 		// only lookup table enums get their own files
 		if !info.LookupTableEnum() {

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -82,16 +82,14 @@ func (s *Step) processActions(processor *codegen.Processor, nodeData *schema.Nod
 	})
 
 	for idx := range nodeData.ActionInfo.Actions {
-		func(idx int) {
-			action := nodeData.ActionInfo.Actions[idx]
-			ret = append(ret, func() error {
-				return writeBaseActionFile(nodeData, processor.Config, action)
-			})
+		action := nodeData.ActionInfo.Actions[idx]
+		ret = append(ret, func() error {
+			return writeBaseActionFile(nodeData, processor.Config, action)
+		})
 
-			ret = append(ret, func() error {
-				return writeActionFile(nodeData, processor.Config, action)
-			})
-		}(idx)
+		ret = append(ret, func() error {
+			return writeActionFile(nodeData, processor.Config, action)
+		})
 	}
 	return ret
 }
@@ -106,24 +104,19 @@ func (s *Step) processEdges(processor *codegen.Processor, nodeData *schema.NodeD
 	})
 
 	for idx := range nodeData.EdgeInfo.Associations {
-		func(idx int) {
-			edge := nodeData.EdgeInfo.Associations[idx]
-			ret = append(ret, func() error {
-				return writeAssocEdgeQueryFile(processor.Schema, nodeData, edge, processor.Config)
-			})
-		}(idx)
+		edge := nodeData.EdgeInfo.Associations[idx]
+		ret = append(ret, func() error {
+			return writeAssocEdgeQueryFile(processor.Schema, nodeData, edge, processor.Config)
+		})
 	}
 
 	// edges with IndexLoaderFactory
 	edges := nodeData.EdgeInfo.GetEdgesForIndexLoader()
 	for idx := range edges {
-		func(idx int) {
-			edge := edges[idx]
-			ret = append(ret, func() error {
-				return writeCustomEdgeQueryFile(processor.Schema, nodeData, edge, processor.Config)
-			})
-
-		}(idx)
+		edge := edges[idx]
+		ret = append(ret, func() error {
+			return writeCustomEdgeQueryFile(processor.Schema, nodeData, edge, processor.Config)
+		})
 	}
 	return ret
 }

--- a/tsent/cmd/codegen_test.go
+++ b/tsent/cmd/codegen_test.go
@@ -45,8 +45,6 @@ func TestSimpleCodegen(t *testing.T) {
 
 	steps := []codegen.Step{
 		new(tscode.Step),
-		// TODO graphql
-		//		new(graphql.TSStep),
 	}
 
 	err = processor.Run(steps, "", codegen.DisablePrompts(), codegen.DisableFormat())
@@ -99,6 +97,17 @@ func TestSchemaWithFkeyEdgeCodegen(t *testing.T) {
 							Column: "ID",
 						},
 					},
+					{
+						Name: "DuplicateUserID",
+						Type: &input.FieldType{
+							DBType: input.UUID,
+						},
+						ForeignKey: &input.ForeignKey{
+							Schema: "User",
+							Column: "ID",
+							Name:   "duplicate_contacts",
+						},
+					},
 				},
 			},
 		},
@@ -130,6 +139,7 @@ func TestSchemaWithFkeyEdgeCodegen(t *testing.T) {
 	validateFileExists(t, rootDir, "src/ent/loadAny.ts")
 	validateFileExists(t, rootDir, "src/ent/generated/user_query_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user/query/user_to_contacts_query.ts")
+	validateFileExists(t, rootDir, "src/ent/user/query/user_to_duplicate_contacts_query.ts")
 }
 
 func TestSchemaWithAssocEdgeCodegen(t *testing.T) {
@@ -156,6 +166,18 @@ func TestSchemaWithAssocEdgeCodegen(t *testing.T) {
 						Name:       "Friends",
 						SchemaName: "User",
 						Symmetric:  true,
+						EdgeActions: []*input.EdgeAction{
+							{
+								Operation: ent.AddEdgeAction,
+							},
+						},
+					},
+					{
+						Name:       "Followers",
+						SchemaName: "User",
+						InverseEdge: &input.InverseAssocEdge{
+							Name: "Followees",
+						},
 						EdgeActions: []*input.EdgeAction{
 							{
 								Operation: ent.AddEdgeAction,
@@ -191,8 +213,13 @@ func TestSchemaWithAssocEdgeCodegen(t *testing.T) {
 	validateFileExists(t, rootDir, "src/ent/loadAny.ts")
 	validateFileExists(t, rootDir, "src/ent/generated/user_query_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user/query/user_to_friends_query.ts")
+	validateFileExists(t, rootDir, "src/ent/user/query/user_to_followers_query.ts")
+	validateFileExists(t, rootDir, "src/ent/user/query/user_to_followees_query.ts")
 	validateFileExists(t, rootDir, "src/ent/user/actions/generated/user_add_friend_action_base.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/generated/user_add_follower_action_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user/actions/user_add_friend_action.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/user_add_follower_action.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/user_builder.ts")
 }
 
 func TestSchemaWithActionsCodegen(t *testing.T) {
@@ -217,6 +244,19 @@ func TestSchemaWithActionsCodegen(t *testing.T) {
 				Actions: []*input.Action{
 					{
 						Operation: ent.CreateAction,
+					},
+					{
+						Operation: ent.EditAction,
+					},
+					{
+						Operation: ent.DeleteAction,
+					},
+					{
+						Operation:         ent.EditAction,
+						Fields:            []string{"name"},
+						CustomActionName:  "EditUserNameAction",
+						CustomGraphQLName: "UserEditName",
+						CustomInputName:   "EditNameInput",
 					},
 				},
 			},
@@ -247,6 +287,12 @@ func TestSchemaWithActionsCodegen(t *testing.T) {
 	validateFileExists(t, rootDir, "src/ent/loadAny.ts")
 	validateFileExists(t, rootDir, "src/ent/user/actions/generated/create_user_action_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user/actions/create_user_action.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/generated/edit_user_action_base.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/edit_user_action.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/generated/edit_user_action_base.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/edit_user_action.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/generated/edit_user_name_action_base.ts")
+	validateFileExists(t, rootDir, "src/ent/user/actions/edit_user_name_action.ts")
 }
 
 func validateFileExists(t *testing.T, root, path string) {

--- a/tsent/cmd/codegen_test.go
+++ b/tsent/cmd/codegen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lolopinto/ent/ent"
 	"github.com/lolopinto/ent/internal/codegen"
+	"github.com/lolopinto/ent/internal/graphql"
 	"github.com/lolopinto/ent/internal/schema"
 	"github.com/lolopinto/ent/internal/schema/base"
 	"github.com/lolopinto/ent/internal/schema/input"
@@ -16,6 +17,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var codegenOptions = []codegen.Option{
+	codegen.DisablePrompts(),
+	codegen.DisableFormat(),
+	codegen.DisableCustomGraphQL(),
+	codegen.FromTest(),
+	codegen.DisableSchemaGQL(),
+}
+
+func runSteps(t *testing.T, s *schema.Schema, rootDir string) {
+	schemaPath := path.Join(rootDir, "src/schema")
+
+	processor, err := codegen.NewCodegenProcessor(s, schemaPath, "", false)
+	require.Nil(t, err)
+
+	steps := []codegen.Step{
+		new(tscode.Step),
+		new(graphql.TSStep),
+	}
+
+	err = processor.Run(steps, "", codegenOptions...)
+	require.Nil(t, err)
+}
 
 func TestSimpleCodegen(t *testing.T) {
 	s, err := schema.ParseFromInputSchema(&input.Schema{
@@ -38,17 +62,7 @@ func TestSimpleCodegen(t *testing.T) {
 	rootDir, err := ioutil.TempDir(os.TempDir(), "root")
 	require.Nil(t, err)
 	defer os.RemoveAll(rootDir)
-	schemaPath := path.Join(rootDir, "src/schema")
-
-	processor, err := codegen.NewCodegenProcessor(s, schemaPath, "", false)
-	require.Nil(t, err)
-
-	steps := []codegen.Step{
-		new(tscode.Step),
-	}
-
-	err = processor.Run(steps, "", codegen.DisablePrompts(), codegen.DisableFormat())
-	require.Nil(t, err)
+	runSteps(t, s, rootDir)
 
 	validateFileExists(t, rootDir, "src/ent/generated/user_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user.ts")
@@ -56,6 +70,12 @@ func TestSimpleCodegen(t *testing.T) {
 	validateFileExists(t, rootDir, "src/ent/internal.ts")
 	validateFileExists(t, rootDir, "src/ent/index.ts")
 	validateFileExists(t, rootDir, "src/ent/loadAny.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/node_query_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/query_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/internal.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/index.ts")
+	validateFileExists(t, rootDir, "src/graphql/schema.ts")
 }
 
 func TestSchemaWithFkeyEdgeCodegen(t *testing.T) {
@@ -117,17 +137,7 @@ func TestSchemaWithFkeyEdgeCodegen(t *testing.T) {
 	rootDir, err := ioutil.TempDir(os.TempDir(), "root")
 	require.Nil(t, err)
 	defer os.RemoveAll(rootDir)
-	schemaPath := path.Join(rootDir, "src/schema")
-
-	processor, err := codegen.NewCodegenProcessor(s, schemaPath, "", false)
-	require.Nil(t, err)
-
-	steps := []codegen.Step{
-		new(tscode.Step),
-	}
-
-	err = processor.Run(steps, "", codegen.DisablePrompts(), codegen.DisableFormat())
-	require.Nil(t, err)
+	runSteps(t, s, rootDir)
 
 	validateFileExists(t, rootDir, "src/ent/generated/user_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user.ts")
@@ -140,6 +150,15 @@ func TestSchemaWithFkeyEdgeCodegen(t *testing.T) {
 	validateFileExists(t, rootDir, "src/ent/generated/user_query_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user/query/user_to_contacts_query.ts")
 	validateFileExists(t, rootDir, "src/ent/user/query/user_to_duplicate_contacts_query.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/contact_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user/user_to_contacts_connection_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user/user_to_duplicate_contacts_connection_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/node_query_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/query_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/internal.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/index.ts")
+	validateFileExists(t, rootDir, "src/graphql/schema.ts")
 }
 
 func TestSchemaWithAssocEdgeCodegen(t *testing.T) {
@@ -193,17 +212,7 @@ func TestSchemaWithAssocEdgeCodegen(t *testing.T) {
 	rootDir, err := ioutil.TempDir(os.TempDir(), "root")
 	require.Nil(t, err)
 	defer os.RemoveAll(rootDir)
-	schemaPath := path.Join(rootDir, "src/schema")
-
-	processor, err := codegen.NewCodegenProcessor(s, schemaPath, "", false)
-	require.Nil(t, err)
-
-	steps := []codegen.Step{
-		new(tscode.Step),
-	}
-
-	err = processor.Run(steps, "", codegen.DisablePrompts(), codegen.DisableFormat())
-	require.Nil(t, err)
+	runSteps(t, s, rootDir)
 
 	validateFileExists(t, rootDir, "src/ent/generated/user_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user.ts")
@@ -220,6 +229,17 @@ func TestSchemaWithAssocEdgeCodegen(t *testing.T) {
 	validateFileExists(t, rootDir, "src/ent/user/actions/user_add_friend_action.ts")
 	validateFileExists(t, rootDir, "src/ent/user/actions/user_add_follower_action.ts")
 	validateFileExists(t, rootDir, "src/ent/user/actions/user_builder.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/node_query_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/query_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/internal.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/index.ts")
+	validateFileExists(t, rootDir, "src/graphql/schema.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user/user_to_friends_connection_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user/user_to_followers_connection_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user/user_to_followees_connection_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/mutations/generated/user/user_add_friend_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/mutations/generated/user/user_add_follower_type.ts")
 }
 
 func TestSchemaWithActionsCodegen(t *testing.T) {
@@ -267,17 +287,7 @@ func TestSchemaWithActionsCodegen(t *testing.T) {
 	rootDir, err := ioutil.TempDir(os.TempDir(), "root")
 	require.Nil(t, err)
 	defer os.RemoveAll(rootDir)
-	schemaPath := path.Join(rootDir, "src/schema")
-
-	processor, err := codegen.NewCodegenProcessor(s, schemaPath, "", false)
-	require.Nil(t, err)
-
-	steps := []codegen.Step{
-		new(tscode.Step),
-	}
-
-	err = processor.Run(steps, "", codegen.DisablePrompts(), codegen.DisableFormat())
-	require.Nil(t, err)
+	runSteps(t, s, rootDir)
 
 	validateFileExists(t, rootDir, "src/ent/generated/user_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user.ts")
@@ -293,6 +303,16 @@ func TestSchemaWithActionsCodegen(t *testing.T) {
 	validateFileExists(t, rootDir, "src/ent/user/actions/edit_user_action.ts")
 	validateFileExists(t, rootDir, "src/ent/user/actions/generated/edit_user_name_action_base.ts")
 	validateFileExists(t, rootDir, "src/ent/user/actions/edit_user_name_action.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/user_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/node_query_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/generated/query_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/internal.ts")
+	validateFileExists(t, rootDir, "src/graphql/resolvers/index.ts")
+	validateFileExists(t, rootDir, "src/graphql/schema.ts")
+	validateFileExists(t, rootDir, "src/graphql/mutations/generated/user/user_create_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/mutations/generated/user/user_edit_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/mutations/generated/user/user_delete_type.ts")
+	validateFileExists(t, rootDir, "src/graphql/mutations/generated/user/user_edit_name_type.ts")
 }
 
 func validateFileExists(t *testing.T, root, path string) {


### PR DESCRIPTION
this chain of changes is apparently cursed.

broken by https://github.com/lolopinto/ent/pull/454 

issue was the last value in the loop captured in the closure was the same for each iteration so we kept rewriting the same files instead of writing  other files. noticed when making another change and not seeing my changes reflected there.
more details: https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable

adds graphql tests that were missing from https://github.com/lolopinto/ent/pull/449. another fix to https://github.com/lolopinto/ent/issues/446