### PR TITLE
action builder, trigger, observer, validator changes

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -39,7 +39,8 @@
         "@types/supertest": "^2.0.11",
         "jest": "^27.1.1",
         "jest-expect-message": "^1.0.2",
-        "ts-jest": "^27.0.5"
+        "ts-jest": "^27.0.5",
+        "tsconfig-paths": "^3.11.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -56,6 +56,7 @@
     "@types/supertest": "^2.0.11",
     "jest": "^27.1.1",
     "jest-expect-message": "^1.0.2",
-    "ts-jest": "^27.0.5"
+    "ts-jest": "^27.0.5",
+    "tsconfig-paths": "^3.11.0"
   }
 }

--- a/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
@@ -25,11 +25,6 @@ export interface AddressInput {
   [x: string]: any;
 }
 
-export interface AddressAction<TData extends AddressInput>
-  extends Action<Address, AddressBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -45,7 +40,7 @@ export class AddressBuilder<TData extends AddressInput = AddressInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AddressAction<TData>,
+    action: Action<Address, Builder<Address>, TData>,
     public readonly existingEnt?: Address | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Address`;

--- a/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
@@ -21,26 +21,31 @@ export interface AddressInput {
   apartment?: string | null;
   ownerID?: ID | Builder<Ent>;
   ownerType?: string;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface AddressAction extends Action<Address> {
-  getInput(): AddressInput;
+export interface AddressAction<TData extends AddressInput>
+  extends Action<Address, AddressBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class AddressBuilder implements Builder<Address> {
-  orchestrator: Orchestrator<Address>;
+export class AddressBuilder<TData extends AddressInput = AddressInput>
+  implements Builder<Address>
+{
+  orchestrator: Orchestrator<Address, TData>;
   readonly placeholderID: ID;
   readonly ent = Address;
-  private input: AddressInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AddressAction,
+    action: AddressAction<TData>,
     public readonly existingEnt?: Address | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Address`;
@@ -59,7 +64,7 @@ export class AddressBuilder implements Builder<Address> {
     });
   }
 
