### PR TITLE
New Schema API

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -10,10 +10,10 @@
       "license": "ISC",
       "dependencies": {
         "@snowtop/ent": "^0.1.0-alpha7",
-        "@snowtop/ent-email": "^0.0.1",
+        "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
-        "@snowtop/ent-phonenumber": "^0.0.1",
+        "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
         "@types/express-session": "^1.17.3",
         "@types/graphql-upload": "^8.0.4",
         "@types/luxon": "^1.26.5",
@@ -1062,14 +1062,14 @@
       }
     },
     "node_modules/@snowtop/ent-email": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent-email/-/ent-email-0.0.1.tgz",
-      "integrity": "sha512-kz/8Isd+tFenTa4mtlN2NWJgYrl4D1t4lRD7mVCq1ha5osqRqyU00JXZPRIEcnZCS37+c21xFFf7Sj/zYQOvfg==",
+      "version": "0.1.0-alpha1",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent-email/-/ent-email-0.1.0-alpha1.tgz",
+      "integrity": "sha512-YabiU/WXdBubXfm0weWMKb/xmTpSUxaKDzFUuVl8DGuUiq+Lby2m1GPjOAfgp82RfOPeHjPXcIGGgtpNh/cODQ==",
       "dependencies": {
         "email-addresses": "^4.0.0"
       },
       "peerDependencies": {
-        "@snowtop/ent": ">= 0.0.1"
+        "@snowtop/ent": ">=0.1.0-alpha"
       }
     },
     "node_modules/@snowtop/ent-graphql-tests": {
@@ -1116,14 +1116,14 @@
       }
     },
     "node_modules/@snowtop/ent-phonenumber": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent-phonenumber/-/ent-phonenumber-0.0.1.tgz",
-      "integrity": "sha512-Odn532BoeHv6DqtSSGScJRvCHYgo44OhOJgwiatlAdVY2x6D+FcOKAG87ptHbHPc21AAV3JuU3dPySIcfeLiEQ==",
+      "version": "0.1.0-alpha1",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent-phonenumber/-/ent-phonenumber-0.1.0-alpha1.tgz",
+      "integrity": "sha512-vCER1AfvNMBxUSeIBbQ4OeV0/ALQVl3YJGkvoQLztjQCSzQ9C1JYB2/bAHgOsm1NK0NNt9u+dTtyOH+SsivfrQ==",
       "dependencies": {
         "libphonenumber-js": "^1.9.17"
       },
       "peerDependencies": {
-        "@snowtop/ent": ">= 0.0.1"
+        "@snowtop/ent": ">= 0.1.0-alpha"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -6968,9 +6968,9 @@
       }
     },
     "@snowtop/ent-email": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent-email/-/ent-email-0.0.1.tgz",
-      "integrity": "sha512-kz/8Isd+tFenTa4mtlN2NWJgYrl4D1t4lRD7mVCq1ha5osqRqyU00JXZPRIEcnZCS37+c21xFFf7Sj/zYQOvfg==",
+      "version": "0.1.0-alpha1",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent-email/-/ent-email-0.1.0-alpha1.tgz",
+      "integrity": "sha512-YabiU/WXdBubXfm0weWMKb/xmTpSUxaKDzFUuVl8DGuUiq+Lby2m1GPjOAfgp82RfOPeHjPXcIGGgtpNh/cODQ==",
       "requires": {
         "email-addresses": "^4.0.0"
       }
@@ -7008,9 +7008,9 @@
       }
     },
     "@snowtop/ent-phonenumber": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent-phonenumber/-/ent-phonenumber-0.0.1.tgz",
-      "integrity": "sha512-Odn532BoeHv6DqtSSGScJRvCHYgo44OhOJgwiatlAdVY2x6D+FcOKAG87ptHbHPc21AAV3JuU3dPySIcfeLiEQ==",
+      "version": "0.1.0-alpha1",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent-phonenumber/-/ent-phonenumber-0.1.0-alpha1.tgz",
+      "integrity": "sha512-vCER1AfvNMBxUSeIBbQ4OeV0/ALQVl3YJGkvoQLztjQCSzQ9C1JYB2/bAHgOsm1NK0NNt9u+dTtyOH+SsivfrQ==",
       "requires": {
         "libphonenumber-js": "^1.9.17"
       }

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -35,10 +35,10 @@
   },
   "dependencies": {
     "@snowtop/ent": "^0.1.0-alpha7",
-    "@snowtop/ent-email": "^0.0.1",
+    "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",
-    "@snowtop/ent-phonenumber": "^0.0.1",
+    "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
     "@types/express-session": "^1.17.3",
     "@types/graphql-upload": "^8.0.4",
     "@types/luxon": "^1.26.5",

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -19,7 +19,6 @@ import { LoggedOutViewer, IDViewer } from "../core/viewer";
 import { Changeset } from "../action";
 import { StringType, TimestampType, UUIDType } from "../schema/field";
 import { JSONBType } from "../schema/json_field";
-import { BaseEntSchema, Field } from "../schema";
 import {
   User,
   Event,
@@ -27,6 +26,7 @@ import {
   Address,
   SimpleBuilder,
   SimpleAction,
+  getBuilderSchemaFromFields,
 } from "../testutils/builder";
 import { FakeComms, Mode } from "../testutils/fake_comms";
 import { Pool } from "pg";
@@ -54,7 +54,6 @@ import {
   Table,
 } from "../testutils/db/test_db";
 import { Dialect } from "../core/db";
-import { FieldMap } from "../schema/schema";
 
 jest.mock("pg");
 QueryRecorder.mockPool(Pool);
@@ -95,19 +94,19 @@ describe("sqlite", () => {
     );
 
     [
-      new UserSchema(),
-      new UserSchemaWithStatus(),
-      new UserSchemaExtended(),
-      new UserSchemaServerDefault(),
-      new UserSchemaDefaultValueOnCreate(),
-      new UserSchemaDefaultValueOnCreateJSON(),
-      new UserSchemaDefaultValueOnCreateInvalidJSON(),
-      new SchemaWithProcessors(),
-      new EventSchema(),
-      new AddressSchemaDerivedFields(),
-      new ContactSchema(),
-      new CustomUserSchema(),
-      new SensitiveValuesSchema(),
+      UserSchema,
+      UserSchemaWithStatus,
+      UserSchemaExtended,
+      UserSchemaServerDefault,
+      UserSchemaDefaultValueOnCreate,
+      UserSchemaDefaultValueOnCreateJSON,
+      UserSchemaDefaultValueOnCreateInvalidJSON,
+      SchemaWithProcessors,
+      EventSchema,
+      AddressSchemaDerivedFields,
+      ContactSchema,
+      CustomUserSchema,
+      SensitiveValuesSchema,
     ].map((s) => tables.push(getSchemaTable(s, Dialect.SQLite)));
     return tables;
   };
@@ -116,96 +115,96 @@ describe("sqlite", () => {
   commonTests();
 });
 
-class UserSchema extends BaseEntSchema {
-  fields: FieldMap = {
+const UserSchema = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
-  };
-  ent = User;
-}
+  },
+  User,
+);
 
 class UserWithStatus extends User {}
