### PR TITLE
support fieldEdge that's not a foreignKey/inverseEdge and optionally validates that id is of type Foo

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.3.0",
         "@sentry/tracing": "^6.3.0",
-        "@snowtop/ent": "^0.0.30-alpha",
+        "@snowtop/ent": "^0.0.32-alpha",
         "@snowtop/ent-email": "0.0.1",
         "@snowtop/ent-passport": "0.0.1",
         "@snowtop/ent-password": "0.0.1",
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.30-alpha",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.30-alpha.tgz",
-      "integrity": "sha512-TP1lbFk3EfvM59P9owBqWY+rFgEx4h46fB1lUxdQb23PIVN8zi64wRAjZ/gce5KcwCvQFYp1N+4Et08fXiWB5g==",
+      "version": "0.0.32-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.tgz",
+      "integrity": "sha512-/8W5FCqMnNO0hEhuXSJT+/31gWP9HFFW2m+VsEmNqRuMUQO3bDXdNkbufJ94JNlg/xpiF35Otha+f2pAowrZGQ==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -7313,9 +7313,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.30-alpha",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.30-alpha.tgz",
-      "integrity": "sha512-TP1lbFk3EfvM59P9owBqWY+rFgEx4h46fB1lUxdQb23PIVN8zi64wRAjZ/gce5KcwCvQFYp1N+4Et08fXiWB5g==",
+      "version": "0.0.32-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.tgz",
+      "integrity": "sha512-/8W5FCqMnNO0hEhuXSJT+/31gWP9HFFW2m+VsEmNqRuMUQO3bDXdNkbufJ94JNlg/xpiF35Otha+f2pAowrZGQ==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "^6.3.0",
     "@sentry/tracing": "^6.3.0",
-    "@snowtop/ent": "^0.0.30-alpha",
+    "@snowtop/ent": "^0.0.32-alpha",
     "@snowtop/ent-email": "0.0.1",
     "@snowtop/ent-passport": "0.0.1",
     "@snowtop/ent-password": "0.0.1",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.30-alpha",
+        "@snowtop/ent": "^0.0.32-alpha",
         "@snowtop/ent-email": "^0.0.1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.30-alpha",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.30-alpha.tgz",
-      "integrity": "sha512-TP1lbFk3EfvM59P9owBqWY+rFgEx4h46fB1lUxdQb23PIVN8zi64wRAjZ/gce5KcwCvQFYp1N+4Et08fXiWB5g==",
+      "version": "0.0.32-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.tgz",
+      "integrity": "sha512-/8W5FCqMnNO0hEhuXSJT+/31gWP9HFFW2m+VsEmNqRuMUQO3bDXdNkbufJ94JNlg/xpiF35Otha+f2pAowrZGQ==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6947,9 +6947,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.30-alpha",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.30-alpha.tgz",
-      "integrity": "sha512-TP1lbFk3EfvM59P9owBqWY+rFgEx4h46fB1lUxdQb23PIVN8zi64wRAjZ/gce5KcwCvQFYp1N+4Et08fXiWB5g==",
+      "version": "0.0.32-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.tgz",
+      "integrity": "sha512-/8W5FCqMnNO0hEhuXSJT+/31gWP9HFFW2m+VsEmNqRuMUQO3bDXdNkbufJ94JNlg/xpiF35Otha+f2pAowrZGQ==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.30-alpha",
+    "@snowtop/ent": "^0.0.32-alpha",
     "@snowtop/ent-email": "^0.0.1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
+++ b/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
@@ -13,12 +13,12 @@ import {
   saveBuilder,
   saveBuilderX,
 } from "@snowtop/ent/action";
