### PR TITLE
use swc for parse schema

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
-      - run: npm install -g ts-node prettier typescript
+      - run: npm install -g ts-node prettier typescript @swc/core @swc/cli
       - run: |
           cd ts 
           npm ci

--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -75,7 +75,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 16.x
-    - run: npm install -g ts-node prettier typescript 
+    - run: npm install -g ts-node prettier typescript @swc/core @swc/cli
     - run: |
         cd ts 
         npm ci

--- a/examples/simple/src/ent/contact.ts
+++ b/examples/simple/src/ent/contact.ts
@@ -1,3 +1,4 @@
+import { GraphQLString } from "graphql";
 import { ContactBase } from "./internal";
 import {
   PrivacyPolicy,
@@ -19,7 +20,10 @@ export class Contact extends ContactBase {
     rules: [new AllowIfViewerIsRule("userID"), AlwaysDenyRule],
   };
 
-  @gqlField()
+  @gqlField({
+    type: GraphQLString,
+    name: "fullName",
+  })
   get fullName(): string {
     return this.firstName + " " + this.lastName;
   }

--- a/examples/simple/src/ent/user.ts
+++ b/examples/simple/src/ent/user.ts
@@ -22,7 +22,10 @@ export class User extends UserBase {
     ],
   };
 
-  @gqlField()
+  @gqlField({
+    type: GraphQLString,
+    name: "fullName",
+  })
   get fullName(): string {
     return this.firstName + " " + this.lastName;
   }

--- a/internal/schema/input/parse_ts.go
+++ b/internal/schema/input/parse_ts.go
@@ -49,6 +49,7 @@ func GetRawSchema(dirPath string, fromTest bool) ([]byte, error) {
 
 	cmdArgs = append(
 		cmdArgs,
+		"--swc",
 		util.GetPathToScript("scripts/read_schema.ts", fromTest),
 		"--path",
 		schemaPath,


### PR DESCRIPTION
latest version of `ts-node` supports `--swc` flag to use that to transpile ts instead of default path.

there's still issues with using `swc` everywhere (see https://github.com/lolopinto/ent/issues/792) so only doing this while parsing the schema but it helps with speeding things up 

addresses https://github.com/lolopinto/ent/issues/595