### PR TITLE
[auto_schema] provide more alembic history options

### DIFF
--- a/python/auto_schema/auto_schema/cli/__init__.py
+++ b/python/auto_schema/auto_schema/cli/__init__.py
@@ -28,8 +28,14 @@ parser.add_argument('-u', '--upgrade', help='upgrade')
 parser.add_argument('-d', '--downgrade', help='downgrade')
 # only applies when downgrading, default is deleting file since it's auto created by schema
 parser.add_argument('--keep_schema_files', action='store_true')
-parser.add_argument('--history', help='alembic history', action='store_true')
+parser.add_argument('--history', help='alembic history',
+                    action='store_true')
 parser.add_argument('--current', help='alembic current', action='store_true')
+parser.add_argument(
+    '--verbose', help='alembic history --verbose', action='store_true')
+parser.add_argument('--last', help='alembic history --verbose --last N')
+parser.add_argument(
+    '--rev_range', help='alembic history --rev_range revn:current')
 parser.add_argument('--show', help='show revision')
 parser.add_argument('--heads', help='alembic heads', action='store_true')
 parser.add_argument('--branches', help='alembic branches', action='store_true')
@@ -43,13 +49,15 @@ parser.add_argument(
 
 
 def main():
-    args = parser.parse_args()
-    sys.path.append(os.path.relpath(args.schema))
-
-    schema = import_module('schema')
-    metadata = schema.get_metadata()
-
     try:
+        args = parser.parse_args()
+
+        print(args)
+        sys.path.append(os.path.relpath(args.schema))
+
+        schema = import_module('schema')
+        metadata = schema.get_metadata()
+
         if args.fix_edges:
             Runner.fix_edges(metadata, args)
         else:
@@ -59,7 +67,9 @@ def main():
             elif args.downgrade is not None:
                 r.downgrade(args.downgrade, not args.keep_schema_files)
             elif args.history is True:
-                r.history()
+                print(args.verbose, args.last, args.rev_range)
+                r.history(verbose=args.verbose, last=args.last,
+                          rev_range=args.rev_range)
             elif args.current is True:
                 r.current()
             elif args.heads is True:

--- a/python/auto_schema/auto_schema/cli/__init__.py
+++ b/python/auto_schema/auto_schema/cli/__init__.py
@@ -52,7 +52,6 @@ def main():
     try:
         args = parser.parse_args()
 
-        print(args)
         sys.path.append(os.path.relpath(args.schema))
 
         schema = import_module('schema')
@@ -67,7 +66,6 @@ def main():
             elif args.downgrade is not None:
                 r.downgrade(args.downgrade, not args.keep_schema_files)
             elif args.history is True:
-                print(args.verbose, args.last, args.rev_range)
                 r.history(verbose=args.verbose, last=args.last,
                           rev_range=args.rev_range)
             elif args.current is True:

--- a/python/auto_schema/auto_schema/command.py
+++ b/python/auto_schema/auto_schema/command.py
@@ -120,8 +120,19 @@ class Command(object):
         return list(script.walk_revisions())
 
     # Simulates running the `alembic history` command
-    def history(self):
-        command.history(self.alembic_cfg, indicate_current=True)
+    def history(self, verbose=False, last=None, rev_range=None):
+        if rev_range is not None and last is not None:
+            raise ValueError(
+                "cannot pass both last and rev_range. please pick one")
+        if last is not None:
+            script = ScriptDirectory.from_config(self.alembic_cfg)
+            revs = list(script.revision_map.iterate_revisions(
+                self.get_heads(), '-%d' % int(last), select_for_downgrade=True
+            ))
+            rev_range = '%s:current' % revs[-1].revision
+
+        command.history(self.alembic_cfg,
+                        indicate_current=True, verbose=verbose, rev_range=rev_range)
 
     # Simulates running the `alembic current` command
     def current(self):

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -227,14 +227,14 @@ class Runner(object):
         # understand diff and make changes as needed
         # pprint.pprint(migrations, indent=2, width=30)
 
-    def upgrade(self, revision='head'):
+    def upgrade(self, revision='heads'):
         return self.cmd.upgrade(revision)
 
     def downgrade(self, revision, delete_files):
         self.cmd.downgrade(revision, delete_files=delete_files)
 
-    def history(self):
-        self.cmd.history()
+    def history(self, verbose=False, last=None, rev_range=None):
+        self.cmd.history(verbose=verbose, last=last, rev_range=rev_range)
 
     def current(self):
         self.cmd.current()

--- a/python/auto_schema/setup.py
+++ b/python/auto_schema/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 # https://test.pypi.org/project/auto-schema-test/#history
 setuptools.setup(
     name="auto_schema",  # auto_schema_test to test
-    version="0.0.16",  # 0.0.11 was last test version
+    version="0.0.16",  # 0.0.12 was last test version
     author="Ola Okelola",
     author_email="email@email.com",
     description="auto schema for a db",

--- a/python/auto_schema/tests/command_test.py
+++ b/python/auto_schema/tests/command_test.py
@@ -132,7 +132,7 @@ def _create_parallel_changes(new_test_runner, metadata_with_table):
     assert len(r3.compute_changes()) > 0
 
     # sucessfully upgrade
-    r3.upgrade('head')
+    r3.upgrade('heads')
 
     files3c = testingutils.get_version_files(r3)
 

--- a/tsent/cmd/alembic.go
+++ b/tsent/cmd/alembic.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/lolopinto/ent/internal/auto_schema"
 	"github.com/lolopinto/ent/internal/codegen"
 	"github.com/lolopinto/ent/internal/db"
 	"github.com/spf13/cobra"
@@ -21,14 +22,21 @@ var validCmds = map[string]int{
 	"merge":     1,
 }
 
+var variableArgs = map[string]bool{
+	"history": true,
+}
+
 var alembicCmd = &cobra.Command{
 	Use:   "alembic",
 	Short: "alembic command",
 	Long:  `This runs the passed in alembic command. Valid alembic commands are upgrade, downgrade, history, current, heads, branches, show, stamp, edit`,
 	Example: `tsent alembic history 
 tsent alembic current
+tsent alembic history --verbose 
+tsent alembic history --verbose --last 4
+tsent alembic history --verbose --rev_range rev1:current
 	`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// another hardcoded place
 		cfg, err := codegen.NewConfig("src/schema", "")
@@ -41,8 +49,13 @@ tsent alembic current
 			return fmt.Errorf("invalid alembic command %s passed in", command)
 		}
 
-		if count+1 != len(args) {
+		if count+1 != len(args) && !variableArgs[command] {
 			return fmt.Errorf("invalid number of args passed. expected %d", count+1)
+		}
+
+		if command == "history" {
+			args[0] = "--history"
+			return auto_schema.RunPythonCommand(cfg.GetRootPathToConfigs(), args...)
 		}
 
 		return db.RunAlembicCommand(cfg, args[0], args[1:]...)

--- a/tsent/cmd/root.go
+++ b/tsent/cmd/root.go
@@ -95,6 +95,8 @@ func init() {
 	generateSchemasCmd.Flags().BoolVar(&schemasInfo.force, "force", false, "if force is true, it overwrites existing schema, otherwise throws error")
 
 	downgradeCmd.Flags().BoolVar(&downgradeInfo.keepSchemaFiles, "keep_schema_files", false, "keep schema files instead of deleting")
+
+	alembicCmd.DisableFlagParsing = true
 }
 
 func Execute() {


### PR DESCRIPTION
exposes verbose flag
exposes rev_range flag
adds a last flag which creates a rev_range to pass to the history command

addresses one of the gripes in https://github.com/lolopinto/ent/issues/642