-import { Comment } from "../../..";
+import { Comment, User } from "../../..";
 import { EdgeType, NodeType } from "../../../generated/const";
 import schema from "../../../../schema/comment";
 
 export interface CommentInput {
-  authorID?: ID;
+  authorID?: ID | Builder<User>;
   body?: string;
   articleID?: ID | Builder<Ent>;
   articleType?: string;
@@ -178,7 +178,7 @@ export class CommentBuilder implements Builder<Comment> {
   }
 
   // get value of AuthorID. Retrieves it from the input if specified or takes it from existingEnt
-  getNewAuthorIDValue(): ID | undefined {
+  getNewAuthorIDValue(): ID | Builder<User> | undefined {
     if (this.input.authorID !== undefined) {
       return this.input.authorID;
     }

--- a/examples/simple/src/ent/comment/actions/generated/create_comment_action_base.ts
+++ b/examples/simple/src/ent/comment/actions/generated/create_comment_action_base.ts
@@ -16,11 +16,11 @@ import {
   Changeset,
   WriteOperation,
 } from "@snowtop/ent/action";
-import { Comment } from "../../..";
+import { Comment, User } from "../../..";
 import { CommentBuilder, CommentInput } from "./comment_builder";
 
 export interface CommentCreateInput {
-  authorID: ID;
+  authorID: ID | Builder<User>;
   body: string;
   articleID: ID | Builder<Ent>;
   articleType: string;

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -27,6 +27,7 @@ import {
   ArticleToCommentsQuery,
   CommentToPostQuery,
   NodeType,
+  User,
 } from "../internal";
 import schema from "../../schema/comment";
 
@@ -193,6 +194,14 @@ export class CommentBase {
       this.articleType as unknown as NodeType,
       this.articleID,
     );
+  }
+
+  async loadAuthor(): Promise<User | null> {
+    return loadEnt(this.viewer, this.authorID, User.loaderOptions());
+  }
+
+  loadAuthorX(): Promise<User> {
+    return loadEntX(this.viewer, this.authorID, User.loaderOptions());
   }
 }
 

--- a/examples/simple/src/ent/tests/user.test.ts
+++ b/examples/simple/src/ent/tests/user.test.ts
@@ -836,7 +836,7 @@ test("likes", async () => {
   expect(ents2[0].id).toBe(user1.id);
 });
 
-test("comments", async () => {
+test.only("comments", async () => {
   const [user1, user2] = await Promise.all([create({}), create({})]);
 
   const comment = await CreateCommentAction.create(user2.viewer, {
@@ -845,6 +845,9 @@ test("comments", async () => {
     articleID: user1.id,
     articleType: user1.nodeType,
   }).saveX();
+
+  const author = await comment.loadAuthorX();
+  expect(author.id).toBe(user2.id);
 
   const action = EditUserAction.create(user1.viewer, user1, {});
   // privacy

--- a/examples/simple/src/graphql/generated/schema.gql
+++ b/examples/simple/src/graphql/generated/schema.gql
@@ -81,8 +81,8 @@ type Address implements Node {
 
 type Comment implements Node {
   article: Node
+  author: User
   id: ID!
-  authorID: ID!
   body: String!
   post(first: Int, after: String, last: Int, before: String): CommentToPostConnection!
 }

--- a/examples/simple/src/graphql/resolvers/generated/comment_type.ts
+++ b/examples/simple/src/graphql/resolvers/generated/comment_type.ts
@@ -18,7 +18,7 @@ import {
   nodeIDEncoder,
 } from "@snowtop/ent/graphql";
 import { Comment, CommentToPostQuery } from "../../../ent";
-import { CommentToPostConnectionType } from "../internal";
+import { CommentToPostConnectionType, UserType } from "../internal";
 
 export const CommentType = new GraphQLObjectType({
   name: "Comment",
@@ -29,11 +29,13 @@ export const CommentType = new GraphQLObjectType({
         return comment.loadArticle();
       },
     },
-    id: {
-      type: GraphQLNonNull(GraphQLID),
-      resolve: nodeIDEncoder,
+    author: {
+      type: UserType,
+      resolve: (comment: Comment, args: {}, context: RequestContext) => {
+        return comment.loadAuthor();
+      },
     },
-    authorID: {
+    id: {
       type: GraphQLNonNull(GraphQLID),
       resolve: nodeIDEncoder,
     },

--- a/examples/simple/src/schema/comment.ts
+++ b/examples/simple/src/schema/comment.ts
@@ -10,7 +10,8 @@ import {
 
 export default class Comment extends BaseEntSchema implements Schema {
   fields: Field[] = [
-    UUIDType({ name: "AuthorID" }),
+    // don't want a foreign key but want to type the User
+    UUIDType({ name: "AuthorID", fieldEdge: { schema: "User" } }),
     StringType({ name: "Body" }),
     // should be postID but don't want to conflict with existing post edge
     UUIDType({ name: "ArticleID", polymorphic: true, index: true }),

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.30-alpha",
+        "@snowtop/ent": "^0.0.32-alpha",
         "@snowtop/ent-phonenumber": "^0.0.1",
         "@types/node": "^15.0.3",
         "@types/pg": "^8.6.1",
@@ -992,9 +992,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.30-alpha",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.30-alpha.tgz",
-      "integrity": "sha512-TP1lbFk3EfvM59P9owBqWY+rFgEx4h46fB1lUxdQb23PIVN8zi64wRAjZ/gce5KcwCvQFYp1N+4Et08fXiWB5g==",
+      "version": "0.0.32-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.tgz",
+      "integrity": "sha512-/8W5FCqMnNO0hEhuXSJT+/31gWP9HFFW2m+VsEmNqRuMUQO3bDXdNkbufJ94JNlg/xpiF35Otha+f2pAowrZGQ==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -7279,9 +7279,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.30-alpha",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.30-alpha.tgz",
-      "integrity": "sha512-TP1lbFk3EfvM59P9owBqWY+rFgEx4h46fB1lUxdQb23PIVN8zi64wRAjZ/gce5KcwCvQFYp1N+4Et08fXiWB5g==",
+      "version": "0.0.32-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.tgz",
+      "integrity": "sha512-/8W5FCqMnNO0hEhuXSJT+/31gWP9HFFW2m+VsEmNqRuMUQO3bDXdNkbufJ94JNlg/xpiF35Otha+f2pAowrZGQ==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -35,7 +35,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.30-alpha",
+    "@snowtop/ent": "^0.0.32-alpha",
     "@snowtop/ent-phonenumber": "^0.0.1",
     "@types/node": "^15.0.3",
     "@types/pg": "^8.6.1",

--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -204,6 +204,7 @@ func (e *EdgeInfo) addFieldEdgeFromInfo(fieldName, configName, inverseEdgeName s
 	// well this is dumb
 	// not an id field, do nothing
 	// TODO we need a test for this
+	// TODO #674
 	if !strings.HasSuffix(fieldName, "ID") && !strings.HasSuffix(fieldName, "id") {
 		return nil
 	}

--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -387,7 +387,6 @@ func (f *Field) EvolvedIDField() bool {
 }
 
 func (f *Field) QueryFromEnt() bool {
-	// TODO #476
 	return f.index && f.polymorphic != nil
 }
 
@@ -402,7 +401,6 @@ func (f *Field) QueryFromEntName() string {
 
 // TODO probably gonna collapse into above
 func (f *Field) QueryFrom() bool {
-	// TODO #476
 	if !f.index || f.polymorphic != nil {
 		return false
 	}
@@ -616,6 +614,9 @@ func (f *Field) EmbeddableInParentAction() bool {
 		return false
 	}
 
+	// TODO this is false if it's not the primary field?
+	// this should be changed
+	// https://github.com/lolopinto/ent/issues/677
 	if f.EvolvedIDField() {
 		return false
 	}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.31",
+  "version": "0.0.32-alpha",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -30,6 +30,7 @@ export interface Builder<T extends Ent> {
   build(): Promise<Changeset<T>>;
   operation: WriteOperation;
   editedEnt?(): Promise<T | null>;
+  //  nodeType: string;
 }
 
 // NB: this is a private API subject to change

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -595,15 +595,20 @@ export class Orchestrator<T extends Ent> {
         throw new Error(`required field ${field.name} not set`);
       }
     } else if (this.isBuilder(value)) {
-      let builder = value;
+      if (field.valid) {
+        const valid = await Promise.resolve(field.valid(value));
+        if (!valid) {
+          throw new Error(`invalid field ${field.name} with value ${value}`);
+        }
+      }
       // keep track of dependencies to resolve
-      this.dependencies.set(builder.placeholderID, builder);
+      this.dependencies.set(value.placeholderID, value);
       // keep track of fields to resolve
       this.fieldsToResolve.push(dbKey);
     } else {
       if (field.valid) {
         // TODO this could be async. handle this better
-        let valid = await Promise.resolve(field.valid(value));
+        const valid = await Promise.resolve(field.valid(value));
         if (!valid) {
           throw new Error(`invalid field ${field.name} with value ${value}`);
         }

--- a/ts/src/schema/base_schema.ts
+++ b/ts/src/schema/base_schema.ts
@@ -39,7 +39,7 @@ let nodeField = UUIDType({
   },
 });
 
-let nodeFields: Field[] = [nodeField].concat(tsFields);
+let nodeFields: Field[] = [nodeField, ...tsFields];
 
 let nodeFieldsWithTZ: Field[] = [
   nodeField,

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -1,4 +1,4 @@
-import { Data, Ent } from "../core/base";
+import { Data, Ent, LoadEntOptions } from "../core/base";
 import { Builder } from "../action/action";
 
 // Schema is the base for every schema in typescript
@@ -213,9 +213,18 @@ export interface ForeignKey {
   disableIndex?: boolean;
 }
 
+type loadRowFn = (type: string) => LoadEntOptions<Ent>;
+
 export interface FieldEdge {
   schema: string;
-  inverseEdge: string;
+  // inverseEdge is optional. if present, indicates it maps to an edge in the other schema
+  inverseEdge?: string;
+
+  // if enforceSchema. implement the valid type.
+  // we use loadRowByType to do it
+  enforceSchema?: boolean;
+  // we only need the loaderfactory but have the entire thing just because
+  loadRowByType?: loadRowFn;
 }
 
 // FieldOptions are configurable options for fields.
@@ -267,7 +276,7 @@ export interface Field extends FieldOptions {
   type: Type;
 
   // optional valid and format to validate and format before storing
-  valid?(val: any): boolean;
+  valid?(val: any): Promise<boolean> | boolean;
   //valid?(val: any): Promise<boolean>;
   format?(val: any): any;
 

--- a/ts/src/schema/uuid_field.test.ts
+++ b/ts/src/schema/uuid_field.test.ts
@@ -1,5 +1,14 @@
-import { UUIDType } from "./field";
+import { UUIDType, StringType } from "./field";
 import { DBType, PolymorphicOptions, Type, FieldOptions } from "./schema";
+import Schema, { Field } from "./schema";
+import { BaseEntSchema } from "./base_schema";
+import { User, SimpleAction } from "../testutils/builder";
+import { LoggedOutViewer } from "../core/viewer";
+import { Pool } from "pg";
+import { QueryRecorder } from "../testutils/db_mock";
+import { ObjectLoaderFactory } from "../core/loaders/object_loader";
+jest.mock("pg");
+QueryRecorder.mockPool(Pool);
 
 test("polymorphic true", () => {
   doTest(true, {
@@ -59,3 +68,228 @@ function doTest(
   expect(derived.type).toStrictEqual(expDerivedType);
   expect(derived.nullable).toBe(opts?.nullable);
 }
+
+describe("fieldEdge no inverseEdge", () => {
+  test("no checks", async () => {
+    class UserSchema extends BaseEntSchema {
+      fields: Field[] = [StringType({ name: "Name" })];
+      ent = User;
+    }
+
+    class Account extends User {}
+    class AccountSchema extends BaseEntSchema {
+      fields: Field[] = [
+        UUIDType({ name: "userID", fieldEdge: { schema: "User" } }),
+      ];
+      ent = Account;
+    }
+
+    const userAction = new SimpleAction(
+      new LoggedOutViewer(),
+      new UserSchema(),
+      new Map<string, any>([["Name", "Jon Snow"]]),
+    );
+    const action = new SimpleAction(
+      new LoggedOutViewer(),
+      new AccountSchema(),
+      new Map<string, any>([["userID", userAction.builder]]),
+    );
+    action.triggers = [
+      {
+        changeset() {
+          return userAction.changeset();
+        },
+      },
+    ];
+
+    const account = await action.saveX();
+    const user = await userAction.editedEntX();
+    expect(user.data.name).toBe("Jon Snow");
+    expect(account.data.user_id).toBe(user.id);
+  });
+
+  test("enforce checks with builder", async () => {
+    class UserSchema extends BaseEntSchema {
+      fields: Field[] = [StringType({ name: "Name" })];
+      ent = User;
+    }
+
+    class Account extends User {}
+    class AccountSchema extends BaseEntSchema {
+      fields: Field[] = [
+        UUIDType({
+          name: "userID",
+          fieldEdge: {
+            schema: "User",
+            enforceSchema: true,
+            loadRowByType: () => {
+              return {
+                tableName: "users",
+                fields: ["id"],
+                ent: User,
+                loaderFactory: new ObjectLoaderFactory({
+                  tableName: "users",
+                  fields: ["id"],
+                  key: "id",
+                }),
+              };
+            },
+          },
+        }),
+      ];
+      ent = Account;
+    }
+
+    const userAction = new SimpleAction(
+      new LoggedOutViewer(),
+      new UserSchema(),
+      new Map<string, any>([["Name", "Jon Snow"]]),
+    );
+    const action = new SimpleAction(
+      new LoggedOutViewer(),
+      new AccountSchema(),
+      new Map<string, any>([["userID", userAction.builder]]),
+    );
+    action.triggers = [
+      {
+        changeset() {
+          return userAction.changeset();
+        },
+      },
+    ];
+
+    const account = await action.saveX();
+    const user = await userAction.editedEntX();
+    expect(user.data.name).toBe("Jon Snow");
+    expect(account.data.user_id).toBe(user.id);
+  });
+
+  test("enforce checks with builder. invalid builder", async () => {
+    class UserSchema extends BaseEntSchema {
+      fields: Field[] = [StringType({ name: "Name" })];
+      ent = User;
+    }
+
+    class Account extends User {}
+    class AccountSchema extends BaseEntSchema {
+      fields: Field[] = [
+        UUIDType({
+          name: "userID",
+          fieldEdge: {
+            schema: "User",
+            enforceSchema: true,
+            loadRowByType: () => {
+              return {
+                tableName: "users",
+                fields: ["id"],
+                ent: User,
+                loaderFactory: new ObjectLoaderFactory({
+                  tableName: "users",
+                  fields: ["id"],
+                  key: "id",
+                }),
+              };
+            },
+          },
+        }),
+      ];
+      ent = Account;
+    }
+
+    const userAction = new SimpleAction(
+      new LoggedOutViewer(),
+      new UserSchema(),
+      new Map<string, any>([["Name", "Jon Snow"]]),
+    );
+    const user = await userAction.saveX();
+    expect(user.data.name).toBe("Jon Snow");
+
+    // action2 valid
+    const action2 = new SimpleAction(
+      new LoggedOutViewer(),
+      new AccountSchema(),
+      new Map<string, any>([["userID", user.id]]),
+    );
+
+    // action3 invalid
+    const action3 = new SimpleAction(
+      new LoggedOutViewer(),
+      new AccountSchema(),
+      new Map<string, any>([["userID", action2]]),
+    );
+
+    try {
+      await action3.saveX();
+      throw new Error(`should have thrown`);
+    } catch (err) {
+      expect((err as Error).message).toMatch(
+        /invalid field userID with value (.+)/,
+      );
+    }
+  });
+
+  test("enforce checks no builder", async () => {
+    class UserSchema extends BaseEntSchema {
+      fields: Field[] = [StringType({ name: "Name" })];
+      ent = User;
+    }
+
+    class Account extends User {}
+    class AccountSchema extends BaseEntSchema {
+      fields: Field[] = [
+        UUIDType({
+          name: "userID",
+          fieldEdge: {
+            schema: "User",
+            enforceSchema: true,
+            loadRowByType: () => {
+              return {
+                tableName: "users",
+                fields: ["id"],
+                ent: User,
+                loaderFactory: new ObjectLoaderFactory({
+                  tableName: "users",
+                  fields: ["id"],
+                  key: "id",
+                }),
+              };
+            },
+          },
+        }),
+      ];
+      ent = Account;
+    }
+
+    const userAction = new SimpleAction(
+      new LoggedOutViewer(),
+      new UserSchema(),
+      new Map<string, any>([["Name", "Jon Snow"]]),
+    );
+    const user = await userAction.saveX();
+    expect(user.data.name).toBe("Jon Snow");
+
+    const action = new SimpleAction(
+      new LoggedOutViewer(),
+      new AccountSchema(),
+      new Map<string, any>([["userID", user.id]]),
+    );
+
+    const account = await action.saveX();
+    expect(account.data.user_id).toBe(user.id);
+
+    const action2 = new SimpleAction(
+      new LoggedOutViewer(),
+      new AccountSchema(),
+      new Map<string, any>([["userID", account.id]]),
+    );
+
+    try {
+      await action2.saveX();
+      throw new Error(`should have thrown`);
+    } catch (err) {
+      expect((err as Error).message).toMatch(
+        /invalid field userID with value (.+)/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
https://github.com/lolopinto/ent/issues/476


```ts title='src/schema/comment.ts'
export default class Comment extends BaseEntSchema implements Schema {
  fields: Field[] = [
    // don't want a foreign key but want to type the User
    UUIDType({ name: "AuthorID", fieldEdge: { schema: "User" } }),
  ];
}
```

generates 

```ts title='src/ent/generated/comment_base.ts'
class CommentBase {
... 
  async loadAuthor(): Promise<User | null> {
    return loadEnt(this.viewer, this.authorID, User.loaderOptions());
  }

  loadAuthorX(): Promise<User> {
    return loadEntX(this.viewer, this.authorID, User.loaderOptions());
  }
}
```

and to enforce the type, update to 

```ts title='src/schema/comment.ts'
export default class Comment extends BaseEntSchema implements Schema {
  fields: Field[] = [
    // don't want a foreign key but want to type the User
    UUIDType({ name: "AuthorID", fieldEdge: { schema: "User", enforceSchema: true, loadRowByType: getLoaderOptions } }),
  ];
}
```