### PR TITLE
Edge query ent privacy

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -39,7 +39,8 @@
         "@types/supertest": "^2.0.11",
         "jest": "^27.1.1",
         "jest-expect-message": "^1.0.2",
-        "ts-jest": "^27.0.5"
+        "ts-jest": "^27.0.5",
+        "tsconfig-paths": "^3.11.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -56,6 +56,7 @@
     "@types/supertest": "^2.0.11",
     "jest": "^27.1.1",
     "jest-expect-message": "^1.0.2",
-    "ts-jest": "^27.0.5"
+    "ts-jest": "^27.0.5",
+    "tsconfig-paths": "^3.11.0"
   }
 }

--- a/examples/ent-rsvp/backend/src/ent/event_activity/query/event_activity_to_declined_query.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/query/event_activity_to_declined_query.ts
@@ -1,6 +1,5 @@
-import { EventActivityToDeclinedQueryBase } from "src/ent/internal";
 import { AssocEdge } from "@snowtop/ent";
-
+import { EventActivityToDeclinedQueryBase } from "src/ent/internal";
 export class EventActivityToDeclinedEdge extends AssocEdge {}
 
 export class EventActivityToDeclinedQuery extends EventActivityToDeclinedQueryBase {}

--- a/examples/ent-rsvp/backend/src/ent/event_activity/query/event_activity_to_invites_query.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/query/event_activity_to_invites_query.ts
@@ -1,6 +1,5 @@
-import { EventActivityToInvitesQueryBase } from "src/ent/internal";
 import { AssocEdge } from "@snowtop/ent";
-
+import { EventActivityToInvitesQueryBase } from "src/ent/internal";
 export class EventActivityToInvitesEdge extends AssocEdge {}
 
 export class EventActivityToInvitesQuery extends EventActivityToInvitesQueryBase {}

--- a/examples/ent-rsvp/backend/src/ent/generated/address_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_query_base.ts
@@ -26,9 +26,9 @@ export class OwnerToAddressesQueryBase extends CustomEdgeQueryBase<
   Ent,
   Address
 > {
-  constructor(viewer: Viewer, src: Ent | ID) {
+  constructor(viewer: Viewer, private srcEnt: Ent) {
     super(viewer, {
-      src: src,
+      src: srcEnt,
       countLoaderFactory: ownerToAddressesCountLoaderFactory,
       dataLoaderFactory: ownerToAddressesDataLoaderFactory,
       options: Address.loaderOptions(),
@@ -36,10 +36,14 @@ export class OwnerToAddressesQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends OwnerToAddressesQueryBase>(
-    this: new (viewer: Viewer, src: Ent | ID) => T,
+    this: new (viewer: Viewer, src: Ent) => T,
     viewer: Viewer,
-    src: Ent | ID,
+    src: Ent,
   ): T {
     return new this(viewer, src);
+  }
+
+  async sourceEnt(id: ID) {
+    return this.srcEnt;
   }
 }

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity_query_base.ts
@@ -5,6 +5,7 @@ import {
   AssocEdgeLoaderFactory,
   AssocEdgeQueryBase,
   EdgeQuerySource,
+  ID,
   Viewer,
 } from "@snowtop/ent";
 import {
@@ -44,12 +45,12 @@ export const eventActivityToInvitesDataLoaderFactory =
     () => EventActivityToInvitesEdge,
   );
 
-export class EventActivityToAttendingQueryBase extends AssocEdgeQueryBase<
+export abstract class EventActivityToAttendingQueryBase extends AssocEdgeQueryBase<
   EventActivity,
   Guest,
   EventActivityToAttendingEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<EventActivity>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<EventActivity, Guest>) {
     super(
       viewer,
       src,
@@ -60,11 +61,15 @@ export class EventActivityToAttendingQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends EventActivityToAttendingQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<EventActivity>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<EventActivity, Guest>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<EventActivity>,
+    src: EdgeQuerySource<EventActivity, Guest>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return EventActivity.load(this.viewer, id);
   }
 
   queryGuestToAttendingEvents(): GuestToAttendingEventsQuery {
@@ -76,12 +81,12 @@ export class EventActivityToAttendingQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class EventActivityToDeclinedQueryBase extends AssocEdgeQueryBase<
+export abstract class EventActivityToDeclinedQueryBase extends AssocEdgeQueryBase<
   EventActivity,
   Guest,
   EventActivityToDeclinedEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<EventActivity>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<EventActivity, Guest>) {
     super(
       viewer,
       src,
@@ -92,11 +97,15 @@ export class EventActivityToDeclinedQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends EventActivityToDeclinedQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<EventActivity>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<EventActivity, Guest>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<EventActivity>,
+    src: EdgeQuerySource<EventActivity, Guest>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return EventActivity.load(this.viewer, id);
   }
 
   queryGuestToAttendingEvents(): GuestToAttendingEventsQuery {
@@ -108,12 +117,12 @@ export class EventActivityToDeclinedQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class EventActivityToInvitesQueryBase extends AssocEdgeQueryBase<
+export abstract class EventActivityToInvitesQueryBase extends AssocEdgeQueryBase<
   EventActivity,
   GuestGroup,
   EventActivityToInvitesEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<EventActivity>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<EventActivity, GuestGroup>) {
     super(
       viewer,
       src,
@@ -124,11 +133,18 @@ export class EventActivityToInvitesQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends EventActivityToInvitesQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<EventActivity>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<EventActivity, GuestGroup>,
+    ) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<EventActivity>,
+    src: EdgeQuerySource<EventActivity, GuestGroup>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return EventActivity.load(this.viewer, id);
   }
 
   queryGuestGroupToInvitedEvents(): GuestGroupToInvitedEventsQuery {

--- a/examples/ent-rsvp/backend/src/ent/generated/event_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_query_base.ts
@@ -85,6 +85,10 @@ export class EventToEventActivitiesQueryBase extends CustomEdgeQueryBase<
   ): T {
     return new this(viewer, src);
   }
+
+  async sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
+  }
 }
 
 export class EventToGuestDataQueryBase extends CustomEdgeQueryBase<
@@ -106,6 +110,10 @@ export class EventToGuestDataQueryBase extends CustomEdgeQueryBase<
     src: Event | ID,
   ): T {
     return new this(viewer, src);
+  }
+
+  async sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
   }
 }
 
@@ -129,6 +137,10 @@ export class EventToGuestGroupsQueryBase extends CustomEdgeQueryBase<
   ): T {
     return new this(viewer, src);
   }
+
+  async sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
+  }
 }
 
 export class EventToGuestsQueryBase extends CustomEdgeQueryBase<Event, Guest> {
@@ -147,5 +159,9 @@ export class EventToGuestsQueryBase extends CustomEdgeQueryBase<Event, Guest> {
     src: Event | ID,
   ): T {
     return new this(viewer, src);
+  }
+
+  async sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
   }
 }

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group_query_base.ts
@@ -43,12 +43,12 @@ export const guestGroupToGuestsDataLoaderFactory = new IndexLoaderFactory(
   },
 );
 
-export class GuestGroupToInvitedEventsQueryBase extends AssocEdgeQueryBase<
+export abstract class GuestGroupToInvitedEventsQueryBase extends AssocEdgeQueryBase<
   GuestGroup,
   EventActivity,
   GuestGroupToInvitedEventsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<GuestGroup>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<GuestGroup, EventActivity>) {
     super(
       viewer,
       src,
@@ -59,11 +59,18 @@ export class GuestGroupToInvitedEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends GuestGroupToInvitedEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<GuestGroup>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<GuestGroup, EventActivity>,
+    ) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<GuestGroup>,
+    src: EdgeQuerySource<GuestGroup, EventActivity>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return GuestGroup.load(this.viewer, id);
   }
 
   queryAttending(): EventActivityToAttendingQuery {
@@ -98,5 +105,9 @@ export class GuestGroupToGuestsQueryBase extends CustomEdgeQueryBase<
     src: GuestGroup | ID,
   ): T {
     return new this(viewer, src);
+  }
+
+  async sourceEnt(id: ID) {
+    return GuestGroup.load(this.viewer, id);
   }
 }

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_query_base.ts
@@ -65,12 +65,12 @@ export const guestToGuestDataDataLoaderFactory = new IndexLoaderFactory(
   },
 );
 
