### PR TITLE
new image

### DIFF
--- a/release_image/main.go
+++ b/release_image/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // next tag
-const TAG = "0.0.24"
+const TAG = "0.0.25"
 
 // current node gets latest tag...
 const CURRENT_NODE_VERSION = 16
@@ -31,8 +31,8 @@ var NODE_VERSIONS = []int{
 	16,
 }
 
-const AUTO_SCHEMA_VERSION = "0.0.9"
-const TSENT_VERSION = "v0.0.23"
+const AUTO_SCHEMA_VERSION = "0.0.10"
+const TSENT_VERSION = "v0.0.24"
 
 var SUFFIXES = []string{
 	"dev",

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -1,5 +1,5 @@
-ARG GOLANG_VERSION=v0.0.23
-ARG AUTO_SCHEMA_VERSION=0.0.9
+ARG GOLANG_VERSION=v0.0.24
+ARG AUTO_SCHEMA_VERSION=0.0.10
 ARG NODE_VERSION=16
 
 # get and install tsent
@@ -18,6 +18,7 @@ RUN python -m venv /opt/venv
 ENV PATH /opt/venv/bin:$PATH
 
 RUN python3 -m pip install auto_schema==$AUTO_SCHEMA_VERSION
+#RUN python3 -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ auto_schema_test==$AUTO_SCHEMA_VERSION
 
 # final image needs to be python-based to have auto-schema work
 FROM python:3.8.11-slim AS final-image
@@ -57,6 +58,7 @@ RUN npm install --save-dev tsconfig-paths@3.11.0
 
 COPY --from=golang-image /go/bin/tsent /go/bin/tsent
 COPY --from=python-image /opt/venv /opt/venv
+# RUN alias auto_schema=auto_schema_test
 COPY --from=golang-image /go/pkg/mod/github.com/lolopinto/ent@$GOLANG_VERSION /go/pkg/mod/github.com/lolopinto/ent@$GOLANG_VERSION
 
 CMD ["node"]

--- a/ts/Dockerfile.tmpl
+++ b/ts/Dockerfile.tmpl
@@ -18,6 +18,7 @@ RUN python -m venv /opt/venv
 ENV PATH /opt/venv/bin:$PATH
 
 RUN python3 -m pip install auto_schema==$AUTO_SCHEMA_VERSION
+#RUN python3 -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ auto_schema_test==$AUTO_SCHEMA_VERSION
 
 # final image needs to be python-based to have auto-schema work
 FROM python:3.8.11-slim AS final-image
@@ -60,6 +61,7 @@ RUN npm install --save-dev tsconfig-paths@3.11.0
 
 COPY --from=golang-image /go/bin/tsent /go/bin/tsent
 COPY --from=python-image /opt/venv /opt/venv
+#RUN alias auto_schema=auto_schema_test
 COPY --from=golang-image /go/pkg/mod/github.com/lolopinto/ent@$GOLANG_VERSION /go/pkg/mod/github.com/lolopinto/ent@$GOLANG_VERSION
 
 CMD ["node"]


### PR DESCRIPTION
new version of [auto_schema](https://github.com/lolopinto/ent/pull/493) and new [go release](https://github.com/lolopinto/ent/releases/tag/v0.0.24) which has #494 and #496