### PR TITLE
kill enttype.InputImportType

### DIFF
--- a/internal/enttype/json_test.go
+++ b/internal/enttype/json_test.go
@@ -80,9 +80,9 @@ func TestJSONType(t *testing.T) {
 		},
 		"json with import type": {
 			&enttype.JSONType{
-				ImportType: &enttype.InputImportType{
-					Type: "Foo",
-					Path: "path",
+				ImportType: &tsimport.ImportPath{
+					Import:     "Foo",
+					ImportPath: "path",
 				},
 			},
 			expType{
@@ -94,9 +94,9 @@ func TestJSONType(t *testing.T) {
 				},
 				tsType: "Foo",
 				nullableType: &enttype.NullableJSONType{
-					ImportType: &enttype.InputImportType{
-						Type: "Foo",
-						Path: "path",
+					ImportType: &tsimport.ImportPath{
+						Import:     "Foo",
+						ImportPath: "path",
 					},
 				},
 				goTypePanics:  true,
@@ -108,9 +108,9 @@ func TestJSONType(t *testing.T) {
 		},
 		"nullable json with import type": {
 			&enttype.NullableJSONType{
-				ImportType: &enttype.InputImportType{
-					Type: "Foo",
-					Path: "path",
+				ImportType: &tsimport.ImportPath{
+					Import:     "Foo",
+					ImportPath: "path",
 				},
 			},
 			expType{
@@ -121,9 +121,9 @@ func TestJSONType(t *testing.T) {
 				},
 				tsType: "Foo | null",
 				nonNullableType: &enttype.JSONType{
-					ImportType: &enttype.InputImportType{
-						Type: "Foo",
-						Path: "path",
+					ImportType: &tsimport.ImportPath{
+						Import:     "Foo",
+						ImportPath: "path",
 					},
 				},
 				goTypePanics:  true,
@@ -135,9 +135,9 @@ func TestJSONType(t *testing.T) {
 		},
 		"jsonb with import type": {
 			&enttype.JSONBType{
-				ImportType: &enttype.InputImportType{
-					Type: "Foo",
-					Path: "path",
+				ImportType: &tsimport.ImportPath{
+					Import:     "Foo",
+					ImportPath: "path",
 				},
 			},
 			expType{
@@ -149,9 +149,9 @@ func TestJSONType(t *testing.T) {
 				},
 				tsType: "Foo",
 				nullableType: &enttype.NullableJSONBType{
-					ImportType: &enttype.InputImportType{
-						Type: "Foo",
-						Path: "path",
+					ImportType: &tsimport.ImportPath{
+						Import:     "Foo",
+						ImportPath: "path",
 					},
 				},
 				goTypePanics:  true,
@@ -163,9 +163,9 @@ func TestJSONType(t *testing.T) {
 		},
 		"nullable jsonb with import type": {
 			&enttype.NullableJSONBType{
-				ImportType: &enttype.InputImportType{
-					Type: "Foo",
-					Path: "path",
+				ImportType: &tsimport.ImportPath{
+					Import:     "Foo",
+					ImportPath: "path",
 				},
 			},
 			expType{
@@ -176,9 +176,9 @@ func TestJSONType(t *testing.T) {
 				},
 				tsType: "Foo | null",
 				nonNullableType: &enttype.JSONBType{
-					ImportType: &enttype.InputImportType{
-						Type: "Foo",
-						Path: "path",
+					ImportType: &tsimport.ImportPath{
+						Import:     "Foo",
+						ImportPath: "path",
 					},
 				},
 				goTypePanics:  true,

--- a/internal/enttype/type.go
+++ b/internal/enttype/type.go
@@ -94,7 +94,7 @@ type TSTypeWithActionFields interface {
 
 type ImportDepsType interface {
 	TSGraphQLType
-	GetImportDepsType() *InputImportType
+	GetImportDepsType() *tsimport.ImportPath
 }
 
 type ListType interface {
@@ -1708,12 +1708,6 @@ func (t *NullableArrayListType) Convert() *tsimport.ImportPath {
 	return elem.convertNullableListWithItem()
 }
 
-// to resolve circular dependency btw input and this
-type InputImportType struct {
-	Path string `json:"path"`
-	Type string `json:"type"`
-}
-
 type jSONType struct {
 }
 
@@ -1739,21 +1733,21 @@ func (t *jSONType) GetGraphQLType() string {
 	return "JSON!"
 }
 
-func (t *jSONType) getTsType(nullable bool, impType *InputImportType) string {
+func (t *jSONType) getTsType(nullable bool, impType *tsimport.ImportPath) string {
 	if impType == nil {
 		return "any"
 	}
 	if nullable {
-		return impType.Type + " | null"
+		return impType.Import + " | null"
 	}
-	return impType.Type
+	return impType.Import
 }
 
-func (t *jSONType) getTsTypeImports(impType *InputImportType) []string {
+func (t *jSONType) getTsTypeImports(impType *tsimport.ImportPath) []string {
 	if impType == nil {
 		return nil
 	}
-	return []string{impType.Type}
+	return []string{impType.Import}
 }
 
 // TODO https://github.com/taion/graphql-type-json
@@ -1777,7 +1771,7 @@ func (t *jSONType) convertNullableListWithItem() *tsimport.ImportPath {
 }
 
 type JSONType struct {
-	ImportType *InputImportType
+	ImportType *tsimport.ImportPath
 	jSONType
 }
 
@@ -1803,12 +1797,12 @@ func (t *JSONType) GetTsTypeImports() []string {
 	return t.getTsTypeImports(t.ImportType)
 }
 
-func (t *JSONType) GetImportDepsType() *InputImportType {
+func (t *JSONType) GetImportDepsType() *tsimport.ImportPath {
 	return t.ImportType
 }
 
 type NullableJSONType struct {
-	ImportType *InputImportType
+	ImportType *tsimport.ImportPath
 	jSONType
 }
 
@@ -1844,12 +1838,12 @@ func (t *NullableJSONType) GetTsTypeImports() []string {
 	return t.getTsTypeImports(t.ImportType)
 }
 
-func (t *NullableJSONType) GetImportDepsType() *InputImportType {
+func (t *NullableJSONType) GetImportDepsType() *tsimport.ImportPath {
 	return t.ImportType
 }
 
 type JSONBType struct {
-	ImportType *InputImportType
+	ImportType *tsimport.ImportPath
 	jSONType
 }
 
@@ -1875,7 +1869,7 @@ func (t *JSONBType) GetTsTypeImports() []string {
 	return t.getTsTypeImports(t.ImportType)
 }
 
-func (t *JSONBType) GetImportDepsType() *InputImportType {
+func (t *JSONBType) GetImportDepsType() *tsimport.ImportPath {
 	return t.ImportType
 }
 
@@ -1884,7 +1878,7 @@ func (t *JSONBType) GetImportType() Import {
 }
 
 type NullableJSONBType struct {
-	ImportType *InputImportType
+	ImportType *tsimport.ImportPath
 	jSONType
 }
 
@@ -1920,7 +1914,7 @@ func (t *NullableJSONBType) GetTsTypeImports() []string {
 	return t.getTsTypeImports(t.ImportType)
 }
 
-func (t *NullableJSONBType) GetImportDepsType() *InputImportType {
+func (t *NullableJSONBType) GetImportDepsType() *tsimport.ImportPath {
 	return t.ImportType
 }
 

--- a/internal/schema/input/parse_ts_field_test.go
+++ b/internal/schema/input/parse_ts_field_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/lolopinto/ent/internal/schema/input"
+	"github.com/lolopinto/ent/internal/tsimport"
 )
 
 func TestParseFields(t *testing.T) {
@@ -687,6 +688,43 @@ func TestParseFields(t *testing.T) {
 							name:       "creator_id",
 							dbType:     input.UUID,
 							foreignKey: &input.ForeignKey{Schema: "User", Column: "ID", DisableIndex: true},
+						},
+					),
+				},
+			},
+		},
+		"jsonb import ype": {
+			code: map[string]string{
+				"user.ts": getCodeWithSchema(`
+				import {Schema, Field, BaseEntSchema, JSONBType } from "{schema}"
+
+				export default class User extends BaseEntSchema implements Schema {
+					fields: Field[] = [
+						JSONBType({name: "foo", importType: {
+							type: "Foo",
+							path: "path/to_foo.ts",
+						} }),
+					]
+				}`),
+			},
+			expectedPatterns: map[string]pattern{
+				"node": {
+					name: "node",
+				},
+			},
+			expectedNodes: map[string]node{
+				"User": {
+					fields: fieldsWithNodeFields(
+						field{
+							name:   "foo",
+							dbType: input.JSONB,
+							typ: &input.FieldType{
+								DBType: input.JSONB,
+								ImportType: &tsimport.ImportPath{
+									ImportPath: "path/to_foo.ts",
+									Import:     "Foo",
+								},
+							},
 						},
 					),
 				},

--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -246,10 +246,7 @@ func (nodeData *NodeData) GetImportsForBaseFile() ([]*tsimport.ImportPath, error
 			imp := t2.GetImportDepsType()
 			if imp != nil {
 				// TODO ignoring relative. do we need it?
-				ret = append(ret, &tsimport.ImportPath{
-					ImportPath: imp.Path,
-					Import:     imp.Type,
-				})
+				ret = append(ret, imp)
 			}
 		}
 	}
@@ -288,10 +285,7 @@ func (nodeData *NodeData) GetImportPathsForDependencies(s *Schema) []*tsimport.I
 			t2 := t.(enttype.ImportDepsType)
 			imp := t2.GetImportDepsType()
 			if imp != nil {
-				ret = append(ret, &tsimport.ImportPath{
-					ImportPath: imp.Path,
-					Import:     imp.Type,
-				})
+				ret = append(ret, imp)
 			}
 		}
 	}


### PR DESCRIPTION
more in the technical debt cleanup

uses json marshalling tricks to make it work

was added by https://github.com/lolopinto/ent/pull/511

also fixes https://github.com/lolopinto/ent/issues/703