### PR TITLE
improvements to writing files + prettier usage

### DIFF
--- a/examples/simple/tsconfig.json
+++ b/examples/simple/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  // TODO eventually generate this from an init step
   "compilerOptions": {
     "lib": ["es2018", "esnext.asynciterable"],
     "outDir": "./dist",

--- a/gent/cmd/root.go
+++ b/gent/cmd/root.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/lolopinto/ent/internal/codegen"
+	"github.com/lolopinto/ent/internal/filehelper"
 	"github.com/lolopinto/ent/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -85,29 +85,18 @@ func getPathToCode(pathToConfig string) (*codegen.Config, error) {
 
 	// walk up the tree until we find a go.mod file
 	// and build the suffix that needs to be added to the end of the module found in a go.mod file
-	curDir := dir
-	suffix := ""
+	result := filehelper.FindAndRead(dir, "go.mod")
+	b := result.Bytes
+	err = result.Error
+	suffix := result.Suffix
+	if err != nil {
+		return nil, err
+	}
+	if b != nil {
+		contents := string(b)
 
-	for {
-		b, err := ioutil.ReadFile(filepath.Join(curDir, "/", "go.mod"))
-		if err == nil {
-			contents := string(b)
-
-			match := r.FindStringSubmatch(contents)
-			return codegen.NewConfig(pathToConfig, match[1]+suffix)
-		}
-
-		suffix = "/" + filepath.Base(curDir) + suffix
-		// go up one directory
-		curDir, err = filepath.Abs(filepath.Join(curDir, ".."))
-		if err != nil {
-			return nil, err
-		}
-
-		// got all the way to the top. bye felicia
-		if curDir == "/" {
-			break
-		}
+		match := r.FindStringSubmatch(contents)
+		return codegen.NewConfig(pathToConfig, match[1]+suffix)
 	}
 
 	// no go.mod in the path

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/vektah/gqlparser v1.1.2
 	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect
-	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
+	golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190515012406-7d7faa4812bd
 	google.golang.org/appengine v1.1.0 // indirect
@@ -39,6 +39,7 @@ require (
 
 require (
 	github.com/agnivade/levenshtein v1.0.1 // indirect
+	github.com/evanw/esbuild v0.13.15 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/evanw/esbuild v0.13.15 h1:yogFIjIkY1f2bVboxMAsv1sHJFWphkwZnm3FZ09Qhxc=
+github.com/evanw/esbuild v0.13.15/go.mod h1:GG+zjdi59yh3ehDn4ZWfPcATxjPDUH53iU4ZJbp7dkY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-chi/chi v3.3.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-redis/redis v6.15.7+incompatible h1:3skhDh95XQMpnqeqNftPkQD9jL9e5e36z/1SUm6dy1U=
@@ -133,6 +135,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365 h1:6wSTsvPddg9gc/mVEEyk9oOAoxn+bT4Z9q1zx+4RwA4=
+golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -216,8 +216,6 @@ func (cfg *Config) GeneratedHeader() string {
 	return ""
 }
 
-const DEFAULT_GLOB = "src/**/*.ts"
-
 // options: https://prettier.io/docs/en/options.html
 var defaultArgs = []string{
 	"--trailing-comma", "all",
@@ -226,22 +224,20 @@ var defaultArgs = []string{
 	"--end-of-line", "lf",
 }
 
-func (cfg *Config) GetPrettierArgs() []string {
+func (cfg *Config) GetPrettierArgs(changedFiles []string) []string {
 	if cfg.config == nil || cfg.config.Codegen == nil || cfg.config.Codegen.Prettier == nil {
 		// defaults
-		return append(defaultArgs, "--write", DEFAULT_GLOB)
+		res := append(defaultArgs, "--write")
+		res = append(res, changedFiles...)
+		return res
 	}
 
 	prettier := cfg.config.Codegen.Prettier
-	glob := DEFAULT_GLOB
-	if prettier.Glob != "" {
-		glob = prettier.Glob
-	}
 	if prettier.Custom {
-		return []string{"--write", glob}
+		return append([]string{"--write"}, changedFiles...)
 	}
 
-	return append(defaultArgs, "--write", glob)
+	return append(defaultArgs, "--write")
 }
 
 // ImportPackage refers to TypeScript paths of what needs to be generated for imports
@@ -311,6 +307,5 @@ type PrivacyConfig struct {
 }
 
 type PrettierConfig struct {
-	Custom bool   `yaml:"custom"`
-	Glob   string `yaml:"glob"`
+	Custom bool `yaml:"custom"`
 }

--- a/internal/file/options.go
+++ b/internal/file/options.go
@@ -1,0 +1,41 @@
+package file
+
+// Options provides a way to configure the file writing process as needed
+// TODO: maybe move things like createDirIfNeeded to here?
+type Options struct {
+	writeOnce  bool
+	disableLog bool
+	tempFile   bool
+}
+
+// WriteOnce specifes that writing to path provided should not occur if the file already exists
+// This is usually configured via code
+func WriteOnce() func(opt *Options) {
+	return func(opt *Options) {
+		opt.writeOnce = true
+	}
+}
+
+// WriteOnceMaybe takes a flag (usually provided via user action) and determines if we should add
+// the writeOnce flag to Options
+func WriteOnceMaybe(forceOverwrite bool) func(opt *Options) {
+	if forceOverwrite {
+		return nil
+	}
+	return WriteOnce()
+}
+
+// DisableLog disables the log that the file was written
+func DisableLog() func(opt *Options) {
+	return func(opt *Options) {
+		opt.disableLog = true
+	}
+}
+
+// TempFile flags a file as temporary so that we don't attempt to do any processing
+// on it after the fact e.g. prettier
+func TempFile() func(opt *Options) {
+	return func(opt *Options) {
+		opt.tempFile = true
+	}
+}

--- a/internal/file/writer.go
+++ b/internal/file/writer.go
@@ -48,6 +48,8 @@ func writeFile(w Writer, cfg *codegen.Config, opts ...func(opt *Options)) error 
 		}
 	}
 	b, err := w.generateBytes()
+	// check nil...
+	// if nil returned, nothing to do
 	if err != nil {
 		return err
 	}

--- a/internal/file/writer.go
+++ b/internal/file/writer.go
@@ -93,8 +93,6 @@ func writeFile(w Writer, cfg *codegen.Config, opts ...func(opt *Options)) error 
 		fileInfo: &fileInfo,
 		err:      err,
 	})
-	// check nil...
-	// if nil returned, nothing to do
 	if err != nil {
 		return err
 	}

--- a/internal/file/writer.go
+++ b/internal/file/writer.go
@@ -11,11 +11,16 @@ import (
 	"github.com/lolopinto/ent/internal/codegen"
 )
 
+type statInfo struct {
+	fileInfo *os.FileInfo
+	err      error
+}
+
 type Writer interface {
 	Write(opts ...func(opt *Options)) error
 	createDirIfNeeded() bool
 	getPathToFile() string
-	generateBytes() ([]byte, error)
+	generateBytes(opt *Options, si *statInfo) ([]byte, error)
 }
 
 func debugLogInfo(opt *Options, str string, a ...interface{}) {
@@ -47,12 +52,6 @@ func writeFile(w Writer, cfg *codegen.Config, opts ...func(opt *Options)) error 
 			fmt.Printf("WARN: file %s which is being written once has generated in the name...\n", pathToFile)
 		}
 	}
-	b, err := w.generateBytes()
-	// check nil...
-	// if nil returned, nothing to do
-	if err != nil {
-		return err
-	}
 
 	fullPath := pathToFile
 	if w.createDirIfNeeded() {
@@ -77,8 +76,9 @@ func writeFile(w Writer, cfg *codegen.Config, opts ...func(opt *Options)) error 
 		}
 	}
 