-export class GuestToAttendingEventsQueryBase extends AssocEdgeQueryBase<
+export abstract class GuestToAttendingEventsQueryBase extends AssocEdgeQueryBase<
   Guest,
   EventActivity,
   GuestToAttendingEventsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Guest>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Guest, EventActivity>) {
     super(
       viewer,
       src,
@@ -81,11 +81,15 @@ export class GuestToAttendingEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends GuestToAttendingEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Guest>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Guest, EventActivity>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Guest>,
+    src: EdgeQuerySource<Guest, EventActivity>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Guest.load(this.viewer, id);
   }
 
   queryAttending(): EventActivityToAttendingQuery {
@@ -101,12 +105,12 @@ export class GuestToAttendingEventsQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class GuestToDeclinedEventsQueryBase extends AssocEdgeQueryBase<
+export abstract class GuestToDeclinedEventsQueryBase extends AssocEdgeQueryBase<
   Guest,
   EventActivity,
   GuestToDeclinedEventsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Guest>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Guest, EventActivity>) {
     super(
       viewer,
       src,
@@ -117,11 +121,15 @@ export class GuestToDeclinedEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends GuestToDeclinedEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Guest>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Guest, EventActivity>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Guest>,
+    src: EdgeQuerySource<Guest, EventActivity>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Guest.load(this.viewer, id);
   }
 
   queryAttending(): EventActivityToAttendingQuery {
@@ -157,6 +165,10 @@ export class GuestToAuthCodesQueryBase extends CustomEdgeQueryBase<
   ): T {
     return new this(viewer, src);
   }
+
+  async sourceEnt(id: ID) {
+    return Guest.load(this.viewer, id);
+  }
 }
 
 export class GuestToGuestDataQueryBase extends CustomEdgeQueryBase<
@@ -178,5 +190,9 @@ export class GuestToGuestDataQueryBase extends CustomEdgeQueryBase<
     src: Guest | ID,
   ): T {
     return new this(viewer, src);
+  }
+
+  async sourceEnt(id: ID) {
+    return Guest.load(this.viewer, id);
   }
 }

--- a/examples/ent-rsvp/backend/src/ent/generated/user_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/user_query_base.ts
@@ -38,4 +38,8 @@ export class UserToEventsQueryBase extends CustomEdgeQueryBase<User, Event> {
   ): T {
     return new this(viewer, src);
   }
+
+  async sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
+  }
 }

--- a/examples/ent-rsvp/backend/src/ent/guest/query/guest_to_declined_events_query.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/query/guest_to_declined_events_query.ts
@@ -1,6 +1,5 @@
-import { GuestToDeclinedEventsQueryBase } from "src/ent/internal";
 import { AssocEdge } from "@snowtop/ent";
-
+import { GuestToDeclinedEventsQueryBase } from "src/ent/internal";
 export class GuestToDeclinedEventsEdge extends AssocEdge {}
 
 export class GuestToDeclinedEventsQuery extends GuestToDeclinedEventsQueryBase {}

--- a/examples/ent-rsvp/backend/src/ent/guest_group/query/guest_group_to_invited_events_query.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/query/guest_group_to_invited_events_query.ts
@@ -1,6 +1,5 @@
-import { GuestGroupToInvitedEventsQueryBase } from "src/ent/internal";
 import { AssocEdge } from "@snowtop/ent";
-
+import { GuestGroupToInvitedEventsQueryBase } from "src/ent/internal";
 export class GuestGroupToInvitedEventsEdge extends AssocEdge {}
 
 export class GuestGroupToInvitedEventsQuery extends GuestGroupToInvitedEventsQueryBase {}

--- a/examples/simple/src/ent/contact/query/contact_to_comments_query.ts
+++ b/examples/simple/src/ent/contact/query/contact_to_comments_query.ts
@@ -2,8 +2,12 @@
  * Copyright whaa whaa
  */
 
+import { Contact } from "../..";
 import { ObjectToCommentsEdge, ObjectToCommentsQuery } from "../../internal";
-
 export class ContactToCommentsEdge extends ObjectToCommentsEdge {}
 
-export class ContactToCommentsQuery extends ObjectToCommentsQuery {}
+export class ContactToCommentsQuery extends ObjectToCommentsQuery {
+  getSourceLoadEntOptions() {
+    return Contact.loaderOptions();
+  }
+}

--- a/examples/simple/src/ent/contact/query/contact_to_likers_query.ts
+++ b/examples/simple/src/ent/contact/query/contact_to_likers_query.ts
@@ -2,8 +2,12 @@
  * Copyright whaa whaa
  */
 
+import { Contact } from "../..";
 import { ObjectToLikersEdge, ObjectToLikersQuery } from "../../internal";
-
 export class ContactToLikersEdge extends ObjectToLikersEdge {}
 
-export class ContactToLikersQuery extends ObjectToLikersQuery {}
+export class ContactToLikersQuery extends ObjectToLikersQuery {
+  getSourceLoadEntOptions() {
+    return Contact.loaderOptions();
+  }
+}

--- a/examples/simple/src/ent/event/query/event_to_attending_query.ts
+++ b/examples/simple/src/ent/event/query/event_to_attending_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { EventToAttendingQueryBase } from "../../internal";
-
 export class EventToAttendingEdge extends AssocEdge {}
 
 export class EventToAttendingQuery extends EventToAttendingQueryBase {}

--- a/examples/simple/src/ent/event/query/event_to_declined_query.ts
+++ b/examples/simple/src/ent/event/query/event_to_declined_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { EventToDeclinedQueryBase } from "../../internal";
-
 export class EventToDeclinedEdge extends AssocEdge {}
 
 export class EventToDeclinedQuery extends EventToDeclinedQueryBase {}

--- a/examples/simple/src/ent/event/query/event_to_hosts_query.ts
+++ b/examples/simple/src/ent/event/query/event_to_hosts_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { EventToHostsQueryBase } from "../../internal";
-
 export class EventToHostsEdge extends AssocEdge {}
 
 export class EventToHostsQuery extends EventToHostsQueryBase {}

--- a/examples/simple/src/ent/event/query/event_to_invited_query.ts
+++ b/examples/simple/src/ent/event/query/event_to_invited_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { EventToInvitedQueryBase } from "../../internal";
-
 export class EventToInvitedEdge extends AssocEdge {}
 
 export class EventToInvitedQuery extends EventToInvitedQueryBase {}

--- a/examples/simple/src/ent/event/query/event_to_maybe_query.ts
+++ b/examples/simple/src/ent/event/query/event_to_maybe_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { EventToMaybeQueryBase } from "../../internal";
-
 export class EventToMaybeEdge extends AssocEdge {}
 
 export class EventToMaybeQuery extends EventToMaybeQueryBase {}