-class UserSchemaWithStatus extends BaseEntSchema {
-  fields: FieldMap = {
+const UserSchemaWithStatus = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
     // let's assume this was hidden from the generated action and has to be set by the builder...
     account_status: StringType(),
-  };
-  ent = UserWithStatus;
-}
+  },
+  UserWithStatus,
+);
 
 class UserExtended extends User {}
 
-class UserSchemaExtended extends BaseEntSchema {
-  fields: FieldMap = {
+const UserSchemaExtended = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
     account_status: StringType(),
     EmailAddress: StringType({ nullable: true }),
-  };
-  ent = UserExtended;
-}
+  },
+  UserExtended,
+);
 
 class UserServerDefault extends User {}
 
-class UserSchemaServerDefault extends BaseEntSchema {
-  fields: FieldMap = {
+const UserSchemaServerDefault = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
     account_status: StringType({
       serverDefault: "ACTIVE",
     }),
-  };
-  ent = UserServerDefault;
-}
+  },
+  UserServerDefault,
+);
 
-class UserSchemaDefaultValueOnCreate extends BaseEntSchema {
-  fields: FieldMap = {
+const UserSchemaDefaultValueOnCreate = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
     account_status: StringType({
       defaultValueOnCreate: () => "ACTIVE",
     }),
-  };
-  ent = UserServerDefault;
-}
+  },
+  UserServerDefault,
+);
 
 class UserDefaultValueOnCreate extends User {}
 
-class UserSchemaDefaultValueOnCreateJSON extends BaseEntSchema {
-  fields: FieldMap = {
+const UserSchemaDefaultValueOnCreateJSON = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
     data: JSONBType({
       defaultValueOnCreate: () => ({}),
     }),
-  };
-  ent = UserDefaultValueOnCreate;
-}
+  },
+  UserDefaultValueOnCreate,
+);
 
-class UserSchemaDefaultValueOnCreateInvalidJSON extends BaseEntSchema {
-  fields: FieldMap = {
+const UserSchemaDefaultValueOnCreateInvalidJSON = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
     data: JSONBType({
       defaultValueOnCreate: () => {},
     }),
-  };
-  ent = UserDefaultValueOnCreate;
-}
+  },
+  UserDefaultValueOnCreate,
+);
 
 class UserWithProcessors extends User {}
-class SchemaWithProcessors extends BaseEntSchema {
-  fields: FieldMap = {
+const SchemaWithProcessors = getBuilderSchemaFromFields(
+  {
     zip: StringType().match(/^\d{5}(-\d{4})?$/),
     username: StringType().toLowerCase(),
-  };
-  ent = UserWithProcessors;
-}
+  },
+  UserWithProcessors,
+);
 
-class AddressSchemaDerivedFields extends BaseEntSchema {
-  fields: FieldMap = {
+const AddressSchemaDerivedFields = getBuilderSchemaFromFields(
+  {
     Street: StringType(),
     City: StringType(),
     State: StringType(),
@@ -215,39 +214,39 @@ class AddressSchemaDerivedFields extends BaseEntSchema {
       index: true,
       polymorphic: true,
     }),
-  };
-  ent = Address;
-}
+  },
+  Address,
+);
 
-class EventSchema extends BaseEntSchema {
-  fields: FieldMap = {
+const EventSchema = getBuilderSchemaFromFields(
+  {
     startTime: TimestampType(),
     endTime: TimestampType(),
-  };
-  ent = Event;
-}
+  },
+  Event,
+);
 
-class ContactSchema extends BaseEntSchema {
-  fields: FieldMap = {
+const ContactSchema = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
     UserID: StringType({
       defaultValueOnCreate: (builder) => builder.viewer.viewerID,
     }),
-  };
-  ent = Contact;
-}
+  },
+  Contact,
+);
 
-class ContactSchema2 extends BaseEntSchema {
-  fields: FieldMap = {
+const ContactSchema2 = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
     UserID: StringType({
       defaultToViewerOnCreate: true,
     }),
-  };
-  ent = Contact;
-}
+  },
+  Contact,
+);
 
 class CustomUser implements Ent {
   id: ID;
@@ -261,28 +260,28 @@ class CustomUser implements Ent {
   }
 }
 
-class CustomUserSchema extends BaseEntSchema {
-  fields: FieldMap = {
+const CustomUserSchema = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType(),
-  };
-  ent = CustomUser;
-}
+  },
+  CustomUser,
+);
 
 class SensitiveUser extends User {}
