### PR TITLE
node 17 support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x]
+        node-version: [14.x, 16.x, 17.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -20,15 +20,15 @@ import (
 const TAG = "0.0.31"
 
 // current node gets latest tag...
-const CURRENT_NODE_VERSION = 16
+const CURRENT_NODE_VERSION = 17
 const REPO = "ghcr.io/lolopinto/ent"
 
 const UPDATE_LATEST = true
 
 var NODE_VERSIONS = []int{
 	14,
-	15,
 	16,
+	17,
 }
 
 const AUTO_SCHEMA_VERSION = "0.0.12"

--- a/ts/package.json
+++ b/ts/package.json
@@ -39,7 +39,7 @@
     }
   },
   "engines": {
-    "node": "^16.1.0"
+    "node": ">=14.0"
   },
   "devDependencies": {
     "@alex_neo/jest-expect-message": "^1.0.5",


### PR DESCRIPTION
based on https://medium.com/the-node-js-collection/node-js-17-is-here-8dba1e14e382

https://github.com/nodejs/release

updated current to 17

fixes https://github.com/lolopinto/ent/issues/583

updates engines https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines. it was somehow set to 16.1 even though we support 14+