+	fileInfo, err := os.Stat(pathToFile)
+	// if write once and file already exists, nothing to do here, we're done
 	if option.writeOnce {
-		_, err := os.Stat(pathToFile)
 		if err == nil {
 			debugLogInfo(option, "file %s already exists so not writing", pathToFile)
 			return nil
@@ -89,6 +89,25 @@ func writeFile(w Writer, cfg *codegen.Config, opts ...func(opt *Options)) error 
 		}
 	}
 
+	b, err := w.generateBytes(option, &statInfo{
+		fileInfo: &fileInfo,
+		err:      err,
+	})
+	// check nil...
+	// if nil returned, nothing to do
+	if err != nil {
+		return err
+	}
+
+	if b == nil {
+		// nothing to do here
+		return nil
+	}
+
+	if !option.tempFile && strings.HasSuffix(fullPath, ".ts") {
+		codegen.AddChangedFile(fullPath)
+	}
+
 	err = ioutil.WriteFile(fullPath, b, 0666)
 	if !option.disableLog {
 		if err == nil {
@@ -96,37 +115,6 @@ func writeFile(w Writer, cfg *codegen.Config, opts ...func(opt *Options)) error 
 		}
 	}
 	return err
-}
-
-// Options provides a way to configure the file writing process as needed
-// TODO: maybe move things like createDirIfNeeded to here?
-type Options struct {
-	writeOnce  bool
-	disableLog bool
-}
-
-// WriteOnce specifes that writing to path provided should not occur if the file already exists
-// This is usually configured via code
-func WriteOnce() func(opt *Options) {
-	return func(opt *Options) {
-		opt.writeOnce = true
-	}
-}
-
-// WriteOnceMaybe takes a flag (usually provided via user action) and determines if we should add
-// the writeOnce flag to Options
-func WriteOnceMaybe(forceOverwrite bool) func(opt *Options) {
-	if forceOverwrite {
-		return nil
-	}
-	return WriteOnce()
-}
-
-// DisableLog disables the log that the file was written
-func DisableLog() func(opt *Options) {
-	return func(opt *Options) {
-		opt.disableLog = true
-	}
 }
 
 func Write(w Writer, opts ...func(opt *Options)) error {

--- a/internal/file/yaml_file_writer.go
+++ b/internal/file/yaml_file_writer.go
@@ -20,7 +20,7 @@ func (fw *YamlFileWriter) getPathToFile() string {
 	return fw.PathToFile
 }
 
-func (fw *YamlFileWriter) generateBytes() ([]byte, error) {
+func (fw *YamlFileWriter) generateBytes(opt *Options, si *statInfo) ([]byte, error) {
 	return yaml.Marshal(fw.Data)
 }
 

--- a/internal/filehelper/parse.go
+++ b/internal/filehelper/parse.go
@@ -1,0 +1,43 @@
+package filehelper
+
+import (
+	"io/ioutil"
+	"path/filepath"
+)
+
+type Result struct {
+	Bytes  []byte
+	Error  error
+	Suffix string
+}
+
+func FindAndRead(start, needle string) *Result {
+	curDir := start
+	suffix := ""
+
+	for {
+		b, err := ioutil.ReadFile(filepath.Join(curDir, "/", needle))
+		if err == nil {
+			return &Result{
+				Bytes:  b,
+				Suffix: suffix,
+			}
+		}
+
+		suffix = "/" + filepath.Base(curDir) + suffix
+		// go up one directory
+		curDir, err = filepath.Abs(filepath.Join(curDir, ".."))
+		if err != nil {
+			return &Result{
+				Error: err,
+			}
+		}
+
+		// got all the way to the top. bye felicia
+		if curDir == "/" {
+			break
+		}
+	}
+
+	return &Result{}
+}

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -2561,5 +2561,6 @@ func writeSchemaFile(cfg *codegen.Config, fileToWrite string, hasMutations bool)
 			CreateDirIfNeeded: true,
 		},
 		file.DisableLog(),
+		file.TempFile(),
 	)
 }

