### PR TITLE
Add generics to AllowIfViewerIsRule

### DIFF
--- a/ts/src/core/privacy.ts
+++ b/ts/src/core/privacy.ts
@@ -1,16 +1,16 @@
 import {
-  Viewer,
-  ID,
+  Allow,
+  Context,
+  Deny,
   Ent,
+  ID,
   LoadEntOptions,
   PrivacyError,
   PrivacyPolicy,
   PrivacyPolicyRule,
-  Context,
   PrivacyResult,
-  Allow,
-  Deny,
   Skip,
+  Viewer,
 } from "./base";
 import { AssocEdge, loadEdgeForID2, loadEnt } from "./ent";
 import { log } from "./logger";
@@ -154,11 +154,11 @@ export class DenyIfFuncRule implements PrivacyPolicyRule {
   }
 }
 
-export class AllowIfViewerIsRule implements PrivacyPolicyRule {
-  constructor(private property: string) {}
+export class AllowIfViewerIsRule<T extends Ent> implements PrivacyPolicyRule {
+  constructor(private property: keyof T) {}
 
-  async apply(v: Viewer, ent?: Ent): Promise<PrivacyResult> {
-    let result: undefined;
+  async apply(v: Viewer, ent?: T): Promise<PrivacyResult> {
+    let result: any;
     if (ent) {
       result = ent[this.property];
     }

--- a/ts/src/core/privacy.ts
+++ b/ts/src/core/privacy.ts
@@ -154,7 +154,27 @@ export class DenyIfFuncRule implements PrivacyPolicyRule {
   }
 }
 
-export class AllowIfViewerIsRule<T extends Ent> implements PrivacyPolicyRule {
+/**
+ * @deprecated use AllowIfViewerIsEntPropertyRule
+ */
+export class AllowIfViewerIsRule implements PrivacyPolicyRule {
+  constructor(private property: string) {}
+
+  async apply(v: Viewer, ent?: Ent): Promise<PrivacyResult> {
+    let result: undefined;
+    if (ent) {
+      result = ent[this.property];
+    }
+    if (result === v.viewerID) {
+      return Allow();
+    }
+    return Skip();
+  }
+}
+
+export class AllowIfViewerIsEntPropertyRule<T extends Ent>
+  implements PrivacyPolicyRule
+{
   constructor(private property: keyof T) {}
 
   async apply(v: Viewer, ent?: T): Promise<PrivacyResult> {

--- a/ts/src/core/privacy.ts
+++ b/ts/src/core/privacy.ts
@@ -158,10 +158,7 @@ export class AllowIfViewerIsRule<T extends Ent> implements PrivacyPolicyRule {
   constructor(private property: keyof T) {}
 
   async apply(v: Viewer, ent?: T): Promise<PrivacyResult> {
-    let result: any;
-    if (ent) {
-      result = ent[this.property];
-    }
+    const result: any = ent && ent[this.property];
     if (result === v.viewerID) {
       return Allow();
     }


### PR DESCRIPTION
Requires a caller to specify the Ent type into the `AllowIfViewerIsRule`, so that Typescript can validate the string key passed in.

This isn't backwards compatible, so leaving up to you whether you want this in. It would just require going in and adding the generic to every use case.

VALID
`new AllowIfViewerIsRule<Ent>('id')`

TYPE ERROR
`new AllowIfViewerIsRule<Ent>('is')`