### PR TITLE
new (old) release

### DIFF
--- a/release_image/main.go
+++ b/release_image/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // next tag
-const TAG = "0.0.34"
+const TAG = "0.0.35"
 
 // current node gets latest tag...
 const CURRENT_NODE_VERSION = 17
@@ -26,23 +26,23 @@ const REPO = "ghcr.io/lolopinto/ent"
 const UPDATE_LATEST = true
 
 var NODE_VERSIONS = []int{
-	14,
-	16,
+	// 14,
+	// 16,
 	17,
 }
 
 const AUTO_SCHEMA_VERSION = "0.0.15"
-const TSENT_VERSION = "v0.0.35"
+const TSENT_VERSION = "v0.0.36"
 
 var SUFFIXES = []string{
 	"dev",
-	"slim",
+	//	"slim",
 }
 
 // can change platforms here to test locally
 var PLATFORMS = []string{
 	"linux/amd64",
-	"linux/arm64",
+	//	"linux/arm64",
 }
 
 func main() {

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -26,8 +26,8 @@ const REPO = "ghcr.io/lolopinto/ent"
 const UPDATE_LATEST = true
 
 var NODE_VERSIONS = []int{
-	// 14,
-	// 16,
+	14,
+	16,
 	17,
 }
 
@@ -36,13 +36,13 @@ const TSENT_VERSION = "v0.0.36"
 
 var SUFFIXES = []string{
 	"dev",
-	//	"slim",
+	"slim",
 }
 
 // can change platforms here to test locally
 var PLATFORMS = []string{
 	"linux/amd64",
-	//	"linux/arm64",
+	"linux/arm64",
 }
 
 func main() {


### PR DESCRIPTION
pointing to https://github.com/lolopinto/ent/releases/tag/v0.0.35 and https://github.com/lolopinto/ent/releases/tag/v0.0.36