### PR TITLE
throw in orchestrator if we get an undefined value from defaultValueOnCreate

### DIFF
--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -498,6 +498,11 @@ export class Orchestrator<T extends Ent> {
           }
           if (field.defaultValueOnCreate) {
             value = field.defaultValueOnCreate(builder, input);
+            if (value === undefined) {
+              throw new Error(
+                `defaultValueOnCreate() returned undefined for field ${field.name}`,
+              );
+            }
           }
         }
 
@@ -597,7 +602,7 @@ export class Orchestrator<T extends Ent> {
     if (!action || !action.viewerForEntLoad) {
       return this.options.viewer;
     }
-    return await action.viewerForEntLoad(data);
+    return action.viewerForEntLoad(data);
   }
 
   async returnedRow(): Promise<Data | null> {
@@ -613,11 +618,7 @@ export class Orchestrator<T extends Ent> {
       return null;
     }
     const viewer = await this.viewerForEntLoad(row);
-    return await applyPrivacyPolicyForRow(
-      viewer,
-      this.options.loaderOptions,
-      row,
-    );
+    return applyPrivacyPolicyForRow(viewer, this.options.loaderOptions, row);
   }
 
   async editedEntX(): Promise<T> {

--- a/ts/src/core/viewer.ts
+++ b/ts/src/core/viewer.ts
@@ -2,7 +2,7 @@ import { ID, Ent, Viewer, Context } from "./base";
 
 export class LoggedOutViewer implements Viewer {
   constructor(public context?: Context) {}
-  viewerID: null;
+  viewerID = null;
   async viewer() {
     return null;
   }


### PR DESCRIPTION
if you have a JSONBType and do

```ts
JSONBType({name: 'blah', defaultValueOnCreate: () => {}})
```

that returns undefined and you get confusing error messages about field not being set when what you want is:

```ts
JSONBType({name: 'blah', defaultValueOnCreate: () => ({})})
```

this hopefully makes it less likely for someone to be confused