### PR TITLE
[auto_schema]: No merge revs

### DIFF
--- a/gent/cmd/upgrade.go
+++ b/gent/cmd/upgrade.go
@@ -20,6 +20,6 @@ var upgradeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return db.UpgradeDB(cfg, revision, false)
+		return db.UpgradeDB(cfg, revision)
 	},
 }

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -419,11 +419,8 @@ func (s *dbSchema) makeDBChanges() error {
 	return auto_schema.RunPythonCommand(s.pathToConfigs)
 }
 
-func UpgradeDB(cfg *codegen.Config, revision string, mergeBranches bool) error {
+func UpgradeDB(cfg *codegen.Config, revision string) error {
 	extraArgs := []string{fmt.Sprintf("-u=%s", revision)}
-	if mergeBranches {
-		extraArgs = append(extraArgs, "--merge_branches")
-	}
 	return auto_schema.RunPythonCommand(cfg.GetRootPathToConfigs(), extraArgs...)
 }
 

--- a/python/auto_schema/auto_schema/cli/__init__.py
+++ b/python/auto_schema/auto_schema/cli/__init__.py
@@ -28,7 +28,6 @@ parser.add_argument('-u', '--upgrade', help='upgrade')
 parser.add_argument('-d', '--downgrade', help='downgrade')
 # only applies when downgrading, default is deleting file since it's auto created by schema
 parser.add_argument('--keep_schema_files', action='store_true')
-parser.add_argument('--merge_branches', action='store_true')
 parser.add_argument('--history', help='alembic history', action='store_true')
 parser.add_argument('--current', help='alembic current', action='store_true')
 parser.add_argument('--show', help='show revision')
@@ -56,8 +55,7 @@ def main():
         else:
             r = Runner.from_command_line(metadata, args)
             if args.upgrade is not None:
-                r.upgrade(revision=args.upgrade,
-                          merge_branches=args.merge_branches)
+                r.upgrade(revision=args.upgrade)
             elif args.downgrade is not None:
                 r.downgrade(args.downgrade, not args.keep_schema_files)
             elif args.history is True:

--- a/python/auto_schema/auto_schema/command.py
+++ b/python/auto_schema/auto_schema/command.py
@@ -5,7 +5,6 @@ from alembic import command
 from alembic.script import ScriptDirectory
 
 from . import runner
-from typing import TypedDict
 
 
 class Command(object):

--- a/python/auto_schema/auto_schema/command.py
+++ b/python/auto_schema/auto_schema/command.py
@@ -8,11 +8,6 @@ from . import runner
 from typing import TypedDict
 
 
-class UpgradeInfo(TypedDict):
-    unmerged_branches: bool
-    merged_and_upgraded_head: bool
-
-
 class Command(object):
 
     def __init__(self, connection, schema_path):
@@ -55,28 +50,25 @@ class Command(object):
     # Simulates running the `alembic revision -m` command
     def revision(self, message):
         heads = self.get_heads()
+        head = 'head'
         if len(heads) > 1:
-            # if multiple heads, now safe to do a merge first before the revision since we can't
-            # keep making (automatic) changes in a branch
-            merge_message = self._get_merge_message(heads)
-            # create a merge revision and upgrade to it
-            command.merge(self.alembic_cfg, 'heads', message=merge_message)
-            command.upgrade(self.alembic_cfg, 'head')
+            head = heads
 
-        command.revision(self.alembic_cfg, message, autogenerate=True)
+        command.revision(self.alembic_cfg, message,
+                         autogenerate=True, head=head)
 
     def get_heads(self):
         script = ScriptDirectory.from_config(self.alembic_cfg)
 
         return script.get_heads()
 
-    def _get_merge_message(self, heads) -> str:
-        return 'merge revisions %s ' % ", ".join(heads)
+    def get_revisions(self, revs):
+        script = ScriptDirectory.from_config(self.alembic_cfg)
+        return script.get_revisions(revs)
 
     # Simulates running the `alembic upgrade` command
-    def upgrade(self, revision='head', merge_branches=False) -> UpgradeInfo:
-        ret: UpgradeInfo = {}
-        merge_message = None
+
+    def upgrade(self, revision='head'):
         if revision == 'head':
             # check for current heads
             # if more than one, update to heads
@@ -84,28 +76,13 @@ class Command(object):
             heads = self.get_heads()
 
             if len(heads) > 1:
-                if merge_branches:
-                    merge_message = self._get_merge_message(heads)
-                else:
-                    ret['unmerged_branches'] = True
-
                 # need to change to upgrade to heads and then merge and upgrade that to head
                 revision = 'heads'
 
         command.upgrade(self.alembic_cfg, revision)
 
-        if merge_message is None:
-            return ret
-
-        # merge the heads
-        command.merge(self.alembic_cfg, 'heads', message=merge_message)
-        # upgrade to head
-        command.upgrade(self.alembic_cfg, 'head')
-        # we want to flag this back somehow so that developer knows what happened
-        ret['merged_and_upgraded_head'] = True
-        return ret
-
     # Simulates running the `alembic downgrade` command
+
     def downgrade(self, revision='', delete_files=True):
         paths = []
         if delete_files:

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -227,8 +227,8 @@ class Runner(object):
         # understand diff and make changes as needed
         # pprint.pprint(migrations, indent=2, width=30)
 
-    def upgrade(self, revision='head', merge_branches=False):
-        return self.cmd.upgrade(revision, merge_branches)
+    def upgrade(self, revision='head'):
+        return self.cmd.upgrade(revision)
 
     def downgrade(self, revision, delete_files):
         self.cmd.downgrade(revision, delete_files=delete_files)

--- a/test_setup/main.go
+++ b/test_setup/main.go
@@ -21,7 +21,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := db.UpgradeDB(cfg, "head", true); err != nil {
+	if err := db.UpgradeDB(cfg, "head"); err != nil {
 		log.Fatal(err)
 	}
 

--- a/tsent/cmd/root.go
+++ b/tsent/cmd/root.go
@@ -95,7 +95,6 @@ func init() {
 	generateSchemasCmd.Flags().BoolVar(&schemasInfo.force, "force", false, "if force is true, it overwrites existing schema, otherwise throws error")
 
 	downgradeCmd.Flags().BoolVar(&downgradeInfo.keepSchemaFiles, "keep_schema_files", false, "keep schema files instead of deleting")
-	upgradeCmd.Flags().BoolVar(&upgradeInfo.mergeBranches, "merge_branches", false, "merge branches found while upgrading")
 }
 
 func Execute() {

--- a/tsent/cmd/upgrade.go
+++ b/tsent/cmd/upgrade.go
@@ -6,22 +6,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type upgradeArgs struct {
-	mergeBranches bool
-}
-
-var upgradeInfo upgradeArgs
-
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "upgrade db",
 	Long:  `This upgrades the database to the latest version`,
 	Example: `tsent upgrade 
-tsent upgrade --merge_branches 
-tsent upgrade --merge_branches head
-tsent upgrade --merge_branches revision
 tsent upgrade revision`,
-	Args: cobra.RangeArgs(0, 2),
+	Args: cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// default to head if not passed in
 		revision := "head"
@@ -34,6 +25,6 @@ tsent upgrade revision`,
 			return err
 		}
 
-		return db.UpgradeDB(cfg, revision, upgradeInfo.mergeBranches)
+		return db.UpgradeDB(cfg, revision)
 	},
 }


### PR DESCRIPTION
 kill merge revisions
    
fixes https://github.com/lolopinto/ent/issues/620
        
when there are multiple branches and we want to create a new revision/change, instead of using a merge revision like we did in https://github.com/lolopinto/ent/pull/546, we should use multiple down branches.

this makes it easier to keep track of what's going on. if one is trying to switch between branches and trying to keep track of changes between branches and has to count the merge revision, it becomes too difficult and annoying

