### PR TITLE
Revert "fix referencing nested object in action (#770)"

### DIFF
--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -270,7 +270,7 @@ func (nodeData *NodeData) ForeignImport(imp string) bool {
 
 // TODO kill this
 // GetImportPathsForDependencies returns imports needed in dependencies e.g. actions and builders
-func (nodeData *NodeData) GetImportPathsForDependencies(s *Schema) []*tsimport.ImportPath {
+func (nodeData *NodeData) GetImportPathsForDependencies() []*tsimport.ImportPath {
 	var ret []*tsimport.ImportPath
 
 	for _, enum := range nodeData.GetTSEnums() {
@@ -285,12 +285,6 @@ func (nodeData *NodeData) GetImportPathsForDependencies(s *Schema) []*tsimport.I
 	for _, unique := range uniqueNodes {
 		ret = append(ret, &tsimport.ImportPath{
 			Import:     unique.Node,
-			ImportPath: codepath.GetExternalImportPath(),
-		})
-	}
-	for _, v := range s.Nodes {
-		ret = append(ret, &tsimport.ImportPath{
-			Import:     v.NodeData.Node,
 			ImportPath: codepath.GetExternalImportPath(),
 		})
 	}

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -3,7 +3,7 @@
 {{ reserveImport "src/ent/" "NodeType"}}
 {{ reserveImport .PrivacyConfig.Path .PrivacyConfig.PolicyName }}
 
-{{ range .NodeData.GetImportPathsForDependencies .Schema -}}
+{{ range .NodeData.GetImportPathsForDependencies -}}
   {{ reserveImportPath . true -}}
 {{ end -}}
 

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -1,14 +1,13 @@
 {{reserveImport .Package.PackagePath "Viewer" "ID" "Ent" "AssocEdgeInputOptions"}}
 {{reserveImport .Package.ActionPackagePath "Action" "Builder" "WriteOperation" "Changeset" "saveBuilder" "saveBuilderX" "Orchestrator"}}
 
-{{ $schema := .Schema}}
 {{with .NodeData -}}
 {{ $schemaPath := printf "src/schema/%s" .PackageName }}
 {{ reserveDefaultImport $schemaPath "schema"}}
 {{ reserveImport "src/ent/generated/const" "EdgeType" "NodeType" }}
 
 
-{{ range .GetImportPathsForDependencies $schema -}}
+{{ range .GetImportPathsForDependencies -}}
   {{ reserveImportPath . true}}
 {{ end}}
 

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -113,7 +113,7 @@ func (s *Step) processActions(processor *codegen.Processor, nodeData *schema.Nod
 	for idx := range nodeData.ActionInfo.Actions {
 		action := nodeData.ActionInfo.Actions[idx]
 		ret = append(ret, func() error {
-			return writeBaseActionFile(processor.Schema, nodeData, processor, action)
+			return writeBaseActionFile(nodeData, processor, action)
 		})
 
 		ret = append(ret, func() error {
@@ -279,7 +279,6 @@ type nodeTemplateCodePath struct {
 	NodeData      *schema.NodeData
 	CodePath      *codegen.Config
 	Package       *codegen.ImportPackage
-	Schema        *schema.Schema
 	Imports       []*tsimport.ImportPath
 	PrivacyConfig *codegen.PrivacyConfig
 }
@@ -809,7 +808,6 @@ func writeBuilderFile(nodeData *schema.NodeData, processor *codegen.Processor) e
 		Data: nodeTemplateCodePath{
 			NodeData: nodeData,
 			CodePath: cfg,
-			Schema:   processor.Schema,
 			Package:  cfg.GetImportPackage(),
 			Imports:  imports,
 		},

--- a/internal/tscode/write_action.go
+++ b/internal/tscode/write_action.go
@@ -20,10 +20,9 @@ type actionTemplate struct {
 	BasePath      string
 	Package       *codegen.ImportPackage
 	PrivacyConfig *codegen.PrivacyConfig
-	Schema        *schema.Schema
 }
 
-func writeBaseActionFile(schema *schema.Schema, nodeData *schema.NodeData, processor *codegen.Processor, action action.Action) error {
+func writeBaseActionFile(nodeData *schema.NodeData, processor *codegen.Processor, action action.Action) error {
 	cfg := processor.Config
 	filePath := getFilePathForActionBaseFile(cfg, nodeData, action)
 	imps := tsimport.NewImports(processor.Config, filePath)
@@ -33,7 +32,6 @@ func writeBaseActionFile(schema *schema.Schema, nodeData *schema.NodeData, proce
 		Data: actionTemplate{
 			NodeData:      nodeData,
 			Action:        action,
-			Schema:        schema,
 			BuilderPath:   getImportPathForBuilderFile(nodeData),
 			Package:       cfg.GetImportPackage(),
 			PrivacyConfig: cfg.GetDefaultActionPolicy(),


### PR DESCRIPTION
This reverts commit b52ab41bbbd94a322601a110baeffa2aacdebeac.

https://github.com/lolopinto/ent/pull/774 and its predecessors https://github.com/lolopinto/ent/pull/772, https://github.com/lolopinto/ent/pull/773 mean we can revert this change