### PR TITLE
improve type for TriggerReturn

### DIFF
--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -57,7 +57,7 @@ export interface Changeset<T extends Ent> {
 
 export type TriggerReturn =
   | void
-  | Promise<Changeset<Ent> | void | Changeset<Ent>[] | Changeset<Ent>>
+  | Promise<Changeset<Ent> | void | (Changeset<Ent> | void)[]>
   | Promise<Changeset<Ent>>[];
 
 export interface Trigger<T extends Ent> {

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -435,7 +435,11 @@ export class Orchestrator<T extends Ent> {
     );
     changesets.forEach((c) => {
       if (Array.isArray(c)) {
-        this.changesets.push(...c);
+        for (const v of c) {
+          if (typeof v === "object") {
+            this.changesets.push(v);
+          }
+        }
       } else if (c) {
         this.changesets.push(c);
       }


### PR DESCRIPTION
what we had was too restrictive and forced things that could return a list of changesets or void not to work