### PR TITLE
update graphql peer dependency to skip 15.4

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -21,7 +21,7 @@
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
-        "graphql": "^15.4.0",
+        "graphql": "^15.7.2",
         "graphql-upload": "^11.0.0",
         "memoizee": "^0.4.15",
         "passport": "^0.4.1",
@@ -3037,9 +3037,10 @@
       "integrity": "sha512-UjpxinnwnV0+IgO70z5JYUsPrStsBtPYi0Aqdj2mFaB+PrpgZAOJc9r7PtxwsG5sButfdFCk00jL2smZACFC3Q=="
     },
     "node_modules/graphql": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.3.tgz",
-      "integrity": "sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.x"
       }
@@ -8654,9 +8655,9 @@
       "integrity": "sha512-UjpxinnwnV0+IgO70z5JYUsPrStsBtPYi0Aqdj2mFaB+PrpgZAOJc9r7PtxwsG5sButfdFCk00jL2smZACFC3Q=="
     },
     "graphql": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.3.tgz",
-      "integrity": "sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA=="
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
     },
     "graphql-upload": {
       "version": "11.0.0",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -38,7 +38,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
-    "graphql": "^15.4.0",
+    "graphql": "^15.7.2",
     "graphql-upload": "^11.0.0",
     "memoizee": "^0.4.15",
     "passport": "^0.4.1",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -27,6 +27,7 @@
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
         "express-session": "^1.17.1",
+        "graphql": "^15.7.2",
         "graphql-type-json": "^0.3.2",
         "graphql-upload": "^12.0.0",
         "jsonwebtoken": "^8.5.1",
@@ -3000,9 +3001,10 @@
       "integrity": "sha512-UjpxinnwnV0+IgO70z5JYUsPrStsBtPYi0Aqdj2mFaB+PrpgZAOJc9r7PtxwsG5sButfdFCk00jL2smZACFC3Q=="
     },
     "node_modules/graphql": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.0.tgz",
-      "integrity": "sha512-WJR872Zlc9hckiEPhXgyUftXH48jp2EjO5tgBBOyNMRJZ9fviL2mJBD6CAysk6N5S0r9BTs09Qk39nnJBkvOXQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.x"
       }
@@ -8584,9 +8586,9 @@
       "integrity": "sha512-UjpxinnwnV0+IgO70z5JYUsPrStsBtPYi0Aqdj2mFaB+PrpgZAOJc9r7PtxwsG5sButfdFCk00jL2smZACFC3Q=="
     },
     "graphql": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.0.tgz",
-      "integrity": "sha512-WJR872Zlc9hckiEPhXgyUftXH48jp2EjO5tgBBOyNMRJZ9fviL2mJBD6CAysk6N5S0r9BTs09Qk39nnJBkvOXQ=="
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
     },
     "graphql-type-json": {
       "version": "0.3.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -53,6 +53,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "express-session": "^1.17.1",
+    "graphql": "^15.7.2",
     "graphql-type-json": "^0.3.2",
     "graphql-upload": "^12.0.0",
     "jsonwebtoken": "^8.5.1",

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -16,7 +16,7 @@
         "better-sqlite3": "^7.4.3",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
-        "graphql": "^15.5.0",
+        "graphql": "^15.7.2",
         "libphonenumber-js": "^1.7.56"
       },
       "devDependencies": {
@@ -2934,9 +2934,10 @@
       "integrity": "sha512-UjpxinnwnV0+IgO70z5JYUsPrStsBtPYi0Aqdj2mFaB+PrpgZAOJc9r7PtxwsG5sButfdFCk00jL2smZACFC3Q=="
     },
     "node_modules/graphql": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.3.tgz",
-      "integrity": "sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.x"
       }
@@ -8599,9 +8600,9 @@
       "integrity": "sha512-UjpxinnwnV0+IgO70z5JYUsPrStsBtPYi0Aqdj2mFaB+PrpgZAOJc9r7PtxwsG5sButfdFCk00jL2smZACFC3Q=="
     },
     "graphql": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.3.tgz",
-      "integrity": "sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA=="
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
     },
     "has": {
       "version": "1.0.3",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -40,7 +40,7 @@
     "better-sqlite3": "^7.4.3",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
-    "graphql": "^15.5.0",
+    "graphql": "^15.7.2",
     "libphonenumber-js": "^1.7.56"
   }
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "better-sqlite3": "^7.4.1",
-    "graphql": ">= 15.3.0"
+    "graphql": "^15.5"
   },
   "peerDependenciesMeta": {
     "better-sqlite3": {


### PR DESCRIPTION
 which is a known bad revision

use https://semver.npmjs.com/ to confirm that it skips it

https://github.com/lolopinto/ent/issues/582

update examples to 15.7.2 (latest) and confirm things work