### PR TITLE
nullable derived type when polymorphic field is null

### DIFF
--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -106,7 +106,7 @@ type Field struct {
 	FieldEdge     *FieldEdge  `json:"fieldEdge"` // this only really makes sense on id fields...
 	ForeignKey    *ForeignKey `json:"foreignKey"`
 	ServerDefault interface{} `json:"serverDefault"`
-	// DisableUserEditable true == DefaultValueOnCreate required
+	// DisableUserEditable true == DefaultValueOnCreate required OR set in trigger
 	DisableUserEditable     bool `json:"disableUserEditable"`
 	HasDefaultValueOnCreate bool `json:"hasDefaultValueOnCreate"`
 	HasDefaultValueOnEdit   bool `json:"hasDefaultValueOnEdit"`

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/schema/field.ts
+++ b/ts/src/schema/field.ts
@@ -75,6 +75,7 @@ export class UUIDField extends BaseField implements Field {
             values: polymorphic.types,
             hideFromGraphQL: true,
             derivedWhenEmbedded: true,
+            nullable: options.nullable,
           }),
         ];
       } else {
@@ -84,6 +85,7 @@ export class UUIDField extends BaseField implements Field {
             name,
             hideFromGraphQL: true,
             derivedWhenEmbedded: true,
+            nullable: options.nullable,
           }),
         ];
       }

--- a/ts/src/schema/string_field.test.ts
+++ b/ts/src/schema/string_field.test.ts
@@ -1,6 +1,4 @@
-import exp from "constants";
-import { textSpanOverlapsWith } from "typescript";
-import { ListField, StringField, StringListType, StringType } from "./field";
+import { ListField, StringField, StringType } from "./field";
 
 interface testCase {
   fn: () => StringField;

--- a/ts/src/schema/uuid_field.test.ts
+++ b/ts/src/schema/uuid_field.test.ts
@@ -1,0 +1,59 @@
+import { UUIDType } from "./field";
+import { DBType, PolymorphicOptions, Type, FieldOptions } from "./schema";
+
+test("polymorphic true", () => {
+  doTest(true, {
+    dbType: DBType.String,
+  });
+});
+
+test("polymorphic true nullable true", () => {
+  doTest(
+    true,
+    {
+      dbType: DBType.String,
+    },
+    {
+      nullable: true,
+    },
+  );
+});
+
+test("polymorphic object", () => {
+  doTest(
+    { types: ["User", "Post"] },
+    {
+      dbType: DBType.StringEnum,
+      values: ["User", "Post"],
+      type: "fooType",
+      graphQLType: "fooType",
+    },
+  );
+});
+
+test("polymorphic object, nullable true", () => {
+  doTest(
+    { types: ["User", "Post"] },
+    {
+      dbType: DBType.StringEnum,
+      values: ["User", "Post"],
+      type: "fooType",
+      graphQLType: "fooType",
+    },
+    {
+      nullable: true,
+    },
+  );
+});
+
+function doTest(
+  polymorphic: boolean | PolymorphicOptions,
+  expDerivedType: Type,
+  opts?: Partial<FieldOptions>,
+) {
+  const f = UUIDType({ name: "fooID", polymorphic: polymorphic, ...opts });
+  expect(f.derivedFields?.length).toBe(1);
+  const derived = f.derivedFields![0];
+  expect(derived.type).toStrictEqual(expDerivedType);
+  expect(derived.nullable).toBe(opts?.nullable);
+}


### PR DESCRIPTION
if we had a polymorphic field that's nullable, the derived `type` field wasn't leading to errors. this fixes that

fixes https://github.com/lolopinto/ent/issues/540