--- a/ts/src/core/config.ts
+++ b/ts/src/core/config.ts
@@ -59,8 +59,6 @@ interface PrettierConfig {
   // indicates you have your own custom prettier configuration and should use that instead of the ent default
   // https://prettier.io/docs/en/configuration.html
   custom?: boolean;
-  // default glob is 'src/**/*.ts', can override this
-  glob?: string;
 }
 
 interface PrivacyConfig {


### PR DESCRIPTION
right now, we overwrite files during codegen even if nothing has changed. we then have to run prettier on large swaths of code which is very slow on non-arm64 builds

this improves that by doing the following things: 
* when a file is to be written once, we skip generating everything if the file already exists on disk
* we use [esbuild](https://github.com/evanw/esbuild)'s API to compare the minified version of the new code with the minified version what exists on disk and skip writing if nothing's changed
* we keep track of changed TS files (if any) and pass that to prettier to only format the files which have changed

this leads to a noticeable performance improvement on non-arm64 builds (e.g. on an AWS devserver). we're doing even more I/O which isn't cheap so there's still lots of improvement that can be made here e.g. keeping a state of the schema and only running codegen when schema changes or when dependencies change but that adds more complexity that we wanna skip for now

combined with https://github.com/lolopinto/ent/pull/638, already seeing huge improvements in codegen

part of addressing #595

next is tackling https://github.com/lolopinto/ent/issues/452