### PR TITLE
change embedded fields in action logic

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.3.0",
         "@sentry/tracing": "^6.3.0",
-        "@snowtop/ent": "^0.0.32-alpha.2",
+        "@snowtop/ent": "^0.0.32-alpha.10",
         "@snowtop/ent-email": "0.0.1",
         "@snowtop/ent-passport": "0.0.1",
         "@snowtop/ent-password": "0.0.1",
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.32-alpha.2",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.2.tgz",
-      "integrity": "sha512-VT0LS5wLlkzmZneVOE+m1dOEwNfxebj2gOYai1d9xikJ1s7rHLu1y9reqDV4qR6QI6VEMgvzf63DPqH0Vyx5vQ==",
+      "version": "0.0.32-alpha.10",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.10.tgz",
+      "integrity": "sha512-8e7lopu6p2PaVrcygXYsGpowGGp5X9o/E427QvKPvHZrHpqemTh3mTvqPnmnMCe+xmBcqth932uY0QBsBIrXkA==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -7313,9 +7313,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.32-alpha.2",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.2.tgz",
-      "integrity": "sha512-VT0LS5wLlkzmZneVOE+m1dOEwNfxebj2gOYai1d9xikJ1s7rHLu1y9reqDV4qR6QI6VEMgvzf63DPqH0Vyx5vQ==",
+      "version": "0.0.32-alpha.10",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.10.tgz",
+      "integrity": "sha512-8e7lopu6p2PaVrcygXYsGpowGGp5X9o/E427QvKPvHZrHpqemTh3mTvqPnmnMCe+xmBcqth932uY0QBsBIrXkA==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "^6.3.0",
     "@sentry/tracing": "^6.3.0",
-    "@snowtop/ent": "^0.0.32-alpha.2",
+    "@snowtop/ent": "^0.0.32-alpha.10",
     "@snowtop/ent-email": "0.0.1",
     "@snowtop/ent-passport": "0.0.1",
     "@snowtop/ent-password": "0.0.1",

