### PR TITLE
compatibility mode for making changes in old schema.

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha",
+        "@snowtop/ent": "^0.1.0-alpha2",
         "@snowtop/ent-email": "^0.0.1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha.tgz",
-      "integrity": "sha512-/6JOfNEt/1l/xp1WOghHuLLytsIyFnam3HqBATfnVNiSNb2O4vZLuKxEok4ohKnsdQciVIvvLBQ9puzHHFQA/w==",
+      "version": "0.1.0-alpha2",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha2.tgz",
+      "integrity": "sha512-PV3gymW7Ko/GWthVy2X9ANlZweb4Dxs32z/wlIq2Nj1+r9Mgfq4N93F8bdwk1jKSaPmID65Cf5BBDlt5w2vohQ==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6941,9 +6941,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha.tgz",
-      "integrity": "sha512-/6JOfNEt/1l/xp1WOghHuLLytsIyFnam3HqBATfnVNiSNb2O4vZLuKxEok4ohKnsdQciVIvvLBQ9puzHHFQA/w==",
+      "version": "0.1.0-alpha2",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha2.tgz",
+      "integrity": "sha512-PV3gymW7Ko/GWthVy2X9ANlZweb4Dxs32z/wlIq2Nj1+r9Mgfq4N93F8bdwk1jKSaPmID65Cf5BBDlt5w2vohQ==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha",
+    "@snowtop/ent": "^0.1.0-alpha2",
     "@snowtop/ent-email": "^0.0.1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha1",
+  "version": "0.1.0-alpha2",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/parse_schema/parse.ts
+++ b/ts/src/parse_schema/parse.ts
@@ -8,10 +8,25 @@ import {
 } from "../schema";
 import { ActionField, FieldMap } from "../schema/schema";
 
-function processFields(src: FieldMap, patternName?: string): ProcessedField[] {
+function processFields(
+  src: FieldMap | Field[],
+  patternName?: string,
+): ProcessedField[] {
   const ret: ProcessedField[] = [];
-  for (const name in src) {
-    const field = src[name];
+  let m: FieldMap = {};
+  if (Array.isArray(src)) {
+    for (const field of src) {
+      const name = field.name;
+      if (!name) {
+        throw new Error(`name is required`);
+      }
+      m[name] = field;
+    }
+  } else {
+    m = src;
+  }
+  for (const name in m) {
+    const field = m[name];
     let f: ProcessedField = { name, ...field };
     f.hasDefaultValueOnCreate = field.defaultValueOnCreate != undefined;
     f.hasDefaultValueOnEdit = field.defaultValueOnEdit != undefined;

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -8,7 +8,7 @@ export declare type FieldMap = {
 // Schema is the base for every schema in typescript
 export default interface Schema {
   // schema has list of fields that are unique to each node
-  fields: FieldMap;
+  fields: FieldMap | Field[];
 
   // optional, can be overriden as needed
   tableName?: string;
@@ -152,7 +152,7 @@ export type Edge = AssocEdge;
 // which automatically provides 3 fields to every ent: id, created_at, updated_at
 export interface Pattern {
   name: string;
-  fields: FieldMap;
+  fields: FieldMap | Field[];
   edges?: Edge[];
 }
 
@@ -286,6 +286,9 @@ export interface FieldOptions {
 
   // takes the name of the field and returns any fields which are derived from current field
   getDerivedFields?(name: string): FieldMap;
+
+  // allow name for now
+  [x: string]: any;
 }
 
 export interface PolymorphicOptions {
@@ -330,7 +333,20 @@ export function getFields(value: SchemaInputType): Map<string, Field> {
     schema = new value();
   }
 
-  function addFields(fields: FieldMap) {
+  function addFields(fields: FieldMap | Field[]) {
+    if (Array.isArray(fields)) {
+      for (const field of fields) {
+        const name = field.name;
+        if (!name) {
+          throw new Error(`name required`);
+        }
+        if (field.getDerivedFields !== undefined) {
+          addFields(field.getDerivedFields(name));
+        }
+        m.set(name, field);
+      }
+      return;
+    }
     for (const name in fields) {
       const field = fields[name];
       if (field.getDerivedFields !== undefined) {
@@ -346,6 +362,7 @@ export function getFields(value: SchemaInputType): Map<string, Field> {
       addFields(pattern.fields);
     }
   }
+
   addFields(schema.fields);
 
   return m;


### PR DESCRIPTION
will be removed before merging back into main

doing this so that transform_schema can be called once when migrating from main -> v0.1 instead of having to be done multiple times. also simplifies the transform_schema code...