### PR TITLE
account for ent.yml changes which may cause schema changes which change files

### DIFF
--- a/examples/todo-sqlite/ent.yml
+++ b/examples/todo-sqlite/ent.yml
@@ -1,5 +1,5 @@
 codegen:
   disableBase64Encoding: true
   generateRootResolvers: true
-  defaultGraphQLMutationName: VERB_NOUN
+  defaultGraphQLMutationName: VerbNoun
   defaultGraphQLFieldFormat: snake_case

--- a/internal/codegen/codegenapi/api.go
+++ b/internal/codegen/codegenapi/api.go
@@ -12,6 +12,8 @@ const (
 	VerbNoun GraphQLMutationName = "VerbNoun"
 )
 
+const DefaultGraphQLMutationName = NounVerb
+
 type GraphQLFieldFormat string
 
 const (

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/iancoleman/strcase"
 	"github.com/lolopinto/ent/internal/action"
 	"github.com/lolopinto/ent/internal/codegen"
@@ -77,7 +78,9 @@ func (s *Step) processNode(processor *codegen.Processor, info *schema.NodeDataIn
 		opts.writeBase = true
 		opts.writeBuilder = true
 		opts.edgeBaseFile = true
-	} else {
+	}
+
+	if processor.Config.UseChanges() {
 		changes := processor.ChangeMap
 		nodeChanges := changes[info.NodeData.Node]
 
@@ -108,6 +111,7 @@ func (s *Step) processNode(processor *codegen.Processor, info *schema.NodeDataIn
 
 			case change.RemoveAction:
 				opts.deletedActionFiles[c.Name] = true
+				spew.Dump("removeAction", c.Name)
 
 			case change.AddEdge:
 				opts.edgeBaseFile = true
@@ -175,7 +179,8 @@ func (s *Step) processPattern(processor *codegen.Processor, pattern *schema.Patt
 	if processor.Config.WriteAllFiles() {
 		opts.writeAllEdges = true
 		opts.edgeBaseFile = true
-	} else {
+	}
+	if processor.Config.UseChanges() {
 		changes := processor.ChangeMap
 		nodeChanges := changes[pattern.Name]
 

--- a/ts/src/core/config.ts
+++ b/ts/src/core/config.ts
@@ -10,8 +10,8 @@ type logType = "query" | "warn" | "info" | "error" | "debug";
 // or ent.yml?
 
 enum graphqlMutationName {
-  NOUN_VERB = "NOUN_VERB",
-  VERB_NOUN = "VERB_NOUN",
+  NOUN_VERB = "NounVerb",
+  VERB_NOUN = "VerbNoun",
 }
 
 enum graphQLFieldFormat {


### PR DESCRIPTION
if ent.yml is changed which can cause a file to be deleted (e.g. graphql mutation name change), we want to delete that file

important if changing from noun_verb to verb_noun or vice versa for mutations

related: https://github.com/lolopinto/ent/pull/816 and https://github.com/lolopinto/ent/pull/819