--- a/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
@@ -36,6 +36,7 @@ export class AddressBuilder implements Builder<Address> {
   readonly placeholderID: ID;
   readonly ent = Address;
   private input: AddressInput;
+  private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
@@ -71,6 +72,16 @@ export class AddressBuilder implements Builder<Address> {
       ...this.input,
       ...input,
     };
+  }
+
+  // store data in Builder that can be retrieved by another validator, trigger, observer later in the action
+  storeData(k: string, v: any) {
+    this.m.set(k, v);
+  }
+
+  // retrieve data stored in this Builder with key
+  getStoredData(k: string) {
+    return this.m.get(k);
   }
 
   async build(): Promise<Changeset<Address>> {

--- a/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -33,6 +33,7 @@ export class AuthCodeBuilder implements Builder<AuthCode> {
   readonly placeholderID: ID;
   readonly ent = AuthCode;
   private input: AuthCodeInput;
+  private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
@@ -68,6 +69,16 @@ export class AuthCodeBuilder implements Builder<AuthCode> {
       ...this.input,
       ...input,
     };
+  }
+
+  // store data in Builder that can be retrieved by another validator, trigger, observer later in the action
+  storeData(k: string, v: any) {
+    this.m.set(k, v);
+  }
+
+  // retrieve data stored in this Builder with key
+  getStoredData(k: string) {
+    return this.m.get(k);
   }
 
   async build(): Promise<Changeset<AuthCode>> {

--- a/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
@@ -32,6 +32,7 @@ export class EventBuilder implements Builder<Event> {
   readonly placeholderID: ID;
   readonly ent = Event;
   private input: EventInput;
+  private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
@@ -67,6 +68,16 @@ export class EventBuilder implements Builder<Event> {
       ...this.input,
       ...input,
     };
+  }
+
+  // store data in Builder that can be retrieved by another validator, trigger, observer later in the action
+  storeData(k: string, v: any) {
+    this.m.set(k, v);
+  }
+
+  // retrieve data stored in this Builder with key
+  getStoredData(k: string) {
+    return this.m.get(k);
   }
 
   async build(): Promise<Changeset<Event>> {

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
@@ -37,6 +37,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
   readonly placeholderID: ID;
   readonly ent = EventActivity;
   private input: EventActivityInput;
+  private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
@@ -73,6 +74,16 @@ export class EventActivityBuilder implements Builder<EventActivity> {
       ...this.input,
       ...input,
     };
+  }
+
+  // store data in Builder that can be retrieved by another validator, trigger, observer later in the action
+  storeData(k: string, v: any) {
+    this.m.set(k, v);
+  }
+
+  // retrieve data stored in this Builder with key
+  getStoredData(k: string) {
+    return this.m.get(k);
   }
 
   // this gets the inputs that have been written for a given edgeType and operation

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
@@ -35,6 +35,7 @@ export class GuestBuilder implements Builder<Guest> {
   readonly placeholderID: ID;
   readonly ent = Guest;
   private input: GuestInput;
+  private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
@@ -70,6 +71,16 @@ export class GuestBuilder implements Builder<Guest> {
       ...this.input,
       ...input,
     };
+  }
+
+  // store data in Builder that can be retrieved by another validator, trigger, observer later in the action
+  storeData(k: string, v: any) {
+    this.m.set(k, v);
+  }
+
+  // retrieve data stored in this Builder with key
+  getStoredData(k: string) {
+    return this.m.get(k);
   }
 
   // this gets the inputs that have been written for a given edgeType and operation

--- a/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
@@ -33,6 +33,7 @@ export class GuestDataBuilder implements Builder<GuestData> {
   readonly placeholderID: ID;
   readonly ent = GuestData;
   private input: GuestDataInput;
+  private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
@@ -69,6 +70,16 @@ export class GuestDataBuilder implements Builder<GuestData> {
       ...this.input,
       ...input,
     };
+  }
+
+  // store data in Builder that can be retrieved by another validator, trigger, observer later in the action
+  storeData(k: string, v: any) {
+    this.m.set(k, v);
+  }
+
+  // retrieve data stored in this Builder with key
+  getStoredData(k: string) {
+    return this.m.get(k);
   }
 
   async build(): Promise<Changeset<GuestData>> {

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
@@ -32,6 +32,7 @@ export class GuestGroupBuilder implements Builder<GuestGroup> {
   readonly placeholderID: ID;
   readonly ent = GuestGroup;
   private input: GuestGroupInput;
+  private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
@@ -68,6 +69,16 @@ export class GuestGroupBuilder implements Builder<GuestGroup> {
       ...this.input,
       ...input,
     };
+  }
+
+  // store data in Builder that can be retrieved by another validator, trigger, observer later in the action
+  storeData(k: string, v: any) {
+    this.m.set(k, v);
+  }
+
+  // retrieve data stored in this Builder with key
+  getStoredData(k: string) {
+    return this.m.get(k);
   }
 
   // this gets the inputs that have been written for a given edgeType and operation

--- a/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
@@ -33,6 +33,7 @@ export class UserBuilder implements Builder<User> {
   readonly placeholderID: ID;
   readonly ent = User;
   private input: UserInput;
+  private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
@@ -68,6 +69,16 @@ export class UserBuilder implements Builder<User> {
       ...this.input,
       ...input,
     };
+  }
+
+  // store data in Builder that can be retrieved by another validator, trigger, observer later in the action
+  storeData(k: string, v: any) {
+    this.m.set(k, v);
+  }
+
+  // retrieve data stored in this Builder with key
+  getStoredData(k: string) {
+    return this.m.get(k);
   }
 
   async build(): Promise<Changeset<User>> {

--- a/examples/ent-rsvp/backend/src/graphql/mutations/generated/address/address_edit_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/mutations/generated/address/address_edit_type.ts
@@ -12,7 +12,10 @@ import {
   GraphQLString,
 } from "graphql";
 import { RequestContext } from "@snowtop/ent";
-import { mustDecodeIDFromGQLID } from "@snowtop/ent/graphql";
+import {
+  mustDecodeIDFromGQLID,
+  mustDecodeNullableIDFromGQLID,
+} from "@snowtop/ent/graphql";
 import { Address } from "src/ent/";
 import EditAddressAction, {
   AddressEditInput,
@@ -21,7 +24,7 @@ import { AddressType } from "src/graphql/resolvers/";
 
 interface customAddressEditInput extends AddressEditInput {
   addressID: string;
-  ownerID: string;
+  ownerID?: string;
 }
 
 interface AddressEditPayload {
@@ -95,6 +98,8 @@ export const AddressEditType: GraphQLFieldConfig<
         state: input.state,
         zipCode: input.zipCode,
         apartment: input.apartment,
+        ownerID: mustDecodeNullableIDFromGQLID(input.ownerID),
+        ownerType: input.ownerType,
       },
     );
     return { address: address };

--- a/examples/ent-rsvp/backend/src/graphql/mutations/generated/event_activity/event_activity_edit_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/mutations/generated/event_activity/event_activity_edit_type.ts
@@ -13,7 +13,11 @@ import {
   GraphQLString,
 } from "graphql";
 import { RequestContext } from "@snowtop/ent";
-import { GraphQLTime, mustDecodeIDFromGQLID } from "@snowtop/ent/graphql";
+import {
+  GraphQLTime,
+  mustDecodeIDFromGQLID,
+  mustDecodeNullableIDFromGQLID,
+} from "@snowtop/ent/graphql";
 import { EventActivity } from "src/ent/";
 import EditEventActivityAction, {
   EventActivityEditInput,
@@ -22,7 +26,7 @@ import { EventActivityType } from "src/graphql/resolvers/";
 
 interface customEventActivityEditInput extends EventActivityEditInput {
   eventActivityID: string;
-  eventID: string;
+  eventID?: string;
 }
 
 interface EventActivityEditPayload {
@@ -95,6 +99,7 @@ export const EventActivityEditType: GraphQLFieldConfig<
       mustDecodeIDFromGQLID(input.eventActivityID),
       {
         name: input.name,
+        eventID: mustDecodeNullableIDFromGQLID(input.eventID),
         startTime: input.startTime,
         endTime: input.endTime,
         location: input.location,

--- a/examples/ent-rsvp/backend/src/schema/event.ts
+++ b/examples/ent-rsvp/backend/src/schema/event.ts
@@ -30,6 +30,7 @@ export default class Event extends BaseEntSchema {
           nullable: true,
           type: "Object",
           actionName: "CreateEventActivityAction",
+          excludedFields: ["eventID"],
         },
       ],
     },

--- a/examples/ent-rsvp/backend/src/schema/event_activity.ts
+++ b/examples/ent-rsvp/backend/src/schema/event_activity.ts
@@ -34,6 +34,7 @@ export default class EventActivity extends BaseEntSchema {
           type: "Object",
           nullable: true,
           actionName: "CreateAddressAction",
+          excludedFields: ["OwnerID"],
         },
       ],
     },

--- a/examples/ent-rsvp/backend/src/schema/guest_group.ts
+++ b/examples/ent-rsvp/backend/src/schema/guest_group.ts
@@ -26,6 +26,7 @@ export default class GuestGroup extends BaseEntSchema {
           nullable: true,
           type: "Object",
           actionName: "CreateGuestAction",
+          excludedFields: ["eventID", "guestGroupID"],
         },
       ],
     },

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.32-alpha.9",
+        "@snowtop/ent": "^0.0.32-alpha.10",
         "@snowtop/ent-email": "^0.0.1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.32-alpha.9",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.9.tgz",
-      "integrity": "sha512-Ts+v6ktf9SobxdbR7REx0DQ58UH+Yx54OE92Azk00/BO/N0rgfF3oNwCsiHGfzoHuKBlE7qPaiUYArArkdwM/g==",
+      "version": "0.0.32-alpha.10",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.10.tgz",
+      "integrity": "sha512-8e7lopu6p2PaVrcygXYsGpowGGp5X9o/E427QvKPvHZrHpqemTh3mTvqPnmnMCe+xmBcqth932uY0QBsBIrXkA==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6941,9 +6941,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.32-alpha.9",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.9.tgz",
-      "integrity": "sha512-Ts+v6ktf9SobxdbR7REx0DQ58UH+Yx54OE92Azk00/BO/N0rgfF3oNwCsiHGfzoHuKBlE7qPaiUYArArkdwM/g==",
+      "version": "0.0.32-alpha.10",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.32-alpha.10.tgz",
+      "integrity": "sha512-8e7lopu6p2PaVrcygXYsGpowGGp5X9o/E427QvKPvHZrHpqemTh3mTvqPnmnMCe+xmBcqth932uY0QBsBIrXkA==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.32-alpha.9",
+    "@snowtop/ent": "^0.0.32-alpha.10",
     "@snowtop/ent-email": "^0.0.1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/src/schema/contact.ts
+++ b/examples/simple/src/schema/contact.ts
@@ -44,6 +44,7 @@ export default class Contact extends BaseEntSchema implements Schema {
           nullable: true,
           type: "Object",
           actionName: "CreateContactEmailAction",
+          excludedFields: ["contactID"],
         },
         {
           name: "phoneNumbers",
@@ -51,6 +52,7 @@ export default class Contact extends BaseEntSchema implements Schema {
           nullable: true,
           type: "Object",
           actionName: "CreateContactPhoneNumberAction",
+          excludedFields: ["contactID"],
         },
       ],
     },

