### PR TITLE
delete_schema command

### DIFF
--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -59,6 +59,7 @@ type Processor struct {
 	debugMode   bool
 	opt         *option
 	noDBChanges bool
+	changes     map[string][]change
 }
 
 func (p *Processor) NoDBChanges() bool {
@@ -168,10 +169,14 @@ func (p *Processor) FormatTS() error {
 }
 
 func postProcess(p *Processor) error {
+	format := true
 	if p.opt != nil && p.opt.disableFormat {
-		return nil
+		format = false
 	}
-	return p.FormatTS()
+	if format {
+		return p.FormatTS()
+	}
+	return nil
 }
 
 func runAndLog(p *Processor, fn func(p *Processor) error, logDiff func(d time.Duration)) error {

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -59,7 +59,6 @@ type Processor struct {
 	debugMode   bool
 	opt         *option
 	noDBChanges bool
-	changes     map[string][]change
 }
 
 func (p *Processor) NoDBChanges() bool {
@@ -169,14 +168,10 @@ func (p *Processor) FormatTS() error {
 }
 
 func postProcess(p *Processor) error {
-	format := true
 	if p.opt != nil && p.opt.disableFormat {
-		format = false
+		return nil
 	}
-	if format {
-		return p.FormatTS()
-	}
-	return nil
+	return p.FormatTS()
 }
 
 func runAndLog(p *Processor, fn func(p *Processor) error, logDiff func(d time.Duration)) error {

--- a/internal/codegen/prompts.go
+++ b/internal/codegen/prompts.go
@@ -1,72 +1,12 @@
 package codegen
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
-	"os"
 
+	"github.com/lolopinto/ent/internal/prompt"
 	"github.com/lolopinto/ent/internal/schema"
 )
-
-type prompt interface {
-	Question() string
-}
-
-type runePrompt interface {
-	prompt
-	HandleRune(r rune, size int) *promptResponse
-}
-
-type promptResponse struct {
-	err error
-	p   prompt
-}
-
-type handler func()
-
-func exitHandler() {
-	os.Exit(1)
-}
-
-func logHandler(f string) handler {
-	return func() {
-		fmt.Print(f)
-	}
-}
-
-type YesNoQuestion struct {
-	question   string
-	yesHandler handler
-	noHandler  handler
-}
-
-func (q *YesNoQuestion) Question() string {
-	return q.question
-}
-
-func (q *YesNoQuestion) HandleRune(r rune, size int) *promptResponse {
-	if r == 'y' || r == 'Y' {
-		if q.yesHandler != nil {
-			q.yesHandler()
-		}
-		return nil
-	} else if r == 'n' || r == 'N' {
-		if q.noHandler != nil {
-			q.noHandler()
-		}
-		return nil
-	}
-
-	// follow-up prompt
-	return &promptResponse{
-		p: &YesNoQuestion{
-			question:   "Please answer Y/N: ",
-			yesHandler: q.yesHandler,
-			noHandler:  q.noHandler,
-		},
-	}
-}
 
 // TODO: this should all be in schema but there's dependency issues
 // because codegen depends on schema and we need schema to depend on the path to schema which we need to fix
@@ -77,24 +17,25 @@ func checkAndHandlePrompts(p *Processor) error {
 		return err
 	}
 
-	m := make(map[string][]change)
+	changes := make(map[string][]change)
 
-	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &changes); err != nil {
 		return err
 	}
+	p.changes = changes
 
-	if len(m) == 0 {
+	if len(changes) == 0 {
 		// we know there's no db changes so we should flag this so that we don't call into python in the future to try and make changes
 		p.noDBChanges = true
 	}
 
-	prompts, err := getPrompts(p.Schema, m)
+	prompts, err := getPrompts(p.Schema, changes)
 	if err != nil {
 		return err
 	}
 
 	if len(prompts) > 0 {
-		if err := handlePrompts(prompts); err != nil {
+		if err := prompt.HandlePrompts(prompts); err != nil {
 			return err
 		}
 	}
@@ -102,8 +43,8 @@ func checkAndHandlePrompts(p *Processor) error {
 	return nil
 }
 
-func getPrompts(s *schema.Schema, changes map[string][]change) ([]prompt, error) {
-	var prompts []prompt
+func getPrompts(s *schema.Schema, changes map[string][]change) ([]prompt.Prompt, error) {
+	var prompts []prompt.Prompt
 	for tableName, changes := range changes {
 		for _, change := range changes {
 			if change.Change != AddColumn {
@@ -121,56 +62,18 @@ func getPrompts(s *schema.Schema, changes map[string][]change) ([]prompt, error)
 
 			// adding new field which isn't nullable, prompt needed
 			if !field.Nullable() {
-				prompts = append(prompts, &YesNoQuestion{
-					question: fmt.Sprintf(
+				prompts = append(prompts, &prompt.YesNoQuestion{
+					Question: fmt.Sprintf(
 						"You're adding a new field '%s' to an existing Node '%s' which isn't nullable. This could result in database errors. Are you sure you want to do that? Y/N: ",
 						field.FieldName,
 						nodeData.Node,
 					),
-					noHandler: exitHandler,
-					//					yesHandler: logHandler("yes answered \n"),
+					NoHandler: prompt.ExitHandler,
+					// YesHandler: prompt.LogHandler("yes answered \n"),
 				})
 			}
 		}
 	}
 
 	return prompts, nil
-}
-
-func handlePrompts(prompts []prompt) error {
-	reader := bufio.NewReader(os.Stdin)
-	for _, p := range prompts {
-
-		if err := handlePrompt(p, reader); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func handlePrompt(p prompt, reader *bufio.Reader) error {
-	rp, ok := p.(runePrompt)
-	if ok {
-		fmt.Print(p.Question())
-		r, size, err := reader.ReadRune()
-		if err != nil {
-			return nil
-		}
-		res := rp.HandleRune(r, size)
-		if res != nil {
-			if res.err != nil {
-				return res.err
-			}
-
-			// new prompt, more questions
-			if res.p != nil {
-				return handlePrompt(res.p, reader)
-			}
-		}
-		return nil
-	}
-
-	// eventually as we need different prompt types, we'll handle here too
-
-	return fmt.Errorf("invalid prompt type")
 }

--- a/internal/codegen/prompts.go
+++ b/internal/codegen/prompts.go
@@ -22,7 +22,6 @@ func checkAndHandlePrompts(p *Processor) error {
 	if err := json.Unmarshal(buf.Bytes(), &changes); err != nil {
 		return err
 	}
-	p.changes = changes
 
 	if len(changes) == 0 {
 		// we know there's no db changes so we should flag this so that we don't call into python in the future to try and make changes

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 type Prompt interface {
@@ -57,8 +55,7 @@ func (q *YesNoQuestion) HandleRune(r rune, size int) *PromptResponse {
 		return nil
 	}
 
-	// hmm i remember this issue in the past...
-	fmt.Println("TODO yes/no PR")
+	// this is being done twice. TODO handle it...
 	// follow-up prompt
 	return &PromptResponse{
 		Prompt: &YesNoQuestion{
@@ -85,7 +82,6 @@ func handlePrompt(p Prompt, reader *bufio.Reader) error {
 	if ok {
 		fmt.Print(p.GetQuestion())
 		r, size, err := reader.ReadRune()
-		spew.Dump(r, size)
 		if err != nil {
 			return nil
 		}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,0 +1,109 @@
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+type Prompt interface {
+	GetQuestion() string
+}
+
+type RunePrompt interface {
+	Prompt
+	HandleRune(r rune, size int) *PromptResponse
+}
+
+type PromptResponse struct {
+	Error  error
+	Prompt Prompt
+}
+
+type Handler func()
+
+func ExitHandler() {
+	os.Exit(1)
+}
+
+func LogHandler(f string) Handler {
+	return func() {
+		fmt.Print(f)
+	}
+}
+
+type YesNoQuestion struct {
+	Question   string
+	YesHandler Handler
+	NoHandler  Handler
+}
+
+func (q *YesNoQuestion) GetQuestion() string {
+	return q.Question
+}
+
+func (q *YesNoQuestion) HandleRune(r rune, size int) *PromptResponse {
+	if r == 'y' || r == 'Y' {
+		if q.YesHandler != nil {
+			q.YesHandler()
+		}
+		return nil
+	} else if r == 'n' || r == 'N' {
+		if q.NoHandler != nil {
+			q.NoHandler()
+		}
+		return nil
+	}
+
+	// hmm i remember this issue in the past...
+	fmt.Println("TODO yes/no PR")
+	// follow-up prompt
+	return &PromptResponse{
+		Prompt: &YesNoQuestion{
+			Question:   "Please answer Y/N: ",
+			YesHandler: q.YesHandler,
+			NoHandler:  q.NoHandler,
+		},
+	}
+}
+
+func HandlePrompts(prompts []Prompt) error {
+	reader := bufio.NewReader(os.Stdin)
+	for _, p := range prompts {
+
+		if err := handlePrompt(p, reader); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func handlePrompt(p Prompt, reader *bufio.Reader) error {
+	rp, ok := p.(RunePrompt)
+	if ok {
+		fmt.Print(p.GetQuestion())
+		r, size, err := reader.ReadRune()
+		spew.Dump(r, size)
+		if err != nil {
+			return nil
+		}
+		res := rp.HandleRune(r, size)
+		if res != nil {
+			if res.Error != nil {
+				return res.Error
+			}
+
+			// new prompt, more questions
+			if res.Prompt != nil {
+				return handlePrompt(res.Prompt, reader)
+			}
+		}
+		return nil
+	}
+
+	// eventually as we need different prompt types, we'll handle here too
+
+	return fmt.Errorf("invalid prompt type")
+}

--- a/tsent/cmd/delete_schema.go
+++ b/tsent/cmd/delete_schema.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lolopinto/ent/internal/prompt"
+	"github.com/lolopinto/ent/internal/schema"
+	"github.com/spf13/cobra"
+)
+
+var deleteSchemaCmd = &cobra.Command{
+	Use:   "delete_schema",
+	Short: "deletes the given schema",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		schemaName := args[0]
+		s, err := parseSchema()
+		if err != nil {
+			return err
+		}
+
+		nodeData, err := s.GetNodeDataForNode(schemaName)
+		if err != nil {
+			return fmt.Errorf("could not find schema %s", schemaName)
+		}
+
+		p := &prompt.YesNoQuestion{
+			Question:  fmt.Sprintf("Are you sure you want to delete the '%s' schema. Note that this deletes all known files. If still referenced in the schema by another schema, there'll be an error later on. Y/N:", schemaName),
+			NoHandler: prompt.ExitHandler,
+		}
+
+		if err := prompt.HandlePrompts([]prompt.Prompt{p}); err != nil {
+			return err
+		}
+
+		if err := deleteFiles(nodeData); err != nil {
+			return err
+		}
+		if err := deleteFolders(nodeData); err != nil {
+			return err
+		}
+
+		// TODO db and then re-run codegen
+		return nil
+	},
+}
+
+func deleteFiles(nodeData *schema.NodeData) error {
+	files := getFiles(nodeData)
+	for _, file := range files {
+		fi, err := os.Stat(file)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return fmt.Errorf("%s is a directory, expected it to be a file. cannot delete", file)
+		}
+		if err := os.Remove(file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteFolders(nodeData *schema.NodeData) error {
+	folders := getFolders(nodeData)
+	for _, folder := range folders {
+		fi, err := os.Stat(folder)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("%s is not a directory, expected it to be one. cannot delete", folder)
+		}
+		if err := os.RemoveAll(folder); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getFiles(nodeData *schema.NodeData) []string {
+	packageName := nodeData.PackageName
+	ret := []string{
+		fmt.Sprintf("src/schema/%s.ts", packageName),
+		fmt.Sprintf("src/ent/generated/%s_base.ts", packageName),
+		fmt.Sprintf("src/ent/%s.ts", packageName),
+		fmt.Sprintf("src/graphql/resolvers/generated/%s_type.ts", packageName),
+	}
+
+	return ret
+}
+
+func getFolders(nodeData *schema.NodeData) []string {
+	packageName := nodeData.PackageName
+	ret := []string{
+		fmt.Sprintf("src/ent/%s", packageName),
+		fmt.Sprintf("src/graphql/resolvers/generated/%s", packageName),
+		fmt.Sprintf("src/graphql/mutations/generated/%s", packageName),
+	}
+
+	return ret
+}

--- a/tsent/cmd/print_schema.go
+++ b/tsent/cmd/print_schema.go
@@ -9,7 +9,7 @@ import (
 )
 
 var printSchemaCmd = &cobra.Command{
-	Use:   "print-schema",
+	Use:   "print_schema",
 	Short: "prints the parsed schema. only exists for debugging purposes and not guaranteed to exist forever",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := os.Getwd()

--- a/tsent/cmd/root.go
+++ b/tsent/cmd/root.go
@@ -78,6 +78,7 @@ func init() {
 		generateCmd,
 		squashCmd,
 		printSchemaCmd,
+		deleteSchemaCmd,
 	})
 
 	addCommands(generateCmd, []*cobra.Command{


### PR DESCRIPTION
fixes https://github.com/lolopinto/ent/issues/670

used as follows:
`tsent delete_schema Holiday`

previously, deleting a schema was annoying and error-prone. Now, it should be better. 