### PR TITLE
changes to golang CLI for new auto_schema version

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'ent/**.go'
       - 'internal/**.go'
-      - ts/src/**
+      - 'ts/src/**'
       - .github/workflows/go_ci.yml
 
 

--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -69,7 +69,7 @@ jobs:
         python-version: '>3.6' 
       
     - name: install auto_schema
-      run: python3 -m pip install wheel auto_schema==0.0.6
+      run: python3 -m pip install wheel auto_schema==0.0.11
 
     - name: Setup nodejs
       uses: actions/setup-node@v2

--- a/gent/cmd/upgrade.go
+++ b/gent/cmd/upgrade.go
@@ -20,6 +20,6 @@ var upgradeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return db.UpgradeDB(cfg, revision)
+		return db.UpgradeDB(cfg, revision, false)
 	},
 }

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -419,15 +419,24 @@ func (s *dbSchema) makeDBChanges() error {
 	return auto_schema.RunPythonCommand(s.pathToConfigs)
 }
 
-func UpgradeDB(cfg *codegen.Config, revision string) error {
-	return auto_schema.RunPythonCommand(cfg.GetRootPathToConfigs(), fmt.Sprintf("-u=%s", revision))
+func UpgradeDB(cfg *codegen.Config, revision string, mergeBranches bool) error {
+	extraArgs := []string{fmt.Sprintf("-u=%s", revision)}
+	if mergeBranches {
+		extraArgs = append(extraArgs, "--merge_branches")
+	}
+	return auto_schema.RunPythonCommand(cfg.GetRootPathToConfigs(), extraArgs...)
 }
 
 func DowngradeDB(cfg *codegen.Config, revision string, keepSchemaFiles bool) error {
 	extraArgs := []string{fmt.Sprintf("-d=%s", revision)}
 	if keepSchemaFiles {
-		extraArgs = append(extraArgs, "--keep_schema_files=True")
+		extraArgs = append(extraArgs, "--keep_schema_files")
 	}
+	return auto_schema.RunPythonCommand(cfg.GetRootPathToConfigs(), extraArgs...)
+}
+
+func Squash(cfg *codegen.Config, squash int) error {
+	extraArgs := []string{fmt.Sprintf("--squash=%d", squash)}
 	return auto_schema.RunPythonCommand(cfg.GetRootPathToConfigs(), extraArgs...)
 }
 

--- a/test_setup/main.go
+++ b/test_setup/main.go
@@ -21,7 +21,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := db.UpgradeDB(cfg, "head"); err != nil {
+	if err := db.UpgradeDB(cfg, "head", true); err != nil {
 		log.Fatal(err)
 	}
 

--- a/tsent/cmd/alembic.go
+++ b/tsent/cmd/alembic.go
@@ -18,6 +18,7 @@ var validCmds = map[string]int{
 	"show":      1,
 	"stamp":     1, // stamp --purge option may be needed. would need a child command or simple flag parsing here
 	"edit":      1,
+	"merge":     1,
 }
 
 var alembicCmd = &cobra.Command{

--- a/tsent/cmd/downgrade.go
+++ b/tsent/cmd/downgrade.go
@@ -15,8 +15,12 @@ var downgradeInfo downgradeArgs
 var downgradeCmd = &cobra.Command{
 	Use:   "downgrade",
 	Short: "downgrade db",
-	Long:  `This downgrades the database to the specified version`,
-	Args:  cobra.MinimumNArgs(1),
+	Long:  `This downgrades the database to the specified version. It also deletes the generated schema files. To keep the generated schema files, pass the --keep_schema_files argument.`,
+	Example: `tsent downgrade --keep_schema_files -- -1
+tsent downgrade --keep_schema_files revision
+tsent downgrade -- -1
+tsent downgrade revision`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// another hardcoded place
 		cfg, err := codegen.NewConfig("src/schema", "")

--- a/tsent/cmd/root.go
+++ b/tsent/cmd/root.go
@@ -73,6 +73,7 @@ func init() {
 		fixEdgesCmd,
 		alembicCmd,
 		generateCmd,
+		squashCmd,
 	})
 
 	addCommands(generateCmd, []*cobra.Command{
@@ -89,6 +90,7 @@ func init() {
 	generateSchemasCmd.Flags().BoolVar(&schemasInfo.force, "force", false, "if force is true, it overwrites existing schema, otherwise throws error")
 
 	downgradeCmd.Flags().BoolVar(&downgradeInfo.keepSchemaFiles, "keep_schema_files", false, "keep schema files instead of deleting")
+	upgradeCmd.Flags().BoolVar(&upgradeInfo.mergeBranches, "merge_branches", false, "merge branches found while upgrading")
 }
 
 func Execute() {

--- a/tsent/cmd/squash.go
+++ b/tsent/cmd/squash.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"strconv"
+
+	"github.com/lolopinto/ent/internal/codegen"
+	"github.com/lolopinto/ent/internal/db"
+	"github.com/spf13/cobra"
+)
+
+var squashCmd = &cobra.Command{
+	Use:     "squash",
+	Short:   "squash last N revs of the db into one",
+	Example: `tsent squash 2`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// another hardcoded place
+		cfg, err := codegen.NewConfig("src/schema", "")
+		if err != nil {
+			return err
+		}
+
+		i, err := strconv.Atoi(args[0])
+		if err != nil {
+			return err
+		}
+		return db.Squash(cfg, i)
+	},
+}

--- a/tsent/cmd/upgrade.go
+++ b/tsent/cmd/upgrade.go
@@ -6,11 +6,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type upgradeArgs struct {
+	mergeBranches bool
+}
+
+var upgradeInfo upgradeArgs
+
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "upgrade db",
 	Long:  `This upgrades the database to the latest version`,
-	Args:  cobra.RangeArgs(0, 1),
+	Example: `tsent upgrade 
+tsent upgrade --merge_branches 
+tsent upgrade --merge_branches head
+tsent upgrade --merge_branches revision
+tsent upgrade revision`,
+	Args: cobra.RangeArgs(0, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// default to head if not passed in
 		revision := "head"
@@ -23,6 +34,6 @@ var upgradeCmd = &cobra.Command{
 			return err
 		}
 
-		return db.UpgradeDB(cfg, revision)
+		return db.UpgradeDB(cfg, revision, upgradeInfo.mergeBranches)
 	},
 }


### PR DESCRIPTION
uses https://github.com/lolopinto/ent/pull/549

* adds `merge_branches` flag to `upgrade` command
* uses `keep_schema_files` in `downgrade` command correctly
* adds new `squash` top level command
* adds new alembic `merge` "subcommand" so that `tsent alembic heads` can be run by developer and not depend on what happens at https://github.com/lolopinto/ent/pull/546