### PR TITLE
ability to customize graphql fields to be snake case instead of lowerCamelCase

### DIFF
--- a/examples/todo-sqlite/ent.yml
+++ b/examples/todo-sqlite/ent.yml
@@ -2,3 +2,4 @@ codegen:
   disableBase64Encoding: true
   generateRootResolvers: true
   defaultGraphQLMutationName: VERB_NOUN
+  defaultGraphQLFieldFormat: snake_case

--- a/examples/todo-sqlite/src/ent/account.ts
+++ b/examples/todo-sqlite/src/ent/account.ts
@@ -48,7 +48,7 @@ export class Account extends AccountBase {
   privacyPolicy = AlwaysAllowPrivacyPolicy;
 
   // showing plural
-  @gqlField({ name: "openTodosPlural", type: "[Todo]" })
+  @gqlField({ name: "open_todos_plural", type: "[Todo]" })
   async openTodosPlural() {
     return await Todo.loadCustom(
       this.viewer,
@@ -57,7 +57,7 @@ export class Account extends AccountBase {
   }
 
   // showing connection
-  @gqlField({ name: "openTodos", type: gqlConnection("Todo") })
+  @gqlField({ name: "open_todos", type: gqlConnection("Todo") })
   openTodos() {
     return new AccountToOpenTodosQuery(this.viewer, this);
   }

--- a/examples/todo-sqlite/src/ent/tests/tag.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/tag.test.ts
@@ -1,6 +1,5 @@
 import CreateTagAction from "src/ent/tag/actions/create_tag_action";
-import { createAccount, createTodo } from "../testutils/util";
-import { Account } from "src/ent";
+import { createAccount, createTodo, createTag } from "../testutils/util";
 import { AccountToTagsQuery } from "../account/query/account_to_tags_query";
 import TodoAddTagAction from "../todo/actions/todo_add_tag_action";
 import TodoRemoveTagAction from "../todo/actions/todo_remove_tag_action";
@@ -8,21 +7,6 @@ import TodoRemoveTagAction from "../todo/actions/todo_remove_tag_action";
 beforeAll(() => {
   process.env.DB_CONNECTION_STRING = `sqlite:///todo.db`;
 });
-
-async function createTag(displayName: string, account?: Account) {
-  if (!account) {
-    account = await createAccount();
-  }
-
-  const tag = await CreateTagAction.create(account.viewer, {
-    ownerID: account.id,
-    displayName,
-  }).saveX();
-  expect(tag.displayName).toBe(displayName);
-  expect(tag.canonicalName).toBe(displayName.trim().toLowerCase());
-  expect(tag.ownerID).toBe(account.id);
-  return tag;
-}
 
 test("create", async () => {
   await createTag("SPORTS");

--- a/examples/todo-sqlite/src/ent/testutils/util.ts
+++ b/examples/todo-sqlite/src/ent/testutils/util.ts
@@ -5,6 +5,8 @@ import { validate } from "uuid";
 import CreateTodoAction, {
   TodoCreateInput,
 } from "src/ent/todo/actions/create_todo_action";
+import CreateTagAction from "../tag/actions/create_tag_action";
+import { Account } from "src/ent";
 
 function randomPhoneNumber(): string {
   const phone = Math.random().toString(10).substring(2, 12);
@@ -45,4 +47,19 @@ export async function createTodo(opts?: Partial<TodoCreateInput>) {
   expect(todo.completed).toBe(false);
 
   return todo;
+}
+
+export async function createTag(displayName: string, account?: Account) {
+  if (!account) {
+    account = await createAccount();
+  }
+
+  const tag = await CreateTagAction.create(account.viewer, {
+    ownerID: account.id,
+    displayName,
+  }).saveX();
+  expect(tag.displayName).toBe(displayName);
+  expect(tag.canonicalName).toBe(displayName.trim().toLowerCase());
+  expect(tag.ownerID).toBe(account.id);
+  return tag;
 }

--- a/examples/todo-sqlite/src/graphql/generated/schema.gql
+++ b/examples/todo-sqlite/src/graphql/generated/schema.gql
@@ -28,18 +28,18 @@ type PageInfo {
 type Account implements Node {
   id: ID!
   name: String!
-  phoneNumber: String!
+  phone_number: String!
   tags(first: Int, after: String, last: Int, before: String): AccountToTagsConnection!
   todos(first: Int, after: String, last: Int, before: String): AccountToTodosConnection!
-  openTodosPlural: [Todo!]!
-  openTodos(first: Int, after: String, last: Int, before: String): AccountToOpenTodosConnection!
+  open_todos_plural: [Todo!]!
+  open_todos(first: Int, after: String, last: Int, before: String): AccountToOpenTodosConnection!
 }
 
 type Tag implements Node {
   owner: Account
   id: ID!
-  displayName: String!
-  canonicalName: String!
+  display_name: String!
+  canonical_name: String!
   todos(first: Int, after: String, last: Int, before: String): TagToTodosConnection!
 }
 
@@ -125,8 +125,8 @@ type TodoToTagsConnection implements Connection {
 
 input AddTodoTagInput {
   """id of Todo"""
-  todoID: ID!
-  tagID: ID!
+  todo_id: ID!
+  tag_id: ID!
 }
 
 type AddTodoTagPayload {
@@ -135,7 +135,7 @@ type AddTodoTagPayload {
 
 input ChangeTodoStatusInput {
   """id of Todo"""
-  todoID: ID!
+  todo_id: ID!
   completed: Boolean
 }
 
@@ -145,7 +145,7 @@ type ChangeTodoStatusPayload {
 
 input CreateAccountInput {
   name: String!
-  phoneNumber: String!
+  phone_number: String!
 }
 
 type CreateAccountPayload {
@@ -153,8 +153,8 @@ type CreateAccountPayload {
 }
 
 input CreateTagInput {
-  displayName: String!
-  ownerID: ID!
+  display_name: String!
+  owner_id: ID!
 }
 
 type CreateTagPayload {
@@ -163,7 +163,7 @@ type CreateTagPayload {
 
 input CreateTodoInput {
   text: String!
-  creatorID: ID!
+  creator_id: ID!
 }
 
 type CreateTodoPayload {
@@ -172,27 +172,27 @@ type CreateTodoPayload {
 
 input DeleteAccountInput {
   """id of Account"""
-  accountID: ID!
+  account_id: ID!
 }
 
 type DeleteAccountPayload {
-  deletedAccountID: ID
+  deleted_account_id: ID
 }
 
 input DeleteTodoInput {
   """id of Todo"""
-  todoID: ID!
+  todo_id: ID!
 }
 
 type DeleteTodoPayload {
-  deletedTodoID: ID
+  deleted_todo_id: ID
 }
 
 input EditAccountInput {
   """id of Account"""
-  accountID: ID!
+  account_id: ID!
   name: String
-  phoneNumber: String
+  phone_number: String
 }
 
 type EditAccountPayload {
@@ -201,8 +201,8 @@ type EditAccountPayload {
 
 input RemoveTodoTagInput {
   """id of Todo"""
-  todoID: ID!
-  tagID: ID!
+  todo_id: ID!
+  tag_id: ID!
 }
 
 type RemoveTodoTagPayload {
@@ -211,7 +211,7 @@ type RemoveTodoTagPayload {
 
 input RenameTodoInput {
   """id of Todo"""
-  todoID: ID!
+  todo_id: ID!
   text: String
 }
 
@@ -221,24 +221,24 @@ type RenameTodoPayload {
 
 type Query {
   account(id: ID!): Account
-  openTodos(id: ID!, first: Int, after: String, last: Int, before: String): RootToOpenTodosConnection!
-  openTodosPlural(id: ID!): [Todo!]!
+  open_todos(id: ID!, first: Int, after: String, last: Int, before: String): RootToOpenTodosConnection!
+  open_todos_plural(id: ID!): [Todo!]!
   tag(id: ID!): Tag
   todo(id: ID!): Todo
 }
 
 type Mutation {
   addTodoTag(input: AddTodoTagInput!): AddTodoTagPayload!
+  changeTodoStatus(input: ChangeTodoStatusInput!): ChangeTodoStatusPayload!
   createAccount(input: CreateAccountInput!): CreateAccountPayload!
   createTag(input: CreateTagInput!): CreateTagPayload!
   createTodo(input: CreateTodoInput!): CreateTodoPayload!
   deleteAccount(input: DeleteAccountInput!): DeleteAccountPayload!
   deleteTodo(input: DeleteTodoInput!): DeleteTodoPayload!
   editAccount(input: EditAccountInput!): EditAccountPayload!
+  markAllTodosAs(accountID: ID!, completed: Boolean!): Account!
+  removeCompletedTodos(accountID: ID!): Account!
   removeTodoTag(input: RemoveTodoTagInput!): RemoveTodoTagPayload!
-  todoChangeStatus(input: ChangeTodoStatusInput!): ChangeTodoStatusPayload!
-  todoRename(input: RenameTodoInput!): RenameTodoPayload!
-  todosMarkAllAs(accountID: ID!, completed: Boolean!): Account!
-  todosRemoveCompleted(accountID: ID!): Account!
+  renameTodo(input: RenameTodoInput!): RenameTodoPayload!
 }
 

--- a/examples/todo-sqlite/src/graphql/generated/schema.ts
+++ b/examples/todo-sqlite/src/graphql/generated/schema.ts
@@ -23,6 +23,10 @@ import {
   AddTodoTagPayloadType,
 } from "src/graphql/mutations/generated/todo/add_todo_tag_type";
 import {
+  ChangeTodoStatusInputType,
+  ChangeTodoStatusPayloadType,
+} from "src/graphql/mutations/generated/todo/change_todo_status_type";
+import {
   CreateTodoInputType,
   CreateTodoPayloadType,
 } from "src/graphql/mutations/generated/todo/create_todo_type";
@@ -35,13 +39,9 @@ import {
   RemoveTodoTagPayloadType,
 } from "src/graphql/mutations/generated/todo/remove_todo_tag_type";
 import {
-  ChangeTodoStatusInputType,
-  ChangeTodoStatusPayloadType,
-} from "src/graphql/mutations/generated/todo/todo_change_status_type";
-import {
   RenameTodoInputType,
   RenameTodoPayloadType,
-} from "src/graphql/mutations/generated/todo/todo_rename_type";
+} from "src/graphql/mutations/generated/todo/rename_todo_type";
 import {
   AccountToOpenTodosConnectionType,
   AccountToTagsConnectionType,

--- a/examples/todo-sqlite/src/graphql/mutations/generated/account/create_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/account/create_account_type.ts
@@ -17,6 +17,11 @@ import CreateAccountAction, {
 } from "src/ent/account/actions/create_account_action";
 import { AccountType } from "src/graphql/resolvers/";
 
+interface customCreateAccountInput
+  extends Omit<AccountCreateInput, "phoneNumber"> {
+  phone_number: string;
+}
+
 interface CreateAccountPayload {
   account: Account;
 }
@@ -27,7 +32,7 @@ export const CreateAccountInputType = new GraphQLInputObjectType({
     name: {
       type: GraphQLNonNull(GraphQLString),
     },
-    phoneNumber: {
+    phone_number: {
       type: GraphQLNonNull(GraphQLString),
     },
   }),
@@ -45,7 +50,7 @@ export const CreateAccountPayloadType = new GraphQLObjectType({
 export const CreateAccountType: GraphQLFieldConfig<
   undefined,
   RequestContext,
-  { [input: string]: AccountCreateInput }
+  { [input: string]: customCreateAccountInput }
 > = {
   type: GraphQLNonNull(CreateAccountPayloadType),
   args: {
@@ -62,7 +67,7 @@ export const CreateAccountType: GraphQLFieldConfig<
   ): Promise<CreateAccountPayload> => {
     const account = await CreateAccountAction.create(context.getViewer(), {
       name: input.name,
-      phoneNumber: input.phoneNumber,
+      phoneNumber: input.phone_number,
     }).saveX();
     return { account: account };
   },

--- a/examples/todo-sqlite/src/graphql/mutations/generated/account/delete_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/account/delete_account_type.ts
@@ -14,17 +14,17 @@ import { RequestContext } from "@snowtop/ent";
 import DeleteAccountAction from "src/ent/account/actions/delete_account_action";
 
 interface customDeleteAccountInput {
-  accountID: string;
+  account_id: string;
 }
 
 interface DeleteAccountPayload {
-  deletedAccountID: string;
+  deleted_account_id: string;
 }
 
 export const DeleteAccountInputType = new GraphQLInputObjectType({
   name: "DeleteAccountInput",
   fields: (): GraphQLInputFieldConfigMap => ({
-    accountID: {
+    account_id: {
       description: "id of Account",
       type: GraphQLNonNull(GraphQLID),
     },
@@ -34,7 +34,7 @@ export const DeleteAccountInputType = new GraphQLInputObjectType({
 export const DeleteAccountPayloadType = new GraphQLObjectType({
   name: "DeleteAccountPayload",
   fields: (): GraphQLFieldConfigMap<DeleteAccountPayload, RequestContext> => ({
-    deletedAccountID: {
+    deleted_account_id: {
       type: GraphQLID,
     },
   }),
@@ -58,7 +58,10 @@ export const DeleteAccountType: GraphQLFieldConfig<
     context: RequestContext,
     _info: GraphQLResolveInfo,
   ): Promise<DeleteAccountPayload> => {
-    await DeleteAccountAction.saveXFromID(context.getViewer(), input.accountID);
-    return { deletedAccountID: input.accountID };
+    await DeleteAccountAction.saveXFromID(
+      context.getViewer(),
+      input.account_id,
+    );
+    return { deleted_account_id: input.account_id };
   },
 };

--- a/examples/todo-sqlite/src/graphql/mutations/generated/account/edit_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/account/edit_account_type.ts
@@ -18,8 +18,9 @@ import EditAccountAction, {
 } from "src/ent/account/actions/edit_account_action";
 import { AccountType } from "src/graphql/resolvers/";
 
-interface customEditAccountInput extends AccountEditInput {
-  accountID: string;
+interface customEditAccountInput extends Omit<AccountEditInput, "phoneNumber"> {
+  account_id: string;
+  phone_number?: string;
 }
 
 interface EditAccountPayload {
@@ -29,14 +30,14 @@ interface EditAccountPayload {
 export const EditAccountInputType = new GraphQLInputObjectType({
   name: "EditAccountInput",
   fields: (): GraphQLInputFieldConfigMap => ({
-    accountID: {
+    account_id: {
       description: "id of Account",
       type: GraphQLNonNull(GraphQLID),
     },
     name: {
       type: GraphQLString,
     },
-    phoneNumber: {
+    phone_number: {
       type: GraphQLString,
     },
   }),
@@ -71,10 +72,10 @@ export const EditAccountType: GraphQLFieldConfig<
   ): Promise<EditAccountPayload> => {
     const account = await EditAccountAction.saveXFromID(
       context.getViewer(),
-      input.accountID,
+      input.account_id,
       {
         name: input.name,
-        phoneNumber: input.phoneNumber,
+        phoneNumber: input.phone_number,
       },
     );
     return { account: account };

--- a/examples/todo-sqlite/src/graphql/mutations/generated/mark_all_todos_as_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/mark_all_todos_as_type.ts
@@ -11,15 +11,15 @@ import { RequestContext } from "@snowtop/ent";
 import { AccountType } from "src/graphql/resolvers/";
 import { TodosResolver } from "../todo/todo_resolver";
 
-interface todosMarkAllAsArgs {
+interface markAllTodosAsArgs {
   accountID: any;
   completed: any;
 }
 
-export const TodosMarkAllAsType: GraphQLFieldConfig<
+export const MarkAllTodosAsType: GraphQLFieldConfig<
   undefined,
   RequestContext,
-  todosMarkAllAsArgs
+  markAllTodosAsArgs
 > = {
   type: GraphQLNonNull(AccountType),
   args: {

--- a/examples/todo-sqlite/src/graphql/mutations/generated/mutation_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/mutation_type.ts
@@ -4,31 +4,31 @@ import { GraphQLObjectType } from "graphql";
 import { CreateAccountType } from "src/graphql/mutations/generated/account/create_account_type";
 import { DeleteAccountType } from "src/graphql/mutations/generated/account/delete_account_type";
 import { EditAccountType } from "src/graphql/mutations/generated/account/edit_account_type";
+import { MarkAllTodosAsType } from "src/graphql/mutations/generated/mark_all_todos_as_type";
+import { RemoveCompletedTodosType } from "src/graphql/mutations/generated/remove_completed_todos_type";
 import { CreateTagType } from "src/graphql/mutations/generated/tag/create_tag_type";
 import { AddTodoTagType } from "src/graphql/mutations/generated/todo/add_todo_tag_type";
+import { ChangeTodoStatusType } from "src/graphql/mutations/generated/todo/change_todo_status_type";
 import { CreateTodoType } from "src/graphql/mutations/generated/todo/create_todo_type";
 import { DeleteTodoType } from "src/graphql/mutations/generated/todo/delete_todo_type";
 import { RemoveTodoTagType } from "src/graphql/mutations/generated/todo/remove_todo_tag_type";
-import { TodoChangeStatusType } from "src/graphql/mutations/generated/todo/todo_change_status_type";
-import { TodoRenameType } from "src/graphql/mutations/generated/todo/todo_rename_type";
-import { TodosMarkAllAsType } from "src/graphql/mutations/generated/todos_mark_all_as_type";
-import { TodosRemoveCompletedType } from "src/graphql/mutations/generated/todos_remove_completed_type";
+import { RenameTodoType } from "src/graphql/mutations/generated/todo/rename_todo_type";
 
 export const MutationType = new GraphQLObjectType({
   name: "Mutation",
   // @ts-ignore graphql-js TS #2152 2829
   fields: () => ({
     addTodoTag: AddTodoTagType,
+    changeTodoStatus: ChangeTodoStatusType,
     createAccount: CreateAccountType,
     createTag: CreateTagType,
     createTodo: CreateTodoType,
     deleteAccount: DeleteAccountType,
     deleteTodo: DeleteTodoType,
     editAccount: EditAccountType,
+    markAllTodosAs: MarkAllTodosAsType,
+    removeCompletedTodos: RemoveCompletedTodosType,
     removeTodoTag: RemoveTodoTagType,
-    todoChangeStatus: TodoChangeStatusType,
-    todoRename: TodoRenameType,
-    todosMarkAllAs: TodosMarkAllAsType,
-    todosRemoveCompleted: TodosRemoveCompletedType,
+    renameTodo: RenameTodoType,
   }),
 });

--- a/examples/todo-sqlite/src/graphql/mutations/generated/remove_completed_todos_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/remove_completed_todos_type.ts
@@ -10,14 +10,14 @@ import { RequestContext } from "@snowtop/ent";
 import { AccountType } from "src/graphql/resolvers/";
 import { TodosResolver } from "../todo/todo_resolver";
 
-interface todosRemoveCompletedArgs {
+interface removeCompletedTodosArgs {
   accountID: any;
 }
 
-export const TodosRemoveCompletedType: GraphQLFieldConfig<
+export const RemoveCompletedTodosType: GraphQLFieldConfig<
   undefined,
   RequestContext,
-  todosRemoveCompletedArgs
+  removeCompletedTodosArgs
 > = {
   type: GraphQLNonNull(AccountType),
   args: {

--- a/examples/todo-sqlite/src/graphql/mutations/generated/tag/create_tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/tag/create_tag_type.ts
@@ -18,6 +18,11 @@ import CreateTagAction, {
 } from "src/ent/tag/actions/create_tag_action";
 import { TagType } from "src/graphql/resolvers/";
 
+interface customCreateTagInput extends Omit<TagCreateInput, "displayName"> {
+  display_name: string;
+  owner_id: string;
+}
+
 interface CreateTagPayload {
   tag: Tag;
 }
@@ -25,10 +30,10 @@ interface CreateTagPayload {
 export const CreateTagInputType = new GraphQLInputObjectType({
   name: "CreateTagInput",
   fields: (): GraphQLInputFieldConfigMap => ({
-    displayName: {
+    display_name: {
       type: GraphQLNonNull(GraphQLString),
     },
-    ownerID: {
+    owner_id: {
       type: GraphQLNonNull(GraphQLID),
     },
   }),
@@ -46,7 +51,7 @@ export const CreateTagPayloadType = new GraphQLObjectType({
 export const CreateTagType: GraphQLFieldConfig<
   undefined,
   RequestContext,
-  { [input: string]: TagCreateInput }
+  { [input: string]: customCreateTagInput }
 > = {
   type: GraphQLNonNull(CreateTagPayloadType),
   args: {
@@ -62,8 +67,8 @@ export const CreateTagType: GraphQLFieldConfig<
     _info: GraphQLResolveInfo,
   ): Promise<CreateTagPayload> => {
     const tag = await CreateTagAction.create(context.getViewer(), {
-      displayName: input.displayName,
-      ownerID: input.ownerID,
+      displayName: input.display_name,
+      ownerID: input.owner_id,
     }).saveX();
     return { tag: tag };
   },

--- a/examples/todo-sqlite/src/graphql/mutations/generated/todo/add_todo_tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/todo/add_todo_tag_type.ts
@@ -16,8 +16,8 @@ import TodoAddTagAction from "src/ent/todo/actions/todo_add_tag_action";
 import { TodoType } from "src/graphql/resolvers/";
 
 interface customAddTodoTagInput {
-  todoID: string;
-  tagID: string;
+  todo_id: string;
+  tag_id: string;
 }
 
 interface AddTodoTagPayload {
@@ -27,11 +27,11 @@ interface AddTodoTagPayload {
 export const AddTodoTagInputType = new GraphQLInputObjectType({
   name: "AddTodoTagInput",
   fields: (): GraphQLInputFieldConfigMap => ({
-    todoID: {
+    todo_id: {
       description: "id of Todo",
       type: GraphQLNonNull(GraphQLID),
     },
-    tagID: {
+    tag_id: {
       type: GraphQLNonNull(GraphQLID),
     },
   }),
@@ -66,8 +66,8 @@ export const AddTodoTagType: GraphQLFieldConfig<
   ): Promise<AddTodoTagPayload> => {
     const todo = await TodoAddTagAction.saveXFromID(
       context.getViewer(),
-      input.todoID,
-      input.tagID,
+      input.todo_id,
+      input.tag_id,
     );
     return { todo: todo };
   },

--- a/examples/todo-sqlite/src/graphql/mutations/generated/todo/change_todo_status_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/todo/change_todo_status_type.ts
@@ -19,7 +19,7 @@ import ChangeTodoStatusAction, {
 import { TodoType } from "src/graphql/resolvers/";
 
 interface customChangeTodoStatusInput extends ChangeTodoStatusInput {
-  todoID: string;
+  todo_id: string;
 }
 
 interface ChangeTodoStatusPayload {
@@ -29,7 +29,7 @@ interface ChangeTodoStatusPayload {
 export const ChangeTodoStatusInputType = new GraphQLInputObjectType({
   name: "ChangeTodoStatusInput",
   fields: (): GraphQLInputFieldConfigMap => ({
-    todoID: {
+    todo_id: {
       description: "id of Todo",
       type: GraphQLNonNull(GraphQLID),
     },
@@ -51,7 +51,7 @@ export const ChangeTodoStatusPayloadType = new GraphQLObjectType({
   }),
 });
 
-export const TodoChangeStatusType: GraphQLFieldConfig<
+export const ChangeTodoStatusType: GraphQLFieldConfig<
   undefined,
   RequestContext,
   { [input: string]: customChangeTodoStatusInput }
@@ -71,7 +71,7 @@ export const TodoChangeStatusType: GraphQLFieldConfig<
   ): Promise<ChangeTodoStatusPayload> => {
     const todo = await ChangeTodoStatusAction.saveXFromID(
       context.getViewer(),
-      input.todoID,
+      input.todo_id,
       {
         completed: input.completed,
       },

--- a/examples/todo-sqlite/src/graphql/mutations/generated/todo/create_todo_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/todo/create_todo_type.ts
@@ -18,6 +18,10 @@ import CreateTodoAction, {
 } from "src/ent/todo/actions/create_todo_action";
 import { TodoType } from "src/graphql/resolvers/";
 
+interface customCreateTodoInput extends TodoCreateInput {
+  creator_id: string;
+}
+
 interface CreateTodoPayload {
   todo: Todo;
 }
@@ -28,7 +32,7 @@ export const CreateTodoInputType = new GraphQLInputObjectType({
     text: {
       type: GraphQLNonNull(GraphQLString),
     },
-    creatorID: {
+    creator_id: {
       type: GraphQLNonNull(GraphQLID),
     },
   }),
@@ -46,7 +50,7 @@ export const CreateTodoPayloadType = new GraphQLObjectType({
 export const CreateTodoType: GraphQLFieldConfig<
   undefined,
   RequestContext,
-  { [input: string]: TodoCreateInput }
+  { [input: string]: customCreateTodoInput }
 > = {
   type: GraphQLNonNull(CreateTodoPayloadType),
   args: {
@@ -63,7 +67,7 @@ export const CreateTodoType: GraphQLFieldConfig<
   ): Promise<CreateTodoPayload> => {
     const todo = await CreateTodoAction.create(context.getViewer(), {
       text: input.text,
-      creatorID: input.creatorID,
+      creatorID: input.creator_id,
     }).saveX();
     return { todo: todo };
   },

--- a/examples/todo-sqlite/src/graphql/mutations/generated/todo/delete_todo_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/todo/delete_todo_type.ts
@@ -14,17 +14,17 @@ import { RequestContext } from "@snowtop/ent";
 import DeleteTodoAction from "src/ent/todo/actions/delete_todo_action";
 
 interface customDeleteTodoInput {
-  todoID: string;
+  todo_id: string;
 }
 
 interface DeleteTodoPayload {
-  deletedTodoID: string;
+  deleted_todo_id: string;
 }
 
 export const DeleteTodoInputType = new GraphQLInputObjectType({
   name: "DeleteTodoInput",
   fields: (): GraphQLInputFieldConfigMap => ({
-    todoID: {
+    todo_id: {
       description: "id of Todo",
       type: GraphQLNonNull(GraphQLID),
     },
@@ -34,7 +34,7 @@ export const DeleteTodoInputType = new GraphQLInputObjectType({
 export const DeleteTodoPayloadType = new GraphQLObjectType({
   name: "DeleteTodoPayload",
   fields: (): GraphQLFieldConfigMap<DeleteTodoPayload, RequestContext> => ({
-    deletedTodoID: {
+    deleted_todo_id: {
       type: GraphQLID,
     },
   }),
@@ -58,7 +58,7 @@ export const DeleteTodoType: GraphQLFieldConfig<
     context: RequestContext,
     _info: GraphQLResolveInfo,
   ): Promise<DeleteTodoPayload> => {
-    await DeleteTodoAction.saveXFromID(context.getViewer(), input.todoID);
-    return { deletedTodoID: input.todoID };
+    await DeleteTodoAction.saveXFromID(context.getViewer(), input.todo_id);
+    return { deleted_todo_id: input.todo_id };
   },
 };

--- a/examples/todo-sqlite/src/graphql/mutations/generated/todo/remove_todo_tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/todo/remove_todo_tag_type.ts
@@ -16,8 +16,8 @@ import TodoRemoveTagAction from "src/ent/todo/actions/todo_remove_tag_action";
 import { TodoType } from "src/graphql/resolvers/";
 
 interface customRemoveTodoTagInput {
-  todoID: string;
-  tagID: string;
+  todo_id: string;
+  tag_id: string;
 }
 
 interface RemoveTodoTagPayload {
@@ -27,11 +27,11 @@ interface RemoveTodoTagPayload {
 export const RemoveTodoTagInputType = new GraphQLInputObjectType({
   name: "RemoveTodoTagInput",
   fields: (): GraphQLInputFieldConfigMap => ({
-    todoID: {
+    todo_id: {
       description: "id of Todo",
       type: GraphQLNonNull(GraphQLID),
     },
-    tagID: {
+    tag_id: {
       type: GraphQLNonNull(GraphQLID),
     },
   }),
@@ -66,8 +66,8 @@ export const RemoveTodoTagType: GraphQLFieldConfig<
   ): Promise<RemoveTodoTagPayload> => {
     const todo = await TodoRemoveTagAction.saveXFromID(
       context.getViewer(),
-      input.todoID,
-      input.tagID,
+      input.todo_id,
+      input.tag_id,
     );
     return { todo: todo };
   },

--- a/examples/todo-sqlite/src/graphql/mutations/generated/todo/rename_todo_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/todo/rename_todo_type.ts
@@ -19,7 +19,7 @@ import RenameTodoStatusAction, {
 import { TodoType } from "src/graphql/resolvers/";
 
 interface customRenameTodoInput extends RenameTodoInput {
-  todoID: string;
+  todo_id: string;
 }
 
 interface RenameTodoPayload {
@@ -29,7 +29,7 @@ interface RenameTodoPayload {
 export const RenameTodoInputType = new GraphQLInputObjectType({
   name: "RenameTodoInput",
   fields: (): GraphQLInputFieldConfigMap => ({
-    todoID: {
+    todo_id: {
       description: "id of Todo",
       type: GraphQLNonNull(GraphQLID),
     },
@@ -48,7 +48,7 @@ export const RenameTodoPayloadType = new GraphQLObjectType({
   }),
 });
 
-export const TodoRenameType: GraphQLFieldConfig<
+export const RenameTodoType: GraphQLFieldConfig<
   undefined,
   RequestContext,
   { [input: string]: customRenameTodoInput }
@@ -68,7 +68,7 @@ export const TodoRenameType: GraphQLFieldConfig<
   ): Promise<RenameTodoPayload> => {
     const todo = await RenameTodoStatusAction.saveXFromID(
       context.getViewer(),
-      input.todoID,
+      input.todo_id,
       {
         text: input.text,
       },

--- a/examples/todo-sqlite/src/graphql/mutations/todo/todo_resolver.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/todo/todo_resolver.ts
@@ -8,7 +8,7 @@ import { GraphQLID } from "graphql";
 import DeleteTodoAction from "src/ent/todo/actions/delete_todo_action";
 
 export class TodosResolver {
-  @gqlMutation({ name: "todosMarkAllAs", type: Account })
+  @gqlMutation({ name: "markAllTodosAs", type: Account })
   async markAllTodos(
     // we're simplifying, no viewer or anything complicated and anyone can perform the action
     @gqlArg("accountID", { type: GraphQLID }) accountID: ID,
@@ -29,7 +29,7 @@ export class TodosResolver {
     return await bulk.saveX();
   }
 
-  @gqlMutation({ name: "todosRemoveCompleted", type: Account })
+  @gqlMutation({ name: "removeCompletedTodos", type: Account })
   async removeCompletedTodos(
     // we're simplifying, no viewer or anything complicated and anyone can perform the action
     @gqlArg("accountID", { type: GraphQLID }) accountID: ID,

--- a/examples/todo-sqlite/src/graphql/resolvers/generated/account_type.ts
+++ b/examples/todo-sqlite/src/graphql/resolvers/generated/account_type.ts
@@ -31,8 +31,11 @@ export const AccountType = new GraphQLObjectType({
     name: {
       type: GraphQLNonNull(GraphQLString),
     },
-    phoneNumber: {
+    phone_number: {
       type: GraphQLNonNull(GraphQLString),
+      resolve: (account: Account, args: {}, context: RequestContext) => {
+        return account.phoneNumber;
+      },
     },
     tags: {
       type: GraphQLNonNull(AccountToTagsConnectionType()),
@@ -92,13 +95,13 @@ export const AccountType = new GraphQLObjectType({
         );
       },
     },
-    openTodosPlural: {
+    open_todos_plural: {
       type: GraphQLNonNull(GraphQLList(GraphQLNonNull(TodoType))),
       resolve: async (account: Account, args: {}, context: RequestContext) => {
         return account.openTodosPlural();
       },
     },
-    openTodos: {
+    open_todos: {
       type: GraphQLNonNull(AccountToOpenTodosConnectionType()),
       args: {
         first: {

--- a/examples/todo-sqlite/src/graphql/resolvers/generated/open_todos_plural_query_type.ts
+++ b/examples/todo-sqlite/src/graphql/resolvers/generated/open_todos_plural_query_type.ts
@@ -11,14 +11,14 @@ import { RequestContext } from "@snowtop/ent";
 import { TodoType } from "src/graphql/resolvers/internal";
 import { TodoResolver } from "../open_todos";
 
-interface openTodosPluralArgs {
+interface open_todos_pluralArgs {
   id: any;
 }
 
 export const OpenTodosPluralQueryType: GraphQLFieldConfig<
   undefined,
   RequestContext,
-  openTodosPluralArgs
+  open_todos_pluralArgs
 > = {
   type: GraphQLNonNull(GraphQLList(GraphQLNonNull(TodoType))),
   args: {

--- a/examples/todo-sqlite/src/graphql/resolvers/generated/open_todos_query_type.ts
+++ b/examples/todo-sqlite/src/graphql/resolvers/generated/open_todos_query_type.ts
@@ -13,14 +13,14 @@ import { GraphQLEdgeConnection } from "@snowtop/ent/graphql";
 import { RootToOpenTodosConnectionType } from "src/graphql/resolvers/internal";
 import { TodoResolver } from "../open_todos";
 
-interface openTodosArgs {
+interface open_todosArgs {
   id: any;
 }
 
 export const OpenTodosQueryType: GraphQLFieldConfig<
   undefined,
   RequestContext,
-  openTodosArgs
+  open_todosArgs
 > = {
   type: GraphQLNonNull(RootToOpenTodosConnectionType()),
   args: {

--- a/examples/todo-sqlite/src/graphql/resolvers/generated/query_type.ts
+++ b/examples/todo-sqlite/src/graphql/resolvers/generated/query_type.ts
@@ -14,8 +14,8 @@ export const QueryType = new GraphQLObjectType({
   // @ts-ignore graphql-js TS #2152 2829
   fields: () => ({
     account: AccountQueryType,
-    openTodos: OpenTodosQueryType,
-    openTodosPlural: OpenTodosPluralQueryType,
+    open_todos: OpenTodosQueryType,
+    open_todos_plural: OpenTodosPluralQueryType,
     tag: TagQueryType,
     todo: TodoQueryType,
   }),

--- a/examples/todo-sqlite/src/graphql/resolvers/generated/tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/resolvers/generated/tag_type.ts
@@ -31,11 +31,17 @@ export const TagType = new GraphQLObjectType({
     id: {
       type: GraphQLNonNull(GraphQLID),
     },
-    displayName: {
+    display_name: {
       type: GraphQLNonNull(GraphQLString),
+      resolve: (tag: Tag, args: {}, context: RequestContext) => {
+        return tag.displayName;
+      },
     },
-    canonicalName: {
+    canonical_name: {
       type: GraphQLNonNull(GraphQLString),
+      resolve: (tag: Tag, args: {}, context: RequestContext) => {
+        return tag.canonicalName;
+      },
     },
     todos: {
       type: GraphQLNonNull(TagToTodosConnectionType()),

--- a/examples/todo-sqlite/src/graphql/resolvers/open_todos.ts
+++ b/examples/todo-sqlite/src/graphql/resolvers/open_todos.ts
@@ -4,14 +4,13 @@ import {
   gqlConnection,
   gqlContextType,
   gqlQuery,
-  GraphQLEdgeConnection,
 } from "@snowtop/ent/graphql";
 import { GraphQLID } from "graphql";
-import { Todo, Account, AccountToOpenTodosQuery } from "src/ent";
+import { Todo, AccountToOpenTodosQuery } from "src/ent";
 
 export class TodoResolver {
   // showing plural
-  @gqlQuery({ name: "openTodosPlural", type: "[Todo]" })
+  @gqlQuery({ name: "open_todos_plural", type: "[Todo]" })
   async openTodosPlural(
     @gqlArg("id", { type: GraphQLID }) id: ID,
   ): Promise<Todo[]> {
@@ -23,7 +22,7 @@ export class TodoResolver {
   }
 
   // showing connection
-  @gqlQuery({ type: gqlConnection("Todo") })
+  @gqlQuery({ name: "open_todos", type: gqlConnection("Todo") })
   openTodos(
     // we're not using context but have it here to show that it works
     @gqlContextType() _context: RequestContext,

--- a/examples/todo-sqlite/src/graphql/tests/tag.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/tag.test.ts
@@ -1,0 +1,32 @@
+import { expectMutation } from "@snowtop/ent-graphql-tests";
+import { Tag } from "src/ent";
+import { createAccount } from "src/ent/testutils/util";
+import schema from "src/graphql/generated/schema";
+
+beforeAll(() => {
+  process.env.DB_CONNECTION_STRING = `sqlite:///todo.db`;
+});
+
+test("create", async () => {
+  const account = await createAccount();
+  await expectMutation(
+    {
+      viewer: account.viewer,
+      schema,
+      mutation: "createTag",
+      args: {
+        owner_id: account.id,
+        display_name: "SPORTS",
+      },
+    },
+    [
+      "tag.id",
+      async (id: string) => {
+        await Tag.loadX(account.viewer, id);
+      },
+    ],
+    ["tag.display_name", "SPORTS"],
+    ["tag.canonical_name", "sports"],
+    ["tag.owner.id", account.id],
+  );
+});

--- a/examples/todo-sqlite/src/graphql/tests/todo.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/todo.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@snowtop/ent-graphql-tests";
 import schema from "src/graphql/generated/schema";
 import ChangeTodoStatusAction from "src/ent/todo/actions/change_todo_status_action";
-import { createAccount, createTodo } from "src/ent/testutils/util";
+import { createAccount, createTodo, createTag } from "src/ent/testutils/util";
 import { advanceBy } from "jest-date-mock";
 beforeAll(() => {
   process.env.DB_CONNECTION_STRING = `sqlite:///todo.db`;
@@ -269,5 +269,27 @@ test("delete", async () => {
       args: { todo_id: todo.id },
     },
     ["deleted_todo_id", todo.id],
+  );
+});
+
+test("todo tag", async () => {
+  const account = await createAccount();
+  const tag = await createTag("sports", account);
+  const todo = await createTodo({
+    creatorID: account.id,
+  });
+
+  await expectMutation(
+    {
+      viewer: account.viewer,
+      schema,
+      mutation: "addTodoTag",
+      args: {
+        todo_id: todo.id,
+        tag_id: tag.id,
+      },
+    },
+    ["todo.tags.rawCount", 1],
+    ["todo.tags.nodes[0].id", tag.id],
   );
 });

--- a/examples/todo-sqlite/src/graphql/tests/todo.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/todo.test.ts
@@ -41,7 +41,7 @@ test("mark all as completed", async () => {
     {
       viewer: account.viewer,
       schema: schema,
-      mutation: "todosMarkAllAs",
+      mutation: "markAllTodosAs",
       args: { accountID: account.id, completed: true },
       disableInputWrapping: true,
     },
@@ -59,7 +59,7 @@ test("mark all as completed", async () => {
     {
       viewer: account.viewer,
       schema: schema,
-      mutation: "todosMarkAllAs",
+      mutation: "markAllTodosAs",
       args: { accountID: account.id, completed: false },
       disableInputWrapping: true,
     },
@@ -92,7 +92,7 @@ test("remove completed", async () => {
     {
       viewer: account.viewer,
       schema: schema,
-      mutation: "todosRemoveCompleted",
+      mutation: "removeCompletedTodos",
       args: { accountID: account.id },
       disableInputWrapping: true,
     },
@@ -120,7 +120,7 @@ test("open todos plural from account", async () => {
       },
     },
     [
-      "openTodosPlural",
+      "open_todos_plural",
       todos.slice(1).map((todo) => {
         return {
           text: todo.text,
@@ -147,9 +147,9 @@ test("open todos connection from account", async () => {
         id: account.id,
       },
     },
-    ["openTodos.rawCount", todos.length - 1],
+    ["open_todos.rawCount", todos.length - 1],
     [
-      "openTodos.nodes",
+      "open_todos.nodes",
       todos.slice(1).map((todo) => {
         return {
           text: todo.text,
@@ -171,7 +171,7 @@ test("open todos plural from root", async () => {
     {
       viewer: account.viewer,
       schema: schema,
-      root: "openTodosPlural",
+      root: "open_todos_plural",
       args: {
         id: account.id,
       },
@@ -199,7 +199,7 @@ test("open todos connection from root", async () => {
     {
       viewer: account.viewer,
       schema: schema,
-      root: "openTodos",
+      root: "open_todos",
       args: {
         id: account.id,
       },
@@ -213,5 +213,61 @@ test("open todos connection from root", async () => {
         };
       }),
     ],
+  );
+});
+
+test("create", async () => {
+  const account = await createAccount();
+  await expectMutation(
+    {
+      viewer: account.viewer,
+      schema: schema,
+      mutation: "createTodo",
+      args: { creator_id: account.id, text: "watch GOT" },
+    },
+    [
+      "todo.id",
+      async (id: string) => {
+        await Todo.loadX(account.viewer, id);
+      },
+    ],
+    ["todo.text", "watch GOT"],
+    ["todo.creator.id", account.id],
+  );
+});
+
+test("edit", async () => {
+  const account = await createAccount();
+  const todo = await createTodo({
+    creatorID: account.id,
+    text: "watch GOT",
+  });
+  await expectMutation(
+    {
+      viewer: account.viewer,
+      schema: schema,
+      mutation: "renameTodo",
+      args: { todo_id: todo.id, text: "watch GOT tomorrow" },
+    },
+    ["todo.id", todo.id],
+    ["todo.text", "watch GOT tomorrow"],
+    ["todo.creator.id", account.id],
+  );
+});
+
+test("delete", async () => {
+  const account = await createAccount();
+  const todo = await createTodo({
+    creatorID: account.id,
+    text: "watch GOT",
+  });
+  await expectMutation(
+    {
+      viewer: account.viewer,
+      schema: schema,
+      mutation: "deleteTodo",
+      args: { todo_id: todo.id },
+    },
+    ["deleted_todo_id", todo.id],
   );
 });

--- a/examples/todo-sqlite/src/schema/todo.ts
+++ b/examples/todo-sqlite/src/schema/todo.ts
@@ -55,14 +55,14 @@ export default class Todo extends BaseEntSchema {
       operation: ActionOperation.Edit,
       fields: ["Completed"],
       actionName: "ChangeTodoStatusAction",
-      graphQLName: "todoChangeStatus",
+      graphQLName: "changeTodoStatus",
       inputName: "ChangeTodoStatusInput",
     },
     {
       operation: ActionOperation.Edit,
       fields: ["Text"],
       actionName: "RenameTodoStatusAction",
-      graphQLName: "todoRename",
+      graphQLName: "renameTodo",
       inputName: "RenameTodoInput",
     },
     {

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -404,35 +404,32 @@ func processEdgeGroupActions(cfg codegenapi.Config, nodeName string, assocGroup 
 		var fields []*field.NonEntField
 		if lang == base.GoLang {
 			fields = []*field.NonEntField{
-				{
-					FieldName: assocGroup.GroupStatusName,
-					FieldType: &enttype.StringType{},
-					Flag:      "Enum",
-				},
-				{
-					FieldName: strcase.ToCamel(assocGroup.DestNodeInfo.Node + "ID"),
-					FieldType: &enttype.StringType{},
-					Flag:      "ID",
-					NodeType:  fmt.Sprintf("models.%sType", assocGroup.DestNodeInfo.Node), // TODO should take it from codegenInfo
-				},
+				field.NewNonEntField(cfg, assocGroup.GroupStatusName, &enttype.StringType{}, false).SetFlag("Enum"),
+				field.NewNonEntField(cfg, strcase.ToCamel(assocGroup.DestNodeInfo.Node+"ID"), &enttype.StringType{}, false).
+					SetFlag("ID").
+					SetNodeType(fmt.Sprintf("models.%sType", assocGroup.DestNodeInfo.Node)),
 			}
 		} else {
 			values := assocGroup.GetStatusValues()
 			typ := fmt.Sprintf("%sInput", assocGroup.ConstType)
 
 			fields = []*field.NonEntField{
-				{
-					FieldName: assocGroup.TSGroupStatusName,
-					FieldType: &enttype.EnumType{
+				field.NewNonEntField(
+					cfg,
+					assocGroup.TSGroupStatusName,
+					&enttype.EnumType{
 						Values:      values,
 						Type:        typ,
 						GraphQLType: typ,
 					},
-				},
-				{
-					FieldName: assocGroup.GetIDArg(),
-					FieldType: &enttype.IDType{},
-				},
+					false,
+				),
+				field.NewNonEntField(
+					cfg,
+					assocGroup.GetIDArg(),
+					&enttype.IDType{},
+					false,
+				),
 			}
 
 			tsEnum, gqlEnum := enum.GetEnums(&enum.Input{

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -317,7 +317,7 @@ func getNonEntFieldsFromInput(cfg codegenapi.Config, nodeName string, action *in
 			return nil, err
 		}
 
-		fields = append(fields, field.NewNonEntField(f.Name, typ, f.Nullable))
+		fields = append(fields, field.NewNonEntField(cfg, f.Name, typ, f.Nullable))
 	}
 	return fields, nil
 }
@@ -339,7 +339,7 @@ func getNonEntFieldsFromAssocGroup(
 		if err != nil {
 			return nil, err
 		}
-		fields = append(fields, field.NewNonEntField(f.Name, typ, f.Nullable))
+		fields = append(fields, field.NewNonEntField(cfg, f.Name, typ, f.Nullable))
 	}
 	return fields, nil
 }

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -1089,10 +1089,11 @@ func verifyNonEntFields(t *testing.T, nonEntFields []*field.NonEntField, expFiel
 
 	for idx, nonEntField := range nonEntFields {
 		actionOnlyField := expFields[idx]
-		require.Equal(t, actionOnlyField.name, nonEntField.FieldName, "name %s not equal. idx %d", nonEntField.FieldName, idx)
-		require.Equal(t, actionOnlyField.nullable, nonEntField.Nullable(), "fieldname %s not equal. idx %d", nonEntField.FieldName, idx)
-		require.Equal(t, actionOnlyField.typ.graphqlType, nonEntField.GetFieldType().GetGraphQLType(), "graphql type %s not equal. idx %d", nonEntField.FieldName, idx)
-		require.Equal(t, actionOnlyField.typ.tsType, nonEntField.GetFieldType().GetTSType(), "ts type %s not equal. idx %d", nonEntField.FieldName, idx)
+		fieldName := nonEntField.GetFieldName()
+		require.Equal(t, actionOnlyField.name, fieldName, "name %s not equal. idx %d", fieldName, idx)
+		require.Equal(t, actionOnlyField.nullable, nonEntField.Nullable(), "fieldname %s not equal. idx %d", fieldName, idx)
+		require.Equal(t, actionOnlyField.typ.graphqlType, nonEntField.GetFieldType().GetGraphQLType(), "graphql type %s not equal. idx %d", fieldName, idx)
+		require.Equal(t, actionOnlyField.typ.tsType, nonEntField.GetGraphQLFieldType().GetTSType(), "ts type %s not equal. idx %d", fieldName, idx)
 	}
 }
 

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -1091,8 +1091,8 @@ func verifyNonEntFields(t *testing.T, nonEntFields []*field.NonEntField, expFiel
 		actionOnlyField := expFields[idx]
 		require.Equal(t, actionOnlyField.name, nonEntField.FieldName, "name %s not equal. idx %d", nonEntField.FieldName, idx)
 		require.Equal(t, actionOnlyField.nullable, nonEntField.Nullable(), "fieldname %s not equal. idx %d", nonEntField.FieldName, idx)
-		require.Equal(t, actionOnlyField.typ.graphqlType, nonEntField.FieldType.GetGraphQLType(), "graphql type %s not equal. idx %d", nonEntField.FieldName, idx)
-		require.Equal(t, actionOnlyField.typ.tsType, nonEntField.FieldType.GetTSType(), "ts type %s not equal. idx %d", nonEntField.FieldName, idx)
+		require.Equal(t, actionOnlyField.typ.graphqlType, nonEntField.GetFieldType().GetGraphQLType(), "graphql type %s not equal. idx %d", nonEntField.FieldName, idx)
+		require.Equal(t, actionOnlyField.typ.tsType, nonEntField.GetFieldType().GetTSType(), "ts type %s not equal. idx %d", nonEntField.FieldName, idx)
 	}
 }
 

--- a/internal/action/compare_action_test.go
+++ b/internal/action/compare_action_test.go
@@ -86,10 +86,12 @@ func TestCompareDeleteActionWithNonEntFields(t *testing.T) {
 		&deleteActionType{},
 		&actionOptions{
 			nonEntFields: []*field.NonEntField{
-				{
-					FieldName: "log",
-					FieldType: &enttype.BoolType{},
-				},
+				field.NewNonEntField(
+					&codegenapi.DummyConfig{},
+					"log",
+					&enttype.BoolType{},
+					false,
+				),
 			},
 		},
 	)
@@ -99,10 +101,12 @@ func TestCompareDeleteActionWithNonEntFields(t *testing.T) {
 		&deleteActionType{},
 		&actionOptions{
 			nonEntFields: []*field.NonEntField{
-				{
-					FieldName: "log",
-					FieldType: &enttype.BoolType{},
-				},
+				field.NewNonEntField(
+					&codegenapi.DummyConfig{},
+					"log",
+					&enttype.BoolType{},
+					false,
+				),
 			},
 		},
 	)
@@ -160,12 +164,12 @@ func TestCompareCreateActionWithDiffFields(t *testing.T) {
 }
 
 func TestCompareAddEdgeAction(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge1, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "createdEvents",
 	})
 	require.Nil(t, err)
-	edge2, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge2, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "createdEvents",
 	})
@@ -197,12 +201,12 @@ func TestCompareAddEdgeAction(t *testing.T) {
 }
 
 func TestCompareRemoveEdgeAction(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge1, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "createdEvents",
 	})
 	require.Nil(t, err)
-	edge2, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge2, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "createdEvents",
 	})
@@ -797,12 +801,12 @@ func TestCompareUnequalCustomInterfaces(t *testing.T) {
 }
 
 func TestCompareEdgeGroupAction(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge1, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "Declined",
 	})
 	require.Nil(t, err)
-	edge2, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge2, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "Attending",
 	})
@@ -845,17 +849,17 @@ func TestCompareEdgeGroupAction(t *testing.T) {
 }
 
 func TestCompareUnequalEdgeGroupAction(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge1, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "Declined",
 	})
 	require.Nil(t, err)
-	edge2, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge2, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "Attending",
 	})
 	require.Nil(t, err)
-	edge3, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
+	edge3, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
 		SchemaName: "User",
 		Name:       "Maybe",
 	})

--- a/internal/action/interface.go
+++ b/internal/action/interface.go
@@ -390,11 +390,11 @@ func ParseFromInput(cfg codegenapi.Config, nodeName string, actions []*input.Act
 }
 
 func ParseFromInputNode(cfg codegenapi.Config, nodeName string, node *input.Node, lang base.Language) (*ActionInfo, error) {
-	fi, err := field.NewFieldInfoFromInputs(node.Fields, &field.Options{})
+	fi, err := field.NewFieldInfoFromInputs(cfg, node.Fields, &field.Options{})
 	if err != nil {
 		return nil, err
 	}
-	ei, err := edge.EdgeInfoFromInput(nodeName, node)
+	ei, err := edge.EdgeInfoFromInput(cfg, nodeName, node)
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +500,7 @@ type EdgeActionTemplateInfo struct {
 	Node               string
 	GraphQLNodeID      string
 	TSEdgeConst        string
-	TSGraphQLNodeID    string
+	TSNodeID           string
 	TSAddMethodName    string
 	TSAddIDMethodName  string
 	TSRemoveMethodName string
@@ -536,7 +536,7 @@ func GetEdgesFromEdges(edges []*edge.AssociationEdge) []EdgeActionTemplateInfo {
 			NodeType: edge.NodeInfo.NodeType,
 			// matches what we do in graphQLSchema.processAction
 			GraphQLNodeID:      fmt.Sprintf("%sID", edge.Singular()),
-			TSGraphQLNodeID:    fmt.Sprintf("%sID", strcase.ToLowerCamel(edge.Singular())),
+			TSNodeID:           fmt.Sprintf("%sID", strcase.ToLowerCamel(edge.Singular())),
 			TSAddIDMethodName:  fmt.Sprintf("add%sID", edge.Singular()),
 			TSAddMethodName:    fmt.Sprintf("add%s", edge.Singular()),
 			TSRemoveMethodName: fmt.Sprintf("remove%s", edge.Singular()),

--- a/internal/action/interface.go
+++ b/internal/action/interface.go
@@ -471,11 +471,12 @@ func GetNonEntFields(action Action) []FieldActionTemplateInfo {
 	// TODO this is only used by go so didn't update this
 	for _, f := range action.GetNonEntFields() {
 
+		fieldName := f.GetFieldName()
 		fields = append(fields, FieldActionTemplateInfo{
-			SetterMethodName: "Add" + f.FieldName,
-			InstanceName:     strcase.ToLowerCamel(f.FieldName),
+			SetterMethodName: "Add" + fieldName,
+			InstanceName:     strcase.ToLowerCamel(fieldName),
 			InstanceType:     "string", // TODO this needs to work for other
-			FieldName:        f.FieldName,
+			FieldName:        fieldName,
 			IsStatusEnum:     f.Flag == "Enum", // TODO best way?
 			IsGroupID:        f.Flag == "ID",
 			NodeType:         f.NodeType,

--- a/internal/codegen/codegenapi/api.go
+++ b/internal/codegen/codegenapi/api.go
@@ -1,5 +1,7 @@
 package codegenapi
 
+import "github.com/iancoleman/strcase"
+
 type GraphQLMutationName string
 
 const (
@@ -10,9 +12,18 @@ const (
 	VerbNoun GraphQLMutationName = "VerbNoun"
 )
 
+type GraphQLFieldFormat string
+
+const (
+	LowerCamelCase GraphQLFieldFormat = "lowerCamel"
+
+	SnakeCase GraphQLFieldFormat = "snake_case"
+)
+
 // this file exists to simplify circular dependencies
 type Config interface {
 	DefaultGraphQLMutationName() GraphQLMutationName
+	DefaultGraphQLFieldFormat() GraphQLFieldFormat
 }
 
 // DummyConfig exists for tests/legacy paths which need Configs and don't want to create the production one
@@ -21,4 +32,19 @@ type DummyConfig struct {
 
 func (cfg *DummyConfig) DefaultGraphQLMutationName() GraphQLMutationName {
 	return NounVerb
+}
+
+func (cfg *DummyConfig) DefaultGraphQLFieldFormat() GraphQLFieldFormat {
+	return LowerCamelCase
+}
+
+var _ Config = &DummyConfig{}
+
+func GraphQLName(cfg Config, name string) string {
+	if cfg.DefaultGraphQLFieldFormat() == LowerCamelCase {
+		// TODO audit strcase.ToLowerCamel everywhere
+		// field & non ent field name has been converted. edge hasn't. what else?
+		return strcase.ToLowerCamel(name)
+	}
+	return strcase.ToSnake(name)
 }

--- a/internal/codegen/codegenapi/api.go
+++ b/internal/codegen/codegenapi/api.go
@@ -42,8 +42,6 @@ var _ Config = &DummyConfig{}
 
 func GraphQLName(cfg Config, name string) string {
 	if cfg.DefaultGraphQLFieldFormat() == LowerCamelCase {
-		// TODO audit strcase.ToLowerCamel everywhere
-		// field & non ent field name has been converted. edge hasn't. what else?
 		return strcase.ToLowerCamel(name)
 	}
 	return strcase.ToSnake(name)

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -279,6 +279,15 @@ func (cfg *Config) DefaultGraphQLMutationName() codegenapi.GraphQLMutationName {
 	return codegenapi.NounVerb
 }
 
+func (cfg *Config) DefaultGraphQLFieldFormat() codegenapi.GraphQLFieldFormat {
+	if codegen := cfg.getCodegenConfig(); codegen != nil {
+		if codegen.DefaultGraphQLFieldFormat != "" {
+			return codegen.DefaultGraphQLFieldFormat
+		}
+	}
+	return codegenapi.LowerCamelCase
+}
+
 const DEFAULT_GLOB = "src/**/*.ts"
 const PRETTIER_FILE_CHUNKS = 20
 
@@ -407,6 +416,7 @@ type CodegenConfig struct {
 	DisableBase64Encoding      bool                           `yaml:"disableBase64Encoding"`
 	GenerateRootResolvers      bool                           `yaml:"generateRootResolvers"`
 	DefaultGraphQLMutationName codegenapi.GraphQLMutationName `yaml:"defaultGraphQLMutationName"`
+	DefaultGraphQLFieldFormat  codegenapi.GraphQLFieldFormat  `yaml:"defaultGraphQLFieldFormat"`
 }
 
 type PrivacyConfig struct {

--- a/internal/edge/compare_edge_test.go
+++ b/internal/edge/compare_edge_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/codegen/nodeinfo"
 	"github.com/lolopinto/ent/internal/schema/base"
 	"github.com/lolopinto/ent/internal/schema/input"
@@ -18,7 +19,7 @@ func TestSimpleAssocEdge(t *testing.T) {
 	})
 
 	testAssocEdge(t, edge, &AssociationEdge{
-		commonEdgeInfo: getCommonEdgeInfo("CreatedEvents", schemaparser.GetEntConfigFromName("Event")),
+		commonEdgeInfo: getCommonEdgeInfoForTest("CreatedEvents", schemaparser.GetEntConfigFromName("Event")),
 		EdgeConst:      "UserToCreatedEventsEdge",
 		TsEdgeConst:    "UserToCreatedEvents",
 		TableName:      "user_created_events_edges",
@@ -32,13 +33,13 @@ func TestSimpleAssocEdge(t *testing.T) {
 
 func TestUnequalAssocEdge(t *testing.T) {
 	edge := &AssociationEdge{
-		commonEdgeInfo: getCommonEdgeInfo("CreatedEvents", schemaparser.GetEntConfigFromName("Event")),
+		commonEdgeInfo: getCommonEdgeInfoForTest("CreatedEvents", schemaparser.GetEntConfigFromName("Event")),
 		EdgeConst:      "UserToCreatedEventsEdge",
 		TsEdgeConst:    "UserToCreatedEvents",
 		TableName:      "user_created_events_edges",
 	}
 	edge2 := &AssociationEdge{
-		commonEdgeInfo: getCommonEdgeInfo("CreatedEvents", schemaparser.GetEntConfigFromName("Event")),
+		commonEdgeInfo: getCommonEdgeInfoForTest("CreatedEvents", schemaparser.GetEntConfigFromName("Event")),
 		EdgeConst:      "UserToCreatedEventsEdge",
 		TsEdgeConst:    "UserToCreatedEvents",
 		TableName:      "user_created_events_edges2",
@@ -56,7 +57,7 @@ func TestSymmetricAssocEdge(t *testing.T) {
 	})
 
 	testAssocEdge(t, edge, &AssociationEdge{
-		commonEdgeInfo: getCommonEdgeInfo("Friends", schemaparser.GetEntConfigFromName("User")),
+		commonEdgeInfo: getCommonEdgeInfoForTest("Friends", schemaparser.GetEntConfigFromName("User")),
 		EdgeConst:      "UserToFriendsEdge",
 		TsEdgeConst:    "UserToFriends",
 		TableName:      "user_friends_edges",
@@ -79,12 +80,12 @@ func TestInverseAssocEdge(t *testing.T) {
 	})
 
 	testAssocEdge(t, edge, &AssociationEdge{
-		commonEdgeInfo: getCommonEdgeInfo("FriendRequestsSent", schemaparser.GetEntConfigFromName("User")),
+		commonEdgeInfo: getCommonEdgeInfoForTest("FriendRequestsSent", schemaparser.GetEntConfigFromName("User")),
 		EdgeConst:      "UserToFriendRequestsSentEdge",
 		TsEdgeConst:    "UserToFriendRequestsSent",
 		TableName:      "user_friend_requests_sent_edges",
 		InverseEdge: &InverseAssocEdge{
-			commonEdgeInfo: getCommonEdgeInfo("FriendRequestsReceived", schemaparser.GetEntConfigFromName("User")),
+			commonEdgeInfo: getCommonEdgeInfoForTest("FriendRequestsReceived", schemaparser.GetEntConfigFromName("User")),
 			EdgeConst:      "UserToFriendRequestsReceivedEdge",
 		},
 	})
@@ -97,23 +98,23 @@ func TestInverseAssocEdge(t *testing.T) {
 
 func TestUnequalInverseAssocEdge(t *testing.T) {
 	edge := &AssociationEdge{
-		commonEdgeInfo: getCommonEdgeInfo("FriendRequestsSent", schemaparser.GetEntConfigFromName("User")),
+		commonEdgeInfo: getCommonEdgeInfoForTest("FriendRequestsSent", schemaparser.GetEntConfigFromName("User")),
 		EdgeConst:      "UserToFriendRequestsSentEdge",
 		TsEdgeConst:    "UserToFriendRequestsSent",
 		TableName:      "user_friend_requests_sent_edges",
 		InverseEdge: &InverseAssocEdge{
-			commonEdgeInfo: getCommonEdgeInfo("FriendRequestsReceived", schemaparser.GetEntConfigFromName("User")),
+			commonEdgeInfo: getCommonEdgeInfoForTest("FriendRequestsReceived", schemaparser.GetEntConfigFromName("User")),
 			EdgeConst:      "UserToFriendRequestsReceivedEdge",
 		},
 	}
 
 	edge2 := &AssociationEdge{
-		commonEdgeInfo: getCommonEdgeInfo("FriendRequestsSent", schemaparser.GetEntConfigFromName("User")),
+		commonEdgeInfo: getCommonEdgeInfoForTest("FriendRequestsSent", schemaparser.GetEntConfigFromName("User")),
 		EdgeConst:      "UserToFriendRequestsSentEdge",
 		TsEdgeConst:    "UserToFriendRequestsSent",
 		TableName:      "user_friend_requests_sent_edges",
 		InverseEdge: &InverseAssocEdge{
-			commonEdgeInfo: getCommonEdgeInfo("FriendRequestsReceived", schemaparser.GetEntConfigFromName("User")),
+			commonEdgeInfo: getCommonEdgeInfoForTest("FriendRequestsReceived", schemaparser.GetEntConfigFromName("User")),
 			EdgeConst:      "UserToFriendRequestsReceivedEdge2",
 		},
 	}
@@ -135,14 +136,14 @@ func TestAssocEdgeWithPattern(t *testing.T) {
 	})
 
 	testAssocEdge(t, edge, &AssociationEdge{
-		commonEdgeInfo: getCommonEdgeInfo("likers", schemaparser.GetEntConfigFromName("User")),
+		commonEdgeInfo: getCommonEdgeInfoForTest("likers", schemaparser.GetEntConfigFromName("User")),
 		// legacy hence confusing
 		EdgeConst:   "UserToLikersEdge",
 		TsEdgeConst: "LikedPostToLikers",
 		TableName:   "user_likers_edges",
 		PatternName: "Likes",
 		InverseEdge: &InverseAssocEdge{
-			commonEdgeInfo: getCommonEdgeInfo("likes", schemaparser.GetEntConfigFromName("User")),
+			commonEdgeInfo: getCommonEdgeInfoForTest("likes", schemaparser.GetEntConfigFromName("User")),
 			EdgeConst:      "UserToLikedObjectsEdge",
 		},
 		overridenQueryName:   "UserToLikersQuery",
@@ -166,18 +167,26 @@ func marshallAndUnmarshallInputAssocEdge(t *testing.T, inputEdge *input.AssocEdg
 }
 
 func createDuplicateAssocEdgeFromInput(t *testing.T, packageName string, inputEdge *input.AssocEdge) (*AssociationEdge, *AssociationEdge) {
-	edge, err := AssocEdgeFromInput(packageName, inputEdge)
+	edge, err := AssocEdgeFromInput(&codegenapi.DummyConfig{}, packageName, inputEdge)
 	require.Nil(t, err)
 	inputEdge2 := marshallAndUnmarshallInputAssocEdge(t, inputEdge)
-	edge2, err := AssocEdgeFromInput(packageName, inputEdge2)
+	edge2, err := AssocEdgeFromInput(&codegenapi.DummyConfig{}, packageName, inputEdge2)
 	require.Nil(t, err)
 
 	return edge, edge2
 }
 
+func getForeignKeyEdgeForTest(dbColName, edgeName, nodeName, sourceNodeName string) *ForeignKeyEdge {
+	return getForeignKeyEdge(&codegenapi.DummyConfig{}, dbColName, edgeName, nodeName, sourceNodeName)
+}
+
+func getIndexedEdgeForTest(tsFieldName, quotedDBColName, nodeName string, polymorphic *base.PolymorphicOptions, foreignNode string) *IndexedEdge {
+	return getIndexedEdge(&codegenapi.DummyConfig{}, tsFieldName, quotedDBColName, nodeName, polymorphic, foreignNode)
+}
+
 func TestForeignKeyEdge(t *testing.T) {
-	edge := getForeignKeyEdge("user_id", "users", "User", "Contact")
-	edge2 := getForeignKeyEdge("user_id", "users", "User", "Contact")
+	edge := getForeignKeyEdgeForTest("user_id", "users", "User", "Contact")
+	edge2 := getForeignKeyEdgeForTest("user_id", "users", "User", "Contact")
 
 	testForeignKeyEdge(t, edge, edge2)
 
@@ -186,16 +195,16 @@ func TestForeignKeyEdge(t *testing.T) {
 }
 
 func TestUnequalForeignKeyEdge(t *testing.T) {
-	edge := getForeignKeyEdge("user_id", "users", "User", "Contact")
-	edge2 := getForeignKeyEdge("user_id", "users", "User2", "Contact")
+	edge := getForeignKeyEdgeForTest("user_id", "users", "User", "Contact")
+	edge2 := getForeignKeyEdgeForTest("user_id", "users", "User2", "Contact")
 
 	l := compareForeignKeyEdge(edge, edge2)
 	require.Len(t, l, 1)
 }
 
 func TestIndexedEdge(t *testing.T) {
-	edge := getIndexedEdge("ownerId", "owner_id", "User", nil, "Contact")
-	edge2 := getIndexedEdge("ownerId", "owner_id", "User", nil, "Contact")
+	edge := getIndexedEdgeForTest("ownerId", "owner_id", "User", nil, "Contact")
+	edge2 := getIndexedEdgeForTest("ownerId", "owner_id", "User", nil, "Contact")
 
 	testIndexedEdge(t, edge, edge2)
 
@@ -204,12 +213,12 @@ func TestIndexedEdge(t *testing.T) {
 }
 
 func TestPolymorphicIndexedEdge(t *testing.T) {
-	edge := getIndexedEdge("ownerId", "owner_id", "User", &base.PolymorphicOptions{
+	edge := getIndexedEdgeForTest("ownerId", "owner_id", "User", &base.PolymorphicOptions{
 		PolymorphicOptions: &input.PolymorphicOptions{},
 		NodeTypeField:      "Node",
 		Unique:             true,
 	}, "Contact")
-	edge2 := getIndexedEdge("ownerId", "owner_id", "User", &base.PolymorphicOptions{
+	edge2 := getIndexedEdgeForTest("ownerId", "owner_id", "User", &base.PolymorphicOptions{
 		PolymorphicOptions: &input.PolymorphicOptions{},
 		NodeTypeField:      "Node",
 		Unique:             true,
@@ -222,12 +231,12 @@ func TestPolymorphicIndexedEdge(t *testing.T) {
 }
 
 func TestUnEqualPolymorphicIndexedEdge(t *testing.T) {
-	edge := getIndexedEdge("ownerId", "owner_id", "User", &base.PolymorphicOptions{
+	edge := getIndexedEdgeForTest("ownerId", "owner_id", "User", &base.PolymorphicOptions{
 		PolymorphicOptions: &input.PolymorphicOptions{},
 		NodeTypeField:      "Node",
 		Unique:             true,
 	}, "Contact")
-	edge2 := getIndexedEdge("ownerId", "owner_id", "User", &base.PolymorphicOptions{
+	edge2 := getIndexedEdgeForTest("ownerId", "owner_id", "User", &base.PolymorphicOptions{
 		PolymorphicOptions: &input.PolymorphicOptions{
 			// only 2 fields we care about here are HideFromInverseGraphQL and Unique
 			HideFromInverseGraphQL: true,
@@ -241,14 +250,20 @@ func TestUnEqualPolymorphicIndexedEdge(t *testing.T) {
 }
 
 func TestFieldEdge(t *testing.T) {
-	edge, err := getFieldEdge("user_id", &base.FieldEdgeInfo{
-		Schema: "Contact",
-	}, true, nil)
+	edge, err := getFieldEdge(
+		&codegenapi.DummyConfig{},
+		"user_id",
+		&base.FieldEdgeInfo{
+			Schema: "Contact",
+		}, true, nil)
 	require.Nil(t, err)
 	require.NotNil(t, edge)
-	edge2, err := getFieldEdge("user_id", &base.FieldEdgeInfo{
-		Schema: "Contact",
-	}, true, nil)
+	edge2, err := getFieldEdge(
+		&codegenapi.DummyConfig{},
+		"user_id",
+		&base.FieldEdgeInfo{
+			Schema: "Contact",
+		}, true, nil)
 	require.Nil(t, err)
 	require.NotNil(t, edge2)
 
@@ -259,14 +274,18 @@ func TestFieldEdge(t *testing.T) {
 }
 
 func TestUnequalFieldEdge(t *testing.T) {
-	edge, err := getFieldEdge("user_id", &base.FieldEdgeInfo{
-		Schema: "Contact",
-	}, true, nil)
+	edge, err := getFieldEdge(
+		&codegenapi.DummyConfig{},
+		"user_id", &base.FieldEdgeInfo{
+			Schema: "Contact",
+		}, true, nil)
 	require.Nil(t, err)
 	require.NotNil(t, edge)
-	edge2, err := getFieldEdge("user_id", &base.FieldEdgeInfo{
-		Schema: "Contact",
-	}, false, nil)
+	edge2, err := getFieldEdge(
+		&codegenapi.DummyConfig{},
+		"user_id", &base.FieldEdgeInfo{
+			Schema: "Contact",
+		}, false, nil)
 	require.Nil(t, err)
 	require.NotNil(t, edge2)
 
@@ -275,20 +294,24 @@ func TestUnequalFieldEdge(t *testing.T) {
 }
 
 func TestFieldEdgeWithInverse(t *testing.T) {
-	edge, err := getFieldEdge("user_id", &base.FieldEdgeInfo{
-		Schema: "Contact",
-		InverseEdge: &input.InverseFieldEdge{
-			EdgeConstName: "Contacts",
-		},
-	}, true, nil)
+	edge, err := getFieldEdge(
+		&codegenapi.DummyConfig{},
+		"user_id", &base.FieldEdgeInfo{
+			Schema: "Contact",
+			InverseEdge: &input.InverseFieldEdge{
+				EdgeConstName: "Contacts",
+			},
+		}, true, nil)
 	require.Nil(t, err)
 	require.NotNil(t, edge)
-	edge2, err := getFieldEdge("user_id", &base.FieldEdgeInfo{
-		Schema: "Contact",
-		InverseEdge: &input.InverseFieldEdge{
-			EdgeConstName: "Contacts",
-		},
-	}, true, nil)
+	edge2, err := getFieldEdge(
+		&codegenapi.DummyConfig{},
+		"user_id", &base.FieldEdgeInfo{
+			Schema: "Contact",
+			InverseEdge: &input.InverseFieldEdge{
+				EdgeConstName: "Contacts",
+			},
+		}, true, nil)
 	require.Nil(t, err)
 	require.NotNil(t, edge2)
 
@@ -299,26 +322,30 @@ func TestFieldEdgeWithInverse(t *testing.T) {
 }
 
 func TestPolymorphicFieldEdge(t *testing.T) {
-	edge, err := getFieldEdge("user_id", &base.FieldEdgeInfo{
-		Schema: "Contact",
-		Polymorphic: &base.PolymorphicOptions{
-			NodeTypeField: "Node",
-			PolymorphicOptions: &input.PolymorphicOptions{
-				Types: []string{"User", "Account"},
+	edge, err := getFieldEdge(
+		&codegenapi.DummyConfig{},
+		"user_id", &base.FieldEdgeInfo{
+			Schema: "Contact",
+			Polymorphic: &base.PolymorphicOptions{
+				NodeTypeField: "Node",
+				PolymorphicOptions: &input.PolymorphicOptions{
+					Types: []string{"User", "Account"},
+				},
 			},
-		},
-	}, true, nil)
+		}, true, nil)
 	require.Nil(t, err)
 	require.NotNil(t, edge)
-	edge2, err := getFieldEdge("user_id", &base.FieldEdgeInfo{
-		Schema: "Contact",
-		Polymorphic: &base.PolymorphicOptions{
-			NodeTypeField: "Node",
-			PolymorphicOptions: &input.PolymorphicOptions{
-				Types: []string{"User", "Account"},
+	edge2, err := getFieldEdge(
+		&codegenapi.DummyConfig{},
+		"user_id", &base.FieldEdgeInfo{
+			Schema: "Contact",
+			Polymorphic: &base.PolymorphicOptions{
+				NodeTypeField: "Node",
+				PolymorphicOptions: &input.PolymorphicOptions{
+					Types: []string{"User", "Account"},
+				},
 			},
-		},
-	}, true, nil)
+		}, true, nil)
 	require.Nil(t, err)
 	require.NotNil(t, edge2)
 
@@ -330,12 +357,12 @@ func TestPolymorphicFieldEdge(t *testing.T) {
 
 func TestAssociationEdgeGroup(t *testing.T) {
 
-	edge1, err := AssocEdgeFromInput("Event", &input.AssocEdge{
+	edge1, err := AssocEdgeFromInput(&codegenapi.DummyConfig{}, "Event", &input.AssocEdge{
 		Name:       "Attending",
 		SchemaName: "User",
 	})
 	require.Nil(t, err)
-	edge2, err := AssocEdgeFromInput("Event", &input.AssocEdge{
+	edge2, err := AssocEdgeFromInput(&codegenapi.DummyConfig{}, "Event", &input.AssocEdge{
 		Name:       "Declined",
 		SchemaName: "User",
 	})

--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/iancoleman/strcase"
 	"github.com/jinzhu/inflection"
 	"github.com/lolopinto/ent/ent"
@@ -1352,6 +1353,9 @@ func getCommonEdgeInfo(
 	entConfig *schemaparser.EntConfigInfo,
 ) commonEdgeInfo {
 
+	if edgeName == "" {
+		spew.Dump("null edgeName")
+	}
 	ret := commonEdgeInfo{
 		EdgeName:        edgeName,
 		entConfig:       entConfig,

--- a/internal/edge/edge_test.go
+++ b/internal/edge/edge_test.go
@@ -35,7 +35,7 @@ func TestAssociationEdge(t *testing.T) {
 	expectedAssocEdge := &AssociationEdge{
 		EdgeConst:   "AccountToFoldersEdge",
 		TsEdgeConst: "AccountToFolders",
-		commonEdgeInfo: getCommonEdgeInfo(
+		commonEdgeInfo: getCommonEdgeInfoForTest(
 			"Folders",
 			schemaparser.GetEntConfigFromName("folder"),
 		),
@@ -67,7 +67,7 @@ func TestSymmetricAssociationEdge(t *testing.T) {
 	expectedAssocEdge := &AssociationEdge{
 		EdgeConst:   "AccountToFriendsEdge",
 		TsEdgeConst: "AccountToFriends",
-		commonEdgeInfo: getCommonEdgeInfo(
+		commonEdgeInfo: getCommonEdgeInfoForTest(
 			"Friends",
 			schemaparser.GetEntConfigFromName("account"),
 		),
@@ -88,7 +88,7 @@ func TestUniqueAssociationEdge(t *testing.T) {
 	expectedAssocEdge := &AssociationEdge{
 		EdgeConst:   "EventToCreatorEdge",
 		TsEdgeConst: "EventToCreator",
-		commonEdgeInfo: getCommonEdgeInfo(
+		commonEdgeInfo: getCommonEdgeInfoForTest(
 			"Creator",
 			schemaparser.GetEntConfigFromName("account"),
 		),
@@ -109,13 +109,13 @@ func TestInverseAssociationEdge(t *testing.T) {
 	expectedAssocEdge := &AssociationEdge{
 		EdgeConst:   "FolderToTodosEdge",
 		TsEdgeConst: "FolderToTodos",
-		commonEdgeInfo: getCommonEdgeInfo(
+		commonEdgeInfo: getCommonEdgeInfoForTest(
 			"Todos",
 			schemaparser.GetEntConfigFromName("todo"),
 		),
 		InverseEdge: &InverseAssocEdge{
 			EdgeConst: "TodoToFoldersEdge",
-			commonEdgeInfo: getCommonEdgeInfo(
+			commonEdgeInfo: getCommonEdgeInfoForTest(
 				"Folders",
 				schemaparser.GetEntConfigFromName("folder"),
 			),
@@ -142,7 +142,7 @@ func TestAddingInverseEdge(t *testing.T) {
 	expectedAssocEdge := &AssociationEdge{
 		EdgeConst:   "TodoToFoldersEdge",
 		TsEdgeConst: "TodoToFolders",
-		commonEdgeInfo: getCommonEdgeInfo(
+		commonEdgeInfo: getCommonEdgeInfoForTest(
 			"Folders",
 			schemaparser.GetEntConfigFromName("folder"),
 		),
@@ -163,13 +163,13 @@ func TestEdgeGroup(t *testing.T) {
 	expectedFriendRequestsEdge := &AssociationEdge{
 		EdgeConst:   "AccountToFriendRequestsEdge",
 		TsEdgeConst: "AccountToFriendRequests",
-		commonEdgeInfo: getCommonEdgeInfo(
+		commonEdgeInfo: getCommonEdgeInfoForTest(
 			"FriendRequests",
 			schemaparser.GetEntConfigFromName("account"),
 		),
 		InverseEdge: &InverseAssocEdge{
 			EdgeConst: "AccountToFriendRequestsReceivedEdge",
-			commonEdgeInfo: getCommonEdgeInfo(
+			commonEdgeInfo: getCommonEdgeInfoForTest(
 				"FriendRequestsReceived",
 				schemaparser.GetEntConfigFromName("account"),
 			),
@@ -216,13 +216,13 @@ func TestEdgeGroupWithCustomActionEdges(t *testing.T) {
 	expectedInvitedEdge := &AssociationEdge{
 		EdgeConst:   "EventToInvitedEdge",
 		TsEdgeConst: "EventToInvited",
-		commonEdgeInfo: getCommonEdgeInfo(
+		commonEdgeInfo: getCommonEdgeInfoForTest(
 			"Invited",
 			schemaparser.GetEntConfigFromName("account"),
 		),
 		InverseEdge: &InverseAssocEdge{
 			EdgeConst: "AccountToInvitedEventsEdge",
-			commonEdgeInfo: getCommonEdgeInfo(
+			commonEdgeInfo: getCommonEdgeInfoForTest(
 				"InvitedEvents",
 				schemaparser.GetEntConfigFromName("event"),
 			),

--- a/internal/enttype/type.go
+++ b/internal/enttype/type.go
@@ -1190,6 +1190,7 @@ func getDefaultGraphQLFieldName(typ types.Type) string {
 	if len(parts) != 2 {
 		return ""
 	}
+	// NB: this is not converted to use codegenapi.GraphQLName() because it seems like it's only used in the legacy go path
 	return strcase.ToLowerCamel(parts[1])
 }
 

--- a/internal/field/compare_field.go
+++ b/internal/field/compare_field.go
@@ -32,6 +32,7 @@ func NonEntFieldsEqual(existing, fields []*NonEntField) bool {
 
 func NonEntFieldEqual(existing, field *NonEntField) bool {
 	return existing.FieldName == field.FieldName &&
+		existing.graphqlName == field.graphqlName &&
 		compareType(existing.FieldType, field.FieldType) &&
 		existing.nullable == field.nullable &&
 		existing.Flag == field.Flag &&

--- a/internal/field/compare_field.go
+++ b/internal/field/compare_field.go
@@ -31,9 +31,9 @@ func NonEntFieldsEqual(existing, fields []*NonEntField) bool {
 }
 
 func NonEntFieldEqual(existing, field *NonEntField) bool {
-	return existing.FieldName == field.FieldName &&
+	return existing.GetFieldName() == field.GetFieldName() &&
 		existing.graphqlName == field.graphqlName &&
-		compareType(existing.FieldType, field.FieldType) &&
+		compareType(existing.GetGraphQLFieldType(), field.GetGraphQLFieldType()) &&
 		existing.nullable == field.nullable &&
 		existing.Flag == field.Flag &&
 		existing.NodeType == field.NodeType

--- a/internal/field/compare_field_test.go
+++ b/internal/field/compare_field_test.go
@@ -12,44 +12,23 @@ import (
 )
 
 func TestCompareNonEntField(t *testing.T) {
-	f := &NonEntField{
-		FieldName: "f1",
-		FieldType: &enttype.IntegerType{},
-		nullable:  true,
-	}
-	f2 := &NonEntField{
-		FieldName: "f1",
-		FieldType: &enttype.IntegerType{},
-		nullable:  true,
-	}
+	f := NewNonEntField(&codegenapi.DummyConfig{}, "f1", &enttype.IntegerType{}, true)
+	f2 := NewNonEntField(&codegenapi.DummyConfig{}, "f1", &enttype.IntegerType{}, true)
+
 	require.True(t, NonEntFieldEqual(f, f2))
 }
 
 func TestCompareUnequalNonEntField(t *testing.T) {
-	f := &NonEntField{
-		FieldName: "f1",
-		FieldType: &enttype.IntegerType{},
-		nullable:  true,
-	}
-	f2 := &NonEntField{
-		FieldName: "f2",
-		FieldType: &enttype.IntegerType{},
-		nullable:  true,
-	}
+	f := NewNonEntField(&codegenapi.DummyConfig{}, "f1", &enttype.IntegerType{}, true)
+	f2 := NewNonEntField(&codegenapi.DummyConfig{}, "f2", &enttype.IntegerType{}, true)
+
 	require.False(t, NonEntFieldEqual(f, f2))
 }
 
 func TestCompareUnequalNonEntFieldType(t *testing.T) {
-	f := &NonEntField{
-		FieldName: "f1",
-		FieldType: &enttype.IntegerType{},
-		nullable:  true,
-	}
-	f2 := &NonEntField{
-		FieldName: "f1",
-		FieldType: &enttype.StringType{},
-		nullable:  true,
-	}
+	f := NewNonEntField(&codegenapi.DummyConfig{}, "f1", &enttype.IntegerType{}, true)
+	f2 := NewNonEntField(&codegenapi.DummyConfig{}, "f1", &enttype.StringType{}, true)
+
 	require.False(t, NonEntFieldEqual(f, f2))
 }
 

--- a/internal/field/compare_field_test.go
+++ b/internal/field/compare_field_test.go
@@ -3,6 +3,7 @@ package field
 import (
 	"testing"
 
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/edge"
 	"github.com/lolopinto/ent/internal/enttype"
 	"github.com/lolopinto/ent/internal/schema/base"
@@ -266,15 +267,19 @@ func TestFieldEdgeWithUnequalPolymorphic(t *testing.T) {
 }
 
 func TestFieldWithInverseEdge(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("User", &input.AssocEdge{
-		Name:       "CreatedEvents",
-		SchemaName: "Event",
-	})
+	edge1, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		"User", &input.AssocEdge{
+			Name:       "CreatedEvents",
+			SchemaName: "Event",
+		})
 	require.Nil(t, err)
-	edge2, err := edge.AssocEdgeFromInput("User", &input.AssocEdge{
-		Name:       "CreatedEvents",
-		SchemaName: "Event",
-	})
+	edge2, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		"User", &input.AssocEdge{
+			Name:       "CreatedEvents",
+			SchemaName: "Event",
+		})
 	require.Nil(t, err)
 
 	f := &Field{
@@ -291,15 +296,19 @@ func TestFieldWithInverseEdge(t *testing.T) {
 }
 
 func TestFieldWithUnequalInverseEdge(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("User", &input.AssocEdge{
-		Name:       "CreatedEvents",
-		SchemaName: "Event",
-	})
+	edge1, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		"User", &input.AssocEdge{
+			Name:       "CreatedEvents",
+			SchemaName: "Event",
+		})
 	require.Nil(t, err)
-	edge2, err := edge.AssocEdgeFromInput("User", &input.AssocEdge{
-		Name:       "eventsCreated",
-		SchemaName: "Event",
-	})
+	edge2, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		"User", &input.AssocEdge{
+			Name:       "eventsCreated",
+			SchemaName: "Event",
+		})
 	require.Nil(t, err)
 
 	f := &Field{

--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/iancoleman/strcase"
 	"github.com/jinzhu/inflection"
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/edge"
 	"github.com/lolopinto/ent/internal/enttype"
 	"github.com/lolopinto/ent/internal/schema/base"
@@ -86,7 +87,7 @@ func NewFieldFromNameAndType(name string, typ enttype.TSGraphQLType) *Field {
 	}
 }
 
-func newFieldFromInput(f *input.Field) (*Field, error) {
+func newFieldFromInput(cfg codegenapi.Config, f *input.Field) (*Field, error) {
 	ret := &Field{
 		FieldName:                  f.Name,
 		nullable:                   f.Nullable,
@@ -124,7 +125,7 @@ func newFieldFromInput(f *input.Field) (*Field, error) {
 			// TODO come up with a better way of handling this
 			ret.graphQLName = "id"
 		} else {
-			ret.graphQLName = strcase.ToLowerCamel(ret.FieldName)
+			ret.graphQLName = codegenapi.GraphQLName(cfg, ret.FieldName)
 		}
 	}
 
@@ -210,8 +211,8 @@ func newFieldFromInput(f *input.Field) (*Field, error) {
 	return ret, nil
 }
 
-func newField(fieldName string) *Field {
-	graphQLName := strcase.ToLowerCamel(fieldName)
+func newField(cfg codegenapi.Config, fieldName string) *Field {
+	graphQLName := codegenapi.GraphQLName(cfg, fieldName)
 	// TODO come up with a better way of handling this
 	if fieldName == "ID" {
 		graphQLName = "id"
@@ -246,22 +247,28 @@ func (f *Field) GetQuotedDBColName() string {
 
 // We're going from field -> edge to be consistent and
 // not have circular dependencies
-func (f *Field) AddForeignKeyFieldEdgeToEdgeInfo(edgeInfo *edge.EdgeInfo) error {
+func (f *Field) AddForeignKeyFieldEdgeToEdgeInfo(
+	cfg codegenapi.Config,
+	edgeInfo *edge.EdgeInfo) error {
 	fkeyInfo := f.ForeignKeyInfo()
 	if fkeyInfo == nil {
 		return fmt.Errorf("invalid field %s added", f.FieldName)
 	}
 
-	return edgeInfo.AddFieldEdgeFromForeignKeyInfo(f.FieldName, fkeyInfo.Schema+"Config", f.Nullable(), f.fieldType)
+	return edgeInfo.AddFieldEdgeFromForeignKeyInfo(cfg, f.FieldName, fkeyInfo.Schema+"Config", f.Nullable(), f.fieldType)
 }
 
-func (f *Field) AddFieldEdgeToEdgeInfo(edgeInfo *edge.EdgeInfo) error {
+func (f *Field) AddFieldEdgeToEdgeInfo(
+	cfg codegenapi.Config,
+	edgeInfo *edge.EdgeInfo,
+) error {
 	fieldEdgeInfo := f.FieldEdgeInfo()
 	if fieldEdgeInfo == nil {
 		return fmt.Errorf("invalid field %s added", f.FieldName)
 	}
 
 	return edgeInfo.AddFieldEdgeFromFieldEdgeInfo(
+		cfg,
 		f.FieldName,
 		fieldEdgeInfo,
 		f.Nullable(),
@@ -269,7 +276,9 @@ func (f *Field) AddFieldEdgeToEdgeInfo(edgeInfo *edge.EdgeInfo) error {
 	)
 }
 
-func (f *Field) AddForeignKeyEdgeToInverseEdgeInfo(edgeInfo *edge.EdgeInfo, nodeName string) error {
+func (f *Field) AddForeignKeyEdgeToInverseEdgeInfo(
+	cfg codegenapi.Config,
+	edgeInfo *edge.EdgeInfo, nodeName string) error {
 	fkeyInfo := f.ForeignKeyInfo()
 	if fkeyInfo == nil {
 		return fmt.Errorf("invalid field %s added", f.FieldName)
@@ -283,6 +292,7 @@ func (f *Field) AddForeignKeyEdgeToInverseEdgeInfo(edgeInfo *edge.EdgeInfo, node
 		edgeName = inflection.Plural(nodeName)
 	}
 	return edgeInfo.AddEdgeFromForeignKeyIndex(
+		cfg,
 		f.GetQuotedDBColName(),
 		edgeName,
 		nodeName,
@@ -615,12 +625,12 @@ func (f *Field) setPrivate() {
 	f.exposeToActionsByDefault = false
 }
 
-func (f *Field) AddInverseEdge(edge *edge.AssociationEdge) error {
+func (f *Field) AddInverseEdge(cfg codegenapi.Config, edge *edge.AssociationEdge) error {
 	if f.fieldEdge == nil {
 		return fmt.Errorf("cannot add an inverse edge on a field without a field edge")
 	}
 	var err error
-	f.inverseEdge, err = edge.CloneWithCommonInfo(f.fieldEdge.Schema + "Config")
+	f.inverseEdge, err = edge.CloneWithCommonInfo(cfg, f.fieldEdge.Schema+"Config")
 	return err
 }
 

--- a/internal/field/new_field_api.go
+++ b/internal/field/new_field_api.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/lolopinto/ent/internal/astparser"
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/schema/input"
 	"github.com/lolopinto/ent/internal/syncerr"
 	"golang.org/x/tools/go/packages"
@@ -59,10 +60,12 @@ func ParseFieldsFunc(pkg *packages.Package, fn *ast.FuncDecl) (*FieldInfo, error
 		return nil, err
 	}
 
-	fieldInfo, err := NewFieldInfoFromInputs(fields, &Options{
-		AddBaseFields: true,
-		SortFields:    true,
-	})
+	fieldInfo, err := NewFieldInfoFromInputs(
+		&codegenapi.DummyConfig{},
+		fields, &Options{
+			AddBaseFields: true,
+			SortFields:    true,
+		})
 	if fieldInfo != nil {
 		fieldInfo.getFieldsFn = true
 	}

--- a/internal/field/non_ent_field.go
+++ b/internal/field/non_ent_field.go
@@ -2,14 +2,16 @@ package field
 
 import (
 	"github.com/iancoleman/strcase"
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/enttype"
 )
 
 type NonEntField struct {
 	// note that if this changes, need to update NonEntFieldEqual
-	FieldName string
-	FieldType enttype.TSGraphQLType
-	nullable  bool // required default = true
+	FieldName   string
+	graphqlName string
+	FieldType   enttype.TSGraphQLType
+	nullable    bool // required default = true
 	// TODO these are both go things. ignore
 	// Flag enum or ID
 	Flag string
@@ -17,11 +19,12 @@ type NonEntField struct {
 	NodeType string
 }
 
-func NewNonEntField(fieldName string, fieldType enttype.TSGraphQLType, nullable bool) *NonEntField {
+func NewNonEntField(cfg codegenapi.Config, fieldName string, fieldType enttype.TSGraphQLType, nullable bool) *NonEntField {
 	return &NonEntField{
-		FieldName: fieldName,
-		FieldType: fieldType,
-		nullable:  nullable,
+		FieldName:   fieldName,
+		graphqlName: codegenapi.GraphQLName(cfg, fieldName),
+		FieldType:   fieldType,
+		nullable:    nullable,
 	}
 }
 
@@ -30,7 +33,7 @@ func (f *NonEntField) Required() bool {
 }
 
 func (f *NonEntField) GetGraphQLName() string {
-	return strcase.ToLowerCamel(f.FieldName)
+	return f.graphqlName
 }
 
 // don't have to deal with all the id field stuff field.Field has to deal with

--- a/internal/field/non_ent_field.go
+++ b/internal/field/non_ent_field.go
@@ -8,9 +8,9 @@ import (
 
 type NonEntField struct {
 	// note that if this changes, need to update NonEntFieldEqual
-	FieldName   string
+	fieldName   string
 	graphqlName string
-	FieldType   enttype.TSGraphQLType
+	fieldType   enttype.TSGraphQLType
 	nullable    bool // required default = true
 	// TODO these are both go things. ignore
 	// Flag enum or ID
@@ -21,11 +21,25 @@ type NonEntField struct {
 
 func NewNonEntField(cfg codegenapi.Config, fieldName string, fieldType enttype.TSGraphQLType, nullable bool) *NonEntField {
 	return &NonEntField{
-		FieldName:   fieldName,
+		fieldName:   fieldName,
 		graphqlName: codegenapi.GraphQLName(cfg, fieldName),
-		FieldType:   fieldType,
+		fieldType:   fieldType,
 		nullable:    nullable,
 	}
+}
+
+func (f *NonEntField) SetFlag(flag string) *NonEntField {
+	f.Flag = flag
+	return f
+}
+
+func (f *NonEntField) SetNodeType(nodeType string) *NonEntField {
+	f.NodeType = nodeType
+	return f
+}
+
+func (f *NonEntField) GetFieldName() string {
+	return f.fieldName
 }
 
 func (f *NonEntField) Required() bool {
@@ -38,15 +52,19 @@ func (f *NonEntField) GetGraphQLName() string {
 
 // don't have to deal with all the id field stuff field.Field has to deal with
 func (f *NonEntField) GetTsType() string {
-	return f.FieldType.GetTSType()
+	return f.fieldType.GetTSType()
 }
 
 func (f *NonEntField) GetFieldType() enttype.EntType {
-	return f.FieldType
+	return f.fieldType
+}
+
+func (f *NonEntField) GetGraphQLFieldType() enttype.TSGraphQLType {
+	return f.fieldType
 }
 
 func (f *NonEntField) TsFieldName() string {
-	return strcase.ToLowerCamel(f.FieldName)
+	return strcase.ToLowerCamel(f.fieldName)
 }
 
 func (f *NonEntField) ForceRequiredInAction() bool {

--- a/internal/graphql/custom_data.go
+++ b/internal/graphql/custom_data.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lolopinto/ent/internal/codegen"
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/codepath"
 	"github.com/lolopinto/ent/internal/schema/change"
 	"github.com/lolopinto/ent/internal/tsimport"
@@ -255,7 +256,7 @@ func CompareCustomData(processor *codegen.Processor, cd1, cd2 *CustomData, exist
 	}
 	for k, l1 := range cd1.Fields {
 		l2 := cd2.Fields[k]
-		eq, conns := customFieldListComparison(l1, l2)
+		eq, conns := customFieldListComparison(processor.Config, l1, l2)
 		for k, v := range conns {
 			if v {
 				ret.customConnectionsChanged[k] = true
@@ -380,7 +381,7 @@ func customFieldEqual(cf1, cf2 *CustomField) bool {
 		cf1.FieldType == cf2.FieldType
 }
 
-func customFieldListComparison(l1, l2 []CustomField) (bool, map[string]bool) {
+func customFieldListComparison(cfg codegenapi.Config, l1, l2 []CustomField) (bool, map[string]bool) {
 	listEqual := len(l1) == len(l2)
 	conns := make(map[string]bool)
 
@@ -397,7 +398,7 @@ func customFieldListComparison(l1, l2 []CustomField) (bool, map[string]bool) {
 		}
 
 		if !ok || !isConnection(*cf1) {
-			edge := getGQLEdge(*cf2, cf2.Node)
+			edge := getGQLEdge(cfg, *cf2, cf2.Node)
 			conns[edge.GetGraphQLConnectionName()] = true
 		}
 	}

--- a/internal/graphql/custom_functions_test.go
+++ b/internal/graphql/custom_functions_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/iancoleman/strcase"
 	"github.com/lolopinto/ent/internal/codegen"
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/codegen/nodeinfo"
 	"github.com/lolopinto/ent/internal/enttype"
 	"github.com/lolopinto/ent/internal/field"
@@ -637,10 +638,7 @@ func parse(t *testing.T, code, dirPath, packagePath string, nodes []string) {
 				PackageName: nodeSnake,
 				FieldInfo: &field.FieldInfo{
 					NonEntFields: []*field.NonEntField{
-						{
-							FieldName: "id",
-							FieldType: &enttype.IDType{},
-						},
+						field.NewNonEntField(&codegenapi.DummyConfig{}, "id", &enttype.IDType{}, false),
 					},
 				},
 			},

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -1871,6 +1871,7 @@ func buildActionInputNode(processor *codegen.Processor, nodeData *schema.NodeDat
 	// use singular version so that this is friendID instead of friendsID
 	for _, edge := range a.GetEdges() {
 		result.Fields = append(result.Fields, &fieldType{
+			// TODO
 			Name:         fmt.Sprintf("%sID", strcase.ToLowerCamel(edge.Singular())),
 			FieldImports: getGQLFileImportsFromStrings([]string{"GraphQLNonNull", "GraphQLID"}),
 		})
@@ -1899,6 +1900,7 @@ func buildActionInputNode(processor *codegen.Processor, nodeData *schema.NodeDat
 		// usually only one edge e.g. addFriend or addAdmin etc
 		for _, edge := range a.GetEdges() {
 			intType.Fields = append(intType.Fields, &interfaceField{
+				// TODO
 				Name: fmt.Sprintf("%sID", strcase.ToLowerCamel(edge.Singular())),
 				// we're doing these as strings instead of ids because we're going to convert from gql id to ent id
 				Type: "string",
@@ -2218,11 +2220,13 @@ func buildActionFieldConfig(processor *codegen.Processor, nodeData *schema.NodeD
 			if base64EncodeIDs {
 				result.FunctionContents = append(
 					result.FunctionContents,
+					// TODO?
 					fmt.Sprintf("const %s = await %s.saveXFromID(context.getViewer(), mustDecodeIDFromGQLID(input.%sID), mustDecodeIDFromGQLID(input.%sID));", nodeData.NodeInstance, a.GetActionName(), nodeData.NodeInstance, strcase.ToLowerCamel(edge.Singular())),
 				)
 			} else {
 				result.FunctionContents = append(
 					result.FunctionContents,
+					// TODO?
 					fmt.Sprintf("const %s = await %s.saveXFromID(context.getViewer(), input.%sID, input.%sID);", nodeData.NodeInstance, a.GetActionName(), nodeData.NodeInstance, strcase.ToLowerCamel(edge.Singular())),
 				)
 			}

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -1813,7 +1813,7 @@ func buildCustomInputNode(c *custominterface.CustomInterface) *objectType {
 	for _, f := range c.NonEntFields {
 		result.Fields = append(result.Fields, &fieldType{
 			Name:         f.GetGraphQLName(),
-			FieldImports: getGQLFileImports(f.FieldType.GetTSGraphQLImports(), true),
+			FieldImports: getGQLFileImports(f.GetGraphQLFieldType().GetTSGraphQLImports(), true),
 		})
 	}
 	return result
@@ -1863,7 +1863,7 @@ func buildActionInputNode(processor *codegen.Processor, nodeData *schema.NodeDat
 	for _, f := range a.GetNonEntFields() {
 		result.Fields = append(result.Fields, &fieldType{
 			Name:         f.GetGraphQLName(),
-			FieldImports: getGQLFileImports(f.FieldType.GetTSGraphQLImports(), true),
+			FieldImports: getGQLFileImports(f.GetGraphQLFieldType().GetTSGraphQLImports(), true),
 		})
 	}
 
@@ -1929,7 +1929,7 @@ func buildActionInputNode(processor *codegen.Processor, nodeData *schema.NodeDat
 
 		for _, f := range a.GetNonEntFields() {
 			// same logic above for regular fields
-			if enttype.IsIDType(f.FieldType) {
+			if enttype.IsIDType(f.GetFieldType()) {
 				intType.Fields = append(intType.Fields, &interfaceField{
 					Name: f.GetGraphQLName(),
 					Type: "string",

--- a/internal/graphql/graphql_schema.go
+++ b/internal/graphql/graphql_schema.go
@@ -667,7 +667,7 @@ func (s *graphQLSchema) processAction(action action.Action) {
 		fieldName: actionName,
 		fieldType: responseTypeName, // TODO should this be required?
 		args: []*graphQLArg{
-			&graphQLArg{
+			{
 				fieldName: "input",
 				fieldType: fmt.Sprintf("%s!", inputTypeName),
 			},

--- a/internal/graphql/graphql_schema.go
+++ b/internal/graphql/graphql_schema.go
@@ -507,7 +507,7 @@ func (s *graphQLSchema) addGraphQLInfoForType(nodeMap schema.NodeMapInfo, nodeDa
 			schemaInfo.addNonEntField(
 				&graphQLNonEntField{
 					fieldName: f.GetGraphQLName(),
-					fieldType: f.FieldType.GetGraphQLType(),
+					fieldType: f.GetGraphQLFieldType().GetGraphQLType(),
 				},
 			)
 		}
@@ -628,7 +628,7 @@ func (s *graphQLSchema) processAction(action action.Action) {
 	for _, f := range action.GetNonEntFields() {
 		inputSchemaInfo.addNonEntField(&graphQLNonEntField{
 			fieldName: f.GetGraphQLName(),
-			fieldType: f.FieldType.GetGraphQLType(),
+			fieldType: f.GetGraphQLFieldType().GetGraphQLType(),
 		})
 	}
 

--- a/internal/schema/compare_schema_test.go
+++ b/internal/schema/compare_schema_test.go
@@ -126,10 +126,13 @@ func TestComparePatternsWithEdgesNoChange(t *testing.T) {
 }
 
 func TestComparePatternsWithAddedEdge(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
-		Name:       "Likes",
-		SchemaName: "User",
-	})
+	edge1, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.AssocEdge{
+			Name:       "Likes",
+			SchemaName: "User",
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Patterns: map[string]*schema.PatternInfo{
@@ -162,10 +165,13 @@ func TestComparePatternsWithAddedEdge(t *testing.T) {
 }
 
 func TestComparePatternsWithRemovedEdge(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
-		Name:       "Likes",
-		SchemaName: "User",
-	})
+	edge1, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.AssocEdge{
+			Name:       "Likes",
+			SchemaName: "User",
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Patterns: map[string]*schema.PatternInfo{
@@ -198,18 +204,23 @@ func TestComparePatternsWithRemovedEdge(t *testing.T) {
 }
 
 func TestComparePatternsWithModifiedEdge(t *testing.T) {
-	edge1, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
-		Name:       "Likes",
-		SchemaName: "User",
-	})
+	edge1, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.AssocEdge{
+			Name:       "Likes",
+			SchemaName: "User",
+		})
 	require.Nil(t, err)
-	edge2, err := edge.AssocEdgeFromInput("user", &input.AssocEdge{
-		Name:       "Likes",
-		SchemaName: "User",
-		InverseEdge: &input.InverseAssocEdge{
-			Name: "likedObjects",
-		},
-	})
+	edge2, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.AssocEdge{
+			Name:       "Likes",
+			SchemaName: "User",
+			InverseEdge: &input.InverseAssocEdge{
+				Name: "likedObjects",
+			},
+		})
 	require.Nil(t, err)
 
 	s1 := &schema.Schema{
@@ -333,20 +344,22 @@ func TestCompareNodesAddField(t *testing.T) {
 			},
 		},
 	}
-	fi, err := field.NewFieldInfoFromInputs([]*input.Field{
-		{
-			Name: "first_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+	fi, err := field.NewFieldInfoFromInputs(
+		&codegenapi.DummyConfig{},
+		[]*input.Field{
+			{
+				Name: "first_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-		{
-			Name: "last_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+			{
+				Name: "last_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-	}, &field.Options{})
+		}, &field.Options{})
 	require.Nil(t, err)
 	s2 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -391,20 +404,22 @@ func TestCompareNodesAddField(t *testing.T) {
 }
 
 func TestCompareNodesRemoveField(t *testing.T) {
-	fi1, err := field.NewFieldInfoFromInputs([]*input.Field{
-		{
-			Name: "first_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+	fi1, err := field.NewFieldInfoFromInputs(
+		&codegenapi.DummyConfig{},
+		[]*input.Field{
+			{
+				Name: "first_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-		{
-			Name: "last_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+			{
+				Name: "last_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-	}, &field.Options{})
+		}, &field.Options{})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -418,14 +433,16 @@ func TestCompareNodesRemoveField(t *testing.T) {
 		},
 	}
 
-	fi2, err := field.NewFieldInfoFromInputs([]*input.Field{
-		{
-			Name: "first_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+	fi2, err := field.NewFieldInfoFromInputs(
+		&codegenapi.DummyConfig{},
+		[]*input.Field{
+			{
+				Name: "first_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-	}, &field.Options{})
+		}, &field.Options{})
 	require.Nil(t, err)
 	s2 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -457,14 +474,16 @@ func TestCompareNodesRemoveField(t *testing.T) {
 }
 
 func TestCompareNodesModifyField(t *testing.T) {
-	fi1, err := field.NewFieldInfoFromInputs([]*input.Field{
-		{
-			Name: "first_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+	fi1, err := field.NewFieldInfoFromInputs(
+		&codegenapi.DummyConfig{},
+		[]*input.Field{
+			{
+				Name: "first_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-	}, &field.Options{})
+		}, &field.Options{})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -478,15 +497,17 @@ func TestCompareNodesModifyField(t *testing.T) {
 		},
 	}
 
-	fi2, err := field.NewFieldInfoFromInputs([]*input.Field{
-		{
-			Name: "first_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+	fi2, err := field.NewFieldInfoFromInputs(
+		&codegenapi.DummyConfig{},
+		[]*input.Field{
+			{
+				Name: "first_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
+				Nullable: true,
 			},
-			Nullable: true,
-		},
-	}, &field.Options{})
+		}, &field.Options{})
 	require.Nil(t, err)
 	s2 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -518,23 +539,27 @@ func TestCompareNodesModifyField(t *testing.T) {
 }
 
 func TestCompareNodesWithEdgesNoChange(t *testing.T) {
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -564,14 +589,16 @@ func TestCompareNodesWithEdgesNoChange(t *testing.T) {
 }
 
 func TestCompareNodesWithEdgesAdded(t *testing.T) {
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -615,14 +642,16 @@ func TestCompareNodesWithEdgesAdded(t *testing.T) {
 }
 
 func TestCompareNodesWithRemovedEdge(t *testing.T) {
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -665,26 +694,30 @@ func TestCompareNodesWithRemovedEdge(t *testing.T) {
 }
 
 func TestCompareNodesWithModifiedEdge(t *testing.T) {
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
-			},
-		},
-	})
-	require.Nil(t, err)
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
-				InverseEdge: &input.InverseAssocEdge{
-					Name: "likedObjects",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
 				},
 			},
-		},
-	})
+		})
+	require.Nil(t, err)
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
+					InverseEdge: &input.InverseAssocEdge{
+						Name: "likedObjects",
+					},
+				},
+			},
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -728,23 +761,29 @@ func TestCompareNodesWithModifiedEdge(t *testing.T) {
 }
 
 func TestCompareNodesWithRenamedEdge(t *testing.T) {
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "LikedPeople",
-				SchemaName: "User",
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "LikedPeople",
+					SchemaName: "User",
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -794,51 +833,56 @@ func TestCompareNodesWithRenamedEdge(t *testing.T) {
 }
 
 func TestCompareNodesWithEdgeGroupNoChange(t *testing.T) {
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdgeGroups: []*input.AssocEdgeGroup{
-			{
-				Name:            "Friendships",
-				GroupStatusName: "FriendshipStatus",
-				AssocEdges: []*input.AssocEdge{
-					{
-						Name:       "Friends",
-						SchemaName: "User",
-						Symmetric:  true,
-					},
-					{
-						Name:       "FriendRequestsSent",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "FriendRequestsReceived",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdgeGroups: []*input.AssocEdgeGroup{
+				{
+					Name:            "Friendships",
+					GroupStatusName: "FriendshipStatus",
+					AssocEdges: []*input.AssocEdge{
+						{
+							Name:       "Friends",
+							SchemaName: "User",
+							Symmetric:  true,
+						},
+						{
+							Name:       "FriendRequestsSent",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "FriendRequestsReceived",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdgeGroups: []*input.AssocEdgeGroup{
-			{
-				Name:            "Friendships",
-				GroupStatusName: "FriendshipStatus",
-				AssocEdges: []*input.AssocEdge{
-					{
-						Name:       "Friends",
-						SchemaName: "User",
-						Symmetric:  true,
-					},
-					{
-						Name:       "FriendRequestsSent",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "FriendRequestsReceived",
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.Node{
+			AssocEdgeGroups: []*input.AssocEdgeGroup{
+				{
+					Name:            "Friendships",
+					GroupStatusName: "FriendshipStatus",
+					AssocEdges: []*input.AssocEdge{
+						{
+							Name:       "Friends",
+							SchemaName: "User",
+							Symmetric:  true,
+						},
+						{
+							Name:       "FriendRequestsSent",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "FriendRequestsReceived",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -868,28 +912,31 @@ func TestCompareNodesWithEdgeGroupNoChange(t *testing.T) {
 }
 
 func TestCompareNodesWithEdgeGroupAdded(t *testing.T) {
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdgeGroups: []*input.AssocEdgeGroup{
-			{
-				Name:            "Friendships",
-				GroupStatusName: "FriendshipStatus",
-				AssocEdges: []*input.AssocEdge{
-					{
-						Name:       "Friends",
-						SchemaName: "User",
-						Symmetric:  true,
-					},
-					{
-						Name:       "FriendRequestsSent",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "FriendRequestsReceived",
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdgeGroups: []*input.AssocEdgeGroup{
+				{
+					Name:            "Friendships",
+					GroupStatusName: "FriendshipStatus",
+					AssocEdges: []*input.AssocEdge{
+						{
+							Name:       "Friends",
+							SchemaName: "User",
+							Symmetric:  true,
+						},
+						{
+							Name:       "FriendRequestsSent",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "FriendRequestsReceived",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -931,28 +978,31 @@ func TestCompareNodesWithEdgeGroupAdded(t *testing.T) {
 }
 
 func TestCompareNodesWithEdgeGroupRemoved(t *testing.T) {
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdgeGroups: []*input.AssocEdgeGroup{
-			{
-				Name:            "Friendships",
-				GroupStatusName: "FriendshipStatus",
-				AssocEdges: []*input.AssocEdge{
-					{
-						Name:       "Friends",
-						SchemaName: "User",
-						Symmetric:  true,
-					},
-					{
-						Name:       "FriendRequestsSent",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "FriendRequestsReceived",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdgeGroups: []*input.AssocEdgeGroup{
+				{
+					Name:            "Friendships",
+					GroupStatusName: "FriendshipStatus",
+					AssocEdges: []*input.AssocEdge{
+						{
+							Name:       "Friends",
+							SchemaName: "User",
+							Symmetric:  true,
+						},
+						{
+							Name:       "FriendRequestsSent",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "FriendRequestsReceived",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -994,55 +1044,61 @@ func TestCompareNodesWithEdgeGroupRemoved(t *testing.T) {
 }
 
 func TestCompareNodesWithEdgeGroupModified(t *testing.T) {
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdgeGroups: []*input.AssocEdgeGroup{
-			{
-				Name:            "Friendships",
-				GroupStatusName: "FriendshipStatus",
-				AssocEdges: []*input.AssocEdge{
-					{
-						Name:       "Friends",
-						SchemaName: "User",
-						Symmetric:  true,
-					},
-					{
-						Name:       "FriendRequestsSent",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "FriendRequestsReceived",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdgeGroups: []*input.AssocEdgeGroup{
+				{
+					Name:            "Friendships",
+					GroupStatusName: "FriendshipStatus",
+					AssocEdges: []*input.AssocEdge{
+						{
+							Name:       "Friends",
+							SchemaName: "User",
+							Symmetric:  true,
+						},
+						{
+							Name:       "FriendRequestsSent",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "FriendRequestsReceived",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdgeGroups: []*input.AssocEdgeGroup{
-			{
-				// contrived change to show something simple changing. GroupStatusName is what we key by
-				Name:            "friends",
-				GroupStatusName: "FriendshipStatus",
-				// keep the table name the same since we should be storing the data in the same table
-				// TODO we should probably confirm this for any edge change as a prompt...
-				TableName: "user_friendships_edges",
-				AssocEdges: []*input.AssocEdge{
-					{
-						Name:       "Friends",
-						SchemaName: "User",
-						Symmetric:  true,
-					},
-					{
-						Name:       "FriendRequestsSent",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "FriendRequestsReceived",
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdgeGroups: []*input.AssocEdgeGroup{
+				{
+					// contrived change to show something simple changing. GroupStatusName is what we key by
+					Name:            "friends",
+					GroupStatusName: "FriendshipStatus",
+					// keep the table name the same since we should be storing the data in the same table
+					// TODO we should probably confirm this for any edge change as a prompt...
+					TableName: "user_friendships_edges",
+					AssocEdges: []*input.AssocEdge{
+						{
+							Name:       "Friends",
+							SchemaName: "User",
+							Symmetric:  true,
+						},
+						{
+							Name:       "FriendRequestsSent",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "FriendRequestsReceived",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1084,58 +1140,64 @@ func TestCompareNodesWithEdgeGroupModified(t *testing.T) {
 }
 
 func TestCompareNodesWithEdgeGroupRenamed(t *testing.T) {
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdgeGroups: []*input.AssocEdgeGroup{
-			{
-				Name:            "Friendships",
-				GroupStatusName: "FriendshipStatus",
-				AssocEdges: []*input.AssocEdge{
-					{
-						Name:       "Friends",
-						SchemaName: "User",
-						Symmetric:  true,
-					},
-					{
-						Name:       "FriendRequestsSent",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "FriendRequestsReceived",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdgeGroups: []*input.AssocEdgeGroup{
+				{
+					Name:            "Friendships",
+					GroupStatusName: "FriendshipStatus",
+					AssocEdges: []*input.AssocEdge{
+						{
+							Name:       "Friends",
+							SchemaName: "User",
+							Symmetric:  true,
+						},
+						{
+							Name:       "FriendRequestsSent",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "FriendRequestsReceived",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdgeGroups: []*input.AssocEdgeGroup{
-			{
-				Name:            "connection",
-				GroupStatusName: "ConnectionStatus",
-				AssocEdges: []*input.AssocEdge{
-					{
-						Name:       "Friends",
-						SchemaName: "User",
-						Symmetric:  true,
-					},
-					{
-						Name:       "FriendRequestsSent",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "FriendRequestsReceived",
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdgeGroups: []*input.AssocEdgeGroup{
+				{
+					Name:            "connection",
+					GroupStatusName: "ConnectionStatus",
+					AssocEdges: []*input.AssocEdge{
+						{
+							Name:       "Friends",
+							SchemaName: "User",
+							Symmetric:  true,
 						},
-					},
-					{
-						Name:       "Following",
-						SchemaName: "User",
-						InverseEdge: &input.InverseAssocEdge{
-							Name: "Followers",
+						{
+							Name:       "FriendRequestsSent",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "FriendRequestsReceived",
+							},
+						},
+						{
+							Name:       "Following",
+							SchemaName: "User",
+							InverseEdge: &input.InverseAssocEdge{
+								Name: "Followers",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1568,10 +1630,18 @@ func TestCompareActionsGraphQLNameModified(t *testing.T) {
 
 func TestForeignKeyEdgeNoChange(t *testing.T) {
 	e1 := edge.NewEdgeInfo("user")
-	require.Nil(t, e1.AddEdgeFromForeignKeyIndex("user_id", "contacts", "User"))
+	require.Nil(t, e1.AddEdgeFromForeignKeyIndex(
+		&codegenapi.DummyConfig{},
+		"user_id",
+		"contacts",
+		"User",
+	))
 
 	e2 := edge.NewEdgeInfo("user")
-	require.Nil(t, e2.AddEdgeFromForeignKeyIndex("user_id", "contacts", "User"))
+	require.Nil(t, e2.AddEdgeFromForeignKeyIndex(&codegenapi.DummyConfig{},
+		"user_id",
+		"contacts",
+		"User"))
 
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1602,7 +1672,9 @@ func TestForeignKeyEdgeNoChange(t *testing.T) {
 
 func TestForeignKeyEdgeAdded(t *testing.T) {
 	e2 := edge.NewEdgeInfo("user")
-	require.Nil(t, e2.AddEdgeFromForeignKeyIndex("user_id", "contacts", "User"))
+	require.Nil(t, e2.AddEdgeFromForeignKeyIndex(
+		&codegenapi.DummyConfig{},
+		"user_id", "contacts", "User"))
 
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1646,7 +1718,9 @@ func TestForeignKeyEdgeAdded(t *testing.T) {
 
 func TestForeignKeyEdgeRemoved(t *testing.T) {
 	e1 := edge.NewEdgeInfo("user")
-	require.Nil(t, e1.AddEdgeFromForeignKeyIndex("user_id", "contacts", "User"))
+	require.Nil(t, e1.AddEdgeFromForeignKeyIndex(
+		&codegenapi.DummyConfig{},
+		"user_id", "contacts", "User"))
 
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1691,9 +1765,16 @@ func TestForeignKeyEdgeRemoved(t *testing.T) {
 func TestForeignKeyEdgeModified(t *testing.T) {
 	// only thing that can really change here is name so instead of modified_edge, we're just going to treat it like dropped edge, added edge
 	e1 := edge.NewEdgeInfo("user")
-	require.Nil(t, e1.AddEdgeFromForeignKeyIndex("user_id", "contacts", "User"))
+	require.Nil(t, e1.AddEdgeFromForeignKeyIndex(&codegenapi.DummyConfig{},
+		"user_id",
+		"contacts",
+		"User"))
 	e2 := edge.NewEdgeInfo("user")
-	require.Nil(t, e2.AddEdgeFromForeignKeyIndex("user_id", "user_contacts", "User"))
+	require.Nil(t, e2.AddEdgeFromForeignKeyIndex(
+		&codegenapi.DummyConfig{},
+		"user_id",
+		"user_contacts",
+		"User"))
 
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1744,14 +1825,24 @@ func TestForeignKeyEdgeModified(t *testing.T) {
 
 func TestIndexedEdgeNochange(t *testing.T) {
 	e1 := edge.NewEdgeInfo("user")
-	require.Nil(t, e1.AddIndexedEdgeFromSource("ownerID", "owner_id", "User", &base.PolymorphicOptions{
-		PolymorphicOptions: &input.PolymorphicOptions{},
-	}))
+	require.Nil(t, e1.AddIndexedEdgeFromSource(
+		&codegenapi.DummyConfig{},
+		"ownerID",
+		"owner_id",
+		"User",
+		&base.PolymorphicOptions{
+			PolymorphicOptions: &input.PolymorphicOptions{},
+		}))
 
 	e2 := edge.NewEdgeInfo("user")
-	require.Nil(t, e2.AddIndexedEdgeFromSource("ownerID", "owner_id", "User", &base.PolymorphicOptions{
-		PolymorphicOptions: &input.PolymorphicOptions{},
-	}))
+	require.Nil(t, e2.AddIndexedEdgeFromSource(
+		&codegenapi.DummyConfig{},
+		"ownerID",
+		"owner_id",
+		"User",
+		&base.PolymorphicOptions{
+			PolymorphicOptions: &input.PolymorphicOptions{},
+		}))
 
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1783,9 +1874,14 @@ func TestIndexedEdgeNochange(t *testing.T) {
 // TODO testindexeEdge which is not polymorphic...
 func TestIndexedEdgeAdded(t *testing.T) {
 	e2 := edge.NewEdgeInfo("user")
-	require.Nil(t, e2.AddIndexedEdgeFromSource("ownerID", "owner_id", "User", &base.PolymorphicOptions{
-		PolymorphicOptions: &input.PolymorphicOptions{},
-	}))
+	require.Nil(t, e2.AddIndexedEdgeFromSource(
+		&codegenapi.DummyConfig{},
+		"ownerID",
+		"owner_id",
+		"User",
+		&base.PolymorphicOptions{
+			PolymorphicOptions: &input.PolymorphicOptions{},
+		}))
 
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1830,9 +1926,14 @@ func TestIndexedEdgeAdded(t *testing.T) {
 
 func TestIndexedEdgeRemoved(t *testing.T) {
 	e1 := edge.NewEdgeInfo("user")
-	require.Nil(t, e1.AddIndexedEdgeFromSource("ownerID", "owner_id", "User", &base.PolymorphicOptions{
-		PolymorphicOptions: &input.PolymorphicOptions{},
-	}))
+	require.Nil(t, e1.AddIndexedEdgeFromSource(
+		&codegenapi.DummyConfig{},
+		"ownerID",
+		"owner_id",
+		"User",
+		&base.PolymorphicOptions{
+			PolymorphicOptions: &input.PolymorphicOptions{},
+		}))
 
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -1877,14 +1978,24 @@ func TestIndexedEdgeRemoved(t *testing.T) {
 
 func TestIndexedEdgeModified(t *testing.T) {
 	e1 := edge.NewEdgeInfo("user")
-	require.Nil(t, e1.AddIndexedEdgeFromSource("owner_id", "owner_id", "User", &base.PolymorphicOptions{
-		PolymorphicOptions: &input.PolymorphicOptions{},
-	}))
+	require.Nil(t, e1.AddIndexedEdgeFromSource(
+		&codegenapi.DummyConfig{},
+		"owner_id",
+		"owner_id",
+		"User",
+		&base.PolymorphicOptions{
+			PolymorphicOptions: &input.PolymorphicOptions{},
+		}))
 	// change field name, keep col name
 	e2 := edge.NewEdgeInfo("user")
-	require.Nil(t, e2.AddIndexedEdgeFromSource("ownerID", "owner_id", "User", &base.PolymorphicOptions{
-		PolymorphicOptions: &input.PolymorphicOptions{},
-	}))
+	require.Nil(t, e2.AddIndexedEdgeFromSource(
+		&codegenapi.DummyConfig{},
+		"ownerID",
+		"owner_id",
+		"User",
+		&base.PolymorphicOptions{
+			PolymorphicOptions: &input.PolymorphicOptions{},
+		}))
 
 	s1 := &schema.Schema{
 		Nodes: map[string]*schema.NodeDataInfo{
@@ -2020,30 +2131,34 @@ func TestEnumModified(t *testing.T) {
 }
 
 func TestCompareSchemaNewNodePlusActionsAndFields(t *testing.T) {
-	fi, err := field.NewFieldInfoFromInputs([]*input.Field{
-		{
-			Name: "first_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+	fi, err := field.NewFieldInfoFromInputs(
+		&codegenapi.DummyConfig{},
+		[]*input.Field{
+			{
+				Name: "first_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-		{
-			Name: "last_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+			{
+				Name: "last_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-	}, &field.Options{})
+		}, &field.Options{})
 	require.Nil(t, err)
 
-	e2, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
+	e2, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user", &input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	a2 := createActionInfoFromInput(t, "user", &input.Node{
 		Fields: []*input.Field{
@@ -2100,30 +2215,35 @@ func TestCompareSchemaNewNodePlusActionsAndFields(t *testing.T) {
 }
 
 func TestCompareSchemaRemoveNodePlusActionsAndFields(t *testing.T) {
-	fi, err := field.NewFieldInfoFromInputs([]*input.Field{
-		{
-			Name: "first_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+	fi, err := field.NewFieldInfoFromInputs(
+		&codegenapi.DummyConfig{},
+		[]*input.Field{
+			{
+				Name: "first_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-		{
-			Name: "last_name",
-			Type: &input.FieldType{
-				DBType: input.String,
+			{
+				Name: "last_name",
+				Type: &input.FieldType{
+					DBType: input.String,
+				},
 			},
-		},
-	}, &field.Options{})
+		}, &field.Options{})
 	require.Nil(t, err)
 
-	e1, err := edge.EdgeInfoFromInput("user", &input.Node{
-		AssocEdges: []*input.AssocEdge{
-			{
-				Name:       "Likes",
-				SchemaName: "User",
+	e1, err := edge.EdgeInfoFromInput(
+		&codegenapi.DummyConfig{},
+		"user",
+		&input.Node{
+			AssocEdges: []*input.AssocEdge{
+				{
+					Name:       "Likes",
+					SchemaName: "User",
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 	a1 := createActionInfoFromInput(t, "user", &input.Node{
 		Fields: []*input.Field{
@@ -2206,10 +2326,16 @@ func getEnumInfo(m map[string]string) *schema.EnumInfo {
 }
 
 func createDuplicateAssocEdgeFromInput(t *testing.T, packageName string, inputEdge *input.AssocEdge) (*edge.AssociationEdge, *edge.AssociationEdge) {
-	edge1, err := edge.AssocEdgeFromInput(packageName, inputEdge)
+	edge1, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		packageName,
+		inputEdge)
 	require.Nil(t, err)
 	inputEdge2 := marshallAndUnmarshallInputAssocEdge(t, inputEdge)
-	edge2, err := edge.AssocEdgeFromInput(packageName, inputEdge2)
+	edge2, err := edge.AssocEdgeFromInput(
+		&codegenapi.DummyConfig{},
+		packageName,
+		inputEdge2)
 	require.Nil(t, err)
 
 	return edge1, edge2

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -368,6 +368,7 @@ func (s *Schema) parseInputSchema(cfg codegenapi.Config, schema *input.Schema, l
 
 		var err error
 		nodeData.FieldInfo, err = field.NewFieldInfoFromInputs(
+			cfg,
 			node.Fields,
 			&field.Options{},
 		)
@@ -397,7 +398,7 @@ func (s *Schema) parseInputSchema(cfg codegenapi.Config, schema *input.Schema, l
 			}
 		}
 
-		nodeData.EdgeInfo, err = edge.EdgeInfoFromInput(packageName, node)
+		nodeData.EdgeInfo, err = edge.EdgeInfoFromInput(cfg, packageName, node)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
@@ -432,7 +433,7 @@ func (s *Schema) parseInputSchema(cfg codegenapi.Config, schema *input.Schema, l
 
 		if err := s.addConfig(&NodeDataInfo{
 			NodeData:      nodeData,
-			depgraph:      s.buildPostRunDepgraph(edgeData),
+			depgraph:      s.buildPostRunDepgraph(cfg, edgeData),
 			ShouldCodegen: true,
 		}); err != nil {
 			errs = append(errs, err)
@@ -445,7 +446,7 @@ func (s *Schema) parseInputSchema(cfg codegenapi.Config, schema *input.Schema, l
 			AssocEdges: make(map[string]*edge.AssociationEdge),
 		}
 		for _, inpEdge := range pattern.AssocEdges {
-			assocEdge, err := edge.AssocEdgeFromInput("object", inpEdge)
+			assocEdge, err := edge.AssocEdgeFromInput(cfg, "object", inpEdge)
 			if err != nil {
 				errs = append(errs, err)
 				continue
@@ -468,6 +469,7 @@ func (s *Schema) parseInputSchema(cfg codegenapi.Config, schema *input.Schema, l
 
 		// add enums from patterns
 		fieldInfo, err := field.NewFieldInfoFromInputs(
+			cfg,
 			pattern.Fields,
 			&field.Options{},
 		)
@@ -546,7 +548,10 @@ func (s *Schema) addConfig(info *NodeDataInfo) error {
 	return nil
 }
 
-func (s *Schema) buildPostRunDepgraph(edgeData *assocEdgeData) *depgraph.Depgraph {
+func (s *Schema) buildPostRunDepgraph(
+	cfg codegenapi.Config,
+	edgeData *assocEdgeData,
+) *depgraph.Depgraph {
 	// things that need all nodeDatas loaded
 	g := &depgraph.Depgraph{}
 
@@ -556,13 +561,13 @@ func (s *Schema) buildPostRunDepgraph(edgeData *assocEdgeData) *depgraph.Depgrap
 		// Actions depends on this.
 		// this adds the linked assoc edge to the field
 		"LinkedEdges", func(info *NodeDataInfo) error {
-			return s.addLinkedEdges(info)
+			return s.addLinkedEdges(cfg, info)
 		},
 		"EdgesFromFields",
 	)
 
 	g.AddItem("EdgesFromFields", func(info *NodeDataInfo) error {
-		return s.addEdgesFromFields(info)
+		return s.addEdgesFromFields(cfg, info)
 	})
 
 	// inverse edges also require everything to be loaded
@@ -712,7 +717,7 @@ func (s *Schema) processDepgrah(edgeData *assocEdgeData) (*assocEdgeData, error)
 }
 
 // this adds the linked assoc edge to the field
-func (s *Schema) addLinkedEdges(info *NodeDataInfo) error {
+func (s *Schema) addLinkedEdges(cfg codegenapi.Config, info *NodeDataInfo) error {
 	nodeData := info.NodeData
 	fieldInfo := nodeData.FieldInfo
 	edgeInfo := nodeData.EdgeInfo
@@ -726,6 +731,7 @@ func (s *Schema) addLinkedEdges(info *NodeDataInfo) error {
 		if e.Polymorphic != nil {
 			// so we want to add it to edges for
 			if err := edgeInfo.AddIndexedEdgeFromSource(
+				cfg,
 				f.TsFieldName(),
 				f.GetQuotedDBColName(),
 				nodeData.Node,
@@ -744,6 +750,7 @@ func (s *Schema) addLinkedEdges(info *NodeDataInfo) error {
 						fEdgeInfo := foreign.NodeData.EdgeInfo
 						//						spew.Dump(nodeData.Node, foreign.NodeData.Node)
 						if err := fEdgeInfo.AddDestinationEdgeFromPolymorphicOptions(
+							cfg,
 							f.TsFieldName(),
 							f.GetQuotedDBColName(),
 							nodeData.Node,
@@ -779,19 +786,22 @@ func (s *Schema) addLinkedEdges(info *NodeDataInfo) error {
 		if fEdge == nil {
 			// add from inverseEdge...
 			var err error
-			fEdge, err = foreignEdgeInfo.AddEdgeFromInverseFieldEdge(info.NodeData.Node, e.NodeInfo.PackageName, e.InverseEdge)
+			fEdge, err = foreignEdgeInfo.AddEdgeFromInverseFieldEdge(cfg, info.NodeData.Node, e.NodeInfo.PackageName, e.InverseEdge)
 			if err != nil {
 				return err
 			}
 		}
-		if err := f.AddInverseEdge(fEdge); err != nil {
+		if err := f.AddInverseEdge(cfg, fEdge); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *Schema) addEdgesFromFields(info *NodeDataInfo) error {
+func (s *Schema) addEdgesFromFields(
+	cfg codegenapi.Config,
+	info *NodeDataInfo,
+) error {
 	nodeData := info.NodeData
 	fieldInfo := nodeData.FieldInfo
 	edgeInfo := nodeData.EdgeInfo
@@ -799,14 +809,14 @@ func (s *Schema) addEdgesFromFields(info *NodeDataInfo) error {
 	for _, f := range fieldInfo.Fields {
 		fkeyInfo := f.ForeignKeyInfo()
 		if fkeyInfo != nil {
-			if err := s.addForeignKeyEdges(nodeData, fieldInfo, edgeInfo, f, fkeyInfo); err != nil {
+			if err := s.addForeignKeyEdges(cfg, nodeData, fieldInfo, edgeInfo, f, fkeyInfo); err != nil {
 				return err
 			}
 		}
 
 		fieldEdgeInfo := f.FieldEdgeInfo()
 		if fieldEdgeInfo != nil {
-			if err := s.addFieldEdge(edgeInfo, f); err != nil {
+			if err := s.addFieldEdge(cfg, edgeInfo, f); err != nil {
 				return err
 			}
 		}
@@ -815,6 +825,7 @@ func (s *Schema) addEdgesFromFields(info *NodeDataInfo) error {
 }
 
 func (s *Schema) addForeignKeyEdges(
+	cfg codegenapi.Config,
 	nodeData *NodeData,
 	fieldInfo *field.FieldInfo,
 	edgeInfo *edge.EdgeInfo,
@@ -838,16 +849,17 @@ func (s *Schema) addForeignKeyEdges(
 
 	// add a field edge on current config so we can load underlying user
 	// and return it in GraphQL appropriately
-	if err := f.AddForeignKeyFieldEdgeToEdgeInfo(edgeInfo); err != nil {
+	if err := f.AddForeignKeyFieldEdgeToEdgeInfo(cfg, edgeInfo); err != nil {
 		return err
 	}
 
 	// TODO need to make sure this is not nil if no fields
 	foreignEdgeInfo := foreignInfo.NodeData.EdgeInfo
-	return f.AddForeignKeyEdgeToInverseEdgeInfo(foreignEdgeInfo, nodeData.Node)
+	return f.AddForeignKeyEdgeToInverseEdgeInfo(cfg, foreignEdgeInfo, nodeData.Node)
 }
 
 func (s *Schema) addFieldEdge(
+	cfg codegenapi.Config,
 	edgeInfo *edge.EdgeInfo,
 	f *field.Field,
 ) error {
@@ -855,7 +867,7 @@ func (s *Schema) addFieldEdge(
 	// and return it in GraphQL appropriately
 	// this also flags that when we write data to this field, we write the inverse edge also
 	// e.g. writing user_id field on an event will also write corresponding user -> events edge
-	return f.AddFieldEdgeToEdgeInfo(edgeInfo)
+	return f.AddFieldEdgeToEdgeInfo(cfg, edgeInfo)
 }
 
 func (s *Schema) addInverseAssocEdgesFromInfo(info *NodeDataInfo) error {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1019,7 +1019,7 @@ func (s *Schema) getNewEdge(edgeData *assocEdgeData, assocEdge *edge.Association
 func (s *Schema) addActionFields(info *NodeDataInfo) error {
 	for _, a := range info.NodeData.ActionInfo.Actions {
 		for _, f := range a.GetNonEntFields() {
-			typ := f.FieldType
+			typ := f.GetFieldType()
 			t, ok := typ.(enttype.TSTypeWithActionFields)
 			if !ok {
 				continue
@@ -1070,7 +1070,7 @@ func (s *Schema) addActionFields(info *NodeDataInfo) error {
 				break
 			}
 			if !foundAction {
-				return fmt.Errorf("invalid action only field %s. couldn't find action with name %s", f.FieldName, actionName)
+				return fmt.Errorf("invalid action only field %s. couldn't find action with name %s", f.GetFieldName(), actionName)
 			}
 		}
 	}

--- a/internal/schema/schema_go.go
+++ b/internal/schema/schema_go.go
@@ -78,7 +78,7 @@ func (s *Schema) parseFile(
 	g := &depgraph.Depgraph{}
 
 	// things that need all nodeDatas loaded
-	g2 := s.buildPostRunDepgraph(edgeData)
+	g2 := s.buildPostRunDepgraph(&codegenapi.DummyConfig{}, edgeData)
 
 	var shouldCodegen bool
 

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -250,7 +250,7 @@ export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}> {
       {{else if edgeAction $action -}}
         {{ range $edge := $edges -}}
           {{/* TODO this assumes there is only one edge */ -}}
-          {{$edge.TSGraphQLNodeID}}: {{useImport "ID"}},
+          {{$edge.TSNodeID}}: {{useImport "ID"}},
         {{end -}}
       {{ end -}}
       {{ if $action.IsDeletingNode -}}
@@ -266,9 +266,9 @@ export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}> {
         {{ range $edge := $edges -}}
           {{/* TODO this assumes there is only one edge */ -}}
           {{if removeEdgeAction $action -}}
-            .{{$edge.TSRemoveMethodName}}({{$edge.TSGraphQLNodeID}})
+            .{{$edge.TSRemoveMethodName}}({{$edge.TSNodeID}})
           {{else -}}
-            .{{$edge.TSAddMethodName}}({{$edge.TSGraphQLNodeID}})
+            .{{$edge.TSAddMethodName}}({{$edge.TSNodeID}})
           {{end -}}
         {{end -}}
         .saveX();

--- a/ts/src/core/config.ts
+++ b/ts/src/core/config.ts
@@ -14,6 +14,11 @@ enum graphqlMutationName {
   VERB_NOUN = "VERB_NOUN",
 }
 
+enum graphQLFieldFormat {
+  LOWER_CAMEL = "lowerCamel",
+  SNAKE_CASE = "snake_case",
+}
+
 export interface Config {
   dbConnectionString?: string;
   dbFile?: string; // config/database.yml is default
@@ -62,6 +67,10 @@ interface CodegenConfig {
   // default names for graphql actions|mutations is nounVerb e.g. userCreate
   // if you wanna change it to verbNoun e.g. createUser, set this field to VERB_NOUN
   defaultGraphQLMutationName?: graphqlMutationName;
+
+  // default format for fields is lowerCamelCase e.g. firstName
+  // if you wanna change it to snake_case e.g. first_name, set this field to snake_case
+  defaultGraphQLFieldFormat?: graphQLFieldFormat;
 }
 
 interface PrettierConfig {


### PR DESCRIPTION
even though the graphql standard is lowerCamelCase, scenarios may exist e.g. when migrating from an existing system where we want it to be snake-case either to simplify migration or because of a preference

this also converts the todo-sqlite example to be snake-case and updates tests in there to confirm things are working