### PR TITLE
multi-issue fix for #694

### DIFF
--- a/.github/testdata/schema1.json
+++ b/.github/testdata/schema1.json
@@ -1,25 +1,27 @@
 {
-  "User": {
-    "fields":[
-      {
-        "name": "name",
-        "type": {
-          "dbType": "String"
-        }
-      },
-      {
-        "name": "email",
-        "type": {
-          "dbType": "String",
-          "customType": "email"
+  "schemas": {
+    "User": {
+      "fields":[
+        {
+          "name": "name",
+          "type": {
+            "dbType": "String"
+          }
         },
-        "unique":true
-      }
-    ],
-    "actions":[
-      {
-        "operation":8
-      }
-    ]
+        {
+          "name": "email",
+          "type": {
+            "dbType": "String",
+            "customType": "email"
+          },
+          "unique":true
+        }
+      ],
+      "actions":[
+        {
+          "operation":8
+        }
+      ]
+    }
   }
 }

--- a/.github/testdata/schema2.json
+++ b/.github/testdata/schema2.json
@@ -1,34 +1,36 @@
 {
-  "User": {
-    "fields":[
-      {
-        "name": "name",
-        "type": {
-          "dbType": "String"
+  "schemas": {
+    "User": {
+      "fields":[
+        {
+          "name": "name",
+          "type": {
+            "dbType": "String"
+          }
+        },
+        {
+          "name": "email",
+          "type": {
+            "dbType": "String",
+            "customType": "email"
+          },
+          "unique":true
+        },
+        {
+          "name": "phone",
+          "type": {
+            "dbType": "String",
+            "customType": "phone"
+          },
+          "nullable":true,
+          "unique":true
         }
-      },
-      {
-        "name": "email",
-        "type": {
-          "dbType": "String",
-          "customType": "email"
-        },
-        "unique":true
-      },
-      {
-        "name": "phone",
-        "type": {
-          "dbType": "String",
-          "customType": "phone"
-        },
-        "nullable":true,
-        "unique":true
-      }
-    ],
-    "actions":[
-      {
-        "operation":8
-      }
-    ]
+      ],
+      "actions":[
+        {
+          "operation":8
+        }
+      ]
+    }
   }
 }

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,7 @@ jobs:
           # clone ent-starter
           git clone https://github.com/lolopinto/ent-starter.git 
           cd ent-starter
-          npm install --force @snowtop/ent @snowtop/ent-email 
+          npm install @snowtop/ent @snowtop/ent-email 
           mkdir -p src/schema
           cat ../.github/testdata/schema1.json | tsent generate schemas 
           tsent codegen

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,7 @@ jobs:
           # clone ent-starter
           git clone https://github.com/lolopinto/ent-starter.git 
           cd ent-starter
-          npm install @snowtop/ent @snowtop/ent-email 
+          npm install --force @snowtop/ent @snowtop/ent-email 
           mkdir -p src/schema
           cat ../.github/testdata/schema1.json | tsent generate schemas 
           tsent codegen

--- a/internal/action/interface.go
+++ b/internal/action/interface.go
@@ -117,6 +117,15 @@ type CustomInterface struct {
 	NonEntFields []*NonEntField
 	Action       Action
 	// if present, means that this interface should be imported in GraphQL instead...
+
+	enumImports []string
+}
+
+func (ci *CustomInterface) GetEnumImports() []string {
+	// TODO https://github.com/lolopinto/ent/issues/703
+	// if we had the correct imports in TsBuilderImports, we don't need this.
+	// can just reserverImports and skip this.
+	return ci.enumImports
 }
 
 type ActionInfo struct {
@@ -263,6 +272,11 @@ func (action *commonActionInfo) getCustomInterface(typ enttype.TSGraphQLType) *C
 func (action *commonActionInfo) AddCustomField(typ enttype.TSGraphQLType, cf *field.Field) {
 	ci := action.getCustomInterface(typ)
 	ci.Fields = append(ci.Fields, cf)
+	enumType, ok := enttype.GetEnumType(cf.GetFieldType())
+	if !ok {
+		return
+	}
+	ci.enumImports = append(ci.enumImports, enumType.GetTSName())
 }
 
 func (action *commonActionInfo) AddCustomNonEntField(typ enttype.TSGraphQLType, cf *NonEntField) {

--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -630,23 +630,7 @@ type InverseAssocEdge struct {
 func ParseSchema(input []byte) (*Schema, error) {
 	s := &Schema{}
 	if err := json.Unmarshal(input, s); err != nil {
-		// don't think this applies but keeping it here just in case
-		nodes := make(map[string]*Node)
-		if err := json.Unmarshal(input, &nodes); err != nil {
-			return nil, err
-		}
-		return &Schema{Nodes: nodes}, nil
-	}
-	// in the old route, it doesn't throw an error but just unmarshalls nothing 😭
-	// TestCustomFields
-	// also need to verify TestCustomListQuery|TestCustomUploadType works
-	// so checking s.Nodes == nil instead of len() == 0
-	if s.Nodes == nil {
-		nodes := make(map[string]*Node)
-		if err := json.Unmarshal(input, &nodes); err != nil {
-			return nil, err
-		}
-		return &Schema{Nodes: nodes}, nil
+		return nil, err
 	}
 	return s, nil
 }

--- a/internal/schema/input/parse_ts_custom_field_test.go
+++ b/internal/schema/input/parse_ts_custom_field_test.go
@@ -12,55 +12,57 @@ import (
 func TestCustomFields(t *testing.T) {
 	data := `
  {
-	 "User": {
-		 "fields": [
-				{
-					"name": "email",
-					"type": {
-						"dbType": "String",
-						"customType": "email"
-					}
-				},
-				{
-					"name": "nullable_email",
-					"type": {
-						"dbType": "String",
-						"customType": "email"
+	 "schemas": {
+		 "User": {
+			"fields": [
+					{
+						"name": "email",
+						"type": {
+							"dbType": "String",
+							"customType": "email"
+						}
 					},
-					"nullable": true
-				},
-				{
-					"name": "password",
-					"type": {
-						"dbType": "String",
-						"customType": "password"
-					}
-				},
-				{
-					"name": "nullable_password",
-					"type": {
-						"dbType": "String",
-						"customType": "password"
+					{
+						"name": "nullable_email",
+						"type": {
+							"dbType": "String",
+							"customType": "email"
+						},
+						"nullable": true
 					},
-					"nullable": true
-				},
-				{
-					"name": "phone",
-					"type": {
-						"dbType": "String",
-						"customType": "phone"
-					}
-				},
-				{
-					"name": "nullable_phone",
-					"type": {
-						"dbType": "String",
-						"customType": "phone"
+					{
+						"name": "password",
+						"type": {
+							"dbType": "String",
+							"customType": "password"
+						}
 					},
-					"nullable": true
-				}
-		 ]
-	 }
+					{
+						"name": "nullable_password",
+						"type": {
+							"dbType": "String",
+							"customType": "password"
+						},
+						"nullable": true
+					},
+					{
+						"name": "phone",
+						"type": {
+							"dbType": "String",
+							"customType": "phone"
+						}
+					},
+					{
+						"name": "nullable_phone",
+						"type": {
+							"dbType": "String",
+							"customType": "phone"
+						},
+						"nullable": true
+					}
+				]
+			}
+		}
 	}`
 
 	s, err := input.ParseSchema([]byte(data))

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -25,7 +25,11 @@
   {{end -}}
 {{ end}}
 
+{{$extImpPath := .Package.ExternalImportPath -}}
 {{ range $int := $action.GetCustomInterfaces -}}
+  {{ range $imp := $int.GetEnumImports -}}
+    {{ reserveImport $extImpPath $imp -}}
+  {{ end -}}
   interface {{$int.TSType}} {
     {{ range $field := $int.Fields -}}
       {{$type := $field.TsBuilderType -}}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.35.alpha",
+  "version": "0.0.35.alpha.2",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/parse_schema/parse.ts
+++ b/ts/src/parse_schema/parse.ts
@@ -22,6 +22,8 @@ function processFields(src: Field[], patternName?: string): ProcessedField[] {
       } else {
         f.polymorphic = field.polymorphic;
       }
+    } else {
+      delete f.polymorphic;
     }
     // convert string to object to make API consumed by go simple
     if (f.fieldEdge && f.fieldEdge.inverseEdge) {
@@ -152,6 +154,7 @@ function processAction(action: Action): OutputAction {
     (f) => {
       let f2 = f as ProcessedActionField;
       if (!f.nullable) {
+        delete f2.nullable;
         return f2;
       }
       if (typeof f.nullable === "boolean") {


### PR DESCRIPTION
fixes https://github.com/lolopinto/ent/issues/694

* ParseSchema() in input.go was changed in https://github.com/lolopinto/ent/pull/506 to support multiple ways to parse the schema because of a breaking change. that ended up masking issues if there was an error json marshalling. considering that was a while ago, simplify by no longer supporting the old way
* when nullable: false is passed, the following error is shown
```
  json: cannot unmarshal bool into Go struct field Action.schemas.actions.actionOnlyFields of type input.NullableItem
```
this is because JS version of the code supports multiple types but go doesn't. update the JS schema parsing to handle when nullable: false is passed. also fix a potential other scenario this could happen with polymorphic: false
* the way imports work in base file is wonky and since enum types have other imports that are needed, that wasn't being passed along
created https://github.com/lolopinto/ent/issues/703 to fix the issue long term. did a workaround in the code generation to import the type