### PR TITLE
fix referencing nested object in action

### DIFF
--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -268,7 +268,7 @@ func (nodeData *NodeData) GetImportsForBaseFile() ([]ImportPath, error) {
 }
 
 // GetImportPathsForDependencies returns imports needed in dependencies e.g. actions and builders
-func (nodeData *NodeData) GetImportPathsForDependencies() []ImportPath {
+func (nodeData *NodeData) GetImportPathsForDependencies(s *Schema) []ImportPath {
 	var ret []ImportPath
 
 	for _, enum := range nodeData.GetTSEnums() {
@@ -283,6 +283,12 @@ func (nodeData *NodeData) GetImportPathsForDependencies() []ImportPath {
 	for _, unique := range uniqueNodes {
 		ret = append(ret, ImportPath{
 			Import:      unique.Node,
+			PackagePath: codepath.GetExternalImportPath(),
+		})
+	}
+	for _, v := range s.Nodes {
+		ret = append(ret, ImportPath{
+			Import:      v.NodeData.Node,
 			PackagePath: codepath.GetExternalImportPath(),
 		})
 	}

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -3,7 +3,7 @@
 {{ reserveImport "src/ent/" "NodeType"}}
 {{ reserveImport .PrivacyConfig.Path .PrivacyConfig.PolicyName }}
 
-{{ range .NodeData.GetImportPathsForDependencies -}}
+{{ range .NodeData.GetImportPathsForDependencies .Schema -}}
   {{ if .DefaultImport -}}
     {{ reserveDefaultImport .PackagePath .Import}}
   {{ else -}}

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -1,13 +1,14 @@
 {{reserveImport .Package.PackagePath "Viewer" "ID" "Ent" "AssocEdgeInputOptions"}}
 {{reserveImport .Package.ActionPackagePath "Action" "Builder" "WriteOperation" "Changeset" "saveBuilder" "saveBuilderX" "Orchestrator"}}
 
+{{ $schema := .Schema}}
 {{with .NodeData -}}
 {{ $schemaPath := printf "src/schema/%s" .PackageName }}
 {{ reserveDefaultImport $schemaPath "schema"}}
 {{ reserveImport "src/ent/generated/const" "EdgeType" "NodeType" }}
 
 
-{{ range .GetImportPathsForDependencies -}}
+{{ range .GetImportPathsForDependencies $schema -}}
   {{ if .DefaultImport -}}
     {{ reserveDefaultImport .PackagePath .Import}}
   {{ else -}}

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -113,7 +113,7 @@ func (s *Step) processActions(processor *codegen.Processor, nodeData *schema.Nod
 	for idx := range nodeData.ActionInfo.Actions {
 		action := nodeData.ActionInfo.Actions[idx]
 		ret = append(ret, func() error {
-			return writeBaseActionFile(nodeData, processor, action)
+			return writeBaseActionFile(processor.Schema, nodeData, processor, action)
 		})
 
 		ret = append(ret, func() error {
@@ -279,6 +279,7 @@ type nodeTemplateCodePath struct {
 	NodeData      *schema.NodeData
 	CodePath      *codegen.Config
 	Package       *codegen.ImportPackage
+	Schema        *schema.Schema
 	Imports       []schema.ImportPath
 	PrivacyConfig *codegen.PrivacyConfig
 }
@@ -808,6 +809,7 @@ func writeBuilderFile(nodeData *schema.NodeData, processor *codegen.Processor) e
 		Data: nodeTemplateCodePath{
 			NodeData: nodeData,
 			CodePath: cfg,
+			Schema:   processor.Schema,
 			Package:  cfg.GetImportPackage(),
 			Imports:  imports,
 		},

--- a/internal/tscode/write_action.go
+++ b/internal/tscode/write_action.go
@@ -20,9 +20,10 @@ type actionTemplate struct {
 	BasePath      string
 	Package       *codegen.ImportPackage
 	PrivacyConfig *codegen.PrivacyConfig
+	Schema        *schema.Schema
 }
 
-func writeBaseActionFile(nodeData *schema.NodeData, processor *codegen.Processor, action action.Action) error {
+func writeBaseActionFile(schema *schema.Schema, nodeData *schema.NodeData, processor *codegen.Processor, action action.Action) error {
 	cfg := processor.Config
 	filePath := getFilePathForActionBaseFile(cfg, nodeData, action)
 	imps := tsimport.NewImports(processor.Config, filePath)
@@ -32,6 +33,7 @@ func writeBaseActionFile(nodeData *schema.NodeData, processor *codegen.Processor
 		Data: actionTemplate{
 			NodeData:      nodeData,
 			Action:        action,
+			Schema:        schema,
 			BuilderPath:   getImportPathForBuilderFile(nodeData),
 			Package:       cfg.GetImportPackage(),
 			PrivacyConfig: cfg.GetDefaultActionPolicy(),


### PR DESCRIPTION
if you have an action that has an action only field which references a foreignKey or anything that generates a fieldEdge, we eventually have an error because we've not "reserved" that object

because field.TsBuilderImports returns strings instead of the full import type, we were trying to reference a field that doesn't exist

correct fix is to change TsBuilderImports from strings to ImportType so we don't need this hack with schema but that's a more involved fix

for now, we're just referencing all nodes in the schema to work around it

Test Plan: works on following schema:

```ts
// cat horse.ts horse_info.ts horse_pedigree_info.ts user.ts 
import { ActionOperation } from "@snowtop/ent";
import { Action, BaseEntSchema, Field, StringType } from "@snowtop/ent";

export default class Horse extends BaseEntSchema {
  fields: Field[] = [StringType({ name: "name" })];

  actions: Action[] = [
    {
      operation: ActionOperation.Create,
      actionOnlyFields: [
        {
          type: "Object",
          name: "horseInfo",
          actionName: "CreateHorseInfoAction",
        },
        {
          type: "Object",
          name: "pedigreeInfo",
          actionName: "CreateHorsePedigreeInfoAction",
        },
      ],
    },
  ];
}
import {
  Action,
  ActionOperation,
  BaseEntSchema,
  Field,
  IntegerType,
  StringType,
} from "@snowtop/ent";

export default class HorseInfo extends BaseEntSchema {
  fields: Field[] = [
    StringType({ name: "name" }),
    IntegerType({ name: "foo" }),
  ];

  actions: Action[] = [
    {
      operation: ActionOperation.Create,
    },
  ];
}
import {
  Action,
  ActionOperation,
  BaseEntSchema,
  Field,
  StringType,
  UUIDType,
} from "@snowtop/ent";

export default class HorsePedigreeInfo extends BaseEntSchema {
  fields: Field[] = [
    StringType({ name: "name" }),
    UUIDType({
      name: "breederID",
      nullable: true,
      foreignKey: {
        schema: "User",
        column: "ID",
        name: "bredBy",
      },
    }),
  ];

  actions: Action[] = [
    {
      operation: ActionOperation.Create,
    },
  ];
}
import { BaseEntSchema, Field, StringType } from "@snowtop/ent";

export default class User extends BaseEntSchema {
  fields: Field[] = [StringType({ name: "name" })];
}
```