### PR TITLE
fix broken enum file generation

### DIFF
--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -167,7 +167,8 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 		funcs = append(funcs, s.processNode(processor, info, &serr)...)
 	}
 
-	for _, info := range processor.Schema.Enums {
+	for k := range processor.Schema.Enums {
+		info := processor.Schema.Enums[k]
 		if !info.OwnEnumFile() {
 			continue
 		}


### PR DESCRIPTION
go and its scope issues

i've seen an extra dangling file a few times because of this