-class SensitiveValuesSchema extends BaseEntSchema {
-  fields: FieldMap = {
+const SensitiveValuesSchema = getBuilderSchemaFromFields(
+  {
     FirstName: StringType(),
     LastName: StringType({ sensitive: true }),
-  };
-  ent = SensitiveUser;
-}
+  },
+  SensitiveUser,
+);
 
 function commonTests() {
   test("schema on create", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -298,7 +297,7 @@ function commonTests() {
   test("missing required field", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map([
         ["FirstName", "Jon"],
         // non-nullable field set to null
@@ -322,7 +321,7 @@ function commonTests() {
   test("required field not set", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map([["FirstName", "Jon"]]),
     );
 
@@ -337,7 +336,7 @@ function commonTests() {
   test("required field fine when server default exists", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchemaServerDefault(),
+      UserSchemaServerDefault,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -350,7 +349,7 @@ function commonTests() {
   test("required field fine when default value on create exists", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchemaDefaultValueOnCreate(),
+      UserSchemaDefaultValueOnCreate,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -363,7 +362,7 @@ function commonTests() {
   test("required field fine when default value on create json ", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchemaDefaultValueOnCreateJSON(),
+      UserSchemaDefaultValueOnCreateJSON,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -376,7 +375,7 @@ function commonTests() {
   test("required field when default value on create json wrong", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchemaDefaultValueOnCreateInvalidJSON(),
+      UserSchemaDefaultValueOnCreateInvalidJSON,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -397,7 +396,7 @@ function commonTests() {
     const user = new User(new LoggedOutViewer(), { id: "1" });
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       // field that's not changed isn't set...
       // simulating what the generated builder will do
       new Map([["LastName", "Targaryen"]]),
@@ -415,7 +414,7 @@ function commonTests() {
     const user = new User(new LoggedOutViewer(), { id: "1" });
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map(),
       WriteOperation.Delete,
       user,
@@ -428,18 +427,18 @@ function commonTests() {
   });
 
   test("schema with null fields", async () => {
-    class SchemaWithNullFields extends BaseEntSchema {
-      fields: FieldMap = {
+    const SchemaWithNullFields = getBuilderSchemaFromFields(
+      {
         startTime: TimestampType(),
         endTime: TimestampType({ nullable: true }),
-      };
-      ent = User;
-    }
+      },
+      User,
+    );
 
     const d = new Date();
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new SchemaWithNullFields(),
+      SchemaWithNullFields,
       new Map([["startTime", d]]),
     );
 
@@ -451,7 +450,7 @@ function commonTests() {
 
     const builder2 = new SimpleBuilder(
       new LoggedOutViewer(),
-      new SchemaWithNullFields(),
+      SchemaWithNullFields,
       new Map([
         ["startTime", d],
         ["endTime", null],
@@ -465,16 +464,16 @@ function commonTests() {
   });
 
   test("schema_with_overriden_storage_key", async () => {
-    class SchemaWithOverridenDBKey extends BaseEntSchema {
-      fields: FieldMap = {
+    const SchemaWithOverridenDBKey = getBuilderSchemaFromFields(
+      {
         emailAddress: StringType({ storageKey: "email" }),
-      };
-      ent = User;
-    }
+      },
+      User,
+    );
 
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new SchemaWithOverridenDBKey(),
+      SchemaWithOverridenDBKey,
       new Map([["emailAddress", "test@email.com"]]),
     );
 
@@ -487,7 +486,7 @@ function commonTests() {
     test("simple case", async () => {
       const builder = new SimpleBuilder(
         new LoggedOutViewer(),
-        new SchemaWithProcessors(),
+        SchemaWithProcessors,
         new Map([
           ["username", "lolopinto"],
           ["zip", "94114"],
@@ -503,7 +502,7 @@ function commonTests() {
     test("username lowered", async () => {
       const builder = new SimpleBuilder(
         new LoggedOutViewer(),
-        new SchemaWithProcessors(),
+        SchemaWithProcessors,
         new Map([
           ["username", "LOLOPINTO"],
           ["zip", "94114"],
@@ -519,7 +518,7 @@ function commonTests() {
     test("invalid zip", async () => {
       const builder = new SimpleBuilder(
         new LoggedOutViewer(),
-        new SchemaWithProcessors(),
+        SchemaWithProcessors,
         new Map([
           ["username", "LOLOPINTO"],
           ["zip", "941"],
@@ -850,7 +849,7 @@ function commonTests() {
 
       const action = new SimpleAction(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -863,7 +862,7 @@ function commonTests() {
           changeset: (builder: SimpleBuilder<User>) => {
             const derivedAction = new SimpleAction(
               new LoggedOutViewer(),
-              new UserSchema(),
+              UserSchema,
               new Map([
                 ["FirstName", "Sansa"],
                 ["LastName", "Stark"],
@@ -937,7 +936,7 @@ function commonTests() {
 
       const action = new SimpleAction(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -954,7 +953,7 @@ function commonTests() {
           changeset: (builder: SimpleBuilder<User>) => {
             const derivedAction = new SimpleAction(
               new LoggedOutViewer(),
-              new UserSchema(),
+              UserSchema,
               new Map([
                 ["FirstName", "Sansa"],
                 ["LastName", "Stark"],
@@ -1338,7 +1337,7 @@ function commonTests() {
 
       const action = new SimpleAction(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1351,7 +1350,7 @@ function commonTests() {
           changeset: (builder: SimpleBuilder<User>) => {
             const derivedAction = new SimpleAction(
               new LoggedOutViewer(),
-              new UserSchema(),
+              UserSchema,
               new Map([
                 ["FirstName", "Sansa"],
                 ["LastName", "Stark"],
@@ -1427,7 +1426,7 @@ function commonTests() {
 
     const action = new SimpleAction(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -1444,7 +1443,7 @@ function commonTests() {
         changeset: (builder: SimpleBuilder<User>) => {
           const derivedAction = new SimpleAction(
             new LoggedOutViewer(),
-            new UserSchema(),
+            UserSchema,
             new Map([
               ["FirstName", "Sansa"],
               ["LastName", "Stark"],
@@ -1591,7 +1590,7 @@ function commonTests() {
       const user = new User(viewer, { id: "1" });
       const builder = new SimpleBuilder(
         viewer,
-        new UserSchema(),
+        UserSchema,
         new Map(),
         WriteOperation.Edit,
         user, // TODO enforce existing ent if not create
@@ -1626,7 +1625,7 @@ function commonTests() {
     test("no ent", async () => {
       const builder = new SimpleBuilder(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map(),
         WriteOperation.Edit,
       );
@@ -1648,7 +1647,7 @@ function commonTests() {
       const user = new User(viewer, { id: "1" });
       const builder = new SimpleBuilder(
         viewer,
-        new UserSchema(),
+        UserSchema,
         new Map(),
         WriteOperation.Edit,
         user, // TODO enforce existing ent if not create
@@ -1683,7 +1682,7 @@ function commonTests() {
     test("no ent", async () => {
       const builder = new SimpleBuilder(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map(),
         WriteOperation.Edit,
       );
@@ -1722,7 +1721,7 @@ function commonTests() {
 
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new EventSchema(),
+        EventSchema,
         new Map([
           ["startTime", now],
           ["endTime", yesterday],
@@ -1745,7 +1744,7 @@ function commonTests() {
 
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new EventSchema(),
+        EventSchema,
         new Map([
           ["startTime", yesterday],
           ["endTime", now],
@@ -1765,7 +1764,7 @@ function commonTests() {
     test("valid", async () => {
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1785,7 +1784,7 @@ function commonTests() {
       const viewer = new IDViewer("1");
       const action = new SimpleAction(
         viewer,
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1805,7 +1804,7 @@ function commonTests() {
       const viewer = new IDViewer("1");
       const action = new SimpleAction(
         viewer,
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1831,7 +1830,7 @@ function commonTests() {
       const viewer = new IDViewer("1");
       const action = new SimpleAction(
         viewer,
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1858,7 +1857,7 @@ function commonTests() {
       const viewer = new IDViewer("1");
       const action = new SimpleAction(
         viewer,
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1885,7 +1884,7 @@ function commonTests() {
       const viewer = new LoggedOutViewer();
       const action = new SimpleAction(
         viewer,
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1911,7 +1910,7 @@ function commonTests() {
     test("unsafe ent in creation. valid", async () => {
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1933,7 +1932,7 @@ function commonTests() {
     test("unsafe ent in creation. invalid", async () => {
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Sansa"],
           ["LastName", "Snow"],
@@ -1968,7 +1967,7 @@ function commonTests() {
       const viewer = new IDViewer("11");
       const action = new SimpleAction(
         viewer,
-        new UserSchemaWithStatus(),
+        UserSchemaWithStatus,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -1999,7 +1998,7 @@ function commonTests() {
       let contactAction: SimpleAction<Contact>;
       const action = new SimpleAction(
         viewer,
-        new UserSchemaWithStatus(),
+        UserSchemaWithStatus,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -2017,7 +2016,7 @@ function commonTests() {
             let lastName = builder.fields.get("LastName");
             contactAction = new SimpleAction(
               viewer,
-              new ContactSchema(),
+              ContactSchema,
               new Map([
                 ["FirstName", firstName],
                 ["LastName", lastName],
@@ -2070,7 +2069,7 @@ function commonTests() {
       const viewer = new IDViewer("11");
       const action = new SimpleAction(
         viewer,
-        new UserSchemaExtended(),
+        UserSchemaExtended,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -2101,7 +2100,7 @@ function commonTests() {
       const viewer = new IDViewer("11");
       const action = new SimpleAction(
         viewer,
-        new UserSchemaExtended(),
+        UserSchemaExtended,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -2138,7 +2137,7 @@ function commonTests() {
       const viewer = new IDViewer("11");
       const action = new SimpleAction(
         viewer,
-        new UserSchemaExtended(),
+        UserSchemaExtended,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -2178,7 +2177,7 @@ function commonTests() {
     ): SimpleAction<UserExtended> => {
       const action = new SimpleAction(
         viewer,
-        new UserSchemaExtended(),
+        UserSchemaExtended,
         fields,
         WriteOperation.Insert,
       );
@@ -2313,7 +2312,7 @@ function commonTests() {
 
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new AddressSchemaDerivedFields(),
+      AddressSchemaDerivedFields,
       new Map([
         ["Street", "1600 Pennsylvania Avenue NW"],
         ["City", "Washington DC"],
@@ -2333,7 +2332,7 @@ function commonTests() {
     async function createUser(): Promise<CustomUser> {
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new CustomUserSchema(),
+        CustomUserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -2360,7 +2359,7 @@ function commonTests() {
     test("can create but can't load user", async () => {
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new CustomUserSchema(),
+        CustomUserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -2379,7 +2378,7 @@ function commonTests() {
       const user = await createUser();
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new CustomUserSchema(),
+        CustomUserSchema,
         new Map([["LastName", "Snow2"]]),
         WriteOperation.Edit,
         user,
@@ -2398,7 +2397,7 @@ function commonTests() {
         // should probably not used a LoggedOutViewer here but for testing purposes...
         // and SimpleAction defaults to AlwaysAllowPrivacyPolicy
         new LoggedOutViewer(),
-        new CustomUserSchema(),
+        CustomUserSchema,
         new Map([["LastName", "Snow2"]]),
         WriteOperation.Edit,
         user,
@@ -2433,7 +2432,7 @@ function commonTests() {
     test("regular", async () => {
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new UserSchema(),
+        UserSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -2452,7 +2451,7 @@ function commonTests() {
     test("sensitive", async () => {
       let action = new SimpleAction(
         new LoggedOutViewer(),
-        new SensitiveValuesSchema(),
+        SensitiveValuesSchema,
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
@@ -2472,7 +2471,7 @@ function commonTests() {
   test("defaultValueOnCreate", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -2483,7 +2482,7 @@ function commonTests() {
 
     const builder2 = new SimpleBuilder(
       new IDViewer(user.id),
-      new ContactSchema(),
+      ContactSchema,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -2496,7 +2495,7 @@ function commonTests() {
 
     const builder3 = new SimpleBuilder(
       new LoggedOutViewer(),
-      new ContactSchema(),
+      ContactSchema,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -2514,7 +2513,7 @@ function commonTests() {
   test("defaultToViewerOnCreate", async () => {
     const builder = new SimpleBuilder(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -2525,7 +2524,7 @@ function commonTests() {
 
     const builder2 = new SimpleBuilder(
       new IDViewer(user.id),
-      new ContactSchema2(),
+      ContactSchema2,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -2538,7 +2537,7 @@ function commonTests() {
 
     const builder3 = new SimpleBuilder(
       new LoggedOutViewer(),
-      new ContactSchema2(),
+      ContactSchema2,
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -2558,7 +2557,7 @@ const getLoggedInBuilder = () => {
   const user = new User(viewer, { id: "1" });
   return new SimpleBuilder(
     viewer,
-    new UserSchema(),
+    UserSchema,
     new Map(),
     WriteOperation.Edit,
     user, // TODO enforce existing ent if not create
@@ -2568,7 +2567,7 @@ const getLoggedInBuilder = () => {
 const getCreateBuilder = (map: Map<string, any>) => {
   return new SimpleBuilder(
     new LoggedOutViewer(),
-    new UserSchema(),
+    UserSchema,
     map,
     WriteOperation.Insert,
   );

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -37,7 +37,7 @@ beforeAll(async () => {
     interval: INTERVAL,
   });
   user2 = await createTestUser();
-  await addEdge(user, new FakeUserSchema(), EdgeType.UserToFriends, false);
+  await addEdge(user, FakeUserSchema, EdgeType.UserToFriends, false);
   QueryRecorder.clearQueries();
 });
 

--- a/ts/src/graphql/node_resolver.test.ts
+++ b/ts/src/graphql/node_resolver.test.ts
@@ -204,7 +204,7 @@ function commonTests() {
     const vc = new IDViewer(user.id);
     const builder = new SimpleBuilder(
       vc,
-      new FakeUserSchema(),
+      FakeUserSchema,
       new Map(),
       WriteOperation.Edit,
       user,

--- a/ts/src/parse_schema/parse.test.ts
+++ b/ts/src/parse_schema/parse.test.ts
@@ -1,0 +1,34 @@
+import { FieldMap, Schema, Field } from "src/schema";
+import { StringType } from "../schema/field";
+import { BaseEntSchema } from "../schema/base_schema";
+import { parseSchema } from "./parse";
+
+test("legacy class", async () => {
+  class Foo extends BaseEntSchema {
+    fields: FieldMap = {
+      name: StringType(),
+    };
+  }
+
+  parseSchema({ foo: Foo });
+});
+
+test("implicit schema", async () => {
+  const Foo: Schema = {
+    fields: {
+      name: StringType(),
+    },
+  };
+
+  parseSchema({ foo: Foo });
+});
+
+test("new API with constructor config", async () => {
+  const Foo = new BaseEntSchema({
+    fields: {
+      name: StringType(),
+    },
+  });
+
+  parseSchema({ foo: Foo });
+});

--- a/ts/src/parse_schema/parse.test.ts
+++ b/ts/src/parse_schema/parse.test.ts
@@ -1,4 +1,4 @@
-import { FieldMap, Schema, Field } from "src/schema";
+import { FieldMap, Schema } from "src/schema";
 import { StringType } from "../schema/field";
 import { BaseEntSchema } from "../schema/base_schema";
 import { parseSchema } from "./parse";

--- a/ts/src/parse_schema/parse.test.ts
+++ b/ts/src/parse_schema/parse.test.ts
@@ -1,6 +1,6 @@
 import { FieldMap, Schema } from "src/schema";
 import { StringType } from "../schema/field";
-import { BaseEntSchema } from "../schema/base_schema";
+import { BaseEntSchema, EntSchema } from "../schema/base_schema";
 import { parseSchema } from "./parse";
 
 test("legacy class", async () => {
@@ -24,7 +24,7 @@ test("implicit schema", async () => {
 });
 
 test("new API with constructor config", async () => {
-  const Foo = new BaseEntSchema({
+  const Foo = new EntSchema({
     fields: {
       name: StringType(),
     },

--- a/ts/src/parse_schema/parse.ts
+++ b/ts/src/parse_schema/parse.ts
@@ -260,10 +260,15 @@ export function parseSchema(potentialSchemas: {}): Result {
   for (const key in potentialSchemas) {
     const value = potentialSchemas[key];
     let schema: Schema;
-    if (value.constructor == Object) {
-      schema = value;
-    } else {
-      schema = new value();
+    const name = value.constructor.name;
+    // named class e.g. new BaseEntSchema
+    switch (name) {
+      case "Function":
+        schema = new value();
+        break;
+      default:
+        // implicit schema or named class
+        schema = value;
     }
     let processedSchema: ProcessedSchema = {
       fields: [],

--- a/ts/src/schema/base_schema.ts
+++ b/ts/src/schema/base_schema.ts
@@ -75,9 +75,9 @@ export const Node: Pattern = {
 
 export interface SchemaConfig extends Schema {}
 
-// Base ent schema. has Node Pattern by default.
+// Ent schema. has Node Pattern by default.
 // exists just to have less typing and easier for clients to implement
-export class BaseEntSchema implements Schema {
+export class EntSchema implements Schema {
   // Field[] compatibility reasons
   fields: FieldMap | Field[];
 
@@ -101,11 +101,7 @@ export class BaseEntSchema implements Schema {
 
   hideFromGraphQL?: boolean;
 
-  // intentionally optional for compatibility reasons
-  constructor(cfg?: SchemaConfig) {
-    if (!cfg) {
-      return;
-    }
+  constructor(cfg: SchemaConfig) {
     this.fields = cfg.fields;
     this.tableName = cfg.tableName;
     if (cfg.patterns) {
@@ -120,14 +116,9 @@ export class BaseEntSchema implements Schema {
     this.indices = cfg.indices;
     this.hideFromGraphQL = cfg.hideFromGraphQL;
   }
-
-  // TODO kill
-  addPatterns(...patterns: Pattern[]) {
-    this.patterns.push(...patterns);
-  }
 }
 
-export class BaseEntSchemaWithTZ {
+export class EntSchemaWithTZ {
   // Field[] compatibility reasons
   fields: FieldMap | Field[];
 
@@ -157,11 +148,7 @@ export class BaseEntSchemaWithTZ {
 
   hideFromGraphQL?: boolean;
 
-  // intentionally optional for compatibility reasons
-  constructor(cfg?: SchemaConfig) {
-    if (!cfg) {
-      return;
-    }
+  constructor(cfg: SchemaConfig) {
     this.fields = cfg.fields;
     this.tableName = cfg.tableName;
     if (cfg.patterns) {
@@ -176,9 +163,28 @@ export class BaseEntSchemaWithTZ {
     this.indices = cfg.indices;
     this.hideFromGraphQL = cfg.hideFromGraphQL;
   }
+}
 
-  // TODO kill
+// @deprecated use EntSchema
+export abstract class BaseEntSchema {
   addPatterns(...patterns: Pattern[]) {
     this.patterns.push(...patterns);
   }
+
+  patterns: Pattern[] = [Node];
+}
+
+// @deprecated use EntSchemaWithTZ
+export abstract class BaseEntSchemaWithTZ {
+  addPatterns(...patterns: Pattern[]) {
+    this.patterns.push(...patterns);
+  }
+
+  patterns: Pattern[] = [
+    {
+      // default schema added
+      name: "nodeWithTZ",
+      fields: nodeFieldsWithTZ,
+    },
+  ];
 }

--- a/ts/src/schema/base_schema.ts
+++ b/ts/src/schema/base_schema.ts
@@ -1,6 +1,7 @@
 import { Field, FieldMap, Pattern } from "./schema";
 import { v4 as uuidv4 } from "uuid";
 import { TimestampType, UUIDType } from "./field";
+import { Action, AssocEdgeGroup, Constraint, Edge, Index, Schema } from ".";
 
 let tsFields: FieldMap = {
   createdAt: TimestampType({
@@ -72,20 +73,65 @@ export const Node: Pattern = {
   fields: nodeFields,
 };
 
+export interface SchemaConfig extends Schema {}
+
 // Base ent schema. has Node Pattern by default.
 // exists just to have less typing and easier for clients to implement
-export abstract class BaseEntSchema {
-  addPatterns(...patterns: Pattern[]) {
-    this.patterns.push(...patterns);
-  }
+export class BaseEntSchema implements Schema {
+  // Field[] compatibility reasons
+  fields: FieldMap | Field[];
+
+  tableName: string | undefined;
 
   patterns: Pattern[] = [Node];
-}
 
-export abstract class BaseEntSchemaWithTZ {
+  edges: Edge[] | undefined;
+
+  edgeGroups: AssocEdgeGroup[] | undefined;
+
+  actions: Action[] | undefined;
+
+  enumTable: boolean | undefined;
+
+  dbRows: { [key: string]: any }[] | undefined;
+
+  constraints: Constraint[] | undefined;
+
+  indices: Index[] | undefined;
+
+  hideFromGraphQL?: boolean;
+
+  // intentionally optional for compatibility reasons
+  constructor(cfg?: SchemaConfig) {
+    if (!cfg) {
+      return;
+    }
+    this.fields = cfg.fields;
+    this.tableName = cfg.tableName;
+    if (cfg.patterns) {
+      this.patterns.push(...cfg.patterns);
+    }
+    this.edges = cfg.edges;
+    this.edgeGroups = cfg.edgeGroups;
+    this.actions = cfg.actions;
+    this.enumTable = cfg.enumTable;
+    this.dbRows = cfg.dbRows;
+    this.constraints = cfg.constraints;
+    this.indices = cfg.indices;
+    this.hideFromGraphQL = cfg.hideFromGraphQL;
+  }
+
+  // TODO kill
   addPatterns(...patterns: Pattern[]) {
     this.patterns.push(...patterns);
   }
+}
+
+export class BaseEntSchemaWithTZ {
+  // Field[] compatibility reasons
+  fields: FieldMap | Field[];
+
+  tableName: string | undefined;
 
   patterns: Pattern[] = [
     {
@@ -94,4 +140,45 @@ export abstract class BaseEntSchemaWithTZ {
       fields: nodeFieldsWithTZ,
     },
   ];
+
+  edges: Edge[] | undefined;
+
+  edgeGroups: AssocEdgeGroup[] | undefined;
+
+  actions: Action[] | undefined;
+
+  enumTable: boolean | undefined;
+
+  dbRows: { [key: string]: any }[] | undefined;
+
+  constraints: Constraint[] | undefined;
+
+  indices: Index[] | undefined;
+
+  hideFromGraphQL?: boolean;
+
+  // intentionally optional for compatibility reasons
+  constructor(cfg?: SchemaConfig) {
+    if (!cfg) {
+      return;
+    }
+    this.fields = cfg.fields;
+    this.tableName = cfg.tableName;
+    if (cfg.patterns) {
+      this.patterns.push(...cfg.patterns);
+    }
+    this.edges = cfg.edges;
+    this.edgeGroups = cfg.edgeGroups;
+    this.actions = cfg.actions;
+    this.enumTable = cfg.enumTable;
+    this.dbRows = cfg.dbRows;
+    this.constraints = cfg.constraints;
+    this.indices = cfg.indices;
+    this.hideFromGraphQL = cfg.hideFromGraphQL;
+  }
+
+  // TODO kill
+  addPatterns(...patterns: Pattern[]) {
+    this.patterns.push(...patterns);
+  }
 }

--- a/ts/src/schema/index.ts
+++ b/ts/src/schema/index.ts
@@ -30,6 +30,8 @@ export {
   Node,
   BaseEntSchema,
   BaseEntSchemaWithTZ,
+  EntSchema,
+  EntSchemaWithTZ,
 } from "./base_schema";
 
 export * from "./field";

--- a/ts/src/schema/uuid_field.test.ts
+++ b/ts/src/schema/uuid_field.test.ts
@@ -1,15 +1,12 @@
 import { Pool } from "pg";
 import { v1 } from "uuid";
 import { UUIDType, UUIDListType, StringType } from "./field";
+import { DBType, PolymorphicOptions, Type, FieldOptions } from "./schema";
 import {
-  DBType,
-  PolymorphicOptions,
-  Type,
-  FieldOptions,
-  FieldMap,
-} from "./schema";
-import { BaseEntSchema } from "./base_schema";
-import { User, SimpleAction } from "../testutils/builder";
+  User,
+  SimpleAction,
+  getBuilderSchemaFromFields,
+} from "../testutils/builder";
 import { LoggedOutViewer } from "../core/viewer";
 import { QueryRecorder } from "../testutils/db_mock";
 import { ObjectLoaderFactory } from "../core/loaders/object_loader";
@@ -88,27 +85,29 @@ function doTest(
 
 describe("fieldEdge no inverseEdge", () => {
   test("no checks", async () => {
-    class UserSchema extends BaseEntSchema {
-      fields: FieldMap = { Name: StringType() };
-      ent = User;
-    }
+    const UserSchema = getBuilderSchemaFromFields(
+      {
+        Name: StringType(),
+      },
+      User,
+    );
 
     class Account extends User {}
-    class AccountSchema extends BaseEntSchema {
-      fields: FieldMap = {
+    const AccountSchema = getBuilderSchemaFromFields(
+      {
         userID: UUIDType({ fieldEdge: { schema: "User" } }),
-      };
-      ent = Account;
-    }
+      },
+      Account,
+    );
 
     const userAction = new SimpleAction(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map<string, any>([["Name", "Jon Snow"]]),
     );
     const action = new SimpleAction(
       new LoggedOutViewer(),
-      new AccountSchema(),
+      AccountSchema,
       new Map<string, any>([["userID", userAction.builder]]),
     );
     action.triggers = [
@@ -126,14 +125,16 @@ describe("fieldEdge no inverseEdge", () => {
   });
 
   test("enforce checks with builder", async () => {
-    class UserSchema extends BaseEntSchema {
-      fields: FieldMap = { Name: StringType() };
-      ent = User;
-    }
+    const UserSchema = getBuilderSchemaFromFields(
+      {
+        Name: StringType(),
+      },
+      User,
+    );
 
     class Account extends User {}
-    class AccountSchema extends BaseEntSchema {
-      fields: FieldMap = {
+    const AccountSchema = getBuilderSchemaFromFields(
+      {
         userID: UUIDType({
           fieldEdge: {
             schema: "User",
@@ -152,18 +153,18 @@ describe("fieldEdge no inverseEdge", () => {
             },
           },
         }),
-      };
-      ent = Account;
-    }
+      },
+      Account,
+    );
 
     const userAction = new SimpleAction(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map<string, any>([["Name", "Jon Snow"]]),
     );
     const action = new SimpleAction(
       new LoggedOutViewer(),
-      new AccountSchema(),
+      AccountSchema,
       new Map<string, any>([["userID", userAction.builder]]),
     );
     action.triggers = [
@@ -181,14 +182,16 @@ describe("fieldEdge no inverseEdge", () => {
   });
 
   test("enforce checks with builder. invalid builder", async () => {
-    class UserSchema extends BaseEntSchema {
-      fields: FieldMap = { Name: StringType() };
-      ent = User;
-    }
+    const UserSchema = getBuilderSchemaFromFields(
+      {
+        Name: StringType(),
+      },
+      User,
+    );
 
     class Account extends User {}
-    class AccountSchema extends BaseEntSchema {
-      fields: FieldMap = {
+    const AccountSchema = getBuilderSchemaFromFields(
+      {
         userID: UUIDType({
           fieldEdge: {
             schema: "User",
@@ -207,13 +210,13 @@ describe("fieldEdge no inverseEdge", () => {
             },
           },
         }),
-      };
-      ent = Account;
-    }
+      },
+      Account,
+    );
 
     const userAction = new SimpleAction(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map<string, any>([["Name", "Jon Snow"]]),
     );
     const user = await userAction.saveX();
@@ -222,14 +225,14 @@ describe("fieldEdge no inverseEdge", () => {
     // action2 valid
     const action2 = new SimpleAction(
       new LoggedOutViewer(),
-      new AccountSchema(),
+      AccountSchema,
       new Map<string, any>([["userID", user.id]]),
     );
 
     // action3 invalid
     const action3 = new SimpleAction(
       new LoggedOutViewer(),
-      new AccountSchema(),
+      AccountSchema,
       new Map<string, any>([["userID", action2.builder]]),
     );
 
@@ -244,14 +247,16 @@ describe("fieldEdge no inverseEdge", () => {
   });
 
   test("enforce checks no builder", async () => {
-    class UserSchema extends BaseEntSchema {
-      fields: FieldMap = { Name: StringType() };
-      ent = User;
-    }
+    const UserSchema = getBuilderSchemaFromFields(
+      {
+        Name: StringType(),
+      },
+      User,
+    );
 
     class Account extends User {}
-    class AccountSchema extends BaseEntSchema {
-      fields: FieldMap = {
+    const AccountSchema = getBuilderSchemaFromFields(
+      {
         userID: UUIDType({
           fieldEdge: {
             schema: "User",
@@ -270,13 +275,13 @@ describe("fieldEdge no inverseEdge", () => {
             },
           },
         }),
-      };
-      ent = Account;
-    }
+      },
+      Account,
+    );
 
     const userAction = new SimpleAction(
       new LoggedOutViewer(),
-      new UserSchema(),
+      UserSchema,
       new Map<string, any>([["Name", "Jon Snow"]]),
     );
     const user = await userAction.saveX();
@@ -284,7 +289,7 @@ describe("fieldEdge no inverseEdge", () => {
 
     const action = new SimpleAction(
       new LoggedOutViewer(),
-      new AccountSchema(),
+      AccountSchema,
       new Map<string, any>([["userID", user.id]]),
     );
 
@@ -293,7 +298,7 @@ describe("fieldEdge no inverseEdge", () => {
 
     const action2 = new SimpleAction(
       new LoggedOutViewer(),
-      new AccountSchema(),
+      AccountSchema,
       new Map<string, any>([["userID", account.id]]),
     );
 
@@ -311,14 +316,16 @@ describe("fieldEdge no inverseEdge", () => {
 describe("fieldEdge list", () => {
   test("enforce checks", async () => {
     class ContactEmail extends User {}
-    class ContactEmailSchema extends BaseEntSchema {
-      fields: FieldMap = { Email: StringType() };
-      ent = ContactEmail;
-    }
+    const ContactEmailSchema = getBuilderSchemaFromFields(
+      {
+        Email: StringType(),
+      },
+      ContactEmail,
+    );
 
     class Contact extends User {}
-    class ContactShema extends BaseEntSchema {
-      fields: FieldMap = {
+    const ContactShema = getBuilderSchemaFromFields(
+      {
         emailIDs: UUIDListType({
           fieldEdge: {
             schema: "ContactEmail",
@@ -337,20 +344,20 @@ describe("fieldEdge list", () => {
             },
           },
         }),
-      };
-      ent = Contact;
-    }
+      },
+      Contact,
+    );
 
     const emailAction1 = new SimpleAction(
       new LoggedOutViewer(),
-      new ContactEmailSchema(),
+      ContactEmailSchema,
       new Map<string, any>([["Email", "foo@bar.com"]]),
     );
     const email1 = await emailAction1.saveX();
     expect(email1.data.email).toBe("foo@bar.com");
     const emailAction2 = new SimpleAction(
       new LoggedOutViewer(),
-      new ContactEmailSchema(),
+      ContactEmailSchema,
       new Map<string, any>([["Email", "foo2@bar.com"]]),
     );
     const email2 = await emailAction2.saveX();
@@ -358,7 +365,7 @@ describe("fieldEdge list", () => {
 
     const action = new SimpleAction(
       new LoggedOutViewer(),
-      new ContactShema(),
+      ContactShema,
       new Map<string, any>([["emailIDs", [email1.id, email2.id]]]),
     );
 
@@ -367,7 +374,7 @@ describe("fieldEdge list", () => {
 
     const action2 = new SimpleAction(
       new LoggedOutViewer(),
-      new ContactShema(),
+      ContactShema,
       new Map<string, any>([["emailIDs", [email1.id, v1()]]]),
     );
 
@@ -383,33 +390,35 @@ describe("fieldEdge list", () => {
 
   test("don't enforce checks", async () => {
     class ContactEmail extends User {}
-    class ContactEmailSchema extends BaseEntSchema {
-      fields: FieldMap = { Email: StringType() };
-      ent = ContactEmail;
-    }
+    const ContactEmailSchema = getBuilderSchemaFromFields(
+      {
+        Email: StringType(),
+      },
+      ContactEmail,
+    );
 
     class Contact extends User {}
-    class ContactShema extends BaseEntSchema {
-      fields: FieldMap = {
+    const ContactShema = getBuilderSchemaFromFields(
+      {
         emailIDs: UUIDListType({
           fieldEdge: {
             schema: "ContactEmail",
           },
         }),
-      };
-      ent = Contact;
-    }
+      },
+      Contact,
+    );
 
     const emailAction1 = new SimpleAction(
       new LoggedOutViewer(),
-      new ContactEmailSchema(),
+      ContactEmailSchema,
       new Map<string, any>([["Email", "foo@bar.com"]]),
     );
     const email1 = await emailAction1.saveX();
     expect(email1.data.email).toBe("foo@bar.com");
     const emailAction2 = new SimpleAction(
       new LoggedOutViewer(),
-      new ContactEmailSchema(),
+      ContactEmailSchema,
       new Map<string, any>([["Email", "foo2@bar.com"]]),
     );
     const email2 = await emailAction2.saveX();
@@ -418,7 +427,7 @@ describe("fieldEdge list", () => {
     const fakeID = v1();
     const action = new SimpleAction(
       new LoggedOutViewer(),
-      new ContactShema(),
+      ContactShema,
       new Map<string, any>([["emailIDs", [email1.id, email2.id, fakeID]]]),
     );
 

--- a/ts/src/scripts/transform_schema.ts
+++ b/ts/src/scripts/transform_schema.ts
@@ -42,12 +42,13 @@ async function main() {
     : ts.ScriptTarget.ESNext;
 
   // filter to only event.ts e.g. for comments and whitespace...
-  files = files.filter((f) => f.endsWith("user.ts"));
+  //  files = files.filter((f) => f.endsWith("user.ts"));
 
   files.forEach((file) => {
     // assume valid file since we do glob above
-    const idx = file.lastIndexOf(".ts");
-    const writeFile = file.substring(0, idx) + "2" + ".ts";
+    //    const idx = file.lastIndexOf(".ts");
+    //    const writeFile = file.substring(0, idx) + "2" + ".ts";
+    const writeFile = file;
 
     let contents = fs.readFileSync(file).toString();
 

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -12,13 +12,18 @@ import {
   saveBuilderX,
   Observer,
 } from "../action";
-import { getFields, Schema } from "../schema";
+import { FieldMap, getFields, Schema } from "../schema";
 import { QueryRecorder } from "./db_mock";
 import pluralize from "pluralize";
 import { snakeCase } from "snake-case";
 import { ObjectLoaderFactory } from "../core/loaders";
 import { convertDate } from "../core/convert";
 import { camelCase } from "camel-case";
+import {
+  SchemaConfig,
+  BaseEntSchema,
+  BaseEntSchemaWithTZ,
+} from "../schema/base_schema";
 
 export class User implements Ent {
   id: ID;
@@ -94,6 +99,36 @@ export class Address implements Ent {
 
 export interface BuilderSchema<T extends Ent> extends Schema {
   ent: EntConstructor<T>;
+}
+
+export function getBuilderSchema<T extends Ent>(
+  cfg: SchemaConfig,
+  ent: EntConstructor<T>,
+): BuilderSchema<T> {
+  return {
+    ...new BaseEntSchema(cfg),
+    ent,
+  };
+}
+
+export function getBuilderSchemaFromFields<T extends Ent>(
+  fields: FieldMap,
+  ent: EntConstructor<T>,
+): BuilderSchema<T> {
+  return {
+    ...new BaseEntSchema({ fields }),
+    ent,
+  };
+}
+
+export function getBuilderSchemaTZFromFields<T extends Ent>(
+  fields: FieldMap,
+  ent: EntConstructor<T>,
+): BuilderSchema<T> {
+  return {
+    ...new BaseEntSchemaWithTZ({ fields }),
+    ent,
+  };
 }
 
 export function getSchemaName(value: BuilderSchema<Ent>) {

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -21,8 +21,8 @@ import { convertDate } from "../core/convert";
 import { camelCase } from "camel-case";
 import {
   SchemaConfig,
-  BaseEntSchema,
-  BaseEntSchemaWithTZ,
+  EntSchema,
+  EntSchemaWithTZ,
 } from "../schema/base_schema";
 
 export class User implements Ent {
@@ -106,7 +106,7 @@ export function getBuilderSchema<T extends Ent>(
   ent: EntConstructor<T>,
 ): BuilderSchema<T> {
   return {
-    ...new BaseEntSchema(cfg),
+    ...new EntSchema(cfg),
     ent,
   };
 }
@@ -116,7 +116,7 @@ export function getBuilderSchemaFromFields<T extends Ent>(
   ent: EntConstructor<T>,
 ): BuilderSchema<T> {
   return {
-    ...new BaseEntSchema({ fields }),
+    ...new EntSchema({ fields }),
     ent,
   };
 }
@@ -126,7 +126,7 @@ export function getBuilderSchemaTZFromFields<T extends Ent>(
   ent: EntConstructor<T>,
 ): BuilderSchema<T> {
   return {
-    ...new BaseEntSchemaWithTZ({ fields }),
+    ...new EntSchemaWithTZ({ fields }),
     ent,
   };
 }

--- a/ts/src/testutils/db/test_db_helpers.test.ts
+++ b/ts/src/testutils/db/test_db_helpers.test.ts
@@ -1,8 +1,10 @@
-import { FieldMap } from "../../schema";
-import { BaseEntSchema } from "../../schema/base_schema";
 import { ID, Ent, Data, Viewer } from "../../core/base";
 import { AlwaysAllowPrivacyPolicy } from "../../core/privacy";
-import { getSchemaName, getTableName } from "../builder";
+import {
+  getBuilderSchemaFromFields,
+  getSchemaName,
+  getTableName,
+} from "../builder";
 import { getSchemaTable } from "./test_db";
 import { Dialect } from "../../core/db";
 
@@ -17,21 +19,18 @@ class Account implements Ent {
   }
 }
 
-class AccountSchema extends BaseEntSchema {
-  ent = Account;
-  fields: FieldMap = {};
-}
+const AccountSchema = getBuilderSchemaFromFields({}, Account);
 
 test("schema name", () => {
-  expect(getSchemaName(new AccountSchema())).toBe("Account");
+  expect(getSchemaName(AccountSchema)).toBe("Account");
 });
 
 test("table name", () => {
-  expect(getTableName(new AccountSchema())).toBe("accounts");
+  expect(getTableName(AccountSchema)).toBe("accounts");
 });
 
 test("fields", () => {
-  const table = getSchemaTable(new AccountSchema(), Dialect.Postgres);
+  const table = getSchemaTable(AccountSchema, Dialect.Postgres);
   expect(table.name).toBe("accounts");
   expect(table.columns.length).toBe(3);
   expect(table.columns.map((col) => col.name)).toEqual([

--- a/ts/src/testutils/fake_data/fake_contact.ts
+++ b/ts/src/testutils/fake_data/fake_contact.ts
@@ -8,14 +8,8 @@ import {
 } from "../../core/base";
 import { loadEnt, loadEntX } from "../../core/ent";
 import { AllowIfViewerIsRule, AlwaysDenyRule } from "../../core/privacy";
-import { BuilderSchema, SimpleBuilder } from "../builder";
-import {
-  Field,
-  StringType,
-  BaseEntSchema,
-  UUIDType,
-  FieldMap,
-} from "../../schema";
+import { getBuilderSchemaFromFields, SimpleBuilder } from "../builder";
+import { StringType, UUIDType } from "../../schema";
 import { NodeType } from "./const";
 import { table, uuid, text, timestamptz } from "../db/test_db";
 import { ObjectLoaderFactory } from "../../core/loaders";
@@ -93,20 +87,17 @@ export class FakeContact implements Ent {
   }
 }
 
-export class FakeContactSchema
-  extends BaseEntSchema
-  implements BuilderSchema<FakeContact>
-{
-  ent = FakeContact;
-  fields: FieldMap = {
+export const FakeContactSchema = getBuilderSchemaFromFields(
+  {
     firstName: StringType(),
     lastName: StringType(),
     emailAddress: StringType(),
     userID: UUIDType({
       foreignKey: { schema: "User", column: "ID" },
     }),
-  };
-}
+  },
+  FakeContact,
+);
 
 export interface ContactCreateInput {
   firstName: string;
@@ -124,7 +115,7 @@ export function getContactBuilder(viewer: Viewer, input: ContactCreateInput) {
   m.set("createdAt", new Date());
   m.set("updatedAt", new Date());
 
-  return new SimpleBuilder(viewer, new FakeContactSchema(), m);
+  return new SimpleBuilder(viewer, FakeContactSchema, m);
 }
 
 export async function createContact(viewer: Viewer, input: ContactCreateInput) {

--- a/ts/src/testutils/fake_data/fake_event.ts
+++ b/ts/src/testutils/fake_data/fake_event.ts
@@ -8,15 +8,8 @@ import {
 } from "../../core/base";
 import { loadEnt, loadEntX } from "../../core/ent";
 import { AlwaysAllowPrivacyPolicy } from "../../core/privacy";
-import { BuilderSchema, SimpleBuilder } from "../builder";
-import {
-  Field,
-  StringType,
-  BaseEntSchema,
-  UUIDType,
-  TimestampType,
-  FieldMap,
-} from "../../schema";
+import { getBuilderSchemaFromFields, SimpleBuilder } from "../builder";
+import { StringType, UUIDType, TimestampType } from "../../schema";
 import { NodeType } from "./const";
 import { table, uuid, text, timestamptz } from "../db/test_db";
 import { ObjectLoaderFactory } from "../../core/loaders";
@@ -101,12 +94,8 @@ export class FakeEvent implements Ent {
   }
 }
 
-export class FakeEventSchema
-  extends BaseEntSchema
-  implements BuilderSchema<FakeEvent>
-{
-  ent = FakeEvent;
-  fields: FieldMap = {
+export const FakeEventSchema = getBuilderSchemaFromFields(
+  {
     startTime: TimestampType({
       index: true,
     }),
@@ -121,8 +110,9 @@ export class FakeEventSchema
     userID: UUIDType({
       foreignKey: { schema: "User", column: "ID" },
     }),
-  };
-}
+  },
+  FakeEvent,
+);
 
 export interface EventCreateInput {
   startTime: Date;
@@ -138,7 +128,7 @@ export function getEventBuilder(viewer: Viewer, input: EventCreateInput) {
   for (const key in input) {
     m.set(key, input[key]);
   }
-  return new SimpleBuilder(viewer, new FakeEventSchema(), m);
+  return new SimpleBuilder(viewer, FakeEventSchema, m);
 }
 
 export async function createEvent(viewer: Viewer, input: EventCreateInput) {

--- a/ts/src/testutils/fake_data/fake_user.ts
+++ b/ts/src/testutils/fake_data/fake_user.ts
@@ -13,8 +13,8 @@ import {
   AllowIfViewerInboundEdgeExistsRule,
   AllowIfConditionAppliesRule,
 } from "../../core/privacy";
-import { BuilderSchema, SimpleAction } from "../builder";
-import { Field, StringType, BaseEntSchema, FieldMap } from "../../schema";
+import { getBuilderSchemaFromFields, SimpleAction } from "../builder";
+import { StringType } from "../../schema";
 import { EdgeType } from "./internal";
 import { NodeType } from "./const";
 import { IDViewer, IDViewerOptions } from "../../core/viewer";
@@ -130,12 +130,8 @@ export class FakeUser implements Ent {
   }
 }
 
-export class FakeUserSchema
-  extends BaseEntSchema
-  implements BuilderSchema<FakeUser>
-{
-  ent = FakeUser;
-  fields: FieldMap = {
+export const FakeUserSchema = getBuilderSchemaFromFields(
+  {
     firstName: StringType(),
     lastName: StringType(),
     emailAddress: StringType(),
@@ -143,8 +139,9 @@ export class FakeUserSchema
     password: StringType({
       nullable: true,
     }),
-  };
-}
+  },
+  FakeUser,
+);
 
 export interface UserCreateInput {
   firstName: string;
@@ -166,7 +163,7 @@ export function getUserAction(viewer: Viewer, input: UserCreateInput) {
   for (const key in input) {
     m.set(key, input[key]);
   }
-  const action = new SimpleAction(viewer, new FakeUserSchema(), m);
+  const action = new SimpleAction(viewer, FakeUserSchema, m);
   action.viewerForEntLoad = (data: Data) => {
     // load the created ent using a VC of the newly created user.
     return new IDViewer(data.id);

--- a/ts/src/testutils/fake_data/test_helpers.ts
+++ b/ts/src/testutils/fake_data/test_helpers.ts
@@ -157,7 +157,7 @@ export async function createUserPlusFriendRequests(
 
   await addEdge(
     user,
-    new FakeUserSchema(),
+    FakeUserSchema,
     EdgeType.UserToFriendRequests,
     true,
     ...friendRequests,


### PR DESCRIPTION
addresses https://github.com/lolopinto/ent/issues/585

changes the API from 

```ts
export default class Holiday extends BaseEntSchemaWithTZ {
  constructor() {
    super();
    this.addPatterns(new DayOfWeek());
  }

  fields: Field[] = [StringType({ name: "label" }), DateType({ name: "date" })];

  actions = [
    {
      operation: ActionOperation.Create,
    },
  ];
}
```

to 

```ts
const Holiday = new EntSchemaWithTZ({
  patterns: [new DayOfWeek()],

  fields: { label: StringType(), date: DateType() },

  actions: [
    {
      operation: ActionOperation.Create,
    },
  ],
});
export default Holiday;
```

new API is easier to use, less likely to make mistakes and don't have to deal with types since that's just passed in the constructor.  using patterns is the cleanest change so far



builds on top of the work done in https://github.com/lolopinto/ent/pull/707