--- a/internal/enttype/type.go
+++ b/internal/enttype/type.go
@@ -81,9 +81,14 @@ type convertListElemType interface {
 	convertNullableListWithItem() FileImport
 }
 
+type ActionFieldsInfo struct {
+	ActionName     string
+	ExcludedFields []string
+}
+
 type TSTypeWithActionFields interface {
 	TSGraphQLType
-	GetActionName() string
+	GetActionFieldsInfo() *ActionFieldsInfo
 }
 
 type ImportDepsType interface {
@@ -994,9 +999,10 @@ func (t *NullableTimetzType) GetImportType() Import {
 
 // public for tests
 type CommonObjectType struct {
-	TSType      string
-	GraphQLType string
-	ActionName  string
+	TSType         string
+	GraphQLType    string
+	ActionName     string
+	ExcludedFields []string
 }
 
 func (t *CommonObjectType) GetDBType() string {
@@ -1011,8 +1017,11 @@ func (t *CommonObjectType) GetCastToMethod() string {
 	panic("GetCastToMethod doesn't apply for objectType")
 }
 
-func (t *CommonObjectType) GetActionName() string {
-	return t.ActionName
+func (t *CommonObjectType) GetActionFieldsInfo() *ActionFieldsInfo {
+	return &ActionFieldsInfo{
+		ActionName:     t.ActionName,
+		ExcludedFields: t.ExcludedFields,
+	}
 }
 
 type ObjectType struct {
@@ -1121,12 +1130,12 @@ func (t *ListWrapperType) GetTSGraphQLImports() []FileImport {
 	return ret
 }
 
-func (t *ListWrapperType) GetActionName() string {
+func (t *ListWrapperType) GetActionFieldsInfo() *ActionFieldsInfo {
 	t2, ok := t.Type.(TSTypeWithActionFields)
 	if !ok {
-		return ""
+		return nil
 	}
-	return t2.GetActionName()
+	return t2.GetActionFieldsInfo()
 }
 
 type typeConfig struct {

--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -631,18 +631,12 @@ func (f *Field) PrimaryKeyIDField() bool {
 }
 
 func (f *Field) EmbeddableInParentAction() bool {
-	if !f.EditableField() {
-		return false
-	}
-
-	// TODO this is false if it's not the primary field?
-	// this should be changed
-	// https://github.com/lolopinto/ent/issues/677
-	if f.EvolvedIDField() {
-		return false
-	}
-
+	// hmm what happens if ownerID field is not excluded...
+	// but ownerType is by default...
 	return !f.derivedWhenEmbedded
+
+	// we could probably also auto-remove fields for which there's a foreignKey to primary key in source
+	// ent or fields which have a fieldEdge to source schema?
 }
 
 type Option func(*Field)

--- a/internal/graphql/graphql_fields_test.go
+++ b/internal/graphql/graphql_fields_test.go
@@ -72,10 +72,10 @@ func TestActionWithFieldEdgeFieldConfig(t *testing.T) {
 
 	verifyFieldsOverlap(t, createAction, editActionCfg)
 
-	createNode := buildActionInputNode(profileCfg.NodeData, createAction, "Profile")
+	createNode := buildActionInputNode(processor, profileCfg.NodeData, createAction, "Profile")
 	assert.Len(t, createNode.Fields, len(createAction.GetFields())+len(createAction.GetNonEntFields()))
 
-	editNode := buildActionInputNode(profileCfg.NodeData, editAction, "Profile")
+	editNode := buildActionInputNode(processor, profileCfg.NodeData, editAction, "Profile")
 	assert.Len(t, editNode.Fields, len(editAction.GetFields())+len(editAction.GetNonEntFields())+1)
 }
 

--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -420,11 +420,12 @@ const NullableContentsAndList NullableItem = "contentsAndList"
 const NullableTrue NullableItem = "true"
 
 type actionField struct {
-	Name       string       `json:"name"`
-	Type       ActionType   `json:"type"`
-	Nullable   NullableItem `json:"nullable"`
-	List       bool         `json:"list"`
-	ActionName string       `json:"actionName"`
+	Name           string       `json:"name"`
+	Type           ActionType   `json:"type"`
+	Nullable       NullableItem `json:"nullable"`
+	List           bool         `json:"list"`
+	ActionName     string       `json:"actionName"`
+	ExcludedFields []string     `json:"excludedFields"`
 }
 
 type ActionField struct {
@@ -434,6 +435,7 @@ type ActionField struct {
 	list             bool
 	nullableContents bool
 	ActionName       string
+	ExcludedFields   []string
 }
 
 func (f *ActionField) UnmarshalJSON(data []byte) error {
@@ -447,6 +449,7 @@ func (f *ActionField) UnmarshalJSON(data []byte) error {
 	f.Name = af.Name
 	f.ActionName = af.ActionName
 	f.Type = af.Type
+	f.ExcludedFields = af.ExcludedFields
 
 	switch af.Nullable {
 	case NullableContentsAndList:
@@ -525,6 +528,7 @@ func (f *ActionField) getEntTypeHelper(inputName string, nullable bool) (enttype
 			typ.TSType = tsType
 			typ.ActionName = f.ActionName
 			typ.GraphQLType = gqlType
+			typ.ExcludedFields = f.ExcludedFields
 
 			return typ, nil
 		}
@@ -532,6 +536,7 @@ func (f *ActionField) getEntTypeHelper(inputName string, nullable bool) (enttype
 		typ.TSType = tsType
 		typ.GraphQLType = gqlType
 		typ.ActionName = f.ActionName
+		typ.ExcludedFields = f.ExcludedFields
 		return typ, nil
 	}
 	return nil, fmt.Errorf("unsupported type %s", f.Type)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -926,9 +926,14 @@ func (s *Schema) addActionFields(info *NodeDataInfo) error {
 			if !ok {
 				continue
 			}
-			actionName := t.GetActionName()
-			if actionName == "" {
+			actionFieldsInfo := t.GetActionFieldsInfo()
+			if actionFieldsInfo == nil || actionFieldsInfo.ActionName == "" {
 				continue
+			}
+			actionName := actionFieldsInfo.ActionName
+			excludedFields := make(map[string]bool)
+			for _, v := range actionFieldsInfo.ExcludedFields {
+				excludedFields[v] = true
 			}
 
 			foundAction := false
@@ -944,7 +949,7 @@ func (s *Schema) addActionFields(info *NodeDataInfo) error {
 				foundAction = true
 
 				for _, f2 := range a2.GetFields() {
-					if f2.EmbeddableInParentAction() {
+					if f2.EmbeddableInParentAction() && !excludedFields[f2.FieldName] {
 
 						f3 := f2
 						if action.IsRequiredField(a2, f2) {

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.32-alpha.9",
+  "version": "0.0.32-alpha.10",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -393,6 +393,11 @@ export interface ActionField {
   // list of something
   list?: boolean;
   actionName?: string; // take the fields of this action and add them as this. only works with type "Object"
+
+  // if actionName is provided, exclude the following fields from being embedded
+  // either because they can be derived or optional and don't need it
+  // no validation on what can be excluded is done. things will eventually fail if done incorrectly
+  excludedFields?: string[];
 }
 
 // provides a way to configure the actions generated for the ent


### PR DESCRIPTION
when an action's input is embedded in another action like

```
actions: Action[] = [
    {
      operation: ActionOperation.Create,
      excludedFields: ["creatorID"],
      actionOnlyFields: [
        {
          name: "activities",
          list: true,
          nullable: true,
          type: "Object",
          actionName: "CreateEventActivityAction",
        },
      ],
    },
```
see https://github.com/lolopinto/ent/blob/main/examples/ent-rsvp/backend/src/schema/event.ts#L22-L35

the logic of which fields to embed was removing all id fields, it worked for all the examples we had but wouldn't work if we had an object with lots of ids. this fixes that to just depend on the developer to understand the embedded contexts and exclude fields as needed

fixes https://github.com/lolopinto/ent/issues/677