-  getInput(): AddressInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/address/actions/generated/create_address_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/generated/create_address_action_base.ts
@@ -14,10 +14,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Address } from "src/ent/";
-import {
-  AddressBuilder,
-  AddressInput,
-} from "src/ent/address/actions/generated/address_builder";
+import { AddressBuilder } from "src/ent/address/actions/generated/address_builder";
 
 export interface AddressCreateInput {
   street: string;
@@ -29,8 +26,11 @@ export interface AddressCreateInput {
   ownerType: string;
 }
 
-export class CreateAddressActionBase implements Action<Address> {
-  public readonly builder: AddressBuilder;
+export class CreateAddressActionBase
+  implements
+    Action<Address, AddressBuilder<AddressCreateInput>, AddressCreateInput>
+{
+  public readonly builder: AddressBuilder<AddressCreateInput>;
   public readonly viewer: Viewer;
   protected input: AddressCreateInput;
 
@@ -44,7 +44,7 @@ export class CreateAddressActionBase implements Action<Address> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): AddressInput {
+  getInput(): AddressCreateInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/address/actions/generated/delete_address_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/generated/delete_address_action_base.ts
@@ -13,8 +13,10 @@ import {
   AddressInput,
 } from "src/ent/address/actions/generated/address_builder";
 
-export class DeleteAddressActionBase implements Action<Address> {
-  public readonly builder: AddressBuilder;
+export class DeleteAddressActionBase
+  implements Action<Address, AddressBuilder<AddressInput>, AddressInput>
+{
+  public readonly builder: AddressBuilder<AddressInput>;
   public readonly viewer: Viewer;
   protected address: Address;
 

--- a/examples/ent-rsvp/backend/src/ent/address/actions/generated/edit_address_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/generated/edit_address_action_base.ts
@@ -14,10 +14,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Address } from "src/ent/";
-import {
-  AddressBuilder,
-  AddressInput,
-} from "src/ent/address/actions/generated/address_builder";
+import { AddressBuilder } from "src/ent/address/actions/generated/address_builder";
 
 export interface AddressEditInput {
   street?: string;
@@ -29,8 +26,11 @@ export interface AddressEditInput {
   ownerType?: string;
 }
 
-export class EditAddressActionBase implements Action<Address> {
-  public readonly builder: AddressBuilder;
+export class EditAddressActionBase
+  implements
+    Action<Address, AddressBuilder<AddressEditInput>, AddressEditInput>
+{
+  public readonly builder: AddressBuilder<AddressEditInput>;
   public readonly viewer: Viewer;
   protected input: AddressEditInput;
   protected address: Address;
@@ -51,7 +51,7 @@ export class EditAddressActionBase implements Action<Address> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): AddressInput {
+  getInput(): AddressEditInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -18,26 +18,31 @@ export interface AuthCodeInput {
   guestID?: ID | Builder<Guest>;
   emailAddress?: string;
   sentCode?: boolean;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface AuthCodeAction extends Action<AuthCode> {
-  getInput(): AuthCodeInput;
+export interface AuthCodeAction<TData extends AuthCodeInput>
+  extends Action<AuthCode, AuthCodeBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class AuthCodeBuilder implements Builder<AuthCode> {
-  orchestrator: Orchestrator<AuthCode>;
+export class AuthCodeBuilder<TData extends AuthCodeInput = AuthCodeInput>
+  implements Builder<AuthCode>
+{
+  orchestrator: Orchestrator<AuthCode, TData>;
   readonly placeholderID: ID;
   readonly ent = AuthCode;
-  private input: AuthCodeInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AuthCodeAction,
+    action: AuthCodeAction<TData>,
     public readonly existingEnt?: AuthCode | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-AuthCode`;
@@ -56,7 +61,7 @@ export class AuthCodeBuilder implements Builder<AuthCode> {
     });
   }
 
-  getInput(): AuthCodeInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -22,11 +22,6 @@ export interface AuthCodeInput {
   [x: string]: any;
 }
 
-export interface AuthCodeAction<TData extends AuthCodeInput>
-  extends Action<AuthCode, AuthCodeBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -42,7 +37,7 @@ export class AuthCodeBuilder<TData extends AuthCodeInput = AuthCodeInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AuthCodeAction<TData>,
+    action: Action<AuthCode, Builder<AuthCode>, TData>,
     public readonly existingEnt?: AuthCode | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-AuthCode`;

--- a/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/create_auth_code_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/create_auth_code_action_base.ts
@@ -13,10 +13,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { AuthCode, Guest } from "src/ent/";
-import {
-  AuthCodeBuilder,
-  AuthCodeInput,
-} from "src/ent/auth_code/actions/generated/auth_code_builder";
+import { AuthCodeBuilder } from "src/ent/auth_code/actions/generated/auth_code_builder";
 
 export interface AuthCodeCreateInput {
   code: string;
@@ -25,8 +22,11 @@ export interface AuthCodeCreateInput {
   sentCode?: boolean;
 }
 
-export class CreateAuthCodeActionBase implements Action<AuthCode> {
-  public readonly builder: AuthCodeBuilder;
+export class CreateAuthCodeActionBase
+  implements
+    Action<AuthCode, AuthCodeBuilder<AuthCodeCreateInput>, AuthCodeCreateInput>
+{
+  public readonly builder: AuthCodeBuilder<AuthCodeCreateInput>;
   public readonly viewer: Viewer;
   protected input: AuthCodeCreateInput;
 
@@ -44,7 +44,7 @@ export class CreateAuthCodeActionBase implements Action<AuthCode> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): AuthCodeInput {
+  getInput(): AuthCodeCreateInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/event/actions/create_event_action.ts
+++ b/examples/ent-rsvp/backend/src/ent/event/actions/create_event_action.ts
@@ -19,9 +19,9 @@ export default class CreateEventAction extends CreateEventActionBase {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  triggers: Trigger<Ent>[] = [
+  triggers: Trigger<EventBuilder, EventCreateInput>[] = [
     {
-      async changeset(builder: EventBuilder, input: EventCreateInput) {
+      async changeset(builder, input) {
         if (!input.activities) {
           return;
         }

--- a/examples/ent-rsvp/backend/src/ent/event/actions/generated/create_event_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/event/actions/generated/create_event_action_base.ts
@@ -7,10 +7,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Event } from "src/ent/";
-import {
-  EventBuilder,
-  EventInput,
-} from "src/ent/event/actions/generated/event_builder";
+import { EventBuilder } from "src/ent/event/actions/generated/event_builder";
 
 interface customActivityInput {
   name: string;
@@ -36,8 +33,10 @@ export interface EventCreateInput {
   activities?: customActivityInput[] | null;
 }
 
-export class CreateEventActionBase implements Action<Event> {
-  public readonly builder: EventBuilder;
+export class CreateEventActionBase
+  implements Action<Event, EventBuilder<EventCreateInput>, EventCreateInput>
+{
+  public readonly builder: EventBuilder<EventCreateInput>;
   public readonly viewer: Viewer;
   protected input: EventCreateInput;
 
@@ -51,7 +50,7 @@ export class CreateEventActionBase implements Action<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): EventInput {
+  getInput(): EventCreateInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/event/actions/generated/delete_event_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/event/actions/generated/delete_event_action_base.ts
@@ -13,8 +13,10 @@ import {
   EventInput,
 } from "src/ent/event/actions/generated/event_builder";
 
-export class DeleteEventActionBase implements Action<Event> {
-  public readonly builder: EventBuilder;
+export class DeleteEventActionBase
+  implements Action<Event, EventBuilder<EventInput>, EventInput>
+{
+  public readonly builder: EventBuilder<EventInput>;
   public readonly viewer: Viewer;
   protected event: Event;
 

--- a/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
@@ -21,11 +21,6 @@ export interface EventInput {
   [x: string]: any;
 }
 
-export interface EventAction<TData extends EventInput>
-  extends Action<Event, EventBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -41,7 +36,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: EventAction<TData>,
+    action: Action<Event, Builder<Event>, TData>,
     public readonly existingEnt?: Event | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Event`;

--- a/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
@@ -17,26 +17,31 @@ export interface EventInput {
   name?: string;
   slug?: string | null;
   creatorID?: ID | Builder<User>;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface EventAction extends Action<Event> {
-  getInput(): EventInput;
+export interface EventAction<TData extends EventInput>
+  extends Action<Event, EventBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class EventBuilder implements Builder<Event> {
-  orchestrator: Orchestrator<Event>;
+export class EventBuilder<TData extends EventInput = EventInput>
+  implements Builder<Event>
+{
+  orchestrator: Orchestrator<Event, TData>;
   readonly placeholderID: ID;
   readonly ent = Event;
-  private input: EventInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: EventAction,
+    action: EventAction<TData>,
     public readonly existingEnt?: Event | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Event`;
@@ -55,7 +60,7 @@ export class EventBuilder implements Builder<Event> {
     });
   }
 
-  getInput(): EventInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/create_event_activity_action.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/create_event_activity_action.ts
@@ -18,9 +18,9 @@ export default class CreateEventActivityAction extends CreateEventActivityAction
     return new AllowIfEventCreatorPrivacyPolicy(this.input.eventID, this.input);
   }
 
-  triggers: Trigger<Ent>[] = [
+  triggers: Trigger<EventActivityBuilder, EventActivityCreateInput>[] = [
     {
-      changeset: async (builder: EventActivityBuilder, _input: Data) => {
+      changeset: async (builder) => {
         if (!this.input.address) {
           return;
         }
@@ -32,10 +32,7 @@ export default class CreateEventActivityAction extends CreateEventActivityAction
       },
     },
     {
-      changeset: async (
-        builder: EventActivityBuilder,
-        input: EventActivityCreateInput,
-      ) => {
+      changeset: async (builder, input) => {
         if (!input.inviteAllGuests) {
           return;
         }

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/create_event_activity_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/create_event_activity_action_base.ts
@@ -13,10 +13,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, EventActivity } from "src/ent/";
-import {
-  EventActivityBuilder,
-  EventActivityInput,
-} from "src/ent/event_activity/actions/generated/event_activity_builder";
+import { EventActivityBuilder } from "src/ent/event_activity/actions/generated/event_activity_builder";
 
 interface customAddressInput {
   street: string;
@@ -37,8 +34,15 @@ export interface EventActivityCreateInput {
   address?: customAddressInput | null;
 }
 
-export class CreateEventActivityActionBase implements Action<EventActivity> {
-  public readonly builder: EventActivityBuilder;
+export class CreateEventActivityActionBase
+  implements
+    Action<
+      EventActivity,
+      EventActivityBuilder<EventActivityCreateInput>,
+      EventActivityCreateInput
+    >
+{
+  public readonly builder: EventActivityBuilder<EventActivityCreateInput>;
   public readonly viewer: Viewer;
   protected input: EventActivityCreateInput;
 
@@ -56,7 +60,7 @@ export class CreateEventActivityActionBase implements Action<EventActivity> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): EventActivityInput {
+  getInput(): EventActivityCreateInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/delete_event_activity_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/delete_event_activity_action_base.ts
@@ -13,8 +13,15 @@ import {
   EventActivityInput,
 } from "src/ent/event_activity/actions/generated/event_activity_builder";
 
-export class DeleteEventActivityActionBase implements Action<EventActivity> {
-  public readonly builder: EventActivityBuilder;
+export class DeleteEventActivityActionBase
+  implements
+    Action<
+      EventActivity,
+      EventActivityBuilder<EventActivityInput>,
+      EventActivityInput
+    >
+{
+  public readonly builder: EventActivityBuilder<EventActivityInput>;
   public readonly viewer: Viewer;
   protected eventActivity: EventActivity;
 

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/edit_event_activity_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/edit_event_activity_action_base.ts
@@ -13,10 +13,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, EventActivity } from "src/ent/";
-import {
-  EventActivityBuilder,
-  EventActivityInput,
-} from "src/ent/event_activity/actions/generated/event_activity_builder";
+import { EventActivityBuilder } from "src/ent/event_activity/actions/generated/event_activity_builder";
 
 export interface EventActivityEditInput {
   name?: string;
@@ -28,8 +25,15 @@ export interface EventActivityEditInput {
   inviteAllGuests?: boolean;
 }
 
-export class EditEventActivityActionBase implements Action<EventActivity> {
-  public readonly builder: EventActivityBuilder;
+export class EditEventActivityActionBase
+  implements
+    Action<
+      EventActivity,
+      EventActivityBuilder<EventActivityEditInput>,
+      EventActivityEditInput
+    >
+{
+  public readonly builder: EventActivityBuilder<EventActivityEditInput>;
   public readonly viewer: Viewer;
   protected input: EventActivityEditInput;
   protected eventActivity: EventActivity;
@@ -54,7 +58,7 @@ export class EditEventActivityActionBase implements Action<EventActivity> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): EventActivityInput {
+  getInput(): EventActivityEditInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/edit_event_activity_rsvp_status_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/edit_event_activity_rsvp_status_action_base.ts
@@ -13,10 +13,7 @@ import {
   setEdgeTypeInGroup,
 } from "@snowtop/ent/action";
 import { EventActivity, NodeType } from "src/ent/";
-import {
-  EventActivityBuilder,
-  EventActivityInput,
-} from "src/ent/event_activity/actions/generated/event_activity_builder";
+import { EventActivityBuilder } from "src/ent/event_activity/actions/generated/event_activity_builder";
 
 export enum EventActivityRsvpStatusInput {
   Attending = "attending",
@@ -30,9 +27,14 @@ export interface EditEventActivityRsvpStatusInput {
 }
 
 export class EditEventActivityRsvpStatusActionBase
-  implements Action<EventActivity>
+  implements
+    Action<
+      EventActivity,
+      EventActivityBuilder<EditEventActivityRsvpStatusInput>,
+      EditEventActivityRsvpStatusInput
+    >
 {
-  public readonly builder: EventActivityBuilder;
+  public readonly builder: EventActivityBuilder<EditEventActivityRsvpStatusInput>;
   public readonly viewer: Viewer;
   protected input: EditEventActivityRsvpStatusInput;
   protected eventActivity: EventActivity;
@@ -57,9 +59,8 @@ export class EditEventActivityRsvpStatusActionBase
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): EventActivityInput {
-    // we use a type assertion to override the weak type detection here
-    return this.input as EventActivityInput;
+  getInput(): EditEventActivityRsvpStatusInput {
+    return this.input;
   }
 
   async changeset(): Promise<Changeset<EventActivity>> {

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_add_invite_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_add_invite_action_base.ts
@@ -19,8 +19,15 @@ import {
   EventActivityInput,
 } from "src/ent/event_activity/actions/generated/event_activity_builder";
 
-export class EventActivityAddInviteActionBase implements Action<EventActivity> {
-  public readonly builder: EventActivityBuilder;
+export class EventActivityAddInviteActionBase
+  implements
+    Action<
+      EventActivity,
+      EventActivityBuilder<EventActivityInput>,
+      EventActivityInput
+    >
+{
+  public readonly builder: EventActivityBuilder<EventActivityInput>;
   public readonly viewer: Viewer;
   protected eventActivity: EventActivity;
 

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
@@ -22,26 +22,32 @@ export interface EventActivityInput {
   location?: string;
   description?: string | null;
   inviteAllGuests?: boolean;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface EventActivityAction extends Action<EventActivity> {
-  getInput(): EventActivityInput;
+export interface EventActivityAction<TData extends EventActivityInput>
+  extends Action<EventActivity, EventActivityBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class EventActivityBuilder implements Builder<EventActivity> {
-  orchestrator: Orchestrator<EventActivity>;
+export class EventActivityBuilder<
+  TData extends EventActivityInput = EventActivityInput,
+> implements Builder<EventActivity>
+{
+  orchestrator: Orchestrator<EventActivity, TData>;
   readonly placeholderID: ID;
   readonly ent = EventActivity;
-  private input: EventActivityInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: EventActivityAction,
+    action: EventActivityAction<TData>,
     public readonly existingEnt?: EventActivity | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-EventActivity`;
@@ -60,7 +66,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
     });
   }
 
-  getInput(): EventActivityInput {
+  getInput(): TData {
     return this.input;
   }
 
@@ -84,7 +90,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
 
   addAttending(
     ...nodes: (ID | Guest | Builder<Guest>)[]
-  ): EventActivityBuilder {
+  ): EventActivityBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addAttendingID(node);
@@ -100,7 +106,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
   addAttendingID(
     id: ID | Builder<Guest>,
     options?: AssocEdgeInputOptions,
-  ): EventActivityBuilder {
+  ): EventActivityBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventActivityToAttending,
@@ -110,7 +116,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
     return this;
   }
 
-  removeAttending(...nodes: (ID | Guest)[]): EventActivityBuilder {
+  removeAttending(...nodes: (ID | Guest)[]): EventActivityBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -127,7 +133,9 @@ export class EventActivityBuilder implements Builder<EventActivity> {
     return this;
   }
 
-  addDeclined(...nodes: (ID | Guest | Builder<Guest>)[]): EventActivityBuilder {
+  addDeclined(
+    ...nodes: (ID | Guest | Builder<Guest>)[]
+  ): EventActivityBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addDeclinedID(node);
@@ -143,7 +151,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
   addDeclinedID(
     id: ID | Builder<Guest>,
     options?: AssocEdgeInputOptions,
-  ): EventActivityBuilder {
+  ): EventActivityBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventActivityToDeclined,
@@ -153,7 +161,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
     return this;
   }
 
-  removeDeclined(...nodes: (ID | Guest)[]): EventActivityBuilder {
+  removeDeclined(...nodes: (ID | Guest)[]): EventActivityBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -172,7 +180,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
 
   addInvite(
     ...nodes: (ID | GuestGroup | Builder<GuestGroup>)[]
-  ): EventActivityBuilder {
+  ): EventActivityBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addInviteID(node);
@@ -188,7 +196,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
   addInviteID(
     id: ID | Builder<GuestGroup>,
     options?: AssocEdgeInputOptions,
-  ): EventActivityBuilder {
+  ): EventActivityBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventActivityToInvites,
@@ -198,7 +206,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
     return this;
   }
 
-  removeInvite(...nodes: (ID | GuestGroup)[]): EventActivityBuilder {
+  removeInvite(...nodes: (ID | GuestGroup)[]): EventActivityBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
@@ -26,11 +26,6 @@ export interface EventActivityInput {
   [x: string]: any;
 }
 
-export interface EventActivityAction<TData extends EventActivityInput>
-  extends Action<EventActivity, EventActivityBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -47,7 +42,7 @@ export class EventActivityBuilder<
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: EventActivityAction<TData>,
+    action: Action<EventActivity, Builder<EventActivity>, TData>,
     public readonly existingEnt?: EventActivity | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-EventActivity`;

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_remove_invite_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_remove_invite_action_base.ts
@@ -14,9 +14,14 @@ import {
 } from "src/ent/event_activity/actions/generated/event_activity_builder";
 
 export class EventActivityRemoveInviteActionBase
-  implements Action<EventActivity>
+  implements
+    Action<
+      EventActivity,
+      EventActivityBuilder<EventActivityInput>,
+      EventActivityInput
+    >
 {
-  public readonly builder: EventActivityBuilder;
+  public readonly builder: EventActivityBuilder<EventActivityInput>;
   public readonly viewer: Viewer;
   protected eventActivity: EventActivity;
 

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/create_guest_action.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/create_guest_action.ts
@@ -17,9 +17,9 @@ export default class CreateGuestAction extends CreateGuestActionBase {
     return new AllowIfEventCreatorPrivacyPolicy(this.input.eventID);
   }
 
-  triggers: Trigger<Ent>[] = [
+  triggers: Trigger<GuestBuilder, GuestCreateInput>[] = [
     {
-      async changeset(builder: GuestBuilder, input: GuestCreateInput) {
+      async changeset(builder, input) {
         if (!input.emailAddress) {
           return;
         }

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/generated/create_guest_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/generated/create_guest_action_base.ts
@@ -13,10 +13,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, Guest, GuestGroup } from "src/ent/";
-import {
-  GuestBuilder,
-  GuestInput,
-} from "src/ent/guest/actions/generated/guest_builder";
+import { GuestBuilder } from "src/ent/guest/actions/generated/guest_builder";
 
 export interface GuestCreateInput {
   name: string;
@@ -26,8 +23,10 @@ export interface GuestCreateInput {
   title?: string | null;
 }
 
-export class CreateGuestActionBase implements Action<Guest> {
-  public readonly builder: GuestBuilder;
+export class CreateGuestActionBase
+  implements Action<Guest, GuestBuilder<GuestCreateInput>, GuestCreateInput>
+{
+  public readonly builder: GuestBuilder<GuestCreateInput>;
   public readonly viewer: Viewer;
   protected input: GuestCreateInput;
 
@@ -41,7 +40,7 @@ export class CreateGuestActionBase implements Action<Guest> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): GuestInput {
+  getInput(): GuestCreateInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/generated/delete_guest_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/generated/delete_guest_action_base.ts
@@ -13,8 +13,10 @@ import {
   GuestInput,
 } from "src/ent/guest/actions/generated/guest_builder";
 
-export class DeleteGuestActionBase implements Action<Guest> {
-  public readonly builder: GuestBuilder;
+export class DeleteGuestActionBase
+  implements Action<Guest, GuestBuilder<GuestInput>, GuestInput>
+{
+  public readonly builder: GuestBuilder<GuestInput>;
   public readonly viewer: Viewer;
   protected guest: Guest;
 

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/generated/edit_guest_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/generated/edit_guest_action_base.ts
@@ -8,18 +8,17 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Guest } from "src/ent/";
-import {
-  GuestBuilder,
-  GuestInput,
-} from "src/ent/guest/actions/generated/guest_builder";
+import { GuestBuilder } from "src/ent/guest/actions/generated/guest_builder";
 
 export interface GuestEditInput {
   name?: string;
   emailAddress?: string | null;
 }
 
-export class EditGuestActionBase implements Action<Guest> {
-  public readonly builder: GuestBuilder;
+export class EditGuestActionBase
+  implements Action<Guest, GuestBuilder<GuestEditInput>, GuestEditInput>
+{
+  public readonly builder: GuestBuilder<GuestEditInput>;
   public readonly viewer: Viewer;
   protected input: GuestEditInput;
   protected guest: Guest;
@@ -40,7 +39,7 @@ export class EditGuestActionBase implements Action<Guest> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): GuestInput {
+  getInput(): GuestEditInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
@@ -20,26 +20,31 @@ export interface GuestInput {
   emailAddress?: string | null;
   guestGroupID?: ID | Builder<GuestGroup>;
   title?: string | null;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface GuestAction extends Action<Guest> {
-  getInput(): GuestInput;
+export interface GuestAction<TData extends GuestInput>
+  extends Action<Guest, GuestBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class GuestBuilder implements Builder<Guest> {
-  orchestrator: Orchestrator<Guest>;
+export class GuestBuilder<TData extends GuestInput = GuestInput>
+  implements Builder<Guest>
+{
+  orchestrator: Orchestrator<Guest, TData>;
   readonly placeholderID: ID;
   readonly ent = Guest;
-  private input: GuestInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: GuestAction,
+    action: GuestAction<TData>,
     public readonly existingEnt?: Guest | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Guest`;
@@ -58,7 +63,7 @@ export class GuestBuilder implements Builder<Guest> {
     });
   }
 
-  getInput(): GuestInput {
+  getInput(): TData {
     return this.input;
   }
 
@@ -82,7 +87,7 @@ export class GuestBuilder implements Builder<Guest> {
 
   addGuestToAttendingEvent(
     ...nodes: (ID | EventActivity | Builder<EventActivity>)[]
-  ): GuestBuilder {
+  ): GuestBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addGuestToAttendingEventID(node);
@@ -98,7 +103,7 @@ export class GuestBuilder implements Builder<Guest> {
   addGuestToAttendingEventID(
     id: ID | Builder<EventActivity>,
     options?: AssocEdgeInputOptions,
-  ): GuestBuilder {
+  ): GuestBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.GuestToAttendingEvents,
@@ -108,7 +113,9 @@ export class GuestBuilder implements Builder<Guest> {
     return this;
   }
 
-  removeGuestToAttendingEvent(...nodes: (ID | EventActivity)[]): GuestBuilder {
+  removeGuestToAttendingEvent(
+    ...nodes: (ID | EventActivity)[]
+  ): GuestBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -127,7 +134,7 @@ export class GuestBuilder implements Builder<Guest> {
 
   addGuestToDeclinedEvent(
     ...nodes: (ID | EventActivity | Builder<EventActivity>)[]
-  ): GuestBuilder {
+  ): GuestBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addGuestToDeclinedEventID(node);
@@ -143,7 +150,7 @@ export class GuestBuilder implements Builder<Guest> {
   addGuestToDeclinedEventID(
     id: ID | Builder<EventActivity>,
     options?: AssocEdgeInputOptions,
-  ): GuestBuilder {
+  ): GuestBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.GuestToDeclinedEvents,
@@ -153,7 +160,9 @@ export class GuestBuilder implements Builder<Guest> {
     return this;
   }
 
-  removeGuestToDeclinedEvent(...nodes: (ID | EventActivity)[]): GuestBuilder {
+  removeGuestToDeclinedEvent(
+    ...nodes: (ID | EventActivity)[]
+  ): GuestBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
@@ -24,11 +24,6 @@ export interface GuestInput {
   [x: string]: any;
 }
 
-export interface GuestAction<TData extends GuestInput>
-  extends Action<Guest, GuestBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -44,7 +39,7 @@ export class GuestBuilder<TData extends GuestInput = GuestInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: GuestAction<TData>,
+    action: Action<Guest, Builder<Guest>, TData>,
     public readonly existingEnt?: Guest | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Guest`;

--- a/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/create_guest_data_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/create_guest_data_action_base.ts
@@ -13,10 +13,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, Guest, GuestData } from "src/ent/";
-import {
-  GuestDataBuilder,
-  GuestDataInput,
-} from "src/ent/guest_data/actions/generated/guest_data_builder";
+import { GuestDataBuilder } from "src/ent/guest_data/actions/generated/guest_data_builder";
 
 export interface GuestDataCreateInput {
   guestID: ID | Builder<Guest>;
@@ -24,8 +21,15 @@ export interface GuestDataCreateInput {
   dietaryRestrictions: string;
 }
 
-export class CreateGuestDataActionBase implements Action<GuestData> {
-  public readonly builder: GuestDataBuilder;
+export class CreateGuestDataActionBase
+  implements
+    Action<
+      GuestData,
+      GuestDataBuilder<GuestDataCreateInput>,
+      GuestDataCreateInput
+    >
+{
+  public readonly builder: GuestDataBuilder<GuestDataCreateInput>;
   public readonly viewer: Viewer;
   protected input: GuestDataCreateInput;
 
@@ -43,7 +47,7 @@ export class CreateGuestDataActionBase implements Action<GuestData> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): GuestDataInput {
+  getInput(): GuestDataCreateInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/delete_guest_data_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/delete_guest_data_action_base.ts
@@ -13,8 +13,11 @@ import {
   GuestDataInput,
 } from "src/ent/guest_data/actions/generated/guest_data_builder";
 
-export class DeleteGuestDataActionBase implements Action<GuestData> {
-  public readonly builder: GuestDataBuilder;
+export class DeleteGuestDataActionBase
+  implements
+    Action<GuestData, GuestDataBuilder<GuestDataInput>, GuestDataInput>
+{
+  public readonly builder: GuestDataBuilder<GuestDataInput>;
   public readonly viewer: Viewer;
   protected guestData: GuestData;
 

--- a/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/edit_guest_data_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/edit_guest_data_action_base.ts
@@ -13,10 +13,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, Guest, GuestData } from "src/ent/";
-import {
-  GuestDataBuilder,
-  GuestDataInput,
-} from "src/ent/guest_data/actions/generated/guest_data_builder";
+import { GuestDataBuilder } from "src/ent/guest_data/actions/generated/guest_data_builder";
 
 export interface GuestDataEditInput {
   guestID?: ID | Builder<Guest>;
@@ -24,8 +21,11 @@ export interface GuestDataEditInput {
   dietaryRestrictions?: string;
 }
 
-export class EditGuestDataActionBase implements Action<GuestData> {
-  public readonly builder: GuestDataBuilder;
+export class EditGuestDataActionBase
+  implements
+    Action<GuestData, GuestDataBuilder<GuestDataEditInput>, GuestDataEditInput>
+{
+  public readonly builder: GuestDataBuilder<GuestDataEditInput>;
   public readonly viewer: Viewer;
   protected input: GuestDataEditInput;
   protected guestData: GuestData;
@@ -46,7 +46,7 @@ export class EditGuestDataActionBase implements Action<GuestData> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): GuestDataInput {
+  getInput(): GuestDataEditInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
@@ -21,11 +21,6 @@ export interface GuestDataInput {
   [x: string]: any;
 }
 
-export interface GuestDataAction<TData extends GuestDataInput>
-  extends Action<GuestData, GuestDataBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -41,7 +36,7 @@ export class GuestDataBuilder<TData extends GuestDataInput = GuestDataInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: GuestDataAction<TData>,
+    action: Action<GuestData, Builder<GuestData>, TData>,
     public readonly existingEnt?: GuestData | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-GuestData`;

--- a/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
@@ -17,26 +17,31 @@ export interface GuestDataInput {
   guestID?: ID | Builder<Guest>;
   eventID?: ID | Builder<Event>;
   dietaryRestrictions?: string;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface GuestDataAction extends Action<GuestData> {
-  getInput(): GuestDataInput;
+export interface GuestDataAction<TData extends GuestDataInput>
+  extends Action<GuestData, GuestDataBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class GuestDataBuilder implements Builder<GuestData> {
-  orchestrator: Orchestrator<GuestData>;
+export class GuestDataBuilder<TData extends GuestDataInput = GuestDataInput>
+  implements Builder<GuestData>
+{
+  orchestrator: Orchestrator<GuestData, TData>;
   readonly placeholderID: ID;
   readonly ent = GuestData;
-  private input: GuestDataInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: GuestDataAction,
+    action: GuestDataAction<TData>,
     public readonly existingEnt?: GuestData | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-GuestData`;
@@ -55,7 +60,7 @@ export class GuestDataBuilder implements Builder<GuestData> {
     });
   }
 
-  getInput(): GuestDataInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/create_guest_group_action.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/create_guest_group_action.ts
@@ -19,12 +19,9 @@ export default class CreateGuestGroupAction extends CreateGuestGroupActionBase {
     return new AllowIfEventCreatorPrivacyPolicy(this.input.eventID);
   }
 
-  triggers: Trigger<Ent>[] = [
+  triggers: Trigger<GuestGroupBuilder, GuestGroupCreateInput>[] = [
     {
-      async changeset(
-        builder: GuestGroupBuilder,
-        input: GuestGroupCreateInput,
-      ) {
+      async changeset(builder, input) {
         if (builder.isBuilder(input.eventID)) {
           return;
         }
@@ -47,10 +44,7 @@ export default class CreateGuestGroupAction extends CreateGuestGroupActionBase {
       },
     },
     {
-      async changeset(
-        builder: GuestGroupBuilder,
-        input: GuestGroupCreateInput,
-      ) {
+      async changeset(builder, input) {
         if (!input.guests) {
           return;
         }

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/create_guest_group_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/create_guest_group_action_base.ts
@@ -13,10 +13,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, GuestGroup } from "src/ent/";
-import {
-  GuestGroupBuilder,
-  GuestGroupInput,
-} from "src/ent/guest_group/actions/generated/guest_group_builder";
+import { GuestGroupBuilder } from "src/ent/guest_group/actions/generated/guest_group_builder";
 
 interface customGuestInput {
   name: string;
@@ -30,8 +27,15 @@ export interface GuestGroupCreateInput {
   guests?: customGuestInput[] | null;
 }
 
-export class CreateGuestGroupActionBase implements Action<GuestGroup> {
-  public readonly builder: GuestGroupBuilder;
+export class CreateGuestGroupActionBase
+  implements
+    Action<
+      GuestGroup,
+      GuestGroupBuilder<GuestGroupCreateInput>,
+      GuestGroupCreateInput
+    >
+{
+  public readonly builder: GuestGroupBuilder<GuestGroupCreateInput>;
   public readonly viewer: Viewer;
   protected input: GuestGroupCreateInput;
 
@@ -49,7 +53,7 @@ export class CreateGuestGroupActionBase implements Action<GuestGroup> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): GuestGroupInput {
+  getInput(): GuestGroupCreateInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/delete_guest_group_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/delete_guest_group_action_base.ts
@@ -13,8 +13,11 @@ import {
   GuestGroupInput,
 } from "src/ent/guest_group/actions/generated/guest_group_builder";
 
-export class DeleteGuestGroupActionBase implements Action<GuestGroup> {
-  public readonly builder: GuestGroupBuilder;
+export class DeleteGuestGroupActionBase
+  implements
+    Action<GuestGroup, GuestGroupBuilder<GuestGroupInput>, GuestGroupInput>
+{
+  public readonly builder: GuestGroupBuilder<GuestGroupInput>;
   public readonly viewer: Viewer;
   protected guestGroup: GuestGroup;
 

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/edit_guest_group_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/edit_guest_group_action_base.ts
@@ -8,17 +8,21 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { GuestGroup } from "src/ent/";
-import {
-  GuestGroupBuilder,
-  GuestGroupInput,
-} from "src/ent/guest_group/actions/generated/guest_group_builder";
+import { GuestGroupBuilder } from "src/ent/guest_group/actions/generated/guest_group_builder";
 
 export interface GuestGroupEditInput {
   invitationName?: string;
 }
 
-export class EditGuestGroupActionBase implements Action<GuestGroup> {
-  public readonly builder: GuestGroupBuilder;
+export class EditGuestGroupActionBase
+  implements
+    Action<
+      GuestGroup,
+      GuestGroupBuilder<GuestGroupEditInput>,
+      GuestGroupEditInput
+    >
+{
+  public readonly builder: GuestGroupBuilder<GuestGroupEditInput>;
   public readonly viewer: Viewer;
   protected input: GuestGroupEditInput;
   protected guestGroup: GuestGroup;
@@ -43,7 +47,7 @@ export class EditGuestGroupActionBase implements Action<GuestGroup> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): GuestGroupInput {
+  getInput(): GuestGroupEditInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
@@ -21,11 +21,6 @@ export interface GuestGroupInput {
   [x: string]: any;
 }
 
-export interface GuestGroupAction<TData extends GuestGroupInput>
-  extends Action<GuestGroup, GuestGroupBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -41,7 +36,7 @@ export class GuestGroupBuilder<TData extends GuestGroupInput = GuestGroupInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: GuestGroupAction<TData>,
+    action: Action<GuestGroup, Builder<GuestGroup>, TData>,
     public readonly existingEnt?: GuestGroup | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-GuestGroup`;

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
@@ -17,26 +17,31 @@ import schema from "src/schema/guest_group";
 export interface GuestGroupInput {
   invitationName?: string;
   eventID?: ID | Builder<Event>;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface GuestGroupAction extends Action<GuestGroup> {
-  getInput(): GuestGroupInput;
+export interface GuestGroupAction<TData extends GuestGroupInput>
+  extends Action<GuestGroup, GuestGroupBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class GuestGroupBuilder implements Builder<GuestGroup> {
-  orchestrator: Orchestrator<GuestGroup>;
+export class GuestGroupBuilder<TData extends GuestGroupInput = GuestGroupInput>
+  implements Builder<GuestGroup>
+{
+  orchestrator: Orchestrator<GuestGroup, TData>;
   readonly placeholderID: ID;
   readonly ent = GuestGroup;
-  private input: GuestGroupInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: GuestGroupAction,
+    action: GuestGroupAction<TData>,
     public readonly existingEnt?: GuestGroup | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-GuestGroup`;
@@ -55,7 +60,7 @@ export class GuestGroupBuilder implements Builder<GuestGroup> {
     });
   }
 
-  getInput(): GuestGroupInput {
+  getInput(): TData {
     return this.input;
   }
 
@@ -79,7 +84,7 @@ export class GuestGroupBuilder implements Builder<GuestGroup> {
 
   addGuestGroupToInvitedEvent(
     ...nodes: (ID | EventActivity | Builder<EventActivity>)[]
-  ): GuestGroupBuilder {
+  ): GuestGroupBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addGuestGroupToInvitedEventID(node);
@@ -95,7 +100,7 @@ export class GuestGroupBuilder implements Builder<GuestGroup> {
   addGuestGroupToInvitedEventID(
     id: ID | Builder<EventActivity>,
     options?: AssocEdgeInputOptions,
-  ): GuestGroupBuilder {
+  ): GuestGroupBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.GuestGroupToInvitedEvents,
@@ -107,7 +112,7 @@ export class GuestGroupBuilder implements Builder<GuestGroup> {
 
   removeGuestGroupToInvitedEvent(
     ...nodes: (ID | EventActivity)[]
-  ): GuestGroupBuilder {
+  ): GuestGroupBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(

--- a/examples/ent-rsvp/backend/src/ent/user/actions/generated/create_user_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/user/actions/generated/create_user_action_base.ts
@@ -7,10 +7,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "src/ent/";
-import {
-  UserBuilder,
-  UserInput,
-} from "src/ent/user/actions/generated/user_builder";
+import { UserBuilder } from "src/ent/user/actions/generated/user_builder";
 
 export interface UserCreateInput {
   firstName: string;
@@ -19,8 +16,10 @@ export interface UserCreateInput {
   password: string;
 }
 
-export class CreateUserActionBase implements Action<User> {
-  public readonly builder: UserBuilder;
+export class CreateUserActionBase
+  implements Action<User, UserBuilder<UserCreateInput>, UserCreateInput>
+{
+  public readonly builder: UserBuilder<UserCreateInput>;
   public readonly viewer: Viewer;
   protected input: UserCreateInput;
 
@@ -34,7 +33,7 @@ export class CreateUserActionBase implements Action<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): UserInput {
+  getInput(): UserCreateInput {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
@@ -18,26 +18,31 @@ export interface UserInput {
   lastName?: string;
   emailAddress?: string;
   password?: string;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface UserAction extends Action<User> {
-  getInput(): UserInput;
+export interface UserAction<TData extends UserInput>
+  extends Action<User, UserBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class UserBuilder implements Builder<User> {
-  orchestrator: Orchestrator<User>;
+export class UserBuilder<TData extends UserInput = UserInput>
+  implements Builder<User>
+{
+  orchestrator: Orchestrator<User, TData>;
   readonly placeholderID: ID;
   readonly ent = User;
-  private input: UserInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: UserAction,
+    action: UserAction<TData>,
     public readonly existingEnt?: User | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-User`;
@@ -56,7 +61,7 @@ export class UserBuilder implements Builder<User> {
     });
   }
 
-  getInput(): UserInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
@@ -22,11 +22,6 @@ export interface UserInput {
   [x: string]: any;
 }
 
-export interface UserAction<TData extends UserInput>
-  extends Action<User, UserBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -42,7 +37,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: UserAction<TData>,
+    action: Action<User, Builder<User>, TData>,
     public readonly existingEnt?: User | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-User`;

--- a/examples/ent-rsvp/backend/src/graphql/mutations/import_guests.ts
+++ b/examples/ent-rsvp/backend/src/graphql/mutations/import_guests.ts
@@ -124,7 +124,6 @@ export class ImportGuestResolver {
       );
     }
 
-    // @ts-ignore TODO
     const action = BaseAction.bulkAction(event, EventBuilder, ...actions);
     return action.saveX();
   }

--- a/examples/ent-rsvp/backend/src/graphql/mutations/import_guests.ts
+++ b/examples/ent-rsvp/backend/src/graphql/mutations/import_guests.ts
@@ -5,7 +5,7 @@ import {
   gqlFileUpload,
   gqlMutation,
 } from "@snowtop/ent/graphql";
-import { Action } from "@snowtop/ent/action";
+import { Action, Builder } from "@snowtop/ent/action";
 import { GraphQLID } from "graphql";
 import { Event } from "src/ent";
 import { FileUpload } from "graphql-upload";
@@ -35,7 +35,7 @@ export class ImportGuestResolver {
 
     let requiredColumns = new Set(["invitationName", "name", "emailAddress"]);
 
-    let actions: Action<Ent>[] = [];
+    let actions: Action<Ent, Builder<Ent>, Data>[] = [];
 
     let parsedHeaders = false;
     let columns: string[] = [];
@@ -124,6 +124,7 @@ export class ImportGuestResolver {
       );
     }
 
+    // @ts-ignore TODO
     const action = BaseAction.bulkAction(event, EventBuilder, ...actions);
     return action.saveX();
   }

--- a/examples/simple/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/simple/src/ent/address/actions/generated/address_builder.ts
@@ -27,11 +27,6 @@ export interface AddressInput {
   [x: string]: any;
 }
 
-export interface AddressAction<TData extends AddressInput>
-  extends Action<Address, AddressBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -47,7 +42,7 @@ export class AddressBuilder<TData extends AddressInput = AddressInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AddressAction<TData>,
+    action: Action<Address, Builder<Address>, TData>,
     public readonly existingEnt?: Address | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Address`;

--- a/examples/simple/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/simple/src/ent/address/actions/generated/address_builder.ts
@@ -23,26 +23,31 @@ export interface AddressInput {
   zip?: string;
   apartment?: string | null;
   country?: string;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface AddressAction extends Action<Address> {
-  getInput(): AddressInput;
+export interface AddressAction<TData extends AddressInput>
+  extends Action<Address, AddressBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class AddressBuilder implements Builder<Address> {
-  orchestrator: Orchestrator<Address>;
+export class AddressBuilder<TData extends AddressInput = AddressInput>
+  implements Builder<Address>
+{
+  orchestrator: Orchestrator<Address, TData>;
   readonly placeholderID: ID;
   readonly ent = Address;
-  private input: AddressInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AddressAction,
+    action: AddressAction<TData>,
     public readonly existingEnt?: Address | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Address`;
@@ -61,7 +66,7 @@ export class AddressBuilder implements Builder<Address> {
     });
   }
 
-  getInput(): AddressInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/simple/src/ent/address/actions/generated/create_address_action_base.ts
+++ b/examples/simple/src/ent/address/actions/generated/create_address_action_base.ts
@@ -21,8 +21,11 @@ export interface AddressCreateInput {
   country?: string;
 }
 
-export class CreateAddressActionBase implements Action<Address> {
-  public readonly builder: AddressBuilder;
+export class CreateAddressActionBase
+  implements
+    Action<Address, AddressBuilder<AddressCreateInput>, AddressCreateInput>
+{
+  public readonly builder: AddressBuilder<AddressCreateInput>;
   public readonly viewer: Viewer;
   protected input: AddressCreateInput;
 
@@ -36,7 +39,7 @@ export class CreateAddressActionBase implements Action<Address> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): AddressInput {
+  getInput(): AddressCreateInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/address/actions/generated/create_address_action_base.ts
+++ b/examples/simple/src/ent/address/actions/generated/create_address_action_base.ts
@@ -10,7 +10,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Address } from "../../..";
-import { AddressBuilder, AddressInput } from "./address_builder";
+import { AddressBuilder } from "./address_builder";
 
 export interface AddressCreateInput {
   streetName: string;

--- a/examples/simple/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -25,11 +25,6 @@ export interface AuthCodeInput {
   [x: string]: any;
 }
 
-export interface AuthCodeAction<TData extends AuthCodeInput>
-  extends Action<AuthCode, AuthCodeBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -45,7 +40,7 @@ export class AuthCodeBuilder<TData extends AuthCodeInput = AuthCodeInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AuthCodeAction<TData>,
+    action: Action<AuthCode, Builder<AuthCode>, TData>,
     public readonly existingEnt?: AuthCode | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-AuthCode`;

--- a/examples/simple/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -21,26 +21,31 @@ export interface AuthCodeInput {
   userID?: ID | Builder<User>;
   emailAddress?: string | null;
   phoneNumber?: string | null;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface AuthCodeAction extends Action<AuthCode> {
-  getInput(): AuthCodeInput;
+export interface AuthCodeAction<TData extends AuthCodeInput>
+  extends Action<AuthCode, AuthCodeBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class AuthCodeBuilder implements Builder<AuthCode> {
-  orchestrator: Orchestrator<AuthCode>;
+export class AuthCodeBuilder<TData extends AuthCodeInput = AuthCodeInput>
+  implements Builder<AuthCode>
+{
+  orchestrator: Orchestrator<AuthCode, TData>;
   readonly placeholderID: ID;
   readonly ent = AuthCode;
-  private input: AuthCodeInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AuthCodeAction,
+    action: AuthCodeAction<TData>,
     public readonly existingEnt?: AuthCode | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-AuthCode`;
@@ -59,7 +64,7 @@ export class AuthCodeBuilder implements Builder<AuthCode> {
     });
   }
 
-  getInput(): AuthCodeInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/simple/src/ent/auth_code/actions/generated/create_auth_code_action_base.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/create_auth_code_action_base.ts
@@ -25,8 +25,11 @@ export interface AuthCodeCreateInput {
   phoneNumber?: string | null;
 }
 
-export class CreateAuthCodeActionBase implements Action<AuthCode> {
-  public readonly builder: AuthCodeBuilder;
+export class CreateAuthCodeActionBase
+  implements
+    Action<AuthCode, AuthCodeBuilder<AuthCodeCreateInput>, AuthCodeCreateInput>
+{
+  public readonly builder: AuthCodeBuilder<AuthCodeCreateInput>;
   public readonly viewer: Viewer;
   protected input: AuthCodeCreateInput;
 
@@ -44,7 +47,7 @@ export class CreateAuthCodeActionBase implements Action<AuthCode> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): AuthCodeInput {
+  getInput(): AuthCodeCreateInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/auth_code/actions/generated/create_auth_code_action_base.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/create_auth_code_action_base.ts
@@ -16,7 +16,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { AuthCode, User } from "../../..";
-import { AuthCodeBuilder, AuthCodeInput } from "./auth_code_builder";
+import { AuthCodeBuilder } from "./auth_code_builder";
 
 export interface AuthCodeCreateInput {
   code: string;

--- a/examples/simple/src/ent/auth_code/actions/generated/delete_auth_code_action_base.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/delete_auth_code_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { AuthCode } from "../../..";
-import { AuthCodeBuilder } from "./auth_code_builder";
+import { AuthCodeBuilder, AuthCodeInput } from "./auth_code_builder";
 
 export class DeleteAuthCodeActionBase
   implements Action<AuthCode, AuthCodeBuilder<AuthCodeInput>, AuthCodeInput>

--- a/examples/simple/src/ent/auth_code/actions/generated/delete_auth_code_action_base.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/delete_auth_code_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { AuthCode } from "../../..";
-import { AuthCodeBuilder, AuthCodeInput } from "./auth_code_builder";
+import { AuthCodeBuilder } from "./auth_code_builder";
 
 export class DeleteAuthCodeActionBase
   implements Action<AuthCode, AuthCodeBuilder<AuthCodeInput>, AuthCodeInput>

--- a/examples/simple/src/ent/auth_code/actions/generated/delete_auth_code_action_base.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/delete_auth_code_action_base.ts
@@ -13,8 +13,10 @@ import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { AuthCode } from "../../..";
 import { AuthCodeBuilder, AuthCodeInput } from "./auth_code_builder";
 
-export class DeleteAuthCodeActionBase implements Action<AuthCode> {
-  public readonly builder: AuthCodeBuilder;
+export class DeleteAuthCodeActionBase
+  implements Action<AuthCode, AuthCodeBuilder<AuthCodeInput>, AuthCodeInput>
+{
+  public readonly builder: AuthCodeBuilder<AuthCodeInput>;
   public readonly viewer: Viewer;
   protected authCode: AuthCode;
 

--- a/examples/simple/src/ent/comment/actions/create_comment_action.ts
+++ b/examples/simple/src/ent/comment/actions/create_comment_action.ts
@@ -18,9 +18,12 @@ export default class CreateCommentAction extends CreateCommentActionBase {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  triggers: Trigger<Ent>[] = [
+  triggers: Trigger<Ent, CommentCreateInput>[] = [
     {
-      changeset(builder: CommentBuilder, input: CommentCreateInput) {
+      changeset(
+        builder: CommentBuilder<CommentCreateInput>,
+        input: CommentCreateInput,
+      ) {
         // creating the comment automatically adds the needed edges
         builder.addPostID(input.articleID, input.articleType as NodeType);
       },

--- a/examples/simple/src/ent/comment/actions/create_comment_action.ts
+++ b/examples/simple/src/ent/comment/actions/create_comment_action.ts
@@ -2,7 +2,7 @@
  * Copyright whaa whaa
  */
 
-import { AlwaysAllowPrivacyPolicy, Ent } from "@snowtop/ent";
+import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
 import { Trigger } from "@snowtop/ent/action";
 import { NodeType } from "../../generated/const";
 import { CommentBuilder } from "./generated/comment_builder";
@@ -18,12 +18,9 @@ export default class CreateCommentAction extends CreateCommentActionBase {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  triggers: Trigger<Ent, CommentCreateInput>[] = [
+  triggers: Trigger<CommentBuilder, CommentCreateInput>[] = [
     {
-      changeset(
-        builder: CommentBuilder<CommentCreateInput>,
-        input: CommentCreateInput,
-      ) {
+      changeset(builder, input) {
         // creating the comment automatically adds the needed edges
         builder.addPostID(input.articleID, input.articleType as NodeType);
       },

--- a/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
+++ b/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
@@ -22,26 +22,31 @@ export interface CommentInput {
   body?: string;
   articleID?: ID | Builder<Ent>;
   articleType?: string;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface CommentAction extends Action<Comment> {
-  getInput(): CommentInput;
+export interface CommentAction<TData extends CommentInput>
+  extends Action<Comment, CommentBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class CommentBuilder implements Builder<Comment> {
-  orchestrator: Orchestrator<Comment>;
+export class CommentBuilder<TData extends CommentInput = CommentInput>
+  implements Builder<Comment>
+{
+  orchestrator: Orchestrator<Comment, TData>;
   readonly placeholderID: ID;
   readonly ent = Comment;
-  private input: CommentInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: CommentAction,
+    action: CommentAction<TData>,
     public readonly existingEnt?: Comment | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Comment`;
@@ -60,7 +65,7 @@ export class CommentBuilder implements Builder<Comment> {
     });
   }
 
-  getInput(): CommentInput {
+  getInput(): TData {
     return this.input;
   }
 
@@ -81,7 +86,7 @@ export class CommentBuilder implements Builder<Comment> {
   clearInputEdges(edgeType: EdgeType, op: WriteOperation, id?: ID) {
     this.orchestrator.clearInputEdges(edgeType, op, id);
   }
-  addPost(...nodes: (Ent | Builder<Ent>)[]): CommentBuilder {
+  addPost(...nodes: (Ent | Builder<Ent>)[]): CommentBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.orchestrator.addOutboundEdge(
@@ -105,7 +110,7 @@ export class CommentBuilder implements Builder<Comment> {
     id: ID | Builder<Ent>,
     nodeType: NodeType,
     options?: AssocEdgeInputOptions,
-  ): CommentBuilder {
+  ): CommentBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.CommentToPost,
@@ -115,7 +120,7 @@ export class CommentBuilder implements Builder<Comment> {
     return this;
   }
 
-  removePost(...nodes: (ID | Ent)[]): CommentBuilder {
+  removePost(...nodes: (ID | Ent)[]): CommentBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.CommentToPost);

--- a/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
+++ b/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
@@ -26,11 +26,6 @@ export interface CommentInput {
   [x: string]: any;
 }
 
-export interface CommentAction<TData extends CommentInput>
-  extends Action<Comment, CommentBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -46,7 +41,7 @@ export class CommentBuilder<TData extends CommentInput = CommentInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: CommentAction<TData>,
+    action: Action<Comment, Builder<Comment>, TData>,
     public readonly existingEnt?: Comment | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Comment`;

--- a/examples/simple/src/ent/comment/actions/generated/create_comment_action_base.ts
+++ b/examples/simple/src/ent/comment/actions/generated/create_comment_action_base.ts
@@ -26,8 +26,11 @@ export interface CommentCreateInput {
   articleType: string;
 }
 
-export class CreateCommentActionBase implements Action<Comment> {
-  public readonly builder: CommentBuilder;
+export class CreateCommentActionBase
+  implements
+    Action<Comment, CommentBuilder<CommentCreateInput>, CommentCreateInput>
+{
+  public readonly builder: CommentBuilder<CommentCreateInput>;
   public readonly viewer: Viewer;
   protected input: CommentCreateInput;
 
@@ -41,7 +44,7 @@ export class CreateCommentActionBase implements Action<Comment> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): CommentInput {
+  getInput(): CommentCreateInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/comment/actions/generated/create_comment_action_base.ts
+++ b/examples/simple/src/ent/comment/actions/generated/create_comment_action_base.ts
@@ -17,7 +17,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Comment } from "../../..";
-import { CommentBuilder, CommentInput } from "./comment_builder";
+import { CommentBuilder } from "./comment_builder";
 
 export interface CommentCreateInput {
   authorID: ID;

--- a/examples/simple/src/ent/contact/actions/generated/contact_builder.ts
+++ b/examples/simple/src/ent/contact/actions/generated/contact_builder.ts
@@ -26,11 +26,6 @@ export interface ContactInput {
   [x: string]: any;
 }
 
-export interface ContactAction<TData extends ContactInput>
-  extends Action<Contact, ContactBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -46,7 +41,7 @@ export class ContactBuilder<TData extends ContactInput = ContactInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: ContactAction<TData>,
+    action: Action<Contact, Builder<Contact>, TData>,
     public readonly existingEnt?: Contact | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Contact`;

--- a/examples/simple/src/ent/contact/actions/generated/contact_builder.ts
+++ b/examples/simple/src/ent/contact/actions/generated/contact_builder.ts
@@ -22,26 +22,31 @@ export interface ContactInput {
   firstName?: string;
   lastName?: string;
   userID?: ID | Builder<User>;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface ContactAction extends Action<Contact> {
-  getInput(): ContactInput;
+export interface ContactAction<TData extends ContactInput>
+  extends Action<Contact, ContactBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class ContactBuilder implements Builder<Contact> {
-  orchestrator: Orchestrator<Contact>;
+export class ContactBuilder<TData extends ContactInput = ContactInput>
+  implements Builder<Contact>
+{
+  orchestrator: Orchestrator<Contact, TData>;
   readonly placeholderID: ID;
   readonly ent = Contact;
-  private input: ContactInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: ContactAction,
+    action: ContactAction<TData>,
     public readonly existingEnt?: Contact | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Contact`;
@@ -60,7 +65,7 @@ export class ContactBuilder implements Builder<Contact> {
     });
   }
 
-  getInput(): ContactInput {
+  getInput(): TData {
     return this.input;
   }
 
@@ -82,7 +87,9 @@ export class ContactBuilder implements Builder<Contact> {
     this.orchestrator.clearInputEdges(edgeType, op, id);
   }
 
-  addComment(...nodes: (ID | Comment | Builder<Comment>)[]): ContactBuilder {
+  addComment(
+    ...nodes: (ID | Comment | Builder<Comment>)[]
+  ): ContactBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addCommentID(node);
@@ -98,7 +105,7 @@ export class ContactBuilder implements Builder<Contact> {
   addCommentID(
     id: ID | Builder<Comment>,
     options?: AssocEdgeInputOptions,
-  ): ContactBuilder {
+  ): ContactBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.ObjectToComments,
@@ -108,7 +115,7 @@ export class ContactBuilder implements Builder<Contact> {
     return this;
   }
 
-  removeComment(...nodes: (ID | Comment)[]): ContactBuilder {
+  removeComment(...nodes: (ID | Comment)[]): ContactBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -122,7 +129,7 @@ export class ContactBuilder implements Builder<Contact> {
     return this;
   }
 
-  addLiker(...nodes: (ID | User | Builder<User>)[]): ContactBuilder {
+  addLiker(...nodes: (ID | User | Builder<User>)[]): ContactBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addLikerID(node);
@@ -138,7 +145,7 @@ export class ContactBuilder implements Builder<Contact> {
   addLikerID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): ContactBuilder {
+  ): ContactBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.ObjectToLikers,
@@ -148,7 +155,7 @@ export class ContactBuilder implements Builder<Contact> {
     return this;
   }
 
-  removeLiker(...nodes: (ID | User)[]): ContactBuilder {
+  removeLiker(...nodes: (ID | User)[]): ContactBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.ObjectToLikers);

--- a/examples/simple/src/ent/contact/actions/generated/create_contact_action_base.ts
+++ b/examples/simple/src/ent/contact/actions/generated/create_contact_action_base.ts
@@ -25,8 +25,11 @@ export interface ContactCreateInput {
   userID: ID | Builder<User>;
 }
 
-export class CreateContactActionBase implements Action<Contact> {
-  public readonly builder: ContactBuilder;
+export class CreateContactActionBase
+  implements
+    Action<Contact, ContactBuilder<ContactCreateInput>, ContactCreateInput>
+{
+  public readonly builder: ContactBuilder<ContactCreateInput>;
   public readonly viewer: Viewer;
   protected input: ContactCreateInput;
 
@@ -40,7 +43,7 @@ export class CreateContactActionBase implements Action<Contact> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): ContactInput {
+  getInput(): ContactCreateInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/contact/actions/generated/create_contact_action_base.ts
+++ b/examples/simple/src/ent/contact/actions/generated/create_contact_action_base.ts
@@ -16,7 +16,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Contact, User } from "../../..";
-import { ContactBuilder, ContactInput } from "./contact_builder";
+import { ContactBuilder } from "./contact_builder";
 
 export interface ContactCreateInput {
   emailAddress: string;

--- a/examples/simple/src/ent/contact/actions/generated/delete_contact_action_base.ts
+++ b/examples/simple/src/ent/contact/actions/generated/delete_contact_action_base.ts
@@ -13,8 +13,10 @@ import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Contact } from "../../..";
 import { ContactBuilder, ContactInput } from "./contact_builder";
 
-export class DeleteContactActionBase implements Action<Contact> {
-  public readonly builder: ContactBuilder;
+export class DeleteContactActionBase
+  implements Action<Contact, ContactBuilder<ContactInput>, ContactInput>
+{
+  public readonly builder: ContactBuilder<ContactInput>;
   public readonly viewer: Viewer;
   protected contact: Contact;
 

--- a/examples/simple/src/ent/contact/actions/generated/delete_contact_action_base.ts
+++ b/examples/simple/src/ent/contact/actions/generated/delete_contact_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Contact } from "../../..";
-import { ContactBuilder, ContactInput } from "./contact_builder";
+import { ContactBuilder } from "./contact_builder";
 
 export class DeleteContactActionBase
   implements Action<Contact, ContactBuilder<ContactInput>, ContactInput>

--- a/examples/simple/src/ent/contact/actions/generated/delete_contact_action_base.ts
+++ b/examples/simple/src/ent/contact/actions/generated/delete_contact_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Contact } from "../../..";
-import { ContactBuilder } from "./contact_builder";
+import { ContactBuilder, ContactInput } from "./contact_builder";
 
 export class DeleteContactActionBase
   implements Action<Contact, ContactBuilder<ContactInput>, ContactInput>

--- a/examples/simple/src/ent/contact/actions/generated/edit_contact_action_base.ts
+++ b/examples/simple/src/ent/contact/actions/generated/edit_contact_action_base.ts
@@ -16,7 +16,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Contact, User } from "../../..";
-import { ContactBuilder, ContactInput } from "./contact_builder";
+import { ContactBuilder } from "./contact_builder";
 
 export interface ContactEditInput {
   emailAddress?: string;

--- a/examples/simple/src/ent/contact/actions/generated/edit_contact_action_base.ts
+++ b/examples/simple/src/ent/contact/actions/generated/edit_contact_action_base.ts
@@ -25,8 +25,11 @@ export interface ContactEditInput {
   userID?: ID | Builder<User>;
 }
 
-export class EditContactActionBase implements Action<Contact> {
-  public readonly builder: ContactBuilder;
+export class EditContactActionBase
+  implements
+    Action<Contact, ContactBuilder<ContactEditInput>, ContactEditInput>
+{
+  public readonly builder: ContactBuilder<ContactEditInput>;
   public readonly viewer: Viewer;
   protected input: ContactEditInput;
   protected contact: Contact;
@@ -47,7 +50,7 @@ export class EditContactActionBase implements Action<Contact> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): ContactInput {
+  getInput(): ContactEditInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/event/actions/create_event_action.ts
+++ b/examples/simple/src/ent/event/actions/create_event_action.ts
@@ -4,7 +4,6 @@ import {
 } from "./generated/create_event_action_base";
 import { Trigger, Validator } from "@snowtop/ent/action";
 import { SharedValidators } from "./event_validators";
-import { Event } from "../../";
 import { EventBuilder } from "./generated/event_builder";
 import { AlwaysAllowPrivacyPolicy, PrivacyPolicy } from "@snowtop/ent";
 
@@ -18,9 +17,11 @@ export default class CreateEventAction extends CreateEventActionBase {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  validators: Validator<Event, EventCreateInput>[] = [...SharedValidators];
+  validators: Validator<EventBuilder, EventCreateInput>[] = [
+    ...SharedValidators,
+  ];
 
-  triggers: Trigger<Event, EventCreateInput>[] = [
+  triggers: Trigger<EventBuilder, EventCreateInput>[] = [
     {
       changeset(
         builder: EventBuilder<EventCreateInput>,

--- a/examples/simple/src/ent/event/actions/create_event_action.ts
+++ b/examples/simple/src/ent/event/actions/create_event_action.ts
@@ -18,11 +18,14 @@ export default class CreateEventAction extends CreateEventActionBase {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  validators: Validator<Event>[] = [...SharedValidators];
+  validators: Validator<Event, EventCreateInput>[] = [...SharedValidators];
 
-  triggers: Trigger<Event>[] = [
+  triggers: Trigger<Event, EventCreateInput>[] = [
     {
-      changeset(builder: EventBuilder, input: EventCreateInput) {
+      changeset(
+        builder: EventBuilder<EventCreateInput>,
+        input: EventCreateInput,
+      ) {
         builder.addHostID(input.creatorID);
       },
     },

--- a/examples/simple/src/ent/event/actions/edit_event_action.ts
+++ b/examples/simple/src/ent/event/actions/edit_event_action.ts
@@ -15,7 +15,7 @@ export { EventEditInput };
 
 // we're only writing this once except with --force and packageName provided
 export default class EditEventAction extends EditEventActionBase {
-  validators: Validator<Event>[] = [...SharedValidators];
+  validators: Validator<Event, EventEditInput>[] = [...SharedValidators];
 
   getPrivacyPolicy(): PrivacyPolicy {
     return {

--- a/examples/simple/src/ent/event/actions/edit_event_action.ts
+++ b/examples/simple/src/ent/event/actions/edit_event_action.ts
@@ -4,18 +4,18 @@ import {
 } from "./generated/edit_event_action_base";
 import { Validator } from "@snowtop/ent/action";
 import { SharedValidators } from "./event_validators";
-import { Event } from "../..";
 import {
   AllowIfViewerIsRule,
   AlwaysDenyRule,
   PrivacyPolicy,
 } from "@snowtop/ent";
+import { EventBuilder } from "./generated/event_builder";
 
 export { EventEditInput };
 
 // we're only writing this once except with --force and packageName provided
 export default class EditEventAction extends EditEventActionBase {
-  validators: Validator<Event, EventEditInput>[] = [...SharedValidators];
+  validators: Validator<EventBuilder, EventEditInput>[] = [...SharedValidators];
 
   getPrivacyPolicy(): PrivacyPolicy {
     return {

--- a/examples/simple/src/ent/event/actions/event_validators.ts
+++ b/examples/simple/src/ent/event/actions/event_validators.ts
@@ -1,9 +1,8 @@
 import { Validator } from "@snowtop/ent/action";
 import { EventBuilder, EventInput } from "./generated/event_builder";
-import { Event } from "../..";
 
-export class EventTimeValidator implements Validator<Event, EventInput> {
-  validate(builder: EventBuilder, input: EventInput): void {
+export class EventTimeValidator implements Validator<EventBuilder, EventInput> {
+  validate(builder: EventBuilder): void {
     const startTime = builder.getNewStartTimeValue();
     const endTime = builder.getNewEndTimeValue();
 

--- a/examples/simple/src/ent/event/actions/event_validators.ts
+++ b/examples/simple/src/ent/event/actions/event_validators.ts
@@ -2,7 +2,7 @@ import { Validator } from "@snowtop/ent/action";
 import { EventBuilder, EventInput } from "./generated/event_builder";
 import { Event } from "../..";
 
-export class EventTimeValidator implements Validator<Event> {
+export class EventTimeValidator implements Validator<Event, EventInput> {
   validate(builder: EventBuilder, input: EventInput): void {
     const startTime = builder.getNewStartTimeValue();
     const endTime = builder.getNewEndTimeValue();

--- a/examples/simple/src/ent/event/actions/generated/create_event_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/create_event_action_base.ts
@@ -26,8 +26,10 @@ export interface EventCreateInput {
   location: string;
 }
 
-export class CreateEventActionBase implements Action<Event> {
-  public readonly builder: EventBuilder;
+export class CreateEventActionBase
+  implements Action<Event, EventBuilder<EventCreateInput>, EventCreateInput>
+{
+  public readonly builder: EventBuilder<EventCreateInput>;
   public readonly viewer: Viewer;
   protected input: EventCreateInput;
 
@@ -41,7 +43,7 @@ export class CreateEventActionBase implements Action<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): EventInput {
+  getInput(): EventCreateInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/event/actions/generated/create_event_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/create_event_action_base.ts
@@ -16,7 +16,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, User } from "../../..";
-import { EventBuilder, EventInput } from "./event_builder";
+import { EventBuilder } from "./event_builder";
 
 export interface EventCreateInput {
   name: string;

--- a/examples/simple/src/ent/event/actions/generated/delete_event_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/delete_event_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Event } from "../../..";
-import { EventBuilder, EventInput } from "./event_builder";
+import { EventBuilder } from "./event_builder";
 
 export class DeleteEventActionBase
   implements Action<Event, EventBuilder<EventInput>, EventInput>

--- a/examples/simple/src/ent/event/actions/generated/delete_event_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/delete_event_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Event } from "../../..";
-import { EventBuilder } from "./event_builder";
+import { EventBuilder, EventInput } from "./event_builder";
 
 export class DeleteEventActionBase
   implements Action<Event, EventBuilder<EventInput>, EventInput>

--- a/examples/simple/src/ent/event/actions/generated/delete_event_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/delete_event_action_base.ts
@@ -13,8 +13,10 @@ import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Event } from "../../..";
 import { EventBuilder, EventInput } from "./event_builder";
 
-export class DeleteEventActionBase implements Action<Event> {
-  public readonly builder: EventBuilder;
+export class DeleteEventActionBase
+  implements Action<Event, EventBuilder<EventInput>, EventInput>
+{
+  public readonly builder: EventBuilder<EventInput>;
   public readonly viewer: Viewer;
   protected event: Event;
 

--- a/examples/simple/src/ent/event/actions/generated/edit_event_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/edit_event_action_base.ts
@@ -26,8 +26,10 @@ export interface EventEditInput {
   location?: string;
 }
 
-export class EditEventActionBase implements Action<Event> {
-  public readonly builder: EventBuilder;
+export class EditEventActionBase
+  implements Action<Event, EventBuilder<EventEditInput>, EventEditInput>
+{
+  public readonly builder: EventBuilder<EventEditInput>;
   public readonly viewer: Viewer;
   protected input: EventEditInput;
   protected event: Event;
@@ -48,7 +50,7 @@ export class EditEventActionBase implements Action<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): EventInput {
+  getInput(): EventEditInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/event/actions/generated/edit_event_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/edit_event_action_base.ts
@@ -16,7 +16,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, User } from "../../..";
-import { EventBuilder, EventInput } from "./event_builder";
+import { EventBuilder } from "./event_builder";
 
 export interface EventEditInput {
   name?: string;

--- a/examples/simple/src/ent/event/actions/generated/edit_event_rsvp_status_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/edit_event_rsvp_status_action_base.ts
@@ -16,7 +16,7 @@ import {
   setEdgeTypeInGroup,
 } from "@snowtop/ent/action";
 import { Event, NodeType } from "../../..";
-import { EventBuilder, EventInput } from "./event_builder";
+import { EventBuilder } from "./event_builder";
 
 export enum EventRsvpStatusInput {
   Attending = "attending",

--- a/examples/simple/src/ent/event/actions/generated/edit_event_rsvp_status_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/edit_event_rsvp_status_action_base.ts
@@ -29,8 +29,15 @@ export interface EditEventRsvpStatusInput {
   userID: ID;
 }
 
-export class EditEventRsvpStatusActionBase implements Action<Event> {
-  public readonly builder: EventBuilder;
+export class EditEventRsvpStatusActionBase
+  implements
+    Action<
+      Event,
+      EventBuilder<EditEventRsvpStatusInput>,
+      EditEventRsvpStatusInput
+    >
+{
+  public readonly builder: EventBuilder<EditEventRsvpStatusInput>;
   public readonly viewer: Viewer;
   protected input: EditEventRsvpStatusInput;
   protected event: Event;
@@ -51,9 +58,8 @@ export class EditEventRsvpStatusActionBase implements Action<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): EventInput {
-    // we use a type assertion to override the weak type detection here
-    return this.input as EventInput;
+  getInput(): EditEventRsvpStatusInput {
+    return this.input;
   }
 
   async changeset(): Promise<Changeset<Event>> {

--- a/examples/simple/src/ent/event/actions/generated/event_add_host_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_add_host_action_base.ts
@@ -17,7 +17,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, User } from "../../..";
-import { EventBuilder, EventInput } from "./event_builder";
+import { EventBuilder } from "./event_builder";
 
 export class EventAddHostActionBase
   implements Action<Event, EventBuilder<EventInput>, EventInput>

--- a/examples/simple/src/ent/event/actions/generated/event_add_host_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_add_host_action_base.ts
@@ -19,8 +19,10 @@ import {
 import { Event, User } from "../../..";
 import { EventBuilder, EventInput } from "./event_builder";
 
-export class EventAddHostActionBase implements Action<Event> {
-  public readonly builder: EventBuilder;
+export class EventAddHostActionBase
+  implements Action<Event, EventBuilder<EventInput>, EventInput>
+{
+  public readonly builder: EventBuilder<EventInput>;
   public readonly viewer: Viewer;
   protected event: Event;
 

--- a/examples/simple/src/ent/event/actions/generated/event_add_host_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_add_host_action_base.ts
@@ -17,7 +17,7 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, User } from "../../..";
-import { EventBuilder } from "./event_builder";
+import { EventBuilder, EventInput } from "./event_builder";
 
 export class EventAddHostActionBase
   implements Action<Event, EventBuilder<EventInput>, EventInput>

--- a/examples/simple/src/ent/event/actions/generated/event_builder.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_builder.ts
@@ -27,11 +27,6 @@ export interface EventInput {
   [x: string]: any;
 }
 
-export interface EventAction<TData extends EventInput>
-  extends Action<Event, EventBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -47,7 +42,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: EventAction<TData>,
+    action: Action<Event, Builder<Event>, TData>,
     public readonly existingEnt?: Event | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Event`;

--- a/examples/simple/src/ent/event/actions/generated/event_builder.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_builder.ts
@@ -23,26 +23,31 @@ export interface EventInput {
   startTime?: Date;
   endTime?: Date | null;
   location?: string;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface EventAction extends Action<Event> {
-  getInput(): EventInput;
+export interface EventAction<TData extends EventInput>
+  extends Action<Event, EventBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class EventBuilder implements Builder<Event> {
-  orchestrator: Orchestrator<Event>;
+export class EventBuilder<TData extends EventInput = EventInput>
+  implements Builder<Event>
+{
+  orchestrator: Orchestrator<Event, TData>;
   readonly placeholderID: ID;
   readonly ent = Event;
-  private input: EventInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: EventAction,
+    action: EventAction<TData>,
     public readonly existingEnt?: Event | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Event`;
@@ -61,7 +66,7 @@ export class EventBuilder implements Builder<Event> {
     });
   }
 
-  getInput(): EventInput {
+  getInput(): TData {
     return this.input;
   }
 
@@ -83,7 +88,7 @@ export class EventBuilder implements Builder<Event> {
     this.orchestrator.clearInputEdges(edgeType, op, id);
   }
 
-  addAttending(...nodes: (ID | User | Builder<User>)[]): EventBuilder {
+  addAttending(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addAttendingID(node);
@@ -99,7 +104,7 @@ export class EventBuilder implements Builder<Event> {
   addAttendingID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder {
+  ): EventBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToAttending,
@@ -109,7 +114,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  removeAttending(...nodes: (ID | User)[]): EventBuilder {
+  removeAttending(...nodes: (ID | User)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -123,7 +128,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  addDeclined(...nodes: (ID | User | Builder<User>)[]): EventBuilder {
+  addDeclined(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addDeclinedID(node);
@@ -139,7 +144,7 @@ export class EventBuilder implements Builder<Event> {
   addDeclinedID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder {
+  ): EventBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToDeclined,
@@ -149,7 +154,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  removeDeclined(...nodes: (ID | User)[]): EventBuilder {
+  removeDeclined(...nodes: (ID | User)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.EventToDeclined);
@@ -160,7 +165,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  addHost(...nodes: (ID | User | Builder<User>)[]): EventBuilder {
+  addHost(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addHostID(node);
@@ -176,7 +181,7 @@ export class EventBuilder implements Builder<Event> {
   addHostID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder {
+  ): EventBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToHosts,
@@ -186,7 +191,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  removeHost(...nodes: (ID | User)[]): EventBuilder {
+  removeHost(...nodes: (ID | User)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.EventToHosts);
@@ -197,7 +202,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  addInvited(...nodes: (ID | User | Builder<User>)[]): EventBuilder {
+  addInvited(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addInvitedID(node);
@@ -213,7 +218,7 @@ export class EventBuilder implements Builder<Event> {
   addInvitedID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder {
+  ): EventBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToInvited,
@@ -223,7 +228,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  removeInvited(...nodes: (ID | User)[]): EventBuilder {
+  removeInvited(...nodes: (ID | User)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.EventToInvited);
@@ -234,7 +239,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  addMaybe(...nodes: (ID | User | Builder<User>)[]): EventBuilder {
+  addMaybe(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addMaybeID(node);
@@ -250,7 +255,7 @@ export class EventBuilder implements Builder<Event> {
   addMaybeID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder {
+  ): EventBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToMaybe,
@@ -260,7 +265,7 @@ export class EventBuilder implements Builder<Event> {
     return this;
   }
 
-  removeMaybe(...nodes: (ID | User)[]): EventBuilder {
+  removeMaybe(...nodes: (ID | User)[]): EventBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.EventToMaybe);

--- a/examples/simple/src/ent/event/actions/generated/event_remove_host_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_remove_host_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Event, User } from "../../..";
-import { EventBuilder, EventInput } from "./event_builder";
+import { EventBuilder } from "./event_builder";
 
 export class EventRemoveHostActionBase
   implements Action<Event, EventBuilder<EventInput>, EventInput>

--- a/examples/simple/src/ent/event/actions/generated/event_remove_host_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_remove_host_action_base.ts
@@ -13,8 +13,10 @@ import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Event, User } from "../../..";
 import { EventBuilder, EventInput } from "./event_builder";
 
-export class EventRemoveHostActionBase implements Action<Event> {
-  public readonly builder: EventBuilder;
+export class EventRemoveHostActionBase
+  implements Action<Event, EventBuilder<EventInput>, EventInput>
+{
+  public readonly builder: EventBuilder<EventInput>;
   public readonly viewer: Viewer;
   protected event: Event;
 

--- a/examples/simple/src/ent/event/actions/generated/event_remove_host_action_base.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_remove_host_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Event, User } from "../../..";
-import { EventBuilder } from "./event_builder";
+import { EventBuilder, EventInput } from "./event_builder";
 
 export class EventRemoveHostActionBase
   implements Action<Event, EventBuilder<EventInput>, EventInput>

--- a/examples/simple/src/ent/holiday/actions/generated/create_holiday_action_base.ts
+++ b/examples/simple/src/ent/holiday/actions/generated/create_holiday_action_base.ts
@@ -17,8 +17,11 @@ export interface HolidayCreateInput {
   date: Date;
 }
 
-export class CreateHolidayActionBase implements Action<Holiday> {
-  public readonly builder: HolidayBuilder;
+export class CreateHolidayActionBase
+  implements
+    Action<Holiday, HolidayBuilder<HolidayCreateInput>, HolidayCreateInput>
+{
+  public readonly builder: HolidayBuilder<HolidayCreateInput>;
   public readonly viewer: Viewer;
   protected input: HolidayCreateInput;
 
@@ -32,7 +35,7 @@ export class CreateHolidayActionBase implements Action<Holiday> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): HolidayInput {
+  getInput(): HolidayCreateInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/holiday/actions/generated/create_holiday_action_base.ts
+++ b/examples/simple/src/ent/holiday/actions/generated/create_holiday_action_base.ts
@@ -10,7 +10,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Holiday } from "../../..";
-import { HolidayBuilder, HolidayInput } from "./holiday_builder";
+import { HolidayBuilder } from "./holiday_builder";
 
 export interface HolidayCreateInput {
   label: string;

--- a/examples/simple/src/ent/holiday/actions/generated/holiday_builder.ts
+++ b/examples/simple/src/ent/holiday/actions/generated/holiday_builder.ts
@@ -19,26 +19,31 @@ import schema from "../../../../schema/holiday";
 export interface HolidayInput {
   label?: string;
   date?: Date;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface HolidayAction extends Action<Holiday> {
-  getInput(): HolidayInput;
+export interface HolidayAction<TData extends HolidayInput>
+  extends Action<Holiday, HolidayBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class HolidayBuilder implements Builder<Holiday> {
-  orchestrator: Orchestrator<Holiday>;
+export class HolidayBuilder<TData extends HolidayInput = HolidayInput>
+  implements Builder<Holiday>
+{
+  orchestrator: Orchestrator<Holiday, TData>;
   readonly placeholderID: ID;
   readonly ent = Holiday;
-  private input: HolidayInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: HolidayAction,
+    action: HolidayAction<TData>,
     public readonly existingEnt?: Holiday | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Holiday`;
@@ -57,7 +62,7 @@ export class HolidayBuilder implements Builder<Holiday> {
     });
   }
 
-  getInput(): HolidayInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/simple/src/ent/holiday/actions/generated/holiday_builder.ts
+++ b/examples/simple/src/ent/holiday/actions/generated/holiday_builder.ts
@@ -23,11 +23,6 @@ export interface HolidayInput {
   [x: string]: any;
 }
 
-export interface HolidayAction<TData extends HolidayInput>
-  extends Action<Holiday, HolidayBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -43,7 +38,7 @@ export class HolidayBuilder<TData extends HolidayInput = HolidayInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: HolidayAction<TData>,
+    action: Action<Holiday, Builder<Holiday>, TData>,
     public readonly existingEnt?: Holiday | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Holiday`;

--- a/examples/simple/src/ent/hours_of_operation/actions/generated/create_hours_of_operation_action_base.ts
+++ b/examples/simple/src/ent/hours_of_operation/actions/generated/create_hours_of_operation_action_base.ts
@@ -23,9 +23,14 @@ export interface HoursOfOperationCreateInput {
 }
 
 export class CreateHoursOfOperationActionBase
-  implements Action<HoursOfOperation>
+  implements
+    Action<
+      HoursOfOperation,
+      HoursOfOperationBuilder<HoursOfOperationCreateInput>,
+      HoursOfOperationCreateInput
+    >
 {
-  public readonly builder: HoursOfOperationBuilder;
+  public readonly builder: HoursOfOperationBuilder<HoursOfOperationCreateInput>;
   public readonly viewer: Viewer;
   protected input: HoursOfOperationCreateInput;
 
@@ -43,7 +48,7 @@ export class CreateHoursOfOperationActionBase
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): HoursOfOperationInput {
+  getInput(): HoursOfOperationCreateInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/hours_of_operation/actions/generated/create_hours_of_operation_action_base.ts
+++ b/examples/simple/src/ent/hours_of_operation/actions/generated/create_hours_of_operation_action_base.ts
@@ -10,10 +10,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { DayOfWeek, DayOfWeekAlt, HoursOfOperation } from "../../..";
-import {
-  HoursOfOperationBuilder,
-  HoursOfOperationInput,
-} from "./hours_of_operation_builder";
+import { HoursOfOperationBuilder } from "./hours_of_operation_builder";
 
 export interface HoursOfOperationCreateInput {
   dayOfWeek: DayOfWeek;

--- a/examples/simple/src/ent/hours_of_operation/actions/generated/hours_of_operation_builder.ts
+++ b/examples/simple/src/ent/hours_of_operation/actions/generated/hours_of_operation_builder.ts
@@ -21,26 +21,32 @@ export interface HoursOfOperationInput {
   open?: string;
   close?: string;
   dayOfWeekAlt?: DayOfWeekAlt | null;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface HoursOfOperationAction extends Action<HoursOfOperation> {
-  getInput(): HoursOfOperationInput;
+export interface HoursOfOperationAction<TData extends HoursOfOperationInput>
+  extends Action<HoursOfOperation, HoursOfOperationBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class HoursOfOperationBuilder implements Builder<HoursOfOperation> {
-  orchestrator: Orchestrator<HoursOfOperation>;
+export class HoursOfOperationBuilder<
+  TData extends HoursOfOperationInput = HoursOfOperationInput,
+> implements Builder<HoursOfOperation>
+{
+  orchestrator: Orchestrator<HoursOfOperation, TData>;
   readonly placeholderID: ID;
   readonly ent = HoursOfOperation;
-  private input: HoursOfOperationInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: HoursOfOperationAction,
+    action: HoursOfOperationAction<TData>,
     public readonly existingEnt?: HoursOfOperation | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-HoursOfOperation`;
@@ -59,7 +65,7 @@ export class HoursOfOperationBuilder implements Builder<HoursOfOperation> {
     });
   }
 
-  getInput(): HoursOfOperationInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/simple/src/ent/hours_of_operation/actions/generated/hours_of_operation_builder.ts
+++ b/examples/simple/src/ent/hours_of_operation/actions/generated/hours_of_operation_builder.ts
@@ -25,11 +25,6 @@ export interface HoursOfOperationInput {
   [x: string]: any;
 }
 
-export interface HoursOfOperationAction<TData extends HoursOfOperationInput>
-  extends Action<HoursOfOperation, HoursOfOperationBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -46,7 +41,7 @@ export class HoursOfOperationBuilder<
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: HoursOfOperationAction<TData>,
+    action: Action<HoursOfOperation, Builder<HoursOfOperation>, TData>,
     public readonly existingEnt?: HoursOfOperation | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-HoursOfOperation`;

--- a/examples/simple/src/ent/user/actions/confirm_edit_email_address_action.ts
+++ b/examples/simple/src/ent/user/actions/confirm_edit_email_address_action.ts
@@ -1,4 +1,3 @@
-import { Ent } from "@snowtop/ent";
 import { Trigger, Validator } from "@snowtop/ent/action";
 import DeleteAuthCodeAction from "../../auth_code/actions/delete_auth_code_action";
 import { User } from "../../";
@@ -24,12 +23,9 @@ async function findAuthCode(
 }
 
 export default class ConfirmEditEmailAddressAction extends ConfirmEditEmailAddressActionBase {
-  validators: Validator<User, ConfirmEditEmailAddressInput>[] = [
+  validators: Validator<UserBuilder, ConfirmEditEmailAddressInput>[] = [
     {
-      async validate(
-        builder: UserBuilder,
-        input: ConfirmEditEmailAddressInput,
-      ) {
+      async validate(builder, input) {
         const authCode = await findAuthCode(
           builder,
           input.code,
@@ -42,12 +38,9 @@ export default class ConfirmEditEmailAddressAction extends ConfirmEditEmailAddre
     },
   ];
 
-  triggers: Trigger<Ent, ConfirmEditEmailAddressInput>[] = [
+  triggers: Trigger<UserBuilder, ConfirmEditEmailAddressInput>[] = [
     {
-      async changeset(
-        builder: UserBuilder,
-        input: ConfirmEditEmailAddressInput,
-      ) {
+      async changeset(builder, input) {
         const authCode = await findAuthCode(
           builder,
           input.code,

--- a/examples/simple/src/ent/user/actions/confirm_edit_email_address_action.ts
+++ b/examples/simple/src/ent/user/actions/confirm_edit_email_address_action.ts
@@ -24,7 +24,7 @@ async function findAuthCode(
 }
 
 export default class ConfirmEditEmailAddressAction extends ConfirmEditEmailAddressActionBase {
-  validators: Validator<User>[] = [
+  validators: Validator<User, ConfirmEditEmailAddressInput>[] = [
     {
       async validate(
         builder: UserBuilder,
@@ -42,7 +42,7 @@ export default class ConfirmEditEmailAddressAction extends ConfirmEditEmailAddre
     },
   ];
 
-  triggers: Trigger<Ent>[] = [
+  triggers: Trigger<Ent, ConfirmEditEmailAddressInput>[] = [
     {
       async changeset(
         builder: UserBuilder,

--- a/examples/simple/src/ent/user/actions/confirm_edit_phone_number_action.ts
+++ b/examples/simple/src/ent/user/actions/confirm_edit_phone_number_action.ts
@@ -23,7 +23,7 @@ async function findAuthCode(
 }
 // we're only writing this once except with --force and packageName provided
 export default class ConfirmEditPhoneNumberAction extends ConfirmEditPhoneNumberActionBase {
-  validators: Validator<User>[] = [
+  validators: Validator<User, ConfirmEditPhoneNumberInput>[] = [
     {
       async validate(builder: UserBuilder, input: ConfirmEditPhoneNumberInput) {
         const authCode = await findAuthCode(
@@ -38,7 +38,7 @@ export default class ConfirmEditPhoneNumberAction extends ConfirmEditPhoneNumber
     },
   ];
 
-  triggers: Trigger<Ent>[] = [
+  triggers: Trigger<Ent, ConfirmEditPhoneNumberInput>[] = [
     {
       async changeset(
         builder: UserBuilder,

--- a/examples/simple/src/ent/user/actions/confirm_edit_phone_number_action.ts
+++ b/examples/simple/src/ent/user/actions/confirm_edit_phone_number_action.ts
@@ -1,4 +1,3 @@
-import { Ent } from "@snowtop/ent";
 import { Trigger, Validator } from "@snowtop/ent/action";
 import {
   ConfirmEditPhoneNumberActionBase,
@@ -23,9 +22,9 @@ async function findAuthCode(
 }
 // we're only writing this once except with --force and packageName provided
 export default class ConfirmEditPhoneNumberAction extends ConfirmEditPhoneNumberActionBase {
-  validators: Validator<User, ConfirmEditPhoneNumberInput>[] = [
+  validators: Validator<UserBuilder, ConfirmEditPhoneNumberInput>[] = [
     {
-      async validate(builder: UserBuilder, input: ConfirmEditPhoneNumberInput) {
+      async validate(builder, input) {
         const authCode = await findAuthCode(
           builder,
           input.code,
@@ -38,12 +37,9 @@ export default class ConfirmEditPhoneNumberAction extends ConfirmEditPhoneNumber
     },
   ];
 
-  triggers: Trigger<Ent, ConfirmEditPhoneNumberInput>[] = [
+  triggers: Trigger<UserBuilder, ConfirmEditPhoneNumberInput>[] = [
     {
-      async changeset(
-        builder: UserBuilder,
-        input: ConfirmEditPhoneNumberInput,
-      ) {
+      async changeset(builder, input) {
         const authCode = await findAuthCode(
           builder,
           input.code,

--- a/examples/simple/src/ent/user/actions/generated/confirm_edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/confirm_edit_email_address_action_base.ts
@@ -18,8 +18,15 @@ export interface ConfirmEditEmailAddressInput {
   code: string;
 }
 
-export class ConfirmEditEmailAddressActionBase implements Action<User> {
-  public readonly builder: UserBuilder;
+export class ConfirmEditEmailAddressActionBase
+  implements
+    Action<
+      User,
+      UserBuilder<ConfirmEditEmailAddressInput>,
+      ConfirmEditEmailAddressInput
+    >
+{
+  public readonly builder: UserBuilder<ConfirmEditEmailAddressInput>;
   public readonly viewer: Viewer;
   protected input: ConfirmEditEmailAddressInput;
   protected user: User;
@@ -40,7 +47,7 @@ export class ConfirmEditEmailAddressActionBase implements Action<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): UserInput {
+  getInput(): ConfirmEditEmailAddressInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/user/actions/generated/confirm_edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/confirm_edit_email_address_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "../../..";
-import { UserBuilder, UserInput } from "./user_builder";
+import { UserBuilder } from "./user_builder";
 
 export interface ConfirmEditEmailAddressInput {
   emailAddress: string;

--- a/examples/simple/src/ent/user/actions/generated/confirm_edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/confirm_edit_phone_number_action_base.ts
@@ -18,8 +18,15 @@ export interface ConfirmEditPhoneNumberInput {
   code: string;
 }
 
-export class ConfirmEditPhoneNumberActionBase implements Action<User> {
-  public readonly builder: UserBuilder;
+export class ConfirmEditPhoneNumberActionBase
+  implements
+    Action<
+      User,
+      UserBuilder<ConfirmEditPhoneNumberInput>,
+      ConfirmEditPhoneNumberInput
+    >
+{
+  public readonly builder: UserBuilder<ConfirmEditPhoneNumberInput>;
   public readonly viewer: Viewer;
   protected input: ConfirmEditPhoneNumberInput;
   protected user: User;
@@ -40,7 +47,7 @@ export class ConfirmEditPhoneNumberActionBase implements Action<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): UserInput {
+  getInput(): ConfirmEditPhoneNumberInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/user/actions/generated/confirm_edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/confirm_edit_phone_number_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "../../..";
-import { UserBuilder, UserInput } from "./user_builder";
+import { UserBuilder } from "./user_builder";
 
 export interface ConfirmEditPhoneNumberInput {
   phoneNumber: string;

--- a/examples/simple/src/ent/user/actions/generated/create_user_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/create_user_action_base.ts
@@ -29,8 +29,10 @@ export interface UserCreateInput {
   prefsList?: UserPrefs[] | null;
 }
 
-export class CreateUserActionBase implements Action<User> {
-  public readonly builder: UserBuilder;
+export class CreateUserActionBase
+  implements Action<User, UserBuilder<UserCreateInput>, UserCreateInput>
+{
+  public readonly builder: UserBuilder<UserCreateInput>;
   public readonly viewer: Viewer;
   protected input: UserCreateInput;
 
@@ -44,7 +46,7 @@ export class CreateUserActionBase implements Action<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): UserInput {
+  getInput(): UserCreateInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/user/actions/generated/create_user_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/create_user_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { DaysOff, PreferredShift, User } from "../../..";
-import { UserBuilder, UserInput } from "./user_builder";
+import { UserBuilder } from "./user_builder";
 import { UserPrefs } from "../../../user_prefs";
 
 export interface UserCreateInput {

--- a/examples/simple/src/ent/user/actions/generated/delete_user_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/delete_user_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "../../..";
-import { UserBuilder } from "./user_builder";
+import { UserBuilder, UserInput } from "./user_builder";
 
 export class DeleteUserActionBase
   implements Action<User, UserBuilder<UserInput>, UserInput>

--- a/examples/simple/src/ent/user/actions/generated/delete_user_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/delete_user_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "../../..";
-import { UserBuilder, UserInput } from "./user_builder";
+import { UserBuilder } from "./user_builder";
 
 export class DeleteUserActionBase
   implements Action<User, UserBuilder<UserInput>, UserInput>

--- a/examples/simple/src/ent/user/actions/generated/delete_user_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/delete_user_action_base.ts
@@ -13,8 +13,10 @@ import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder, UserInput } from "./user_builder";
 
-export class DeleteUserActionBase implements Action<User> {
-  public readonly builder: UserBuilder;
+export class DeleteUserActionBase
+  implements Action<User, UserBuilder<UserInput>, UserInput>
+{
+  public readonly builder: UserBuilder<UserInput>;
   public readonly viewer: Viewer;
   protected user: User;
 

--- a/examples/simple/src/ent/user/actions/generated/edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/edit_email_address_action_base.ts
@@ -17,8 +17,11 @@ export interface EditEmailAddressInput {
   newEmail: string;
 }
 
-export class EditEmailAddressActionBase implements Action<User> {
-  public readonly builder: UserBuilder;
+export class EditEmailAddressActionBase
+  implements
+    Action<User, UserBuilder<EditEmailAddressInput>, EditEmailAddressInput>
+{
+  public readonly builder: UserBuilder<EditEmailAddressInput>;
   public readonly viewer: Viewer;
   protected input: EditEmailAddressInput;
   protected user: User;
@@ -39,9 +42,8 @@ export class EditEmailAddressActionBase implements Action<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): UserInput {
-    // we use a type assertion to override the weak type detection here
-    return this.input as UserInput;
+  getInput(): EditEmailAddressInput {
+    return this.input;
   }
 
   async changeset(): Promise<Changeset<User>> {

--- a/examples/simple/src/ent/user/actions/generated/edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/edit_email_address_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "../../..";
-import { UserBuilder, UserInput } from "./user_builder";
+import { UserBuilder } from "./user_builder";
 
 export interface EditEmailAddressInput {
   newEmail: string;

--- a/examples/simple/src/ent/user/actions/generated/edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/edit_phone_number_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "../../..";
-import { UserBuilder, UserInput } from "./user_builder";
+import { UserBuilder } from "./user_builder";
 
 export interface EditPhoneNumberInput {
   newPhoneNumber: string;

--- a/examples/simple/src/ent/user/actions/generated/edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/edit_phone_number_action_base.ts
@@ -17,8 +17,11 @@ export interface EditPhoneNumberInput {
   newPhoneNumber: string;
 }
 
-export class EditPhoneNumberActionBase implements Action<User> {
-  public readonly builder: UserBuilder;
+export class EditPhoneNumberActionBase
+  implements
+    Action<User, UserBuilder<EditPhoneNumberInput>, EditPhoneNumberInput>
+{
+  public readonly builder: UserBuilder<EditPhoneNumberInput>;
   public readonly viewer: Viewer;
   protected input: EditPhoneNumberInput;
   protected user: User;
@@ -39,9 +42,8 @@ export class EditPhoneNumberActionBase implements Action<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): UserInput {
-    // we use a type assertion to override the weak type detection here
-    return this.input as UserInput;
+  getInput(): EditPhoneNumberInput {
+    return this.input;
   }
 
   async changeset(): Promise<Changeset<User>> {

--- a/examples/simple/src/ent/user/actions/generated/edit_user_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/edit_user_action_base.ts
@@ -18,8 +18,10 @@ export interface UserEditInput {
   lastName?: string;
 }
 
-export class EditUserActionBase implements Action<User> {
-  public readonly builder: UserBuilder;
+export class EditUserActionBase
+  implements Action<User, UserBuilder<UserEditInput>, UserEditInput>
+{
+  public readonly builder: UserBuilder<UserEditInput>;
   public readonly viewer: Viewer;
   protected input: UserEditInput;
   protected user: User;
@@ -40,7 +42,7 @@ export class EditUserActionBase implements Action<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): UserInput {
+  getInput(): UserEditInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/user/actions/generated/edit_user_action_base.ts
+++ b/examples/simple/src/ent/user/actions/generated/edit_user_action_base.ts
@@ -11,7 +11,7 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { User } from "../../..";
-import { UserBuilder, UserInput } from "./user_builder";
+import { UserBuilder } from "./user_builder";
 
 export interface UserEditInput {
   firstName?: string;

--- a/examples/simple/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/simple/src/ent/user/actions/generated/user_builder.ts
@@ -48,11 +48,6 @@ export interface UserInput {
   [x: string]: any;
 }
 
-export interface UserAction<TData extends UserInput>
-  extends Action<User, UserBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -68,7 +63,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: UserAction<TData>,
+    action: Action<User, Builder<User>, TData>,
     public readonly existingEnt?: User | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-User`;

--- a/examples/simple/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/simple/src/ent/user/actions/generated/user_builder.ts
@@ -44,26 +44,31 @@ export interface UserInput {
   funUuids?: ID[] | null;
   newCol?: string | null;
   newCol2?: string | null;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface UserAction extends Action<User> {
-  getInput(): UserInput;
+export interface UserAction<TData extends UserInput>
+  extends Action<User, UserBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class UserBuilder implements Builder<User> {
-  orchestrator: Orchestrator<User>;
+export class UserBuilder<TData extends UserInput = UserInput>
+  implements Builder<User>
+{
+  orchestrator: Orchestrator<User, TData>;
   readonly placeholderID: ID;
   readonly ent = User;
-  private input: UserInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: UserAction,
+    action: UserAction<TData>,
     public readonly existingEnt?: User | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-User`;
@@ -82,7 +87,7 @@ export class UserBuilder implements Builder<User> {
     });
   }
 
-  getInput(): UserInput {
+  getInput(): TData {
     return this.input;
   }
 
@@ -104,7 +109,9 @@ export class UserBuilder implements Builder<User> {
     this.orchestrator.clearInputEdges(edgeType, op, id);
   }
 
-  addComment(...nodes: (ID | Comment | Builder<Comment>)[]): UserBuilder {
+  addComment(
+    ...nodes: (ID | Comment | Builder<Comment>)[]
+  ): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addCommentID(node);
@@ -120,7 +127,7 @@ export class UserBuilder implements Builder<User> {
   addCommentID(
     id: ID | Builder<Comment>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.ObjectToComments,
@@ -130,7 +137,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeComment(...nodes: (ID | Comment)[]): UserBuilder {
+  removeComment(...nodes: (ID | Comment)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -144,7 +151,9 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addCreatedEvent(...nodes: (ID | Event | Builder<Event>)[]): UserBuilder {
+  addCreatedEvent(
+    ...nodes: (ID | Event | Builder<Event>)[]
+  ): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addCreatedEventID(node);
@@ -160,7 +169,7 @@ export class UserBuilder implements Builder<User> {
   addCreatedEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToCreatedEvents,
@@ -170,7 +179,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeCreatedEvent(...nodes: (ID | Event)[]): UserBuilder {
+  removeCreatedEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -187,7 +196,9 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addDeclinedEvent(...nodes: (ID | Event | Builder<Event>)[]): UserBuilder {
+  addDeclinedEvent(
+    ...nodes: (ID | Event | Builder<Event>)[]
+  ): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addDeclinedEventID(node);
@@ -203,7 +214,7 @@ export class UserBuilder implements Builder<User> {
   addDeclinedEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToDeclinedEvents,
@@ -213,7 +224,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeDeclinedEvent(...nodes: (ID | Event)[]): UserBuilder {
+  removeDeclinedEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -230,7 +241,9 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addEventsAttending(...nodes: (ID | Event | Builder<Event>)[]): UserBuilder {
+  addEventsAttending(
+    ...nodes: (ID | Event | Builder<Event>)[]
+  ): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addEventsAttendingID(node);
@@ -246,7 +259,7 @@ export class UserBuilder implements Builder<User> {
   addEventsAttendingID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToEventsAttending,
@@ -256,7 +269,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeEventsAttending(...nodes: (ID | Event)[]): UserBuilder {
+  removeEventsAttending(...nodes: (ID | Event)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -273,7 +286,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addFriend(...nodes: (ID | User | Builder<User>)[]): UserBuilder {
+  addFriend(...nodes: (ID | User | Builder<User>)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addFriendID(node);
@@ -289,7 +302,7 @@ export class UserBuilder implements Builder<User> {
   addFriendID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToFriends,
@@ -299,7 +312,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeFriend(...nodes: (ID | User)[]): UserBuilder {
+  removeFriend(...nodes: (ID | User)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.UserToFriends);
@@ -310,7 +323,9 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addInvitedEvent(...nodes: (ID | Event | Builder<Event>)[]): UserBuilder {
+  addInvitedEvent(
+    ...nodes: (ID | Event | Builder<Event>)[]
+  ): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addInvitedEventID(node);
@@ -326,7 +341,7 @@ export class UserBuilder implements Builder<User> {
   addInvitedEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToInvitedEvents,
@@ -336,7 +351,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeInvitedEvent(...nodes: (ID | Event)[]): UserBuilder {
+  removeInvitedEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -353,7 +368,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addLiker(...nodes: (ID | User | Builder<User>)[]): UserBuilder {
+  addLiker(...nodes: (ID | User | Builder<User>)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addLikerID(node);
@@ -369,7 +384,7 @@ export class UserBuilder implements Builder<User> {
   addLikerID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.ObjectToLikers,
@@ -379,7 +394,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeLiker(...nodes: (ID | User)[]): UserBuilder {
+  removeLiker(...nodes: (ID | User)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.ObjectToLikers);
@@ -390,7 +405,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addLike(...nodes: (Ent | Builder<Ent>)[]): UserBuilder {
+  addLike(...nodes: (Ent | Builder<Ent>)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.orchestrator.addOutboundEdge(
@@ -414,7 +429,7 @@ export class UserBuilder implements Builder<User> {
     id: ID | Builder<Ent>,
     nodeType: NodeType,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToLikes,
@@ -424,7 +439,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeLike(...nodes: (ID | Ent)[]): UserBuilder {
+  removeLike(...nodes: (ID | Ent)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.UserToLikes);
@@ -435,7 +450,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addMaybeEvent(...nodes: (ID | Event | Builder<Event>)[]): UserBuilder {
+  addMaybeEvent(...nodes: (ID | Event | Builder<Event>)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addMaybeEventID(node);
@@ -451,7 +466,7 @@ export class UserBuilder implements Builder<User> {
   addMaybeEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToMaybeEvents,
@@ -461,7 +476,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeMaybeEvent(...nodes: (ID | Event)[]): UserBuilder {
+  removeMaybeEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -475,7 +490,9 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addSelfContact(...nodes: (ID | Contact | Builder<Contact>)[]): UserBuilder {
+  addSelfContact(
+    ...nodes: (ID | Contact | Builder<Contact>)[]
+  ): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addSelfContactID(node);
@@ -491,7 +508,7 @@ export class UserBuilder implements Builder<User> {
   addSelfContactID(
     id: ID | Builder<Contact>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToSelfContact,
@@ -501,7 +518,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeSelfContact(...nodes: (ID | Contact)[]): UserBuilder {
+  removeSelfContact(...nodes: (ID | Contact)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -515,7 +532,9 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  addUserToHostedEvent(...nodes: (ID | Event | Builder<Event>)[]): UserBuilder {
+  addUserToHostedEvent(
+    ...nodes: (ID | Event | Builder<Event>)[]
+  ): UserBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addUserToHostedEventID(node);
@@ -531,7 +550,7 @@ export class UserBuilder implements Builder<User> {
   addUserToHostedEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder {
+  ): UserBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToHostedEvents,
@@ -541,7 +560,7 @@ export class UserBuilder implements Builder<User> {
     return this;
   }
 
-  removeUserToHostedEvent(...nodes: (ID | Event)[]): UserBuilder {
+  removeUserToHostedEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(

--- a/examples/simple/src/graphql/mutations/import_contact.ts
+++ b/examples/simple/src/graphql/mutations/import_contact.ts
@@ -1,4 +1,4 @@
-import { ID, RequestContext, Ent } from "@snowtop/ent";
+import { ID, RequestContext, Ent, Data } from "@snowtop/ent";
 import {
   gqlArg,
   gqlContextType,
@@ -13,6 +13,7 @@ import { BaseAction } from "@snowtop/ent/action/experimental_action";
 import { User } from "../../ent";
 import CreateContactAction from "../../ent/contact/actions/create_contact_action";
 import { UserBuilder } from "../../ent/user/actions/generated/user_builder";
+import { ContactBuilder } from "src/ent/contact/actions/generated/contact_builder";
 
 export class ImportContactResolver {
   @gqlMutation({ type: User })
@@ -24,7 +25,7 @@ export class ImportContactResolver {
     const file2 = await file;
 
     const user = await User.loadX(context.getViewer(), userID);
-    let actions: Action<Ent>[] = [];
+    let actions: Action<Ent, ContactBuilder, Data>[] = [];
 
     const parser = file2.createReadStream().pipe(
       parse({
@@ -46,6 +47,7 @@ export class ImportContactResolver {
       );
     }
 
+    // @ts-ignore. TODO come back
     const action = BaseAction.bulkAction(user, UserBuilder, ...actions);
     return await action.saveX();
   }

--- a/examples/simple/src/graphql/mutations/import_contact.ts
+++ b/examples/simple/src/graphql/mutations/import_contact.ts
@@ -47,7 +47,6 @@ export class ImportContactResolver {
       );
     }
 
-    // @ts-ignore. TODO come back
     const action = BaseAction.bulkAction(user, UserBuilder, ...actions);
     return await action.saveX();
   }

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -30,7 +30,8 @@
         "jest-date-mock": "^1.0.8",
         "jest-expect-message": "^1.0.2",
         "supertest": "^6.1.3",
-        "ts-jest": "^27.0.5"
+        "ts-jest": "^27.0.5",
+        "tsconfig-paths": "^3.11.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -30,7 +30,8 @@
     "jest-date-mock": "^1.0.8",
     "jest-expect-message": "^1.0.2",
     "supertest": "^6.1.3",
-    "ts-jest": "^27.0.5"
+    "ts-jest": "^27.0.5",
+    "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
     "@snowtop/ent": "^0.0.24",

--- a/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
@@ -16,26 +16,31 @@ import schema from "src/schema/account";
 export interface AccountInput {
   name?: string;
   phoneNumber?: string;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface AccountAction extends Action<Account> {
-  getInput(): AccountInput;
+export interface AccountAction<TData extends AccountInput>
+  extends Action<Account, AccountBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class AccountBuilder implements Builder<Account> {
-  orchestrator: Orchestrator<Account>;
+export class AccountBuilder<TData extends AccountInput = AccountInput>
+  implements Builder<Account>
+{
+  orchestrator: Orchestrator<Account, TData>;
   readonly placeholderID: ID;
   readonly ent = Account;
-  private input: AccountInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AccountAction,
+    action: AccountAction<TData>,
     public readonly existingEnt?: Account | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Account`;
@@ -54,7 +59,7 @@ export class AccountBuilder implements Builder<Account> {
     });
   }
 
-  getInput(): AccountInput {
+  getInput(): TData {
     return this.input;
   }
 

--- a/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
@@ -20,11 +20,6 @@ export interface AccountInput {
   [x: string]: any;
 }
 
-export interface AccountAction<TData extends AccountInput>
-  extends Action<Account, AccountBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -40,7 +35,7 @@ export class AccountBuilder<TData extends AccountInput = AccountInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: AccountAction<TData>,
+    action: Action<Account, Builder<Account>, TData>,
     public readonly existingEnt?: Account | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Account`;

--- a/examples/todo-sqlite/src/ent/account/actions/generated/create_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/create_account_action_base.ts
@@ -7,18 +7,18 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Account } from "src/ent/";
-import {
-  AccountBuilder,
-  AccountInput,
-} from "src/ent/account/actions/generated/account_builder";
+import { AccountBuilder } from "src/ent/account/actions/generated/account_builder";
 
 export interface AccountCreateInput {
   name: string;
   phoneNumber: string;
 }
 
-export class CreateAccountActionBase implements Action<Account> {
-  public readonly builder: AccountBuilder;
+export class CreateAccountActionBase
+  implements
+    Action<Account, AccountBuilder<AccountCreateInput>, AccountCreateInput>
+{
+  public readonly builder: AccountBuilder<AccountCreateInput>;
   public readonly viewer: Viewer;
   protected input: AccountCreateInput;
 
@@ -32,7 +32,7 @@ export class CreateAccountActionBase implements Action<Account> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): AccountInput {
+  getInput(): AccountCreateInput {
     return this.input;
   }
 

--- a/examples/todo-sqlite/src/ent/account/actions/generated/delete_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/delete_account_action_base.ts
@@ -13,8 +13,10 @@ import {
   AccountInput,
 } from "src/ent/account/actions/generated/account_builder";
 
-export class DeleteAccountActionBase implements Action<Account> {
-  public readonly builder: AccountBuilder;
+export class DeleteAccountActionBase
+  implements Action<Account, AccountBuilder<AccountInput>, AccountInput>
+{
+  public readonly builder: AccountBuilder<AccountInput>;
   public readonly viewer: Viewer;
   protected account: Account;
 

--- a/examples/todo-sqlite/src/ent/account/actions/generated/edit_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/edit_account_action_base.ts
@@ -8,18 +8,18 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Account } from "src/ent/";
-import {
-  AccountBuilder,
-  AccountInput,
-} from "src/ent/account/actions/generated/account_builder";
+import { AccountBuilder } from "src/ent/account/actions/generated/account_builder";
 
 export interface AccountEditInput {
   name?: string;
   phoneNumber?: string;
 }
 
-export class EditAccountActionBase implements Action<Account> {
-  public readonly builder: AccountBuilder;
+export class EditAccountActionBase
+  implements
+    Action<Account, AccountBuilder<AccountEditInput>, AccountEditInput>
+{
+  public readonly builder: AccountBuilder<AccountEditInput>;
   public readonly viewer: Viewer;
   protected input: AccountEditInput;
   protected account: Account;
@@ -40,7 +40,7 @@ export class EditAccountActionBase implements Action<Account> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): AccountInput {
+  getInput(): AccountEditInput {
     return this.input;
   }
 

--- a/examples/todo-sqlite/src/ent/tag/actions/create_tag_action.ts
+++ b/examples/todo-sqlite/src/ent/tag/actions/create_tag_action.ts
@@ -13,9 +13,9 @@ export default class CreateTagAction extends CreateTagActionBase {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  triggers: Trigger<Ent>[] = [
+  triggers: Trigger<TagBuilder, TagCreateInput>[] = [
     {
-      async changeset(builder: TagBuilder, input: TagCreateInput) {
+      async changeset(builder, input) {
         builder.updateInput({
           canonicalName: input.displayName,
         });

--- a/examples/todo-sqlite/src/ent/tag/actions/generated/create_tag_action_base.ts
+++ b/examples/todo-sqlite/src/ent/tag/actions/generated/create_tag_action_base.ts
@@ -13,18 +13,17 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Account, Tag } from "src/ent/";
-import {
-  TagBuilder,
-  TagInput,
-} from "src/ent/tag/actions/generated/tag_builder";
+import { TagBuilder } from "src/ent/tag/actions/generated/tag_builder";
 
 export interface TagCreateInput {
   displayName: string;
   ownerID: ID | Builder<Account>;
 }
 
-export class CreateTagActionBase implements Action<Tag> {
-  public readonly builder: TagBuilder;
+export class CreateTagActionBase
+  implements Action<Tag, TagBuilder<TagCreateInput>, TagCreateInput>
+{
+  public readonly builder: TagBuilder<TagCreateInput>;
   public readonly viewer: Viewer;
   protected input: TagCreateInput;
 
@@ -38,7 +37,7 @@ export class CreateTagActionBase implements Action<Tag> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): TagInput {
+  getInput(): TagCreateInput {
     return this.input;
   }
 

--- a/examples/todo-sqlite/src/ent/tag/actions/generated/tag_builder.ts
+++ b/examples/todo-sqlite/src/ent/tag/actions/generated/tag_builder.ts
@@ -22,11 +22,6 @@ export interface TagInput {
   [x: string]: any;
 }
 
-export interface TagAction<TData extends TagInput>
-  extends Action<Tag, TagBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -42,7 +37,7 @@ export class TagBuilder<TData extends TagInput = TagInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: TagAction<TData>,
+    action: Action<Tag, Builder<Tag>, TData>,
     public readonly existingEnt?: Tag | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Tag`;

--- a/examples/todo-sqlite/src/ent/tag/actions/generated/tag_builder.ts
+++ b/examples/todo-sqlite/src/ent/tag/actions/generated/tag_builder.ts
@@ -18,26 +18,31 @@ export interface TagInput {
   displayName?: string;
   canonicalName?: string;
   ownerID?: ID | Builder<Account>;
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface TagAction extends Action<Tag> {
-  getInput(): TagInput;
+export interface TagAction<TData extends TagInput>
+  extends Action<Tag, TagBuilder<TData>, TData> {
+  getInput(): TData;
 }
 
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class TagBuilder implements Builder<Tag> {
-  orchestrator: Orchestrator<Tag>;
+export class TagBuilder<TData extends TagInput = TagInput>
+  implements Builder<Tag>
+{
+  orchestrator: Orchestrator<Tag, TData>;
   readonly placeholderID: ID;
   readonly ent = Tag;
-  private input: TagInput;
+  private input: TData;
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: TagAction,
+    action: TagAction<TData>,
     public readonly existingEnt?: Tag | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Tag`;
@@ -56,7 +61,7 @@ export class TagBuilder implements Builder<Tag> {
     });
   }
 
-  getInput(): TagInput {
+  getInput(): TData {
     return this.input;
   }
 
@@ -78,7 +83,7 @@ export class TagBuilder implements Builder<Tag> {
     this.orchestrator.clearInputEdges(edgeType, op, id);
   }
 
-  addTodo(...nodes: (ID | Todo | Builder<Todo>)[]): TagBuilder {
+  addTodo(...nodes: (ID | Todo | Builder<Todo>)[]): TagBuilder<TData> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addTodoID(node);
@@ -94,7 +99,7 @@ export class TagBuilder implements Builder<Tag> {
   addTodoID(
     id: ID | Builder<Todo>,
     options?: AssocEdgeInputOptions,
-  ): TagBuilder {
+  ): TagBuilder<TData> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.TagToTodos,
@@ -104,7 +109,7 @@ export class TagBuilder implements Builder<Tag> {
     return this;
   }
 
-  removeTodo(...nodes: (ID | Todo)[]): TagBuilder {
+  removeTodo(...nodes: (ID | Todo)[]): TagBuilder<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.TagToTodos);

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/change_todo_status_action_base.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/change_todo_status_action_base.ts
@@ -8,17 +8,17 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Todo } from "src/ent/";
-import {
-  TodoBuilder,
-  TodoInput,
-} from "src/ent/todo/actions/generated/todo_builder";
+import { TodoBuilder } from "src/ent/todo/actions/generated/todo_builder";
 
 export interface ChangeTodoStatusInput {
   completed?: boolean;
 }
 
-export class ChangeTodoStatusActionBase implements Action<Todo> {
-  public readonly builder: TodoBuilder;
+export class ChangeTodoStatusActionBase
+  implements
+    Action<Todo, TodoBuilder<ChangeTodoStatusInput>, ChangeTodoStatusInput>
+{
+  public readonly builder: TodoBuilder<ChangeTodoStatusInput>;
   public readonly viewer: Viewer;
   protected input: ChangeTodoStatusInput;
   protected todo: Todo;
@@ -39,7 +39,7 @@ export class ChangeTodoStatusActionBase implements Action<Todo> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): TodoInput {
+  getInput(): ChangeTodoStatusInput {
     return this.input;
   }
 

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/create_todo_action_base.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/create_todo_action_base.ts
@@ -13,18 +13,17 @@ import {
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Account, Todo } from "src/ent/";
-import {
-  TodoBuilder,
-  TodoInput,
-} from "src/ent/todo/actions/generated/todo_builder";
+import { TodoBuilder } from "src/ent/todo/actions/generated/todo_builder";
 
 export interface TodoCreateInput {
   text: string;
   creatorID: ID | Builder<Account>;
 }
 
-export class CreateTodoActionBase implements Action<Todo> {
-  public readonly builder: TodoBuilder;
+export class CreateTodoActionBase
+  implements Action<Todo, TodoBuilder<TodoCreateInput>, TodoCreateInput>
+{
+  public readonly builder: TodoBuilder<TodoCreateInput>;
   public readonly viewer: Viewer;
   protected input: TodoCreateInput;
 
@@ -38,7 +37,7 @@ export class CreateTodoActionBase implements Action<Todo> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): TodoInput {
+  getInput(): TodoCreateInput {
     return this.input;
   }
 

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/delete_todo_action_base.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/delete_todo_action_base.ts
@@ -13,8 +13,10 @@ import {
   TodoInput,
 } from "src/ent/todo/actions/generated/todo_builder";
 
-export class DeleteTodoActionBase implements Action<Todo> {
-  public readonly builder: TodoBuilder;
+export class DeleteTodoActionBase
+  implements Action<Todo, TodoBuilder<TodoInput>, TodoInput>
+{
+  public readonly builder: TodoBuilder<TodoInput>;
   public readonly viewer: Viewer;
   protected todo: Todo;
 

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/rename_todo_status_action_base.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/rename_todo_status_action_base.ts
@@ -8,17 +8,16 @@ import {
 } from "@snowtop/ent";
 import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
 import { Todo } from "src/ent/";
-import {
-  TodoBuilder,
-  TodoInput,
-} from "src/ent/todo/actions/generated/todo_builder";
+import { TodoBuilder } from "src/ent/todo/actions/generated/todo_builder";
 
 export interface RenameTodoInput {
   text?: string;
 }
 
-export class RenameTodoStatusActionBase implements Action<Todo> {
-  public readonly builder: TodoBuilder;
+export class RenameTodoStatusActionBase
+  implements Action<Todo, TodoBuilder<RenameTodoInput>, RenameTodoInput>
+{
+  public readonly builder: TodoBuilder<RenameTodoInput>;
   public readonly viewer: Viewer;
   protected input: RenameTodoInput;
   protected todo: Todo;
@@ -39,7 +38,7 @@ export class RenameTodoStatusActionBase implements Action<Todo> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getInput(): TodoInput {
+  getInput(): RenameTodoInput {
     return this.input;
   }
 

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/todo_add_tag_action_base.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/todo_add_tag_action_base.ts
@@ -19,8 +19,10 @@ import {
   TodoInput,
 } from "src/ent/todo/actions/generated/todo_builder";
 
-export class TodoAddTagActionBase implements Action<Todo> {
-  public readonly builder: TodoBuilder;
+export class TodoAddTagActionBase
+  implements Action<Todo, TodoBuilder<TodoInput>, TodoInput>
+{
+  public readonly builder: TodoBuilder<TodoInput>;
   public readonly viewer: Viewer;
   protected todo: Todo;
 

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/todo_builder.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/todo_builder.ts
@@ -22,11 +22,6 @@ export interface TodoInput {
   [x: string]: any;
 }
 
-export interface TodoAction<TData extends TodoInput>
-  extends Action<Todo, TodoBuilder<TData>, TData> {
-  getInput(): TData;
-}
-
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -42,7 +37,7 @@ export class TodoBuilder<TData extends TodoInput = TodoInput>
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: TodoAction<TData>,
+    action: Action<Todo, Builder<Todo>, TData>,
     public readonly existingEnt?: Todo | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Todo`;

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/todo_remove_tag_action_base.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/todo_remove_tag_action_base.ts
@@ -13,8 +13,10 @@ import {
   TodoInput,
 } from "src/ent/todo/actions/generated/todo_builder";
 
-export class TodoRemoveTagActionBase implements Action<Todo> {
-  public readonly builder: TodoBuilder;
+export class TodoRemoveTagActionBase
+  implements Action<Todo, TodoBuilder<TodoInput>, TodoInput>
+{
+  public readonly builder: TodoBuilder<TodoInput>;
   public readonly viewer: Viewer;
   protected todo: Todo;
 

--- a/examples/todo-sqlite/src/graphql/mutations/todo/todo_resolver.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/todo/todo_resolver.ts
@@ -21,7 +21,6 @@ export class TodosResolver {
     const todos = await AccountToTodosQuery.query(vc, viewer).queryEnts();
     const bulk = BaseAction.bulkAction(
       account,
-      // @ts-ignore TODO
       AccountBuilder,
       ...todos.map((todo) =>
         ChangeTodoStatusAction.create(vc, todo, { completed: completed }),
@@ -44,7 +43,6 @@ export class TodosResolver {
 
     const bulk = BaseAction.bulkAction(
       account,
-      // @ts-ignore TODO
       AccountBuilder,
       ...completedTodos.map((todo) => DeleteTodoAction.create(vc, todo)),
     );

--- a/examples/todo-sqlite/src/graphql/mutations/todo/todo_resolver.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/todo/todo_resolver.ts
@@ -21,6 +21,7 @@ export class TodosResolver {
     const todos = await AccountToTodosQuery.query(vc, viewer).queryEnts();
     const bulk = BaseAction.bulkAction(
       account,
+      // @ts-ignore TODO
       AccountBuilder,
       ...todos.map((todo) =>
         ChangeTodoStatusAction.create(vc, todo, { completed: completed }),
@@ -43,6 +44,7 @@ export class TodosResolver {
 
     const bulk = BaseAction.bulkAction(
       account,
+      // @ts-ignore TODO
       AccountBuilder,
       ...completedTodos.map((todo) => DeleteTodoAction.create(vc, todo)),
     );

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -105,7 +105,7 @@
   {{ $hasSaveFromID = true}}
 {{end -}}
 
-{{ $inputData := useImport $builderInput -}}
+{{ $inputData := $builderInput -}}
 {{ if $hasInput -}}
   {{ $inputData = $inputName -}}
 {{ end -}}

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -105,8 +105,13 @@
   {{ $hasSaveFromID = true}}
 {{end -}}
 
-export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}> {
-  public readonly builder: {{useImport $builderName}};
+{{ $inputData := useImport $builderInput -}}
+{{ if $hasInput -}}
+  {{ $inputData = $inputName -}}
+{{ end -}}
+
+export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}, {{useImport $builderName}}<{{$inputData}}>, {{$inputData}}> {
+  public readonly builder: {{useImport $builderName}}<{{$inputData}}>;
   public readonly viewer: {{$viewer}}
   {{ if $hasInput -}}
     protected input: {{$inputName}};
@@ -141,14 +146,9 @@ export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}> {
     {{ end -}}
   };
 
-  getInput(): {{useImport $builderInput}} {
+  getInput(): {{$inputData}} {
     {{ if $hasInput -}}
-      {{ if hasOnlyActionOnlyFields $action}}
-        // we use a type assertion to override the weak type detection here
-        return this.input as {{useImport $builderInput}};
-      {{ else -}}
-        return this.input;
-      {{end -}}
+      return this.input;
     {{ else -}}
       return {};
     {{end -}}

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -108,6 +108,8 @@
 {{ $inputData := $builderInput -}}
 {{ if $hasInput -}}
   {{ $inputData = $inputName -}}
+{{ else -}}
+  {{ $inputData = useImport $inputData -}}
 {{ end -}}
 
 export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}, {{useImport $builderName}}<{{$inputData}}>, {{$inputData}}> {

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -15,7 +15,10 @@
   {{ end -}}
 {{ end}}
 
-export interface {{.Node}}Input {
+{{$builder := printf "%sBuilder" .Node}}
+{{$input := printf "%sInput" .Node}}
+
+export interface {{$input}} {
   {{range $field := .FieldInfo.GetEditableFields -}}
     {{$type := $field.TsBuilderType -}}
       {{range $import := $field.TsBuilderImports -}}
@@ -23,10 +26,12 @@ export interface {{.Node}}Input {
       {{end -}}
     {{$field.TsFieldName}}?: {{$type}};
   {{end -}}
+  // allow other properties. useful for action-only fields
+  [x: string]: any;
 }
 
-export interface {{.Node}}Action extends {{useImport "Action"}}<{{useImport .Node}}> {
-  getInput(): {{.Node}}Input;
+export interface {{.Node}}Action<TData extends {{$input}}> extends {{useImport "Action"}}<{{useImport .Node}}, {{$builder}}<TData>, TData> {
+  getInput(): TData;
 }
 
 {{/* TODO better way of doing this? */}}
@@ -37,18 +42,17 @@ function randomNum(): string {
 }
 
 {{$node := useImport .Node}}
-{{$builder := printf "%sBuilder" .Node}}
 
-export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
-  orchestrator: {{useImport "Orchestrator"}}<{{$node}}>;
+export class {{$builder}}<TData extends {{$input}} = {{$input}}> implements {{useImport "Builder"}}<{{$node}}> {
+  orchestrator: {{useImport "Orchestrator"}}<{{$node}}, TData>;
   readonly placeholderID: {{useImport "ID"}};
   readonly ent = {{$node}};
-  private input: {{.Node}}Input;
+  private input: TData;
 
   public constructor(
     public readonly viewer: {{useImport "Viewer"}},
     public readonly operation: {{useImport "WriteOperation"}},
-    action: {{.Node}}Action,
+    action: {{.Node}}Action<TData>,
     public readonly existingEnt?: {{$node}} | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-{{$node}}`;
@@ -67,11 +71,11 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
     });
   }
 
-  getInput(): {{.Node}}Input {
+  getInput(): TData {
     return this.input;
   }
 
-  updateInput(input: {{.Node}}Input) {
+  updateInput(input: {{$input}}) {
     // override input
     this.input = {
       ...this.input,
@@ -96,10 +100,10 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
     {{ $node := useImport .Node -}}
     {{ $polymorphicEdge := $edge.Edge.PolymorphicEdge -}}
   {{ if $polymorphicEdge -}}
-    {{$edge.TSAddMethodName}}(...nodes: ({{$node}} | Builder<{{$node}}>)[]): {{$builder}} {
+    {{$edge.TSAddMethodName}}(...nodes: ({{$node}} | Builder<{{$node}}>)[]): {{$builder}}<TData> {
   {{ else -}}
   {{/* for PolymorphicEdges, this API doesn't work since we don't know the type. callers should call addLikerID in a map */}}  
-    {{$edge.TSAddMethodName}}(...nodes: (ID | {{$node}} | Builder<{{$node}}>)[]): {{$builder}} {
+    {{$edge.TSAddMethodName}}(...nodes: (ID | {{$node}} | Builder<{{$node}}>)[]): {{$builder}}<TData> {
   {{ end -}}
     for (const node of nodes) {
       {{ if $polymorphicEdge -}}
@@ -136,7 +140,7 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
       nodeType: {{useImport "NodeType"}},
     {{ end -}}
     options?: {{useImport "AssocEdgeInputOptions"}}
-  ): {{$builder}} {
+  ): {{$builder}}<TData> {
     {{/* TODO need inbound edges also */}}
     this.orchestrator.addOutboundEdge(
       id, 
@@ -151,7 +155,7 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
     return this;
   }
 
-  {{$edge.TSRemoveMethodName}}(...nodes: (ID | {{$node}})[]): {{$builder}} {
+  {{$edge.TSRemoveMethodName}}(...nodes: (ID | {{$node}})[]): {{$builder}}<TData> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, {{useImport "EdgeType"}}.{{$edge.TSEdgeConst}});

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -30,10 +30,6 @@ export interface {{$input}} {
   [x: string]: any;
 }
 
-export interface {{.Node}}Action<TData extends {{$input}}> extends {{useImport "Action"}}<{{useImport .Node}}, {{$builder}}<TData>, TData> {
-  getInput(): TData;
-}
-
 {{/* TODO better way of doing this? */}}
 function randomNum(): string {
   return Math.random()
@@ -52,7 +48,7 @@ export class {{$builder}}<TData extends {{$input}} = {{$input}}> implements {{us
   public constructor(
     public readonly viewer: {{useImport "Viewer"}},
     public readonly operation: {{useImport "WriteOperation"}},
-    action: {{.Node}}Action<TData>,
+    action: {{useImport "Action"}}<{{$node}}, {{useImport "Builder"}}<{{$node}}>, TData>,
     public readonly existingEnt?: {{$node}} | undefined,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-{{$node}}`;

--- a/ts/CONTRIBUTING.md
+++ b/ts/CONTRIBUTING.md
@@ -9,3 +9,12 @@ tsc && cp -r dist/* ~/code/ent/examples/todo-sqlite/node_modules/@snowtop/snowto
 ```
 
 to update the version of the package. Update from todo-sqlite to the right path you want to see being used.
+
+To make local changes:
+
+* in `/ts`, run `tsc && cd dist && npm link @snowtop/ent`
+* Test in one of the example folders as follows:
+
+  + `npm link @snowtop/ent`
+  + `rm -rf node_modules/graphql`
+  + run `tsent codegen` or whatever command to see your changes

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@snowtop/ent",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^15.0.2",
@@ -55,6 +55,7 @@
         "better-sqlite3": "^7.4.1",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
+        "graphql": "^15.3.0",
         "graphql-type-json": "^0.3.2",
         "graphql-upload": "^12.0.0",
         "jest": "^27.1.1",
@@ -71,7 +72,8 @@
         "node": "^16.1.0"
       },
       "peerDependencies": {
-        "better-sqlite3": "^7.4.1"
+        "better-sqlite3": "^7.4.1",
+        "graphql": "^15.5"
       },
       "peerDependenciesMeta": {
         "better-sqlite3": {

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -60,19 +60,19 @@ export type TriggerReturn =
   | Promise<Changeset<Ent> | void | (Changeset<Ent> | void)[]>
   | Promise<Changeset<Ent>>[];
 
-export interface Trigger<TEnt extends Ent, TData extends Data> {
+export interface Trigger<TBuilder extends Builder<Ent>, TData extends Data> {
   // TODO: way in the future. detect any writes happening in changesets and optionally throw if configured to do so
   // can throw if it wants. not expected to throw tho.
-  changeset(builder: Builder<TEnt>, input: TData): TriggerReturn;
+  changeset(builder: TBuilder, input: TData): TriggerReturn;
 }
 
-export interface Observer<TEnt extends Ent, TData extends Data> {
-  observe(builder: Builder<TEnt>, input: TData): void | Promise<void>;
+export interface Observer<TBuilder extends Builder<Ent>, TData extends Data> {
+  observe(builder: TBuilder, input: TData): void | Promise<void>;
 }
 
-export interface Validator<TEnt extends Ent, TData extends Data> {
+export interface Validator<TBuilder extends Builder<Ent>, TData extends Data> {
   // can throw if it wants
-  validate(builder: Builder<TEnt>, input: TData): Promise<void> | void;
+  validate(builder: TBuilder, input: TData): Promise<void> | void;
 }
 
 export interface Action<
@@ -85,9 +85,13 @@ export interface Action<
   builder: TBuilder;
   // TODO template ent
   getPrivacyPolicy(): PrivacyPolicy;
-  triggers?: Trigger<TEnt, TData>[];
-  observers?: Observer<TEnt, TData>[];
-  validators?: Validator<TEnt, TData>[];
+
+  // TODO consider making these methods. maybe they'll be easier to use then?
+  // performance implications of methods being called multiple times and new instances?
+  // even when declared in base class, if overriden in subclasses, still need to type it...
+  triggers?: Trigger<TBuilder, TData>[];
+  observers?: Observer<TBuilder, TData>[];
+  validators?: Validator<TBuilder, TData>[];
   getInput(): TData; // this input is passed to Triggers, Observers, Validators
 
   valid(): Promise<boolean>;

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -60,30 +60,35 @@ export type TriggerReturn =
   | Promise<Changeset<Ent> | void | (Changeset<Ent> | void)[]>
   | Promise<Changeset<Ent>>[];
 
-export interface Trigger<T extends Ent> {
+export interface Trigger<TEnt extends Ent, TData extends Data> {
   // TODO: way in the future. detect any writes happening in changesets and optionally throw if configured to do so
   // can throw if it wants. not expected to throw tho.
-  changeset(builder: Builder<T>, input: Data): TriggerReturn;
+  changeset(builder: Builder<TEnt>, input: TData): TriggerReturn;
 }
 
-export interface Observer<T extends Ent> {
-  observe(builder: Builder<T>, input: Data): void | Promise<void>;
+export interface Observer<TEnt extends Ent, TData extends Data> {
+  observe(builder: Builder<TEnt>, input: TData): void | Promise<void>;
 }
 
-export interface Validator<T extends Ent> {
+export interface Validator<TEnt extends Ent, TData extends Data> {
   // can throw if it wants
-  validate(builder: Builder<T>, input: Data): Promise<void> | void;
+  validate(builder: Builder<TEnt>, input: TData): Promise<void> | void;
 }
 
-export interface Action<T extends Ent> {
+export interface Action<
+  TEnt extends Ent,
+  TBuilder extends Builder<TEnt>,
+  TData extends Data,
+> {
   readonly viewer: Viewer;
-  changeset(): Promise<Changeset<T>>;
-  builder: Builder<T>;
+  changeset(): Promise<Changeset<TEnt>>;
+  builder: TBuilder;
+  // TODO template ent
   getPrivacyPolicy(): PrivacyPolicy;
-  triggers?: Trigger<T>[];
-  observers?: Observer<T>[];
-  validators?: Validator<T>[];
-  getInput(): Data; // this input is passed to Triggers, Observers, Validators
+  triggers?: Trigger<TEnt, TData>[];
+  observers?: Observer<TEnt, TData>[];
+  validators?: Validator<TEnt, TData>[];
+  getInput(): TData; // this input is passed to Triggers, Observers, Validators
 
   valid(): Promise<boolean>;
   // throws if invalid

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -234,9 +234,9 @@ class MessageAction extends SimpleAction<Message> {
     super(viewer, new MessageSchema(), fields, operation, existingEnt);
   }
 
-  triggers: Trigger<Ent, Data>[] = [
+  triggers: Trigger<SimpleBuilder<Message>, Data>[] = [
     {
-      changeset: (builder: SimpleBuilder<Ent>, _input): void => {
+      changeset: (builder, _input): void => {
         let sender = builder.fields.get("sender");
         let recipient = builder.fields.get("recipient");
 
@@ -250,7 +250,9 @@ class MessageAction extends SimpleAction<Message> {
     },
   ];
 
-  observers: Observer<Ent, Data>[] = [new EntCreationObserver<Message>()];
+  observers: Observer<SimpleBuilder<Message>, Data>[] = [
+    new EntCreationObserver<Message>(),
+  ];
 }
 
 class UserAction extends SimpleAction<User> {
@@ -265,11 +267,9 @@ class UserAction extends SimpleAction<User> {
     super(viewer, new UserSchema(), fields, operation, existingEnt);
   }
 
-  triggers: Trigger<User, Data>[] = [
+  triggers: Trigger<SimpleBuilder<User>, Data>[] = [
     {
-      changeset: (
-        builder: SimpleBuilder<User>,
-      ): Promise<Changeset<Contact>> => {
+      changeset: (builder): Promise<Changeset<Contact>> => {
         let firstName = builder.fields.get("FirstName");
         let lastName = builder.fields.get("LastName");
         this.contactAction = new SimpleAction(
@@ -295,7 +295,9 @@ class UserAction extends SimpleAction<User> {
     },
   ];
 
-  observers: Observer<User, Data>[] = [new EntCreationObserver<User>()];
+  observers: Observer<SimpleBuilder<User>, Data>[] = [
+    new EntCreationObserver<User>(),
+  ];
 }
 
 function randomEmail(): string {

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -46,6 +46,7 @@ import {
   setupSqlite,
   Table,
 } from "../testutils/db/test_db";
+import { Use } from "node-sql-parser";
 
 jest.mock("pg");
 QueryRecorder.mockPool(Pool);
@@ -132,7 +133,7 @@ async function saveBuilder<T extends Ent>(builder: Builder<T>): Promise<void> {
 }
 
 async function executeAction<T extends Ent, E = any>(
-  action: Action<T>,
+  action: Action<T, Builder<T>, Data>,
   name?: E,
 ): Promise<Executor> {
   const exec = await executor(action.builder);
@@ -233,9 +234,9 @@ class MessageAction extends SimpleAction<Message> {
     super(viewer, new MessageSchema(), fields, operation, existingEnt);
   }
 
-  triggers: Trigger<Message>[] = [
+  triggers: Trigger<Ent, Data>[] = [
     {
-      changeset: (builder: SimpleBuilder<Message>, _input: Data): void => {
+      changeset: (builder: SimpleBuilder<Ent>, _input): void => {
         let sender = builder.fields.get("sender");
         let recipient = builder.fields.get("recipient");
 
@@ -249,7 +250,7 @@ class MessageAction extends SimpleAction<Message> {
     },
   ];
 
-  observers: Observer<Message>[] = [new EntCreationObserver<Message>()];
+  observers: Observer<Ent, Data>[] = [new EntCreationObserver<Message>()];
 }
 
 class UserAction extends SimpleAction<User> {
@@ -264,7 +265,7 @@ class UserAction extends SimpleAction<User> {
     super(viewer, new UserSchema(), fields, operation, existingEnt);
   }
 
-  triggers: Trigger<User>[] = [
+  triggers: Trigger<User, Data>[] = [
     {
       changeset: (
         builder: SimpleBuilder<User>,
@@ -294,7 +295,7 @@ class UserAction extends SimpleAction<User> {
     },
   ];
 
-  observers: Observer<User>[] = [new EntCreationObserver<User>()];
+  observers: Observer<User, Data>[] = [new EntCreationObserver<User>()];
 }
 
 function randomEmail(): string {

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -1,4 +1,4 @@
-import { ID, Ent, Viewer, EntConstructor, Context } from "../core/base";
+import { ID, Ent, Viewer, EntConstructor, Context, Data } from "../core/base";
 import { DataOperation } from "../core/ent";
 import { Changeset, Executor } from "../action";
 import { Builder } from "../action";
@@ -15,7 +15,7 @@ export class ListBasedExecutor<T extends Ent> implements Executor {
     public placeholderID: ID,
     private ent: EntConstructor<T>,
     private operations: DataOperation[],
-    private options?: OrchestratorOptions<T>,
+    private options?: OrchestratorOptions<T, Data>,
   ) {}
   private lastOp: DataOperation | undefined;
   private createdEnt: T | null = null;
@@ -118,7 +118,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
     operations: DataOperation[],
     dependencies: Map<ID, Builder<T>>,
     changesets: Changeset<T>[],
-    private options?: OrchestratorOptions<T>,
+    private options?: OrchestratorOptions<T, Data>,
   ) {
     let graph = Graph();
 

--- a/ts/src/action/experimental_action.ts
+++ b/ts/src/action/experimental_action.ts
@@ -40,7 +40,7 @@ export class BaseAction<TEnt extends Ent, TData extends Data>
 
   constructor(
     public viewer: Viewer,
-    public builderCtr: BuilderConstructor<TEnt>,
+    public builderCtr: BuilderConstructor<TEnt, TData>,
     options?: ActionOptions<TEnt, TData> | null,
   ) {
     let operation = options?.operation;
@@ -60,28 +60,28 @@ export class BaseAction<TEnt extends Ent, TData extends Data>
     );
   }
 
-  static createBuilder<T extends Ent>(
+  static createBuilder<TEnt extends Ent, TData extends Data>(
     viewer: Viewer,
-    builderCtr: BuilderConstructor<T>,
-    options?: ActionOptions<T, Data> | null,
-  ): Builder<T> {
+    builderCtr: BuilderConstructor<TEnt, TData>,
+    options?: ActionOptions<TEnt, TData> | null,
+  ): Builder<TEnt> {
     let action = new BaseAction(viewer, builderCtr, options);
     return action.builder;
   }
 
   // perform a bulk action in a transaction rooted on ent T
   // it ends up creating triggers and having all the given actions performed in a transaction
-  static bulkAction<T extends Ent>(
-    ent: T,
-    builderCtr: BuilderConstructor<T>,
-    ...actions: Action<T, Builder<T>, Data>[]
-  ): BaseAction<T, Data> {
+  static bulkAction<TEnt extends Ent, TData extends Data>(
+    ent: TEnt,
+    builderCtr: BuilderConstructor<TEnt, TData>,
+    ...actions: Action<Ent, Builder<Ent>, Data>[]
+  ): BaseAction<TEnt, TData> {
     let action = new BaseAction(ent.viewer, builderCtr, {
       existingEnt: ent,
     });
     action.triggers = [
       {
-        changeset: (builder: Builder<T>, _input): Promise<Changeset<Ent>>[] => {
+        changeset: (): Promise<Changeset<Ent>>[] => {
           return actions.map((action) => action.changeset());
         },
       },
@@ -116,11 +116,11 @@ export class BaseAction<TEnt extends Ent, TData extends Data>
   }
 }
 
-interface BuilderConstructor<T extends Ent> {
+interface BuilderConstructor<TEnt extends Ent, TData extends Data> {
   new (
     viewer: Viewer,
     operation: WriteOperation,
-    action: Action<T, Builder<T>, Data>,
-    existingEnt?: T | undefined,
-  ): EntBuilder<T>;
+    action: Action<TEnt, EntBuilder<TEnt>, TData>,
+    existingEnt?: TEnt | undefined,
+  ): EntBuilder<TEnt>;
 }

--- a/ts/src/action/experimental_action.ts
+++ b/ts/src/action/experimental_action.ts
@@ -30,9 +30,9 @@ export class BaseAction<TEnt extends Ent, TData extends Data>
 {
   builder: EntBuilder<TEnt>;
   private input: TData;
-  triggers: Trigger<TEnt, TData>[] = [];
-  observers: Observer<TEnt, TData>[] = [];
-  validators: Validator<TEnt, TData>[] = [];
+  triggers: Trigger<EntBuilder<TEnt>, TData>[] = [];
+  observers: Observer<EntBuilder<TEnt>, TData>[] = [];
+  validators: Validator<EntBuilder<TEnt>, TData>[] = [];
 
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -1701,9 +1701,9 @@ function commonTests() {
   });
 
   describe("validators", () => {
-    const validators: Validator<Event, Data>[] = [
+    const validators: Validator<SimpleBuilder<Event>, Data>[] = [
       {
-        validate: async (builder: SimpleBuilder<Event>): Promise<void> => {
+        validate: async (builder): Promise<void> => {
           let startTime: Date = builder.fields.get("startTime");
           let endTime: Date = builder.fields.get("endTime");
 
@@ -1914,12 +1914,12 @@ function commonTests() {
   describe("trigger", () => {
     let now = new Date();
 
-    const accountStatusTrigger = {
+    const accountStatusTrigger: Trigger<SimpleBuilder<UserWithStatus>, Data> = {
       changeset: (builder: SimpleBuilder<UserWithStatus>): void => {
         builder.fields.set("account_status", "VALID");
       },
     };
-    const triggers: Trigger<UserWithStatus, Data>[] = [accountStatusTrigger];
+    const triggers = [accountStatusTrigger];
 
     test("update builder", async () => {
       advanceTo(now);
@@ -2598,8 +2598,8 @@ async function getEdgeOpFromBuilder<T extends Ent>(
   fail(`could not find edge operation with edgeType ${edgeType}`);
 }
 
-let sendEmailObserver: Observer<User, Data> = {
-  observe: (builder: SimpleBuilder<User>): void => {
+let sendEmailObserver: Observer<SimpleBuilder<User>, Data> = {
+  observe: (builder): void => {
     let email = builder.fields.get("EmailAddress");
     if (!email) {
       return;
@@ -2615,8 +2615,8 @@ let sendEmailObserver: Observer<User, Data> = {
   },
 };
 
-let sendEmailObserverAsync: Observer<User, Data> = {
-  observe: async (builder: SimpleBuilder<User>) => {
+let sendEmailObserverAsync: Observer<SimpleBuilder<User>, Data> = {
+  observe: async (builder) => {
     let email = builder.fields.get("EmailAddress");
     if (!email) {
       return;

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -1701,7 +1701,7 @@ function commonTests() {
   });
 
   describe("validators", () => {
-    const validators: Validator<Event>[] = [
+    const validators: Validator<Event, Data>[] = [
       {
         validate: async (builder: SimpleBuilder<Event>): Promise<void> => {
           let startTime: Date = builder.fields.get("startTime");
@@ -1919,7 +1919,7 @@ function commonTests() {
         builder.fields.set("account_status", "VALID");
       },
     };
-    const triggers: Trigger<UserWithStatus>[] = [accountStatusTrigger];
+    const triggers: Trigger<UserWithStatus, Data>[] = [accountStatusTrigger];
 
     test("update builder", async () => {
       advanceTo(now);
@@ -2598,7 +2598,7 @@ async function getEdgeOpFromBuilder<T extends Ent>(
   fail(`could not find edge operation with edgeType ${edgeType}`);
 }
 
-let sendEmailObserver: Observer<User> = {
+let sendEmailObserver: Observer<User, Data> = {
   observe: (builder: SimpleBuilder<User>): void => {
     let email = builder.fields.get("EmailAddress");
     if (!email) {
@@ -2615,7 +2615,7 @@ let sendEmailObserver: Observer<User> = {
   },
 };
 
-let sendEmailObserverAsync: Observer<User> = {
+let sendEmailObserverAsync: Observer<User, Data> = {
   observe: async (builder: SimpleBuilder<User>) => {
     let email = builder.fields.get("EmailAddress");
     if (!email) {

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -426,7 +426,7 @@ export class Orchestrator<TEnt extends Ent, TData extends Data> {
   private async triggers(
     action: Action<TEnt, Builder<TEnt>, TData>,
     builder: Builder<TEnt>,
-    triggers: Trigger<TEnt, TData>[],
+    triggers: Trigger<Builder<TEnt>, TData>[],
   ): Promise<void> {
     await Promise.all(
       triggers.map(async (trigger) => {
@@ -449,7 +449,7 @@ export class Orchestrator<TEnt extends Ent, TData extends Data> {
   }
 
   private async validators(
-    validators: Validator<TEnt, TData>[],
+    validators: Validator<Builder<TEnt>, TData>[],
     action: Action<TEnt, Builder<TEnt>, TData>,
     builder: Builder<TEnt>,
   ): Promise<void> {

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -27,17 +27,17 @@ import { ListBasedExecutor, ComplexExecutor } from "./executor";
 import { log } from "../core/logger";
 import { Trigger } from "./action";
 
-export interface OrchestratorOptions<T extends Ent> {
+export interface OrchestratorOptions<TEnt extends Ent, TData extends Data> {
   viewer: Viewer;
   operation: WriteOperation;
   tableName: string;
   // should we make it nullable for delete?
-  loaderOptions: LoadEntOptions<T>;
+  loaderOptions: LoadEntOptions<TEnt>;
   // key, usually 'id' that's being updated
   key: string;
 
-  builder: Builder<T>;
-  action?: Action<T>;
+  builder: Builder<TEnt>;
+  action?: Action<TEnt, Builder<TEnt>, TData>;
   schema: SchemaInputType;
   editedFields(): Map<string, any>;
 }
@@ -92,7 +92,7 @@ type OperationMap = Map<WriteOperation, IDMap>;
 // }
 type EdgeMap = Map<string, OperationMap>;
 
-function getViewer(action: Action<Ent>) {
+function getViewer(action: Action<Ent, Builder<Ent>, Data>) {
   if (!action.viewer.viewerID) {
     return "Logged out Viewer";
   } else {
@@ -101,7 +101,10 @@ function getViewer(action: Action<Ent>) {
 }
 class EntCannotCreateEntError extends Error implements PrivacyError {
   privacyPolicy: PrivacyPolicy;
-  constructor(privacyPolicy: PrivacyPolicy, action: Action<Ent>) {
+  constructor(
+    privacyPolicy: PrivacyPolicy,
+    action: Action<Ent, Builder<Ent>, Data>,
+  ) {
     let msg = `${getViewer(action)} does not have permission to create ${
       action.builder.ent.name
     }`;
@@ -112,7 +115,11 @@ class EntCannotCreateEntError extends Error implements PrivacyError {
 
 class EntCannotEditEntError extends Error implements PrivacyError {
   privacyPolicy: PrivacyPolicy;
-  constructor(privacyPolicy: PrivacyPolicy, action: Action<Ent>, ent: Ent) {
+  constructor(
+    privacyPolicy: PrivacyPolicy,
+    action: Action<Ent, Builder<Ent>, Data>,
+    ent: Ent,
+  ) {
     let msg = `${getViewer(action)} does not have permission to edit ${
       ent.constructor.name
     }`;
@@ -123,7 +130,11 @@ class EntCannotEditEntError extends Error implements PrivacyError {
 
 class EntCannotDeleteEntError extends Error implements PrivacyError {
   privacyPolicy: PrivacyPolicy;
-  constructor(privacyPolicy: PrivacyPolicy, action: Action<Ent>, ent: Ent) {
+  constructor(
+    privacyPolicy: PrivacyPolicy,
+    action: Action<Ent, Builder<Ent>, Data>,
+    ent: Ent,
+  ) {
     let msg = `${getViewer(action)} does not have permission to delete ${
       ent.constructor.name
     }`;
@@ -132,18 +143,18 @@ class EntCannotDeleteEntError extends Error implements PrivacyError {
   }
 }
 
-export class Orchestrator<T extends Ent> {
+export class Orchestrator<TEnt extends Ent, TData extends Data> {
   private edgeSet: Set<string> = new Set<string>();
   private edges: EdgeMap = new Map();
   private validatedFields: Data | null;
   private logValues: Data | null;
   private changesets: Changeset<Ent>[] = [];
-  private dependencies: Map<ID, Builder<T>> = new Map();
+  private dependencies: Map<ID, Builder<TEnt>> = new Map();
   private fieldsToResolve: string[] = [];
   private mainOp: DataOperation | null;
   viewer: Viewer;
 
-  constructor(private options: OrchestratorOptions<T>) {
+  constructor(private options: OrchestratorOptions<TEnt, TData>) {
     this.viewer = options.viewer;
   }
 
@@ -413,9 +424,9 @@ export class Orchestrator<T extends Ent> {
   }
 
   private async triggers(
-    action: Action<T>,
-    builder: Builder<T>,
-    triggers: Trigger<T>[],
+    action: Action<TEnt, Builder<TEnt>, TData>,
+    builder: Builder<TEnt>,
+    triggers: Trigger<TEnt, TData>[],
   ): Promise<void> {
     await Promise.all(
       triggers.map(async (trigger) => {
@@ -438,9 +449,9 @@ export class Orchestrator<T extends Ent> {
   }
 
   private async validators(
-    validators: Validator<T>[],
-    action: Action<T>,
-    builder: Builder<T>,
+    validators: Validator<TEnt, TData>[],
+    action: Action<TEnt, Builder<TEnt>, TData>,
+    builder: Builder<TEnt>,
   ): Promise<void> {
     let promises: Promise<void>[] = [];
     validators.forEach((validator) => {
@@ -452,13 +463,13 @@ export class Orchestrator<T extends Ent> {
     await Promise.all(promises);
   }
 
-  private isBuilder(val: Builder<T> | any): val is Builder<T> {
-    return (val as Builder<T>).placeholderID !== undefined;
+  private isBuilder(val: Builder<TEnt> | any): val is Builder<TEnt> {
+    return (val as Builder<TEnt>).placeholderID !== undefined;
   }
 
   private async validateFields(
-    builder: Builder<T>,
-    action?: Action<T> | undefined,
+    builder: Builder<TEnt>,
+    action?: Action<TEnt, Builder<TEnt>, TData> | undefined,
   ): Promise<void> {
     // existing ent required for edit or delete operations
     switch (this.options.operation) {
@@ -578,7 +589,7 @@ export class Orchestrator<T extends Ent> {
     return this.validate();
   }
 
-  async build(): Promise<EntChangeset<T>> {
+  async build(): Promise<EntChangeset<TEnt>> {
     // validate everything first
     await this.validX();
 
@@ -612,7 +623,7 @@ export class Orchestrator<T extends Ent> {
     return null;
   }
 
-  async editedEnt(): Promise<T | null> {
+  async editedEnt(): Promise<TEnt | null> {
     const row = await this.returnedRow();
     if (!row) {
       return null;
@@ -621,7 +632,7 @@ export class Orchestrator<T extends Ent> {
     return applyPrivacyPolicyForRow(viewer, this.options.loaderOptions, row);
   }
 
-  async editedEntX(): Promise<T> {
+  async editedEntX(): Promise<TEnt> {
     const row = await this.returnedRow();
     if (!row) {
       throw new Error(`ent was not created`);
@@ -652,7 +663,7 @@ export class EntChangeset<T extends Ent> implements Changeset<T> {
     public operations: DataOperation[],
     public dependencies?: Map<ID, Builder<T>>,
     public changesets?: Changeset<Ent>[],
-    private options?: OrchestratorOptions<T>,
+    private options?: OrchestratorOptions<T, Data>,
   ) {}
 
   executor(): Executor {

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -109,7 +109,7 @@ function randomNum(): string {
 export class SimpleBuilder<T extends Ent> implements Builder<T> {
   ent: EntConstructor<T>;
   placeholderID: ID;
-  public orchestrator: Orchestrator<T>;
+  public orchestrator: Orchestrator<T, Data>;
   public fields: Map<string, any>;
 
   constructor(
@@ -118,7 +118,7 @@ export class SimpleBuilder<T extends Ent> implements Builder<T> {
     fields: Map<string, any>,
     public operation: WriteOperation = WriteOperation.Insert,
     public existingEnt: Ent | undefined = undefined,
-    action?: Action<T> | undefined,
+    action?: Action<T, SimpleBuilder<T>, Data> | undefined,
   ) {
     // create dynamic placeholder
     // TODO: do we need to use this as the node when there's an existingEnt
@@ -150,7 +150,7 @@ export class SimpleBuilder<T extends Ent> implements Builder<T> {
     }
     this.ent = schema.ent;
     const tableName = getTableName(schema);
-    this.orchestrator = new Orchestrator<T>({
+    this.orchestrator = new Orchestrator<T, Data>({
       viewer: this.viewer,
       operation: operation,
       tableName: tableName,
@@ -207,11 +207,13 @@ interface viewerEntLoadFunc {
   (data: Data): Viewer | Promise<Viewer>;
 }
 
-export class SimpleAction<T extends Ent> implements Action<T> {
+export class SimpleAction<T extends Ent>
+  implements Action<T, SimpleBuilder<T>, Data>
+{
   builder: SimpleBuilder<T>;
-  validators: Validator<T>[] = [];
-  triggers: Trigger<T>[] = [];
-  observers: Observer<T>[] = [];
+  validators: Validator<T, Data>[] = [];
+  triggers: Trigger<T, Data>[] = [];
+  observers: Observer<T, Data>[] = [];
   viewerForEntLoad: viewerEntLoadFunc | undefined;
 
   constructor(

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -211,9 +211,9 @@ export class SimpleAction<T extends Ent>
   implements Action<T, SimpleBuilder<T>, Data>
 {
   builder: SimpleBuilder<T>;
-  validators: Validator<T, Data>[] = [];
-  triggers: Trigger<T, Data>[] = [];
-  observers: Observer<T, Data>[] = [];
+  validators: Validator<SimpleBuilder<T>, Data>[] = [];
+  triggers: Trigger<SimpleBuilder<T>, Data>[] = [];
+  observers: Observer<SimpleBuilder<T>, Data>[] = [];
   viewerForEntLoad: viewerEntLoadFunc | undefined;
 
   constructor(


### PR DESCRIPTION
changes interface definitions of Action, Trigger, Builder, Observer to templatize and make it easier to write triggers, validators, observers and to provide default types. 

addresses https://github.com/lolopinto/ent/issues/593 and https://github.com/lolopinto/ent/issues/592

feels better in the examples and I can already see how other code can/will be better. still not ideal methinks