### PR TITLE
fix weird bug with assoc_edge_loader

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/loaders/assoc_edge_loader.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.ts
@@ -196,11 +196,14 @@ export class AssocEdgeLoaderFactory<T extends AssocEdge>
     return this.createConfigurableLoader({}, context);
   }
 
-  private isFunction(
+  private isConstructor(
     edgeCtr: AssocEdgeConstructor<T> | (() => AssocEdgeConstructor<T>),
-  ): edgeCtr is () => AssocEdgeConstructor<T> {
-    // not constructor
-    return !(edgeCtr.prototype && edgeCtr.prototype.constructor === edgeCtr);
+  ): edgeCtr is AssocEdgeConstructor<T> {
+    return (
+      edgeCtr.prototype &&
+      edgeCtr.prototype.constructor &&
+      edgeCtr.prototype.constructor.name.length > 0
+    );
   }
 
   createConfigurableLoader(
@@ -211,7 +214,7 @@ export class AssocEdgeLoaderFactory<T extends AssocEdge>
     // in generated code, the edge is not necessarily defined at the time of loading
     // so we call this as follows:
     // const loader = new AssocEdgeLoaderFactory(EdgeType.Foo, ()=>DerivedEdgeClass);
-    if (this.isFunction(edgeCtr)) {
+    if (!this.isConstructor(edgeCtr)) {
       edgeCtr = edgeCtr();
     }
     // rename to make TS happy


### PR DESCRIPTION
this was exposed by changing from `tsc` to `@swc/jest` and some tests (in a client) started failing

```
> const AssocEdge = require('./core/ent').AssocEdge
undefined
> const fn = ()=>AssocEdge
undefined
> AssocEdge.prototype.constructor.name
'AssocEdge'
> fn.prototype?.constructor.name
undefined
>
```

not really sure what's happening here but it seems like with @swc/jest, the prototype of an anonymous function is defined.

current "fix" is to chehck if the length of the name is > 0

code here was originally introduced in https://github.com/lolopinto/ent/pull/285