--- a/examples/simple/src/ent/generated/comment_query_base.ts
+++ b/examples/simple/src/ent/generated/comment_query_base.ts
@@ -76,7 +76,6 @@ export class ArticleToCommentsQueryBase extends CustomEdgeQueryBase<
   Ent,
   Comment
 > {
-  // TODO this is how polymorphic edges should work for now
   constructor(viewer: Viewer, private srcEnt: Ent) {
     super(viewer, {
       src: srcEnt,

--- a/examples/simple/src/ent/generated/comment_query_base.ts
+++ b/examples/simple/src/ent/generated/comment_query_base.ts
@@ -44,12 +44,12 @@ export const articleToCommentsDataLoaderFactory = new IndexLoaderFactory(
   },
 );
 
-export class CommentToPostQueryBase extends AssocEdgeQueryBase<
+export abstract class CommentToPostQueryBase extends AssocEdgeQueryBase<
   Comment,
   Ent,
   CommentToPostEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Comment>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Comment, Ent>) {
     super(
       viewer,
       src,
@@ -60,11 +60,15 @@ export class CommentToPostQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends CommentToPostQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Comment>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Comment, Ent>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Comment>,
+    src: EdgeQuerySource<Comment, Ent>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Comment.load(this.viewer, id);
   }
 }
 
@@ -72,9 +76,10 @@ export class ArticleToCommentsQueryBase extends CustomEdgeQueryBase<
   Ent,
   Comment
 > {
-  constructor(viewer: Viewer, src: Ent | ID) {
+  // TODO this is how polymorphic edges should work for now
+  constructor(viewer: Viewer, private srcEnt: Ent) {
     super(viewer, {
-      src: src,
+      src: srcEnt,
       countLoaderFactory: articleToCommentsCountLoaderFactory,
       dataLoaderFactory: articleToCommentsDataLoaderFactory,
       options: Comment.loaderOptions(),
@@ -82,10 +87,14 @@ export class ArticleToCommentsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends ArticleToCommentsQueryBase>(
-    this: new (viewer: Viewer, src: Ent | ID) => T,
+    this: new (viewer: Viewer, src: Ent) => T,
     viewer: Viewer,
-    src: Ent | ID,
+    src: Ent,
   ): T {
     return new this(viewer, src);
+  }
+
+  async sourceEnt(id: ID) {
+    return this.srcEnt;
   }
 }

--- a/examples/simple/src/ent/generated/event_query_base.ts
+++ b/examples/simple/src/ent/generated/event_query_base.ts
@@ -8,6 +8,7 @@ import {
   AssocEdgeLoaderFactory,
   AssocEdgeQueryBase,
   EdgeQuerySource,
+  ID,
   Viewer,
 } from "@snowtop/ent";
 import {
@@ -70,12 +71,12 @@ export const eventToMaybeDataLoaderFactory = new AssocEdgeLoaderFactory(
   () => EventToMaybeEdge,
 );
 
-export class EventToAttendingQueryBase extends AssocEdgeQueryBase<
+export abstract class EventToAttendingQueryBase extends AssocEdgeQueryBase<
   Event,
   User,
   EventToAttendingEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Event>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Event, User>) {
     super(
       viewer,
       src,
@@ -86,11 +87,15 @@ export class EventToAttendingQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends EventToAttendingQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Event>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Event, User>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Event>,
+    src: EdgeQuerySource<Event, User>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
   }
 
   queryComments(): UserToCommentsQuery {
@@ -138,12 +143,12 @@ export class EventToAttendingQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class EventToDeclinedQueryBase extends AssocEdgeQueryBase<
+export abstract class EventToDeclinedQueryBase extends AssocEdgeQueryBase<
   Event,
   User,
   EventToDeclinedEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Event>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Event, User>) {
     super(
       viewer,
       src,
@@ -154,11 +159,15 @@ export class EventToDeclinedQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends EventToDeclinedQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Event>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Event, User>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Event>,
+    src: EdgeQuerySource<Event, User>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
   }
 
   queryComments(): UserToCommentsQuery {
@@ -206,12 +215,12 @@ export class EventToDeclinedQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class EventToHostsQueryBase extends AssocEdgeQueryBase<
+export abstract class EventToHostsQueryBase extends AssocEdgeQueryBase<
   Event,
   User,
   EventToHostsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Event>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Event, User>) {
     super(
       viewer,
       src,
@@ -222,11 +231,15 @@ export class EventToHostsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends EventToHostsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Event>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Event, User>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Event>,
+    src: EdgeQuerySource<Event, User>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
   }
 
   queryComments(): UserToCommentsQuery {
@@ -274,12 +287,12 @@ export class EventToHostsQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class EventToInvitedQueryBase extends AssocEdgeQueryBase<
+export abstract class EventToInvitedQueryBase extends AssocEdgeQueryBase<
   Event,
   User,
   EventToInvitedEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Event>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Event, User>) {
     super(
       viewer,
       src,
@@ -290,11 +303,15 @@ export class EventToInvitedQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends EventToInvitedQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Event>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Event, User>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Event>,
+    src: EdgeQuerySource<Event, User>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
   }
 
   queryComments(): UserToCommentsQuery {
@@ -342,12 +359,12 @@ export class EventToInvitedQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class EventToMaybeQueryBase extends AssocEdgeQueryBase<
+export abstract class EventToMaybeQueryBase extends AssocEdgeQueryBase<
   Event,
   User,
   EventToMaybeEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Event>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Event, User>) {
     super(
       viewer,
       src,
@@ -358,11 +375,15 @@ export class EventToMaybeQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends EventToMaybeQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Event>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Event, User>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Event>,
+    src: EdgeQuerySource<Event, User>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Event.load(this.viewer, id);
   }
 
   queryComments(): UserToCommentsQuery {

--- a/examples/simple/src/ent/generated/patterns/feedback_query_base.ts
+++ b/examples/simple/src/ent/generated/patterns/feedback_query_base.ts
@@ -9,7 +9,10 @@ import {
   AssocEdgeQueryBase,
   EdgeQuerySource,
   Ent,
+  ID,
+  LoadEntOptions,
   Viewer,
+  loadEnt,
 } from "@snowtop/ent";
 import {
   Comment,
@@ -46,12 +49,12 @@ export const objectToLikersDataLoaderFactory = new AssocEdgeLoaderFactory(
   () => ObjectToLikersEdge,
 );
 
-export class ObjectToCommentsQueryBase extends AssocEdgeQueryBase<
+export abstract class ObjectToCommentsQueryBase extends AssocEdgeQueryBase<
   Ent,
   Comment,
   ObjectToCommentsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Ent>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Ent, Comment>) {
     super(
       viewer,
       src,
@@ -62,11 +65,17 @@ export class ObjectToCommentsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends ObjectToCommentsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Ent>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Ent, Comment>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Ent>,
+    src: EdgeQuerySource<Ent, Comment>,
   ): T {
     return new this(viewer, src);
+  }
+
+  protected abstract getSourceLoadEntOptions(): LoadEntOptions<Ent>;
+
+  sourceEnt(id: ID) {
+    return loadEnt(this.viewer, id, this.getSourceLoadEntOptions());
   }
 
   queryPost(): CommentToPostQuery {
@@ -74,12 +83,12 @@ export class ObjectToCommentsQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class ObjectToLikersQueryBase extends AssocEdgeQueryBase<
+export abstract class ObjectToLikersQueryBase extends AssocEdgeQueryBase<
   Ent,
   User,
   ObjectToLikersEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Ent>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Ent, User>) {
     super(
       viewer,
       src,
@@ -90,11 +99,17 @@ export class ObjectToLikersQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends ObjectToLikersQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Ent>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Ent, User>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Ent>,
+    src: EdgeQuerySource<Ent, User>,
   ): T {
     return new this(viewer, src);
+  }
+
+  protected abstract getSourceLoadEntOptions(): LoadEntOptions<Ent>;
+
+  sourceEnt(id: ID) {
+    return loadEnt(this.viewer, id, this.getSourceLoadEntOptions());
   }
 
   queryComments(): UserToCommentsQuery {

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -49,7 +49,6 @@ import {
 } from "../internal";
 import { UserPrefs } from "../user_prefs";
 import schema from "../../schema/user";
-import { User } from "..";
 
 const tableName = "users";
 const fields = [

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -49,6 +49,7 @@ import {
 } from "../internal";
 import { UserPrefs } from "../user_prefs";
 import schema from "../../schema/user";
+import { User } from "..";
 
 const tableName = "users";
 const fields = [

--- a/examples/simple/src/ent/generated/user_query_base.ts
+++ b/examples/simple/src/ent/generated/user_query_base.ts
@@ -588,9 +588,7 @@ export class UserToAuthCodesQueryBase extends CustomEdgeQueryBase<
     return new this(viewer, src);
   }
 
-  // TODO change non polymorphic edges like this
-
-  sourceEnt(id: ID) {
+  async sourceEnt(id: ID) {
     return User.load(this.viewer, id);
   }
 }
@@ -614,5 +612,9 @@ export class UserToContactsQueryBase extends CustomEdgeQueryBase<
     src: User | ID,
   ): T {
     return new this(viewer, src);
+  }
+
+  async sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 }

--- a/examples/simple/src/ent/generated/user_query_base.ts
+++ b/examples/simple/src/ent/generated/user_query_base.ts
@@ -143,12 +143,12 @@ export const userToContactsDataLoaderFactory = new IndexLoaderFactory(
   },
 );
 
-export class UserToCreatedEventsQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToCreatedEventsQueryBase extends AssocEdgeQueryBase<
   User,
   Event,
   UserToCreatedEventsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, Event>) {
     super(
       viewer,
       src,
@@ -159,11 +159,15 @@ export class UserToCreatedEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToCreatedEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, Event>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, Event>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 
   queryAttending(): EventToAttendingQuery {
@@ -187,12 +191,12 @@ export class UserToCreatedEventsQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class UserToDeclinedEventsQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToDeclinedEventsQueryBase extends AssocEdgeQueryBase<
   User,
   Event,
   UserToDeclinedEventsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, Event>) {
     super(
       viewer,
       src,
@@ -203,11 +207,15 @@ export class UserToDeclinedEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToDeclinedEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, Event>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, Event>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 
   queryAttending(): EventToAttendingQuery {
@@ -231,12 +239,12 @@ export class UserToDeclinedEventsQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class UserToEventsAttendingQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToEventsAttendingQueryBase extends AssocEdgeQueryBase<
   User,
   Event,
   UserToEventsAttendingEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, Event>) {
     super(
       viewer,
       src,
@@ -247,11 +255,15 @@ export class UserToEventsAttendingQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToEventsAttendingQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, Event>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, Event>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 
   queryAttending(): EventToAttendingQuery {
@@ -275,12 +287,12 @@ export class UserToEventsAttendingQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class UserToFriendsQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToFriendsQueryBase extends AssocEdgeQueryBase<
   User,
   User,
   UserToFriendsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, User>) {
     super(
       viewer,
       src,
@@ -291,11 +303,15 @@ export class UserToFriendsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToFriendsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, User>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, User>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 
   queryComments(): UserToCommentsQuery {
@@ -343,12 +359,12 @@ export class UserToFriendsQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class UserToInvitedEventsQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToInvitedEventsQueryBase extends AssocEdgeQueryBase<
   User,
   Event,
   UserToInvitedEventsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, Event>) {
     super(
       viewer,
       src,
@@ -359,11 +375,15 @@ export class UserToInvitedEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToInvitedEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, Event>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, Event>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 
   queryAttending(): EventToAttendingQuery {
@@ -387,12 +407,12 @@ export class UserToInvitedEventsQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class UserToLikesQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToLikesQueryBase extends AssocEdgeQueryBase<
   User,
   Ent,
   UserToLikesEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, Ent>) {
     super(
       viewer,
       src,
@@ -403,20 +423,24 @@ export class UserToLikesQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToLikesQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, Ent>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, Ent>,
   ): T {
     return new this(viewer, src);
   }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
+  }
 }
 
-export class UserToMaybeEventsQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToMaybeEventsQueryBase extends AssocEdgeQueryBase<
   User,
   Event,
   UserToMaybeEventsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, Event>) {
     super(
       viewer,
       src,
@@ -427,11 +451,15 @@ export class UserToMaybeEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToMaybeEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, Event>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, Event>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 
   queryAttending(): EventToAttendingQuery {
@@ -455,12 +483,12 @@ export class UserToMaybeEventsQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class UserToSelfContactQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToSelfContactQueryBase extends AssocEdgeQueryBase<
   User,
   Contact,
   UserToSelfContactEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, Contact>) {
     super(
       viewer,
       src,
@@ -471,11 +499,15 @@ export class UserToSelfContactQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToSelfContactQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, Contact>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, Contact>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 
   queryComments(): ContactToCommentsQuery {
@@ -487,12 +519,12 @@ export class UserToSelfContactQueryBase extends AssocEdgeQueryBase<
   }
 }
 
-export class UserToHostedEventsQueryBase extends AssocEdgeQueryBase<
+export abstract class UserToHostedEventsQueryBase extends AssocEdgeQueryBase<
   User,
   Event,
   UserToHostedEventsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<User>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<User, Event>) {
     super(
       viewer,
       src,
@@ -503,11 +535,15 @@ export class UserToHostedEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends UserToHostedEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<User>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<User, Event>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<User>,
+    src: EdgeQuerySource<User, Event>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 
   queryAttending(): EventToAttendingQuery {
@@ -550,6 +586,12 @@ export class UserToAuthCodesQueryBase extends CustomEdgeQueryBase<
     src: User | ID,
   ): T {
     return new this(viewer, src);
+  }
+
+  // TODO change non polymorphic edges like this
+
+  sourceEnt(id: ID) {
+    return User.load(this.viewer, id);
   }
 }
 

--- a/examples/simple/src/ent/patterns/query/object_to_comments_query.ts
+++ b/examples/simple/src/ent/patterns/query/object_to_comments_query.ts
@@ -6,4 +6,4 @@ import { AssocEdge } from "@snowtop/ent";
 import { ObjectToCommentsQueryBase } from "../../internal";
 export class ObjectToCommentsEdge extends AssocEdge {}
 
-export class ObjectToCommentsQuery extends ObjectToCommentsQueryBase {}
+export abstract class ObjectToCommentsQuery extends ObjectToCommentsQueryBase {}

--- a/examples/simple/src/ent/patterns/query/object_to_likers_query.ts
+++ b/examples/simple/src/ent/patterns/query/object_to_likers_query.ts
@@ -4,7 +4,6 @@
 
 import { AssocEdge } from "@snowtop/ent";
 import { ObjectToLikersQueryBase } from "../../internal";
-
 export class ObjectToLikersEdge extends AssocEdge {}
 
-export class ObjectToLikersQuery extends ObjectToLikersQueryBase {}
+export abstract class ObjectToLikersQuery extends ObjectToLikersQueryBase {}

--- a/examples/simple/src/ent/user/query/user_to_comments_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_comments_query.ts
@@ -2,7 +2,12 @@
  * Copyright whaa whaa
  */
 
+import { User } from "../..";
 import { ObjectToCommentsEdge, ObjectToCommentsQuery } from "../../internal";
 export class UserToCommentsEdge extends ObjectToCommentsEdge {}
 
-export class UserToCommentsQuery extends ObjectToCommentsQuery {}
+export class UserToCommentsQuery extends ObjectToCommentsQuery {
+  getSourceLoadEntOptions() {
+    return User.loaderOptions();
+  }
+}

--- a/examples/simple/src/ent/user/query/user_to_created_events_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_created_events_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { UserToCreatedEventsQueryBase } from "../../internal";
-
 export class UserToCreatedEventsEdge extends AssocEdge {}
 
 export class UserToCreatedEventsQuery extends UserToCreatedEventsQueryBase {}

--- a/examples/simple/src/ent/user/query/user_to_declined_events_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_declined_events_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { UserToDeclinedEventsQueryBase } from "../../internal";
-
 export class UserToDeclinedEventsEdge extends AssocEdge {}
 
 export class UserToDeclinedEventsQuery extends UserToDeclinedEventsQueryBase {}

--- a/examples/simple/src/ent/user/query/user_to_events_attending_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_events_attending_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { UserToEventsAttendingQueryBase } from "../../internal";
-
 export class UserToEventsAttendingEdge extends AssocEdge {}
 
 export class UserToEventsAttendingQuery extends UserToEventsAttendingQueryBase {}

--- a/examples/simple/src/ent/user/query/user_to_friends_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_friends_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { UserToFriendsQueryBase } from "../../internal";
-
 export class UserToFriendsEdge extends AssocEdge {}
 
 export class UserToFriendsQuery extends UserToFriendsQueryBase {}

--- a/examples/simple/src/ent/user/query/user_to_hosted_events_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_hosted_events_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { UserToHostedEventsQueryBase } from "../../internal";
-
 export class UserToHostedEventsEdge extends AssocEdge {}
 
 export class UserToHostedEventsQuery extends UserToHostedEventsQueryBase {}

--- a/examples/simple/src/ent/user/query/user_to_invited_events_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_invited_events_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { UserToInvitedEventsQueryBase } from "../../internal";
-
 export class UserToInvitedEventsEdge extends AssocEdge {}
 
 export class UserToInvitedEventsQuery extends UserToInvitedEventsQueryBase {}

--- a/examples/simple/src/ent/user/query/user_to_likers_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_likers_query.ts
@@ -2,7 +2,12 @@
  * Copyright whaa whaa
  */
 
+import { User } from "../..";
 import { ObjectToLikersEdge, ObjectToLikersQuery } from "../../internal";
 export class UserToLikersEdge extends ObjectToLikersEdge {}
 
-export class UserToLikersQuery extends ObjectToLikersQuery {}
+export class UserToLikersQuery extends ObjectToLikersQuery {
+  getSourceLoadEntOptions() {
+    return User.loaderOptions();
+  }
+}

--- a/examples/simple/src/ent/user/query/user_to_maybe_events_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_maybe_events_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { UserToMaybeEventsQueryBase } from "../../internal";
-
 export class UserToMaybeEventsEdge extends AssocEdge {}
 
 export class UserToMaybeEventsQuery extends UserToMaybeEventsQueryBase {}

--- a/examples/simple/src/ent/user/query/user_to_self_contact_query.ts
+++ b/examples/simple/src/ent/user/query/user_to_self_contact_query.ts
@@ -1,6 +1,9 @@
+/**
+ * Copyright whaa whaa
+ */
+
 import { AssocEdge } from "@snowtop/ent";
 import { UserToSelfContactQueryBase } from "../../internal";
-
 export class UserToSelfContactEdge extends AssocEdge {}
 
 export class UserToSelfContactQuery extends UserToSelfContactQueryBase {}

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -25,12 +25,13 @@
         "@types/jest": "^27.0.1",
         "@types/jest-expect-message": "^1.0.3",
         "@types/supertest": "^2.0.11",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.1",
         "jest": "^27.1.1",
         "jest-date-mock": "^1.0.8",
         "jest-expect-message": "^1.0.2",
         "supertest": "^6.1.3",
-        "ts-jest": "^27.0.5"
+        "ts-jest": "^27.0.5",
+        "tsconfig-paths": "^3.11.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -25,12 +25,13 @@
     "@types/jest": "^27.0.1",
     "@types/jest-expect-message": "^1.0.3",
     "@types/supertest": "^2.0.11",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^8.3.1",
     "jest": "^27.1.1",
     "jest-date-mock": "^1.0.8",
     "jest-expect-message": "^1.0.2",
     "supertest": "^6.1.3",
-    "ts-jest": "^27.0.5"
+    "ts-jest": "^27.0.5",
+    "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
     "@snowtop/ent": "^0.0.24",

--- a/examples/todo-sqlite/src/ent/generated/account_query_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_query_base.ts
@@ -49,6 +49,10 @@ export class AccountToTagsQueryBase extends CustomEdgeQueryBase<Account, Tag> {
   ): T {
     return new this(viewer, src);
   }
+
+  async sourceEnt(id: ID) {
+    return Account.load(this.viewer, id);
+  }
 }
 
 export class AccountToTodosQueryBase extends CustomEdgeQueryBase<
@@ -70,5 +74,9 @@ export class AccountToTodosQueryBase extends CustomEdgeQueryBase<
     src: Account | ID,
   ): T {
     return new this(viewer, src);
+  }
+
+  async sourceEnt(id: ID) {
+    return Account.load(this.viewer, id);
   }
 }

--- a/examples/todo-sqlite/src/ent/generated/tag_query_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_query_base.ts
@@ -5,6 +5,7 @@ import {
   AssocEdgeLoaderFactory,
   AssocEdgeQueryBase,
   EdgeQuerySource,
+  ID,
   Viewer,
 } from "@snowtop/ent";
 import {
@@ -23,12 +24,12 @@ export const tagToTodosDataLoaderFactory = new AssocEdgeLoaderFactory(
   () => TagToTodosEdge,
 );
 
-export class TagToTodosQueryBase extends AssocEdgeQueryBase<
+export abstract class TagToTodosQueryBase extends AssocEdgeQueryBase<
   Tag,
   Todo,
   TagToTodosEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Tag>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Tag, Todo>) {
     super(
       viewer,
       src,
@@ -39,11 +40,15 @@ export class TagToTodosQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends TagToTodosQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Tag>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Tag, Todo>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Tag>,
+    src: EdgeQuerySource<Tag, Todo>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Tag.load(this.viewer, id);
   }
 
   queryTags(): TodoToTagsQuery {

--- a/examples/todo-sqlite/src/ent/generated/todo_query_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_query_base.ts
@@ -5,6 +5,7 @@ import {
   AssocEdgeLoaderFactory,
   AssocEdgeQueryBase,
   EdgeQuerySource,
+  ID,
   Viewer,
 } from "@snowtop/ent";
 import {
@@ -23,12 +24,12 @@ export const todoToTagsDataLoaderFactory = new AssocEdgeLoaderFactory(
   () => TodoToTagsEdge,
 );
 
-export class TodoToTagsQueryBase extends AssocEdgeQueryBase<
+export abstract class TodoToTagsQueryBase extends AssocEdgeQueryBase<
   Todo,
   Tag,
   TodoToTagsEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<Todo>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<Todo, Tag>) {
     super(
       viewer,
       src,
@@ -39,11 +40,15 @@ export class TodoToTagsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends TodoToTagsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Todo>) => T,
+    this: new (viewer: Viewer, src: EdgeQuerySource<Todo, Tag>) => T,
     viewer: Viewer,
-    src: EdgeQuerySource<Todo>,
+    src: EdgeQuerySource<Todo, Tag>,
   ): T {
     return new this(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return Todo.load(this.viewer, id);
   }
 
   queryTodos(): TagToTodosQuery {

--- a/examples/todo-sqlite/src/ent/tag/query/tag_to_todos_query.ts
+++ b/examples/todo-sqlite/src/ent/tag/query/tag_to_todos_query.ts
@@ -1,6 +1,5 @@
 import { AssocEdge } from "@snowtop/ent";
 import { TagToTodosQueryBase } from "src/ent/internal";
-
 export class TagToTodosEdge extends AssocEdge {}
 
 export class TagToTodosQuery extends TagToTodosQueryBase {}

--- a/examples/todo-sqlite/src/ent/todo/query/todo_to_tags_query.ts
+++ b/examples/todo-sqlite/src/ent/todo/query/todo_to_tags_query.ts
@@ -1,6 +1,5 @@
 import { AssocEdge } from "@snowtop/ent";
 import { TodoToTagsQueryBase } from "src/ent/internal";
-
 export class TodoToTagsEdge extends AssocEdge {}
 
 export class TodoToTagsQuery extends TodoToTagsQueryBase {}

--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -335,6 +335,7 @@ type ConnectionEdge interface {
 
 type IndexedConnectionEdge interface {
 	ConnectionEdge
+	SourceIsPolymorphic() bool
 	QuotedDBColName() string
 }
 
@@ -440,6 +441,10 @@ func (e *ForeignKeyEdge) GetSourceNodeName() string {
 	return e.SourceNodeName
 }
 
+func (e *ForeignKeyEdge) SourceIsPolymorphic() bool {
+	return false
+}
+
 func (e *ForeignKeyEdge) TsEdgeQueryName() string {
 	return fmt.Sprintf("%sTo%sQuery", e.SourceNodeName, strcase.ToCamel(e.EdgeName))
 }
@@ -529,7 +534,12 @@ func (e *IndexedEdge) TsEdgeQueryName() string {
 }
 
 func (e *IndexedEdge) GetSourceNodeName() string {
+	// hmm. what generates this? why is it always ent?
 	return "Ent"
+}
+
+func (e *IndexedEdge) SourceIsPolymorphic() bool {
+	return true
 }
 
 func (e *IndexedEdge) GetGraphQLConnectionName() string {

--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -624,6 +624,11 @@ func (e *AssociationEdge) CreateEdge() bool {
 	return true
 }
 
+func (e *AssociationEdge) GenerateSourceLoadEntOptions() bool {
+	// when there's a pattern edge, need to provide the getSourceLoadEntOptions method
+	return e.PatternName != ""
+}
+
 func (e *AssociationEdge) GenerateBase() bool {
 	// only generate base when edge is not from a pattern
 	return e.PatternName == ""

--- a/internal/tscode/assoc_ent_query.tmpl
+++ b/internal/tscode/assoc_ent_query.tmpl
@@ -13,4 +13,15 @@
 
 export class {{$edgeName}} extends {{useImport $assocEdgeBase}} {}
 
-export class {{$name}} extends {{useImport $base}} {}
+{{ if eq .SourceNode "Ent" -}}
+export abstract class {{$name}} extends {{useImport $base}} {
+{{ else -}}
+export class {{$name}} extends {{useImport $base}} {
+{{ end -}}
+  {{if .Edge.GenerateSourceLoadEntOptions -}}
+  {{reserveImport .Package.ExternalImportPath .SourceNode -}}
+    getSourceLoadEntOptions() {
+      return {{useImport .SourceNode}}.loaderOptions();
+    }
+  {{end -}}
+}

--- a/internal/tscode/ent_query_base.tmpl
+++ b/internal/tscode/ent_query_base.tmpl
@@ -1,5 +1,5 @@
 {{ reserveImport .Package.InternalImportPath "EdgeType" "NodeType" }}
-{{ reserveImport .Package.PackagePath "Ent" "ID" "Data" "Viewer" "EdgeQuerySource" "BaseEdgeQuery" "AssocEdge" "AssocEdgeQueryBase" "CustomEdgeQueryBase" "query" "RawCountLoaderFactory" "AssocEdgeCountLoaderFactory" "AssocEdgeLoaderFactory" "IndexLoaderFactory"}}
+{{ reserveImport .Package.PackagePath "Ent" "ID" "Data" "Viewer" "EdgeQuerySource" "BaseEdgeQuery" "AssocEdge" "AssocEdgeQueryBase" "CustomEdgeQueryBase" "query" "RawCountLoaderFactory" "AssocEdgeCountLoaderFactory" "AssocEdgeLoaderFactory" "IndexLoaderFactory" "loadEnt" "LoadEntOptions"}}
 {{$importPath := .Package.InternalImportPath -}}
 {{reserveImport "src/ent/generated/loadAny" "getLoaderOptions" -}}
 
@@ -16,6 +16,7 @@
   {{ end}}
 
   {{$node := useImport .Node}}
+  {{$sourcePolymorphic := .SourcePolymorphic }}
 
   {{range $edge := .AssocEdges}}
     {{$edgeType := printf "%s.%s" (useImport "EdgeType") $edge.TsEdgeConst -}}
@@ -50,10 +51,14 @@
     {{$name := printf "%sBase" $edge.TsEdgeQueryName -}}
     {{ reserveImport $importPath $edge.TsEdgeQueryEdgeName -}}
     {{$edgeName := useImport $edge.TsEdgeQueryEdgeName -}}
-    {{$thisType := printf "new (viewer: Viewer, src: EdgeQuerySource<%s>) => T" $node }}
+    {{$destNode := useImport .NodeInfo.Node -}}
+    {{$thisType := printf "new (viewer: Viewer, src: EdgeQuerySource<%s, %s>) => T" $node $destNode}}
 
-  export class {{$name}} extends {{useImport "AssocEdgeQueryBase"}}<{{$node}}, {{useImport .NodeInfo.Node}}, {{$edgeName}}> {
-    constructor(viewer: {{useImport "Viewer"}}, src: {{useImport "EdgeQuerySource"}}<{{$node}}>) {
+  export abstract class {{$name}} extends {{useImport "AssocEdgeQueryBase"}}<{{$node}}, {{$destNode}}, {{$edgeName}}> {
+    constructor(
+      viewer: {{useImport "Viewer"}}, 
+      src: {{useImport "EdgeQuerySource"}}<{{$node}}, {{$destNode}}>,
+    ) {
       super(
         viewer, 
         src, 
@@ -70,9 +75,21 @@
     static query<T extends {{$name}}>(
       this: {{$thisType}},
       viewer: {{useImport "Viewer"}},
-      src: {{useImport "EdgeQuerySource"}}<{{$node}}>,
+      src: {{useImport "EdgeQuerySource"}}<{{$node}}, {{$destNode}}>,
     ): T {
       return new this(viewer, src);
+    }
+
+    {{ if $sourcePolymorphic -}}
+      protected abstract getSourceLoadEntOptions(): {{useImport "LoadEntOptions"}}<{{useImport "Ent"}}>;
+    {{ end }}
+
+    sourceEnt(id: {{useImport "ID"}}) {
+      {{if $sourcePolymorphic -}}
+        return {{useImport "loadEnt"}}(this.viewer, id, this.getSourceLoadEntOptions());
+      {{ else -}}
+        return {{$node}}.load(this.viewer, id);
+      {{ end -}}
     }
 
     {{if not $edge.PolymorphicEdge -}}

--- a/internal/tscode/ent_query_base.tmpl
+++ b/internal/tscode/ent_query_base.tmpl
@@ -109,12 +109,24 @@
     {{$name := printf "%sBase" $edge.TsEdgeQueryName -}}
     {{$srcNode := useImport $edge.GetSourceNodeName -}}
     {{$node := useImport $edge.GetNodeInfo.Node -}}
-    {{$thisType := printf "new (viewer: Viewer, src: %s | ID ) => T" $srcNode }}
+    {{$srcPoly := $edge.SourceIsPolymorphic -}}
+    {{$srcType := printf "%s | %s " $srcNode (useImport "ID") }}
+    {{ if $srcPoly -}}
+      {{$srcType = $srcNode }}
+    {{ end -}}
+
+    {{$thisType := printf "new (viewer: Viewer, src: %s  ) => T" $srcType }}
 
     export class {{$name}} extends {{useImport "CustomEdgeQueryBase"}}<{{$srcNode}}, {{$node}}> {
-      constructor(viewer: {{useImport "Viewer"}}, src: {{$srcNode}} | {{useImport "ID"}}) {
+    {{ if $srcPoly -}}
+      constructor(viewer: {{useImport "Viewer"}}, private srcEnt: {{$srcType }}) {
+        super(viewer, {
+          src: srcEnt, 
+    {{ else -}}
+      constructor(viewer: {{useImport "Viewer"}}, src: {{$srcType }}) {
         super(viewer, {
           src: src, 
+    {{ end -}}
           countLoaderFactory: {{$edge.GetCountFactoryName}},
           dataLoaderFactory: {{$edge.GetDataFactoryName}},
           options:{{$node}}.loaderOptions(), 
@@ -124,9 +136,17 @@
       static query<T extends {{$name}}>(
         this: {{$thisType}},
         viewer: {{useImport "Viewer"}},
-        src: {{$srcNode}} | {{useImport "ID"}},
+        src: {{$srcType}},
       ): T {
         return new this(viewer, src);
+      }
+
+      async sourceEnt(id: ID) {
+        {{ if $srcPoly -}}
+          return this.srcEnt;
+        {{ else -}}
+          return {{$srcNode}}.load(this.viewer, id);
+        {{ end -}}
       }
     }
 

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -508,7 +508,7 @@ func writeAssocEdgeQueryFile(processor *codegen.Processor, e *edge.AssociationEd
 		TsImports:         imps,
 		FuncMap:           imps.FuncMap(),
 		EditableCode:      true,
-	})
+	}, file.WriteOnce())
 }
 
 func writeCustomEdgeQueryFile(processor *codegen.Processor, nodeData *schema.NodeData, e edge.ConnectionEdge) error {

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -91,6 +91,7 @@ func (s *Step) processPattern(processor *codegen.Processor, pattern *schema.Patt
 			return writeAssocEdgeQueryFile(
 				processor,
 				edge,
+				"Ent",
 				getFilePathForPatternAssocEdgeQueryFile(processor.Config, pattern, edge),
 			)
 		})
@@ -137,6 +138,7 @@ func (s *Step) processEdges(processor *codegen.Processor, nodeData *schema.NodeD
 			return writeAssocEdgeQueryFile(
 				processor,
 				edge,
+				nodeData.Node,
 				getFilePathForAssocEdgeQueryFile(processor.Config, nodeData, edge),
 			)
 		})
@@ -484,18 +486,20 @@ func writeBaseQueryFile(processor *codegen.Processor, nodeData *schema.NodeData)
 	})
 }
 
-func writeAssocEdgeQueryFile(processor *codegen.Processor, e *edge.AssociationEdge, filePath string) error {
+func writeAssocEdgeQueryFile(processor *codegen.Processor, e *edge.AssociationEdge, sourceNode, filePath string) error {
 	cfg := processor.Config
 	imps := tsimport.NewImports(processor.Config, filePath)
 
 	return file.Write(&file.TemplatedBasedFileWriter{
 		Config: processor.Config,
 		Data: struct {
-			Edge    *edge.AssociationEdge
-			Package *codegen.ImportPackage
+			Edge       *edge.AssociationEdge
+			Package    *codegen.ImportPackage
+			SourceNode string
 		}{
-			Edge:    e,
-			Package: cfg.GetImportPackage(),
+			Edge:       e,
+			Package:    cfg.GetImportPackage(),
+			SourceNode: sourceNode,
 		},
 		CreateDirIfNeeded: true,
 		AbsPathToTemplate: util.GetAbsolutePath("assoc_ent_query.tmpl"),
@@ -504,7 +508,7 @@ func writeAssocEdgeQueryFile(processor *codegen.Processor, e *edge.AssociationEd
 		TsImports:         imps,
 		FuncMap:           imps.FuncMap(),
 		EditableCode:      true,
-	}, file.WriteOnce())
+	})
 }
 
 func writeCustomEdgeQueryFile(processor *codegen.Processor, nodeData *schema.NodeData, e edge.ConnectionEdge) error {
@@ -537,6 +541,10 @@ type BaseQueryEdgeInfo struct {
 	IndexedEdges []edge.IndexedConnectionEdge
 	Node         string
 	FilePath     string
+}
+
+func (b *BaseQueryEdgeInfo) SourcePolymorphic() bool {
+	return b.Node == "Ent"
 }
 
 func writeBasePatternQueryFile(processor *codegen.Processor, pattern *schema.PatternInfo) error {

--- a/ts/src/core/query/custom_query.ts
+++ b/ts/src/core/query/custom_query.ts
@@ -9,7 +9,7 @@ import {
   ConfigurableLoaderFactory,
 } from "../base";
 import { applyPrivacyPolicyForRows, DefaultLimit } from "../ent";
-import { BaseEdgeQuery, IDInfo } from "./query";
+import { BaseEdgeQuery, IDInfo, EdgeQuery } from "./query";
 
 export interface CustomEdgeQueryOptions<
   TSource extends Ent,
@@ -23,10 +23,13 @@ export interface CustomEdgeQueryOptions<
   sortColumn?: string;
 }
 
-export class CustomEdgeQueryBase<
-  TSource extends Ent,
-  TDest extends Ent,
-> extends BaseEdgeQuery<TSource, TDest, Data> {
+export abstract class CustomEdgeQueryBase<
+    TSource extends Ent,
+    TDest extends Ent,
+  >
+  extends BaseEdgeQuery<TSource, TDest, Data>
+  implements EdgeQuery<TSource, TDest, Data>
+{
   private id: ID;
   constructor(
     public viewer: Viewer,
@@ -40,6 +43,8 @@ export class CustomEdgeQueryBase<
       this.id = options.src;
     }
   }
+
+  abstract sourceEnt(id: ID): Promise<Ent | null>;
 
   private async idVisible() {
     const ids = await this.genIDInfosToFetch();

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -40,13 +40,12 @@ export interface EdgeQuery<
 
   getPrivacyPolicy(): PrivacyPolicy;
 
-  // TODO rename. load source ent
   // there's no requirement that you have to be able to see
   // an ent to see edges from that ent so the ent is optional
-  // however, this means that the ent passed to applyPrivacyPolicy() can be undefined
-  // if you want to encourage an ent passed down, implement this function
-  // to generate an ent that will be used.
-  // if there's a multi-id situation (EdgeQuerySource), we'll call this for each id/ent passed in
+  // however, a few privacy policies and rules are dependent on the Ent so we try and load
+  // the Ent if the ent isn't passed as the source to the query.
+  // If the Viewer can see the Ent, that's what's passed to the Privacy Policies
+  // to determine if the edge is visible
   sourceEnt(id: ID): Promise<Ent | null>;
 }
 

--- a/ts/src/testutils/fake_data/events_query.ts
+++ b/ts/src/testutils/fake_data/events_query.ts
@@ -1,4 +1,4 @@
-import { Viewer } from "../../core/base";
+import { ID, Viewer } from "../../core/base";
 import { AssocEdge } from "../../core/ent";
 import {
   AssocEdgeQueryBase,
@@ -22,7 +22,7 @@ export class EventToAttendeesQuery extends AssocEdgeQueryBase<
   FakeUser,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent, FakeUser>) {
     super(
       viewer,
       src,
@@ -34,9 +34,13 @@ export class EventToAttendeesQuery extends AssocEdgeQueryBase<
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeEvent>,
+    src: EdgeQuerySource<FakeEvent, FakeUser>,
   ): EventToAttendeesQuery {
     return new EventToAttendeesQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeEvent.load(this.viewer, id);
   }
 }
 
@@ -45,7 +49,7 @@ export class EventToInvitedQuery extends AssocEdgeQueryBase<
   FakeUser,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent, FakeUser>) {
     super(
       viewer,
       src,
@@ -57,9 +61,13 @@ export class EventToInvitedQuery extends AssocEdgeQueryBase<
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeEvent>,
+    src: EdgeQuerySource<FakeEvent, FakeUser>,
   ): EventToInvitedQuery {
     return new EventToInvitedQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeEvent.load(this.viewer, id);
   }
 }
 
@@ -68,7 +76,7 @@ export class EventToDeclinedQuery extends AssocEdgeQueryBase<
   FakeUser,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent, FakeUser>) {
     super(
       viewer,
       src,
@@ -80,9 +88,13 @@ export class EventToDeclinedQuery extends AssocEdgeQueryBase<
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeEvent>,
+    src: EdgeQuerySource<FakeEvent, FakeUser>,
   ): EventToDeclinedQuery {
     return new EventToDeclinedQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeEvent.load(this.viewer, id);
   }
 }
 
@@ -91,7 +103,7 @@ export class EventToMaybeQuery extends AssocEdgeQueryBase<
   FakeUser,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent, FakeUser>) {
     super(
       viewer,
       src,
@@ -103,9 +115,13 @@ export class EventToMaybeQuery extends AssocEdgeQueryBase<
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeEvent>,
+    src: EdgeQuerySource<FakeEvent, FakeUser>,
   ): EventToMaybeQuery {
     return new EventToMaybeQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeEvent.load(this.viewer, id);
   }
 }
 
@@ -114,7 +130,7 @@ export class EventToHostsQuery extends AssocEdgeQueryBase<
   FakeUser,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeEvent, FakeUser>) {
     super(
       viewer,
       src,
@@ -126,8 +142,12 @@ export class EventToHostsQuery extends AssocEdgeQueryBase<
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeEvent>,
+    src: EdgeQuerySource<FakeEvent, FakeUser>,
   ): EventToHostsQuery {
     return new EventToHostsQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeEvent.load(this.viewer, id);
   }
 }

--- a/ts/src/testutils/fake_data/user_query.ts
+++ b/ts/src/testutils/fake_data/user_query.ts
@@ -50,6 +50,10 @@ export class UserToContactsQuery extends AssocEdgeQueryBase<
   ): UserToContactsQuery {
     return new UserToContactsQuery(viewer, src);
   }
+
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
+  }
 }
 
 export const userToContactsCountLoaderFactory = new RawCountLoaderFactory({
@@ -81,6 +85,10 @@ export class UserToContactsFkeyQuery extends CustomEdgeQueryBase<
   static query(viewer: Viewer, src: FakeUser | ID): UserToContactsFkeyQuery {
     return new UserToContactsFkeyQuery(viewer, src);
   }
+
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
+  }
 }
 
 export class UserToFriendsQuery extends AssocEdgeQueryBase<
@@ -103,6 +111,10 @@ export class UserToFriendsQuery extends AssocEdgeQueryBase<
     src: EdgeQuerySource<FakeUser>,
   ): UserToFriendsQuery {
     return new UserToFriendsQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
   }
 
   queryContacts(): UserToContactsQuery {
@@ -155,6 +167,10 @@ export class UserToCustomEdgeQuery extends AssocEdgeQueryBase<
     return new UserToCustomEdgeQuery(viewer, src);
   }
 
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
+  }
+
   queryContacts(): UserToContactsQuery {
     return UserToContactsQuery.query(this.viewer, this);
   }
@@ -194,6 +210,10 @@ export class UserToFriendRequestsQuery extends AssocEdgeQueryBase<
     return new UserToFriendRequestsQuery(viewer, src);
   }
 
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
+  }
+
   queryContacts(): UserToContactsQuery {
     return UserToContactsQuery.query(this.viewer, this);
   }
@@ -220,7 +240,7 @@ export class UserToIncomingFriendRequestsQuery extends AssocEdgeQueryBase<
   FakeUser,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser, FakeUser>) {
     super(
       viewer,
       src,
@@ -237,13 +257,13 @@ export class UserToIncomingFriendRequestsQuery extends AssocEdgeQueryBase<
     return AllowIfViewerPrivacyPolicy;
   }
 
-  entForPrivacy(id: ID) {
+  sourceEnt(id: ID) {
     return FakeUser.load(this.viewer, id);
   }
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeUser>,
+    src: EdgeQuerySource<FakeUser, FakeUser>,
   ): UserToIncomingFriendRequestsQuery {
     return new UserToIncomingFriendRequestsQuery(viewer, src);
   }
@@ -274,7 +294,7 @@ export class UserToEventsAttendingQuery extends AssocEdgeQueryBase<
   FakeEvent,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser, FakeEvent>) {
     super(
       viewer,
       src,
@@ -286,9 +306,13 @@ export class UserToEventsAttendingQuery extends AssocEdgeQueryBase<
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeUser>,
+    src: EdgeQuerySource<FakeUser, FakeEvent>,
   ): UserToEventsAttendingQuery {
     return new UserToEventsAttendingQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
   }
 
   queryHosts(): EventToHostsQuery {
@@ -313,7 +337,7 @@ export class UserToHostedEventsQuery extends AssocEdgeQueryBase<
   FakeEvent,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser, FakeEvent>) {
     super(
       viewer,
       src,
@@ -325,9 +349,13 @@ export class UserToHostedEventsQuery extends AssocEdgeQueryBase<
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeUser>,
+    src: EdgeQuerySource<FakeUser, FakeEvent>,
   ): UserToHostedEventsQuery {
     return new UserToHostedEventsQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
   }
 
   queryHosts(): EventToHostsQuery {
@@ -405,11 +433,12 @@ export class UserToEventsInNextWeekQuery extends CustomEdgeQueryBase<
     return new UserToEventsInNextWeekQuery(viewer, src);
   }
 
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
+  }
+
   getPrivacyPolicy() {
     return AllowIfViewerPrivacyPolicy;
-  }
-  async entForPrivacy(id: ID) {
-    return FakeUser.load(this.viewer, id);
   }
 }
 
@@ -418,7 +447,7 @@ export class UserToFollowingQuery extends AssocEdgeQueryBase<
   Ent,
   AssocEdge
 > {
-  constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser>) {
+  constructor(viewer: Viewer, src: EdgeQuerySource<FakeUser, FakeUser>) {
     super(
       viewer,
       src,
@@ -430,8 +459,12 @@ export class UserToFollowingQuery extends AssocEdgeQueryBase<
 
   static query(
     viewer: Viewer,
-    src: EdgeQuerySource<FakeUser>,
+    src: EdgeQuerySource<FakeUser, FakeUser>,
   ): UserToFollowingQuery {
     return new UserToFollowingQuery(viewer, src);
+  }
+
+  sourceEnt(id: ID) {
+    return FakeUser.load(this.viewer, id);
   }
 }


### PR DESCRIPTION
fixes https://github.com/lolopinto/ent/issues/612

adds `sourceEnt` method to each EntQuery. replaces `entForPrivacy`

generated base classes implement it when we know the source

for polymorphic sources, it's left to the generated sub class to provide the information e.g. `getSourceLoadEntOptions` for assoc based edge

for polymorphic sources with index/foreign keys, removed the option of passing an id for now 