### PR TITLE
[work-in-progress] Migrate core TS APIs to typed IDs

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -7104,6 +7104,7 @@
       "requires": {
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
+        "jest-expect-message": "^1.0.2",
         "supertest": "^6.1.3"
       }
     },

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -75,7 +75,7 @@ export class {{$baseClass}} {
   static async load<T extends {{$baseClass}}>(
     this: {{$thisType}},
     viewer: {{$viewerType}}, 
-    id: {{$idType}},
+    id: T["id"],
   ): Promise<T | null>{
     return await {{useImport "loadEnt"}}(
       viewer, 
@@ -87,7 +87,7 @@ export class {{$baseClass}} {
   static async loadX<T extends {{$baseClass}}>(
     this: {{$thisType}},
     viewer: {{$viewerType}}, 
-    id: {{$idType}},
+    id: T["id"],
   ): Promise<T> {
     return await {{useImport "loadEntX"}}(
       viewer, 
@@ -100,7 +100,7 @@ export class {{$baseClass}} {
   static async loadMany<T extends {{$baseClass}}>(
     this: {{$thisType}},
     viewer: {{$viewerType}},
-    ...ids: {{$idType}}[]
+    ...ids: T["id"][]
   ): Promise<T[]> {
     return await {{useImport "loadEnts"}}(
       viewer, 
@@ -135,7 +135,7 @@ export class {{$baseClass}} {
 
   static async loadRawData<T extends {{$baseClass}}>(
     this: {{$thisType}},
-    id: ID,
+    id: T["id"],
     context?: {{useImport "Context"}},
   ): Promise<{{$dataType}} | null> {
     return {{$loaderName}}.createLoader(context).load(id);
@@ -143,7 +143,7 @@ export class {{$baseClass}} {
 
   static async loadRawDataX<T extends {{$baseClass}}>(
     this: {{$thisType}},
-    id: ID,
+    id: T["id"],
     context?: {{useImport "Context"}},
   ): Promise<{{$dataType}}> {
     const row = await {{$loaderName}}.createLoader(context).load(id);

--- a/ts/packages/ent-graphql-tests/package-lock.json
+++ b/ts/packages/ent-graphql-tests/package-lock.json
@@ -3588,8 +3588,7 @@
     "node_modules/jest-expect-message": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.0.2.tgz",
-      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q==",
-      "peer": true
+      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q=="
     },
     "node_modules/jest-get-type": {
       "version": "27.0.6",
@@ -9133,8 +9132,7 @@
     "jest-expect-message": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.0.2.tgz",
-      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q==",
-      "peer": true
+      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q=="
     },
     "jest-get-type": {
       "version": "27.0.6",

--- a/ts/packages/ent-passport/package-lock.json
+++ b/ts/packages/ent-passport/package-lock.json
@@ -6943,6 +6943,7 @@
       "requires": {
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
+        "jest-expect-message": "^1.0.2",
         "supertest": "^6.1.3"
       }
     },

--- a/ts/packages/ent-passport/src/passport.test.ts
+++ b/ts/packages/ent-passport/src/passport.test.ts
@@ -10,6 +10,7 @@ import {
   loadRow,
   query,
   Ent,
+  Context,
 } from "@snowtop/ent";
 import {
   expectQueryFromRoot,
@@ -60,7 +61,7 @@ let userType = new GraphQLObjectType({
 });
 
 class UserClass implements Ent {
-  id: ID;
+  id: ID<UserClass>;
   nodeType = "User";
   privacyPolicy = AlwaysAllowPrivacyPolicy;
   firstName: string;
@@ -96,8 +97,8 @@ let viewerType = new GraphQLObjectType({
   fields: {
     user: {
       type: userType,
-      async resolve(_source, args, context) {
-        const v = context.getViewer() as IDViewer;
+      async resolve(_source, args, context: Context<IDViewer>) {
+        const v = context.getViewer();
 
         return await v.viewer();
       },

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -179,7 +179,7 @@ class UserSchema extends BaseEntSchema {
 }
 
 class Account implements Ent {
-  id: ID;
+  id: ID<Account>;
   accountID: string = "";
   nodeType = "Account";
   privacyPolicy = AlwaysAllowPrivacyPolicy;

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -20,7 +20,7 @@ export class ListBasedExecutor<T extends Ent> implements Executor {
   private lastOp: DataOperation | undefined;
   private createdEnt: T | null = null;
 
-  resolveValue(val: ID): Ent | null {
+  resolveValue(val: T["id"]): T | null {
     if (val === this.placeholderID && val !== undefined) {
       return this.createdEnt;
     }

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -252,7 +252,7 @@ class ContactSchema2 extends BaseEntSchema {
 }
 
 class CustomUser implements Ent {
-  id: ID;
+  id: ID<CustomUser>;
   accountID: string = "";
   nodeType = "User";
   privacyPolicy: PrivacyPolicy = {
@@ -2277,7 +2277,7 @@ function commonTests() {
         ["City", "Washington DC"],
         ["State", "DC"],
         ["ZipCode", "20500"],
-        ["OwnerID", user.id],
+        ["OwnerID", user.id.toString()],
         ["OwnerType", user.nodeType],
       ]),
     );

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -63,8 +63,8 @@ interface queryOptions {
   orderby?: string;
 }
 
-export interface Context {
-  getViewer(): Viewer;
+export interface Context<T extends Viewer = Viewer> {
+  getViewer(): T;
   // optional per (request)contet
   // absence means we are not doing any caching
   // presence means we have loader, ent cache etc
@@ -73,9 +73,9 @@ export interface Context {
   cache?: cache;
 }
 
-export interface Viewer {
-  viewerID: ID | null;
-  viewer: () => Promise<Ent | null>;
+export interface Viewer<T extends Ent = Ent> {
+  viewerID: T["id"] | null;
+  viewer: () => Promise<T | null>;
   instanceKey: () => string;
   //  isOmniscient?(): boolean; // optional function to indicate a viewer that can see anything e.g. admin
   // TODO determine if we want this here.
@@ -104,7 +104,14 @@ export interface EntConstructor<T extends Ent> {
   new (viewer: Viewer, data: Data): T;
 }
 
-export type ID = string | number;
+type Brand<T, TBrand> = [TBrand] extends [never] // don't apply any brand if `never` is the brand type
+  ? T
+  : T & { __brand__: TBrand };
+
+export type ID<
+  TBrand = never,
+  TBase extends string | number = string | number,
+> = Brand<TBase, TBrand>;
 
 export interface DataOptions {
   // TODO pool or client later since we should get it from there

--- a/ts/src/core/context.ts
+++ b/ts/src/core/context.ts
@@ -6,8 +6,8 @@ import { log } from "./logger";
 import { Context } from "./base";
 
 // RequestBasedContext e.g. from an HTTP request with a server/response conponent
-export interface RequestContext extends Context {
-  authViewer(viewer: Viewer): Promise<void>; //logs user in and changes viewer to this
+export interface RequestContext<T extends Viewer = Viewer> extends Context<T> {
+  authViewer(viewer: T): Promise<void>; //logs user in and changes viewer to this
   logout(): Promise<void>;
   request: IncomingMessage;
   response: ServerResponse;

--- a/ts/src/core/ent.test.ts
+++ b/ts/src/core/ent.test.ts
@@ -112,7 +112,7 @@ beforeEach(async () => {
 const loggedOutViewer = new LoggedOutViewer();
 
 class DerivedUser implements Ent {
-  id: ID;
+  id: ID<DerivedUser>;
   accountID: string;
   nodeType = "User";
   privacyPolicy: PrivacyPolicy = {
@@ -275,18 +275,18 @@ function commonTests() {
     const ctx = new TestContext();
 
     test("loadEnt. no data. no context", async () => {
-      const ent = await loadEnt(noCtxV, "1", options);
+      const ent = await loadEnt(noCtxV, "1" as ID<User>, options);
       expect(ent).toBeNull();
     });
 
     test("loadEnt. no data. with context", async () => {
-      const ent = await loadEnt(ctx.getViewer(), "1", options);
+      const ent = await loadEnt(ctx.getViewer(), "1" as ID<User>, options);
       expect(ent).toBeNull();
     });
 
     test("loadEntX. no data. no context", async () => {
       try {
-        await loadEntX(noCtxV, "1", options);
+        await loadEntX(noCtxV, "1" as ID<User>, options);
         fail("should have thrown");
       } catch (e) {
         expect(e.message).toMatch(/couldn't find row for value/);
@@ -295,7 +295,7 @@ function commonTests() {
 
     test("loadEntX. no data. with context", async () => {
       try {
-        await loadEntX(ctx.getViewer(), "1", options);
+        await loadEntX(ctx.getViewer(), "1" as ID<User>, options);
         fail("should have thrown");
       } catch (e) {
         expect(e.message).toMatch(/couldn't find row for value 1/);
@@ -329,7 +329,7 @@ function commonTests() {
     });
 
     class User2 implements Ent {
-      id: ID;
+      id: ID<User2>;
       accountID: string;
       nodeType = "User2";
       privacyPolicy = {

--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -61,7 +61,7 @@ describe("sqlite", () => {
 });
 
 class User implements Ent {
-  id: ID;
+  id: ID<User>;
   accountID: string;
   nodeType = "User";
   privacyPolicy: PrivacyPolicy = {

--- a/ts/src/core/ent_data.test.ts
+++ b/ts/src/core/ent_data.test.ts
@@ -37,7 +37,7 @@ const selectOptions: SelectDataOptions = {
 const loaderFactory = new ObjectLoaderFactory(selectOptions);
 
 class User implements Ent {
-  id: ID;
+  id: ID<User>;
   accountID: string;
   nodeType = "User";
   privacyPolicy: PrivacyPolicy = {
@@ -47,11 +47,11 @@ class User implements Ent {
     this.id = data["bar"];
   }
 
-  static async load(v: Viewer, id: ID): Promise<User | null> {
+  static async load(v: Viewer, id: ID<User>): Promise<User | null> {
     return ent.loadEnt(v, id, User.loaderOptions());
   }
 
-  static async loadX(v: Viewer, id: ID): Promise<User> {
+  static async loadX(v: Viewer, id: ID<User>): Promise<User> {
     return ent.loadEntX(v, id, User.loaderOptions());
   }
 
@@ -385,7 +385,7 @@ function commonTests() {
 
       const testEnt = async (vc: Viewer) => {
         return await loadTestEnt(
-          () => ent.loadEnt(vc, 1, User.loaderOptions()),
+          () => ent.loadEnt(vc, 1 as ID<User>, User.loaderOptions()),
           () => {
             const queryOption = {
               query: ent.buildQuery(options),
@@ -414,7 +414,7 @@ function commonTests() {
       const [ent1, ent2] = await testEnt(vc);
 
       // // same context, change viewer
-      const vc2 = getIDViewer(1, ctx);
+      const vc2 = getIDViewer(1 as ID<User>, ctx);
 
       // // we still reuse the same raw-data query since it's viewer agnostic
       // // context cache works as viewer is changed
@@ -442,7 +442,7 @@ function commonTests() {
       };
 
       await loadTestEnt(
-        () => ent.loadEnt(vc, 1, User.loaderOptions()),
+        () => ent.loadEnt(vc, 1 as ID<User>, User.loaderOptions()),
         () => {
           const queryOption = {
             query: ent.buildQuery(options),
@@ -472,13 +472,13 @@ function commonTests() {
     });
 
     test("parallel queries with context", async () => {
-      const vc = getIDViewer(1);
+      const vc = getIDViewer(1 as ID<User>);
 
       // 3 loadEnts at the same time
       const [ent1, ent2, ent3] = await Promise.all([
-        ent.loadEnt(vc, 1, User.loaderOptions()),
-        ent.loadEnt(vc, 2, User.loaderOptions()),
-        ent.loadEnt(vc, 3, User.loaderOptions()),
+        ent.loadEnt(vc, 1 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 2 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 3 as ID<User>, User.loaderOptions()),
       ]);
 
       // only 1 ent visible
@@ -503,9 +503,9 @@ function commonTests() {
       // load the data again
       // everything should still be in cache
       const [ent4, ent5, ent6] = await Promise.all([
-        ent.loadEnt(vc, 1, User.loaderOptions()),
-        ent.loadEnt(vc, 2, User.loaderOptions()),
-        ent.loadEnt(vc, 3, User.loaderOptions()),
+        ent.loadEnt(vc, 1 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 2 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 3 as ID<User>, User.loaderOptions()),
       ]);
 
       // only 1 ent visible (same as before)
@@ -536,13 +536,13 @@ function commonTests() {
     });
 
     test("parallel queries without context", async () => {
-      const vc = new IDViewer(1);
+      const vc = new IDViewer(1 as ID<User>);
 
       // 3 loadEnts at the same time
       const [ent1, ent2, ent3] = await Promise.all([
-        ent.loadEnt(vc, 1, User.loaderOptions()),
-        ent.loadEnt(vc, 2, User.loaderOptions()),
-        ent.loadEnt(vc, 3, User.loaderOptions()),
+        ent.loadEnt(vc, 1 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 2 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 3 as ID<User>, User.loaderOptions()),
       ]);
 
       // only 1 ent visible
@@ -566,9 +566,9 @@ function commonTests() {
 
       // load the data again
       const [ent4, ent5, ent6] = await Promise.all([
-        ent.loadEnt(vc, 1, User.loaderOptions()),
-        ent.loadEnt(vc, 2, User.loaderOptions()),
-        ent.loadEnt(vc, 3, User.loaderOptions()),
+        ent.loadEnt(vc, 1 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 2 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 3 as ID<User>, User.loaderOptions()),
       ]);
 
       // only 1 ent visible (same as before)
@@ -582,7 +582,7 @@ function commonTests() {
 
   describe("loadEntX", () => {
     test("with context", async () => {
-      const vc = getIDViewer(1);
+      const vc = getIDViewer(1 as ID<User>);
 
       const options = {
         ...User.loaderOptions(),
@@ -592,7 +592,7 @@ function commonTests() {
 
       const testEnt = async (vc: Viewer) => {
         return await loadTestEnt(
-          () => ent.loadEntX(vc, 1, User.loaderOptions()),
+          () => ent.loadEntX(vc, 1 as ID<User>, User.loaderOptions()),
           () => {
             const qOption = {
               query: ent.buildQuery(options),
@@ -622,7 +622,7 @@ function commonTests() {
     });
 
     test("without context", async () => {
-      const vc = new IDViewer(1);
+      const vc = new IDViewer(1 as ID<User>);
 
       const options = {
         ...User.loaderOptions(),
@@ -631,7 +631,7 @@ function commonTests() {
       };
 
       await loadTestEnt(
-        () => ent.loadEntX(vc, 1, User.loaderOptions()),
+        () => ent.loadEntX(vc, 1 as ID<User>, User.loaderOptions()),
         () => {
           const queryOption = {
             query: ent.buildQuery(options),
@@ -653,7 +653,7 @@ function commonTests() {
     };
 
     test("with context", async () => {
-      const vc = getIDViewer(1);
+      const vc = getIDViewer(1 as ID<User>);
 
       await loadTestEnt(
         () => ent.loadEntFromClause(vc, User.loaderOptions(), cls),
@@ -679,7 +679,7 @@ function commonTests() {
     });
 
     test("without context", async () => {
-      const vc = new IDViewer(1);
+      const vc = new IDViewer(1 as ID<User>);
 
       await loadTestEnt(
         () => ent.loadEntFromClause(vc, User.loaderOptions(), cls),
@@ -696,7 +696,7 @@ function commonTests() {
     });
 
     test("loadEntXFromClause with context", async () => {
-      const vc = getIDViewer(1);
+      const vc = getIDViewer(1 as ID<User>);
 
       await loadTestEnt(
         () => ent.loadEntXFromClause(vc, User.loaderOptions(), cls),
@@ -722,7 +722,7 @@ function commonTests() {
     });
 
     test("loadEntXFromClause without context", async () => {
-      const vc = new IDViewer(1);
+      const vc = new IDViewer(1 as ID<User>);
 
       await loadTestEnt(
         () => ent.loadEntXFromClause(vc, User.loaderOptions(), cls),
@@ -752,8 +752,14 @@ function commonTests() {
     });
 
     test("with context", async () => {
-      const vc = getIDViewer(1);
-      const ents = await ent.loadEnts(vc, User.loaderOptions(), 1, 2, 3);
+      const vc = getIDViewer(1 as ID<User>);
+      const ents = await ent.loadEnts(
+        vc,
+        User.loaderOptions(),
+        1 as ID<User>,
+        2 as ID<User>,
+        3 as ID<User>,
+      );
 
       // only loading self worked because of privacy
       expect(ents.length).toBe(1);
@@ -774,9 +780,9 @@ function commonTests() {
 
       // reload each of these in a different place
       await Promise.all([
-        ent.loadEnt(vc, 1, User.loaderOptions()),
-        ent.loadEnt(vc, 2, User.loaderOptions()),
-        ent.loadEnt(vc, 3, User.loaderOptions()),
+        ent.loadEnt(vc, 1 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 2 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 3 as ID<User>, User.loaderOptions()),
       ]);
 
       const cacheHits = [
@@ -797,15 +803,27 @@ function commonTests() {
       validateQueries(expQueries2);
 
       // reload all
-      await ent.loadEnts(vc, User.loaderOptions(), 1, 2, 3);
+      await ent.loadEnts(
+        vc,
+        User.loaderOptions(),
+        1 as ID<User>,
+        2 as ID<User>,
+        3 as ID<User>,
+      );
 
       // more cache hits
       validateQueries([...expQueries2, ...cacheHits]);
     });
 
     test("without context", async () => {
-      const vc = new IDViewer(1);
-      const ents = await ent.loadEnts(vc, User.loaderOptions(), 1, 2, 3);
+      const vc = new IDViewer(1 as ID<User>);
+      const ents = await ent.loadEnts(
+        vc,
+        User.loaderOptions(),
+        1 as ID<User>,
+        2 as ID<User>,
+        3 as ID<User>,
+      );
 
       // only loading self worked because of privacy
       expect(ents.length).toBe(1);
@@ -840,16 +858,22 @@ function commonTests() {
 
       // reload each of these in a different place
       await Promise.all([
-        ent.loadEnt(vc, 1, User.loaderOptions()),
-        ent.loadEnt(vc, 2, User.loaderOptions()),
-        ent.loadEnt(vc, 3, User.loaderOptions()),
+        ent.loadEnt(vc, 1 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 2 as ID<User>, User.loaderOptions()),
+        ent.loadEnt(vc, 3 as ID<User>, User.loaderOptions()),
       ]);
 
       // should now have 3 more queries
       validateQueries(expQueries2);
 
       // reload all
-      await ent.loadEnts(vc, User.loaderOptions(), 1, 2, 3);
+      await ent.loadEnts(
+        vc,
+        User.loaderOptions(),
+        1 as ID<User>,
+        2 as ID<User>,
+        3 as ID<User>,
+      );
 
       const expQueries3 = expQueries2.concat(inQuery);
 
@@ -885,19 +909,19 @@ function commonTests() {
     });
 
     test("with context", async () => {
-      const vc = getIDViewer(1);
+      const vc = getIDViewer(1 as ID<User>);
 
       const ents = await ent.loadEntsFromClause(vc, cls, User.loaderOptions());
       // only loading self worked because of privacy
       expect(ents.size).toBe(1);
-      expect(ents.has(1)).toBe(true);
+      expect(ents.has(1 as ID<User>)).toBe(true);
 
       validateQueries([qOption]);
 
       const ents2 = await ent.loadEntsFromClause(vc, cls, User.loaderOptions());
       // only loading self worked because of privacy
       expect(ents2.size).toBe(1);
-      expect(ents2.has(1)).toBe(true);
+      expect(ents2.has(1 as ID<User>)).toBe(true);
 
       validateQueries([
         qOption,
@@ -909,12 +933,12 @@ function commonTests() {
     });
 
     test("without context", async () => {
-      const vc = new IDViewer(1);
+      const vc = new IDViewer(1 as ID<User>);
 
       const ents = await ent.loadEntsFromClause(vc, cls, User.loaderOptions());
       // only loading self worked because of privacy
       expect(ents.size).toBe(1);
-      expect(ents.has(1)).toBe(true);
+      expect(ents.has(1 as ID<User>)).toBe(true);
 
       const expQueries = [qOption];
 
@@ -923,7 +947,7 @@ function commonTests() {
       const ents2 = await ent.loadEntsFromClause(vc, cls, User.loaderOptions());
       // only loading self worked because of privacy
       expect(ents2.size).toBe(1);
-      expect(ents2.has(1)).toBe(true);
+      expect(ents2.has(1 as ID<User>)).toBe(true);
 
       validateQueries([qOption, qOption]);
     });
@@ -979,7 +1003,7 @@ function commonTests() {
           options2.fields = { ...options.fields, baz: "baz3" };
           options2.fieldsToLog = options2.fields;
           // we need a different row so that querying after still returns one row
-          return editRowForTest(options2, 1);
+          return editRowForTest(options2, 1 as ID<User>);
         },
         () => {
           const [query, _, logValues] = buildUpdateQuery(
@@ -989,7 +1013,7 @@ function commonTests() {
               tableName: selectOptions.tableName,
               key: "bar",
             },
-            1,
+            1 as ID<User>,
           );
           return { query, values: logValues };
         },

--- a/ts/src/core/ent_logs.test.ts
+++ b/ts/src/core/ent_logs.test.ts
@@ -23,6 +23,7 @@ import { MockLogs } from "../testutils/mock_log";
 import { ObjectLoaderFactory } from "./loaders";
 import {
   EditRowOptions,
+  ID,
   LoadEntOptions,
   LoadRowOptions,
   LoadRowsOptions,
@@ -489,7 +490,7 @@ function commonTests() {
         ent: User,
         context: ctx,
       };
-      await loadEnt(ctx.getViewer(), 1, options);
+      await loadEnt(ctx.getViewer(), 1 as ID<User>, options);
 
       // regular row fetch. hit db
       expect(ml.logs.length).toEqual(1);
@@ -506,7 +507,7 @@ function commonTests() {
 
       ml.clear();
       // fetch again
-      await loadEnt(ctx.getViewer(), 1, options);
+      await loadEnt(ctx.getViewer(), 1 as ID<User>, options);
 
       expect(ml.logs.length).toEqual(1);
       expect(ml.logs[0]).toStrictEqual({
@@ -581,7 +582,7 @@ function commonTests() {
     // this was interfering with above batch so we're breaking it out
     test("log disabled", async () => {
       clearLogLevels();
-      await loadEnt(ctx.getViewer(), 1, {
+      await loadEnt(ctx.getViewer(), 1 as ID<User>, {
         fields,
         tableName,
         loaderFactory: new ObjectLoaderFactory({
@@ -616,7 +617,7 @@ function commonTests() {
 
     test("log disabled", async () => {
       clearLogLevels();
-      await loadEnt(v, 1, {
+      await loadEnt(v, 1 as ID<User>, {
         fields,
         tableName,
         loaderFactory: new ObjectLoaderFactory({
@@ -641,7 +642,7 @@ function commonTests() {
           key: "id",
         }),
       };
-      await loadEnt(v, 1, options);
+      await loadEnt(v, 1 as ID<User>, options);
 
       // regular row fetch. hit db
       expect(ml.logs.length).toEqual(1);
@@ -656,7 +657,7 @@ function commonTests() {
       });
 
       // fetch again
-      await loadEnt(v, 1, options);
+      await loadEnt(v, 1 as ID<User>, options);
 
       expect(ml.logs.length).toEqual(2);
       // no context. hit db

--- a/ts/src/core/loaders/assoc_edge_loader.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.ts
@@ -16,6 +16,7 @@ import {
   loadEdgeForID2,
   buildGroupQuery,
   AssocEdgeData,
+  AssocDataOf,
 } from "../ent";
 import * as clause from "../clause";
 import { logEnabled } from "../logger";
@@ -90,7 +91,7 @@ function createLoader<T extends AssocEdge>(
           `malformed query. got ${srcID} back but didn't query for it`,
         );
       }
-      result[idx].push(new edgeCtr(row));
+      result[idx].push(new edgeCtr(row as AssocDataOf<T>));
     }
     return result;
   }, loaderOptions);

--- a/ts/src/core/privacy.test.ts
+++ b/ts/src/core/privacy.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 const loggedOutViewer = new LoggedOutViewer();
 
 class User implements Ent {
-  id: ID;
+  id: ID<User>;
   accountID: string;
   privacyPolicy: PrivacyPolicy;
   nodeType = "User";
@@ -45,9 +45,9 @@ class User implements Ent {
   }
 }
 
-const getUser = function(
+const getUser = function (
   v: Viewer,
-  id: string,
+  id: ID<User>,
   privacyPolicy: PrivacyPolicy,
   accountID: string = "2",
 ): User {
@@ -63,13 +63,13 @@ describe("alwaysAllowRule", () => {
   };
 
   test("AlwaysAllowRule", async () => {
-    const user = getUser(loggedOutViewer, "1", policy);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(true);
   });
 
   test("id viewer", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(true);
   });
@@ -81,13 +81,13 @@ describe("AlwaysDenyRule", () => {
   };
 
   test("loggedOutViewer", async () => {
-    const user = getUser(loggedOutViewer, "1", policy);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(false);
   });
 
   test("id viewer", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(false);
   });
@@ -102,25 +102,25 @@ describe("DenyIfLoggedOutRule", () => {
   };
 
   test("loggedOutViewer invalid rule", async () => {
-    const user = getUser(loggedOutViewer, "1", policy);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(false);
   });
 
   test("loggedOutViewer", async () => {
-    const user = getUser(loggedOutViewer, "1", policy2);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(false);
   });
 
   test("id viewer invalid rule", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(false);
   });
 
   test("id viewer", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy2);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(true);
   });
@@ -135,31 +135,31 @@ describe("AllowIfViewerRule", () => {
   };
 
   test("loggedOutViewer invalid rule", async () => {
-    const user = getUser(loggedOutViewer, "1", policy);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(false);
   });
 
   test("loggedOutViewer", async () => {
-    const user = getUser(loggedOutViewer, "1", policy2);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(false);
   });
 
   test("id viewer invalid rule", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(true);
   });
 
   test("id viewer", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy2);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(true);
   });
 
   test("different viewer", async () => {
-    const user = getUser(new IDViewer("2"), "1", policy2);
+    const user = getUser(new IDViewer("2"), "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(false);
   });
@@ -177,31 +177,31 @@ describe("AllowIfFuncRule", () => {
   };
 
   test("loggedOutViewer invalid rule", async () => {
-    const user = getUser(loggedOutViewer, "1", policy);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(false);
   });
 
   test("loggedOutViewer", async () => {
-    const user = getUser(loggedOutViewer, "1", policy2);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(false);
   });
 
   test("id viewer invalid rule", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(true);
   });
 
   test("id viewer", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy2);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(true);
   });
 
   test("different viewer", async () => {
-    const user = getUser(new IDViewer("2"), "1", policy2);
+    const user = getUser(new IDViewer("2"), "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(false);
   });
@@ -216,31 +216,31 @@ describe("AllowIfViewerIsRule", () => {
   };
 
   test("loggedOutViewer invalid rule", async () => {
-    const user = getUser(loggedOutViewer, "1", policy);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(false);
   });
 
   test("loggedOutViewer", async () => {
-    const user = getUser(loggedOutViewer, "1", policy2);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(false);
   });
 
   test("id viewer does not match account invalid rule", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy);
     const bool = await applyPrivacyPolicy(user.viewer, policy, user);
     expect(bool).toBe(false);
   });
 
   test("id viewer does not match account", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy2);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(false);
   });
 
   test("viewer matches account id", async () => {
-    const user = getUser(new IDViewer("2"), "1", policy2);
+    const user = getUser(new IDViewer("2"), "1" as ID<User>, policy2);
     const bool = await applyPrivacyPolicy(user.viewer, policy2, user);
     expect(bool).toBe(true);
   });
@@ -252,7 +252,7 @@ describe("applyPrivacyPolicyX", () => {
   };
 
   test("privacy not allowed", async () => {
-    const user = getUser(loggedOutViewer, "1", policy);
+    const user = getUser(loggedOutViewer, "1" as ID<User>, policy);
     try {
       await applyPrivacyPolicyX(user.viewer, policy, user);
       fail("should not get here");
@@ -264,7 +264,7 @@ describe("applyPrivacyPolicyX", () => {
   });
 
   test("privacy yay!", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy);
     try {
       const bool = await applyPrivacyPolicyX(user.viewer, policy, user);
       expect(bool).toBe(true);
@@ -278,7 +278,7 @@ async function createUser() {
   await createRowForTest({
     tableName: DefinedUser.loaderOptions().tableName,
     fields: {
-      id: "1",
+      id: "1" as ID<User>,
       name: "name",
     },
   });
@@ -307,7 +307,7 @@ describe("AllowIfEntIsVisibleRule", () => {
     await createUser();
   });
   const policy = new AllowIfEntIsVisiblePolicy(
-    "1",
+    "1" as ID<User>,
     DefinedUser.loaderOptions(),
   );
 
@@ -316,7 +316,7 @@ describe("AllowIfEntIsVisibleRule", () => {
     const bool = await applyPrivacyPolicy(
       vc,
       policy,
-      new DefinedUser(vc, { id: "1" }),
+      new DefinedUser(vc, { id: "1" as ID<User> }),
     );
     expect(bool).toBe(true);
   });
@@ -326,7 +326,7 @@ describe("AllowIfEntIsVisibleRule", () => {
     const bool = await applyPrivacyPolicy(
       vc,
       policy,
-      new DefinedUser(vc, { id: "1" }),
+      new DefinedUser(vc, { id: "1" as ID<User> }),
     );
     expect(bool).toBe(false);
   });
@@ -336,14 +336,17 @@ describe("DenyIfEntIsVisibleRule", () => {
   beforeEach(async () => {
     await createUser();
   });
-  const policy = new DenyIfEntIsVisiblePolicy("1", DefinedUser.loaderOptions());
+  const policy = new DenyIfEntIsVisiblePolicy(
+    "1" as ID<User>,
+    DefinedUser.loaderOptions(),
+  );
 
   test("passes", async () => {
     const vc = new IDViewer("1");
     const bool = await applyPrivacyPolicy(
       vc,
       policy,
-      new DefinedUser(vc, { id: "1" }),
+      new DefinedUser(vc, { id: "1" as ID<User> }),
     );
     expect(bool).toBe(false);
   });
@@ -353,7 +356,7 @@ describe("DenyIfEntIsVisibleRule", () => {
     const bool = await applyPrivacyPolicy(
       vc,
       policy,
-      new DefinedUser(vc, { id: "1" }),
+      new DefinedUser(vc, { id: "1" as ID<User> }),
     );
     expect(bool).toBe(true);
   });
@@ -381,7 +384,7 @@ describe("denywithReason", () => {
   };
 
   test("privacy not allowed", async () => {
-    const user = getUser(new IDViewer("1"), "1", policy);
+    const user = getUser(new IDViewer("1"), "1" as ID<User>, policy);
     try {
       await applyPrivacyPolicyX(user.viewer, policy, user);
       fail("should not get here");
@@ -391,7 +394,7 @@ describe("denywithReason", () => {
   });
 
   test("privacy allowed!", async () => {
-    const user = getUser(new IDViewer("2"), "1", policy);
+    const user = getUser(new IDViewer("2"), "1" as ID<User>, policy);
     try {
       const bool = await applyPrivacyPolicyX(user.viewer, policy, user);
       expect(bool).toBe(true);

--- a/ts/src/core/privacy.ts
+++ b/ts/src/core/privacy.ts
@@ -189,7 +189,7 @@ export class AllowIfViewerIsEntPropertyRule<T extends Ent>
 export class AllowIfEntIsVisibleRule<T extends Ent>
   implements PrivacyPolicyRule
 {
-  constructor(private id: ID, private options: LoadEntOptions<T>) {}
+  constructor(private id: T["id"], private options: LoadEntOptions<T>) {}
 
   async apply(v: Viewer, _ent?: Ent): Promise<PrivacyResult> {
     const visible = await loadEnt(v, this.id, this.options);
@@ -203,7 +203,7 @@ export class AllowIfEntIsVisibleRule<T extends Ent>
 export class AllowIfEntIsNotVisibleRule<T extends Ent>
   implements PrivacyPolicyRule
 {
-  constructor(private id: ID, private options: LoadEntOptions<T>) {}
+  constructor(private id: T["id"], private options: LoadEntOptions<T>) {}
 
   async apply(v: Viewer, _ent?: Ent): Promise<PrivacyResult> {
     const visible = await loadEnt(v, this.id, this.options);
@@ -215,13 +215,13 @@ export class AllowIfEntIsNotVisibleRule<T extends Ent>
 }
 
 export class AllowIfEntIsVisiblePolicy<T extends Ent> implements PrivacyPolicy {
-  constructor(private id: ID, private options: LoadEntOptions<T>) {}
+  constructor(private id: T["id"], private options: LoadEntOptions<T>) {}
 
   rules = [new AllowIfEntIsVisibleRule(this.id, this.options), AlwaysDenyRule];
 }
 
 export class DenyIfEntIsVisiblePolicy<T extends Ent> implements PrivacyPolicy {
-  constructor(private id: ID, private options: LoadEntOptions<T>) {}
+  constructor(private id: T["id"], private options: LoadEntOptions<T>) {}
 
   rules = [new DenyIfEntIsVisibleRule(this.id, this.options), AlwaysAllowRule];
 }
@@ -229,7 +229,7 @@ export class DenyIfEntIsVisiblePolicy<T extends Ent> implements PrivacyPolicy {
 export class DenyIfEntIsVisibleRule<T extends Ent>
   implements PrivacyPolicyRule
 {
-  constructor(private id: ID, private options: LoadEntOptions<T>) {}
+  constructor(private id: T["id"], private options: LoadEntOptions<T>) {}
 
   async apply(v: Viewer, _ent?: Ent): Promise<PrivacyResult> {
     const visible = await loadEnt(v, this.id, this.options);
@@ -243,7 +243,7 @@ export class DenyIfEntIsVisibleRule<T extends Ent>
 export class DenyIfEntIsNotVisibleRule<T extends Ent>
   implements PrivacyPolicyRule
 {
-  constructor(private id: ID, private options: LoadEntOptions<T>) {}
+  constructor(private id: T["id"], private options: LoadEntOptions<T>) {}
 
   async apply(v: Viewer, _ent?: Ent): Promise<PrivacyResult> {
     const visible = await loadEnt(v, this.id, this.options);

--- a/ts/src/core/query/shared_assoc_test.ts
+++ b/ts/src/core/query/shared_assoc_test.ts
@@ -679,7 +679,7 @@ export function assocTests() {
       expect(ids.length).toBe(this.expCount);
 
       const expIDs = this.users
-        .map((user) => user.id)
+        .map((user): ID => user.id)
         .concat(this.events.map((event) => event.id))
         .reverse();
 

--- a/ts/src/core/viewer.ts
+++ b/ts/src/core/viewer.ts
@@ -1,6 +1,6 @@
 import { ID, Ent, Viewer, Context } from "./base";
 
-export class LoggedOutViewer implements Viewer {
+export class LoggedOutViewer implements Viewer<never> {
   constructor(public context?: Context) {}
   viewerID = null;
   async viewer() {
@@ -11,20 +11,20 @@ export class LoggedOutViewer implements Viewer {
   }
 }
 
-export interface IDViewerOptions {
-  viewerID: ID;
+export interface IDViewerOptions<T extends Ent = Ent> {
+  viewerID: T["id"];
   context?: Context;
-  ent?: Ent | null;
+  ent?: T | null;
 }
 
-export class IDViewer implements Viewer {
-  public viewerID: ID;
-  private ent: Ent | null = null;
+export class IDViewer<T extends Ent = Ent> implements Viewer<T> {
+  public viewerID: T["id"];
+  private ent: T | null = null;
   public context?: Context;
 
-  constructor(viewerID: ID, opts?: Partial<IDViewerOptions>);
-  constructor(opts: IDViewerOptions);
-  constructor(args: IDViewerOptions | ID, opts?: IDViewerOptions) {
+  constructor(viewerID: T["id"], opts?: Partial<IDViewerOptions<T>>);
+  constructor(opts: IDViewerOptions<T>);
+  constructor(args: IDViewerOptions<T> | T["id"], opts?: IDViewerOptions<T>) {
     if (typeof args === "object") {
       this.viewerID = args.viewerID;
       opts = args;

--- a/ts/src/graphql/node_resolver.test.ts
+++ b/ts/src/graphql/node_resolver.test.ts
@@ -31,7 +31,7 @@ import {
 } from "./node_resolver";
 import { IDViewer } from "../core/viewer";
 import { RequestContext } from "../core/context";
-import { SimpleBuilder } from "../testutils/builder";
+import { SimpleBuilder, User } from "../testutils/builder";
 import { WriteOperation } from "../action";
 import {
   GraphQLObjectType,
@@ -163,7 +163,7 @@ class SearchResultResolver implements NodeResolver {
       },
     });
 
-    const user = await FakeUser.load(viewer, parts[2]);
+    const user = await FakeUser.load(viewer, parts[2] as ID<FakeUser>);
     if (!user) {
       return null;
     }
@@ -315,7 +315,7 @@ function commonTests() {
       fields: {
         user: {
           type: GraphQLNonNull(userType),
-          resolve: (_source, {}, context: RequestContext) => {
+          resolve: (_source, {}, context: RequestContext<Viewer<FakeUser>>) => {
             const v = context.getViewer();
             if (!v.viewerID) {
               // will throw. we claim non-null
@@ -356,7 +356,7 @@ function commonTests() {
 
     const user = await createTestUser();
 
-    let cfg: queryRootConfig = {
+    let cfg: queryRootConfig<Viewer<FakeUser>> = {
       schema: schema,
       root: "viewer",
       viewer: new IDViewer(user.id),
@@ -366,7 +366,7 @@ function commonTests() {
     const expectedID = resolver.encode(user);
     await expectQueryFromRoot(cfg, ["user.id", expectedID]);
 
-    let cfg2: queryRootConfig = {
+    let cfg2: queryRootConfig<Viewer<FakeUser>> = {
       schema: schema,
       root: "node",
       viewer: new IDViewer(user.id),

--- a/ts/src/graphql/query/connection_type.ts
+++ b/ts/src/graphql/query/connection_type.ts
@@ -12,7 +12,7 @@ import { GraphQLEdge, GraphQLEdgeConnection } from "./edge_connection";
 import { GraphQLPageInfo } from "./page_info";
 import { GraphQLEdgeInterface } from "../builtins/edge";
 import { GraphQLConnectionInterface } from "../builtins/connection";
-import { Data, Ent } from "../../core/base";
+import { Ent, Data } from "../../core/base";
 
 type nodeType = GraphQLObjectType | GraphQLInterfaceType;
 export class GraphQLEdgeType<

--- a/ts/src/schema/postgres_schema_live.test.ts
+++ b/ts/src/schema/postgres_schema_live.test.ts
@@ -273,7 +273,7 @@ test("timestamptz", async () => {
 });
 
 class Hours implements Ent {
-  id: ID;
+  id: ID<Hours>;
   accountID: string;
   nodeType = "Hours";
   privacyPolicy = AlwaysAllowPrivacyPolicy;
@@ -426,7 +426,7 @@ describe("timetz", () => {
 });
 
 class Holiday implements Ent {
-  id: ID;
+  id: ID<Holiday>;
   accountID: string;
   nodeType = "Holiday";
   privacyPolicy = AlwaysAllowPrivacyPolicy;

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -20,7 +20,7 @@ import { ObjectLoaderFactory } from "../core/loaders";
 import { convertDate } from "../core/convert";
 
 export class User implements Ent {
-  id: ID;
+  id: ID<User>;
   accountID: string = "";
   nodeType = "User";
   privacyPolicy = AlwaysAllowPrivacyPolicy;
@@ -33,7 +33,7 @@ export class User implements Ent {
 }
 
 export class Event implements Ent {
-  id: ID;
+  id: ID<Event>;
   accountID: string = "";
   nodeType = "Event";
   privacyPolicy = AlwaysAllowPrivacyPolicy;
@@ -44,7 +44,7 @@ export class Event implements Ent {
 }
 
 export class Contact implements Ent {
-  id: ID;
+  id: ID<Contact>;
   accountID: string = "";
   nodeType = "Contact";
   privacyPolicy = AlwaysAllowPrivacyPolicy;
@@ -57,9 +57,9 @@ export class Contact implements Ent {
 }
 
 export class Group implements Ent {
-  id: ID;
+  id: ID<Group>;
   accountID: string = "";
-  nodeType = "Group";
+  nodeType = "Group" as const;
   privacyPolicy = AlwaysAllowPrivacyPolicy;
 
   constructor(public viewer: Viewer, public data: Data) {
@@ -68,7 +68,7 @@ export class Group implements Ent {
 }
 
 export class Message implements Ent {
-  id: ID;
+  id: ID<Message>;
   accountID: string = "";
   nodeType = "Message";
   privacyPolicy = AlwaysAllowPrivacyPolicy;
@@ -79,7 +79,7 @@ export class Message implements Ent {
 }
 
 export class Address implements Ent {
-  id: ID;
+  id: ID<Address>;
   accountID: string = "";
   nodeType = "Address";
   privacyPolicy = AlwaysAllowPrivacyPolicy;

--- a/ts/src/testutils/db/test_db_helpers.test.ts
+++ b/ts/src/testutils/db/test_db_helpers.test.ts
@@ -7,7 +7,7 @@ import { getSchemaTable } from "./test_db";
 import { Dialect } from "../../core/db";
 
 class Account implements Ent {
-  id: ID;
+  id: ID<Account>;
   accountID: string;
   nodeType = "Account";
   privacyPolicy = AlwaysAllowPrivacyPolicy;

--- a/ts/src/testutils/ent-graphql-tests/index.ts
+++ b/ts/src/testutils/ent-graphql-tests/index.ts
@@ -268,9 +268,9 @@ function expectQueryResult(
 
 export type Option = [string, any];
 
-interface queryConfig {
+interface queryConfig<T extends Viewer = Viewer> {
   // if neither viewer nor init is passed, we end with a logged out viewer
-  viewer?: Viewer;
+  viewer?: T;
   // to init express e.g. session, passport initialize etc
   init?: (app: Express) => void;
   test?:
@@ -290,7 +290,8 @@ interface queryConfig {
   customHandlers?: RequestHandler[];
 }
 
-export interface queryRootConfig extends queryConfig {
+export interface queryRootConfig<T extends Viewer = Viewer>
+  extends queryConfig<T> {
   root: string;
   rootQueryNull?: boolean;
   nullQueryPaths?: string[];

--- a/ts/src/testutils/fake_data/fake_contact.ts
+++ b/ts/src/testutils/fake_data/fake_contact.ts
@@ -16,7 +16,7 @@ import { ObjectLoaderFactory } from "../../core/loaders";
 import { convertDate } from "../../core/convert";
 
 export class FakeContact implements Ent {
-  readonly id: ID;
+  readonly id: ID<FakeContact>;
   readonly data: Data;
   readonly nodeType = NodeType.FakeContact;
   readonly createdAt: Date;
@@ -78,11 +78,14 @@ export class FakeContact implements Ent {
       }),
     };
   }
-  static async load(v: Viewer, id: ID): Promise<FakeContact | null> {
+  static async load(
+    v: Viewer,
+    id: ID<FakeContact>,
+  ): Promise<FakeContact | null> {
     return loadEnt(v, id, FakeContact.loaderOptions());
   }
 
-  static async loadX(v: Viewer, id: ID): Promise<FakeContact> {
+  static async loadX(v: Viewer, id: ID<FakeContact>): Promise<FakeContact> {
     return loadEntX(v, id, FakeContact.loaderOptions());
   }
 }

--- a/ts/src/testutils/fake_data/fake_event.ts
+++ b/ts/src/testutils/fake_data/fake_event.ts
@@ -22,7 +22,7 @@ import { ObjectLoaderFactory } from "../../core/loaders";
 import { convertDate, convertNullableDate } from "../../core/convert";
 
 export class FakeEvent implements Ent {
-  readonly id: ID;
+  readonly id: ID<FakeEvent>;
   readonly data: Data;
   readonly nodeType = NodeType.FakeEvent;
   readonly createdAt: Date;
@@ -91,11 +91,11 @@ export class FakeEvent implements Ent {
       }),
     };
   }
-  static async load(v: Viewer, id: ID): Promise<FakeEvent | null> {
+  static async load(v: Viewer, id: ID<FakeEvent>): Promise<FakeEvent | null> {
     return loadEnt(v, id, FakeEvent.loaderOptions());
   }
 
-  static async loadX(v: Viewer, id: ID): Promise<FakeEvent> {
+  static async loadX(v: Viewer, id: ID<FakeEvent>): Promise<FakeEvent> {
     return loadEntX(v, id, FakeEvent.loaderOptions());
   }
 }

--- a/ts/src/testutils/fake_data/fake_user.ts
+++ b/ts/src/testutils/fake_data/fake_user.ts
@@ -38,7 +38,7 @@ export class ViewerWithAccessToken extends IDViewer {
 }
 
 export class FakeUser implements Ent {
-  readonly id: ID;
+  readonly id: ID<FakeUser>;
   readonly data: Data;
   readonly nodeType = NodeType.FakeUser;
   readonly createdAt: Date;
@@ -121,11 +121,11 @@ export class FakeUser implements Ent {
       loaderFactory: userLoader,
     };
   }
-  static async load(v: Viewer, id: ID): Promise<FakeUser | null> {
+  static async load(v: Viewer, id: ID<FakeUser>): Promise<FakeUser | null> {
     return loadEnt(v, id, FakeUser.loaderOptions());
   }
 
-  static async loadX(v: Viewer, id: ID): Promise<FakeUser> {
+  static async loadX(v: Viewer, id: ID<FakeUser>): Promise<FakeUser> {
     return loadEntX(v, id, FakeUser.loaderOptions());
   }
 }

--- a/ts/src/testutils/fake_data/test_helpers.ts
+++ b/ts/src/testutils/fake_data/test_helpers.ts
@@ -1,7 +1,7 @@
 import { fail } from "assert";
 import { advanceBy, advanceTo } from "jest-date-mock";
 import { IDViewer, LoggedOutViewer } from "../../core/viewer";
-import { Data, Ent } from "../../core/base";
+import { Ent, Data } from "../../core/base";
 import { AssocEdge, loadEdgeData } from "../../core/ent";
 import { snakeCase } from "snake-case";
 import { createRowForTest } from "../write";

--- a/ts/src/testutils/fake_data/user_query.ts
+++ b/ts/src/testutils/fake_data/user_query.ts
@@ -1,6 +1,6 @@
 import { Ent, ID, Viewer } from "../../core/base";
 import { CustomEdgeQueryBase } from "../../core/query/custom_query";
-import { AssocEdge } from "../../core/ent";
+import { AssocData, AssocEdge } from "../../core/ent";
 import * as clause from "../../core/clause";
 import {
   AssocEdgeQueryBase,
@@ -26,7 +26,7 @@ import { clear } from "jest-date-mock";
 import { Interval } from "luxon";
 import { QueryLoaderFactory } from "../../core/loaders/query_loader";
 import { MockDate } from "./../mock_date";
-import { getLoaderOptions } from ".";
+import { getLoaderOptions, NodeType } from ".";
 import { AllowIfViewerPrivacyPolicy } from "../../core/privacy";
 
 export class UserToContactsQuery extends AssocEdgeQueryBase<
@@ -127,7 +127,7 @@ export class UserToFriendsQuery extends AssocEdgeQueryBase<
 }
 
 // example with custom method
-export class CustomEdge extends AssocEdge {
+export class CustomEdge<T extends ID> extends AssocEdge<T, ID<FakeUser>> {
   async loadUser(viewer: Viewer) {
     return await FakeUser.load(viewer, this.id2);
   }
@@ -136,14 +136,14 @@ export class CustomEdge extends AssocEdge {
 export class UserToCustomEdgeQuery extends AssocEdgeQueryBase<
   FakeUser,
   FakeUser,
-  CustomEdge
+  CustomEdge<ID<FakeUser>>
 > {
   constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser>) {
     super(
       viewer,
       src,
       new AssocEdgeCountLoaderFactory(EdgeType.UserToCustomEdge),
-      new AssocEdgeLoaderFactory(EdgeType.UserToCustomEdge, CustomEdge),
+      new AssocEdgeLoaderFactory(EdgeType.UserToCustomEdge, () => CustomEdge),
       FakeUser.loaderOptions(),
     );
   }
@@ -237,7 +237,7 @@ export class UserToIncomingFriendRequestsQuery extends AssocEdgeQueryBase<
     return AllowIfViewerPrivacyPolicy;
   }
 
-  entForPrivacy(id: ID) {
+  entForPrivacy(id: ID<FakeUser>) {
     return FakeUser.load(this.viewer, id);
   }
 
@@ -408,14 +408,14 @@ export class UserToEventsInNextWeekQuery extends CustomEdgeQueryBase<
   getPrivacyPolicy() {
     return AllowIfViewerPrivacyPolicy;
   }
-  async entForPrivacy(id: ID) {
+  async entForPrivacy(id: ID<FakeUser>) {
     return FakeUser.load(this.viewer, id);
   }
 }
 
 export class UserToFollowingQuery extends AssocEdgeQueryBase<
   FakeUser,
-  Ent,
+  FakeUser,
   AssocEdge
 > {
   constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser>) {


### PR DESCRIPTION
Summary of changes:
- Left definition of `Ent` interface alone, meaning that typed IDs is opt-in for manually-created Ents.
- Changed definition of `ID` type.
  - When no generic argument is passed in, the current behavior will be preserved, i.e. `ID == number | string`
  - Supports two generic arguments, `ID<Brand, Base>`:
    - the first is the "Brand" type, which is what determines whether two ID types are compatible
    - the second is optional, which lets you narrow the ID supertype to either `string` or `number`.
  - IDs are covariant by default, meaning if `Square` extends `Shape`, then `ID<Square>` extends `ID<Shape>`.
- Made `Viewer` interface generic with respect to `Ent` type so that the `viewerID` field can be typed more precisely
- Made `Context` (and `RequestContext`) interface generic with respect to `Viewer` type.
  - Note:`Viewer` also contains a `context` field, which I decided to leave typed as just `Context` rather than something like `Context<Viewer<T>>`, since I didn't know if it was safe to assume that the viewer reference in the context has the same ent type as the viewer the context is contained in.
- Make `AssocEdge` generic with respect to inbound/outbound ID types
- Updated examples to make use of typed IDs

Todo:
- Update codegen to generate typed IDs
- Make PrivacyPolicy generic so that privacy policy definitions are more precisely typed

