### PR TITLE
remove NodeResolver.encode

### DIFF
--- a/ts/src/graphql/node_resolver.ts
+++ b/ts/src/graphql/node_resolver.ts
@@ -7,7 +7,6 @@ interface Node {
 }
 
 export interface NodeResolver {
-  encode(node: Node): string;
   decodeObj(viewer: Viewer, id: string): Promise<Node | null>;
 }
 
@@ -84,7 +83,7 @@ export const nodeIDEncoder: GraphQLFieldResolver<Ent, {}> = (
   source: Ent,
   _args: {},
 ) => {
-  const r = resolvers.get("entNode");
+  const r = resolvers.get("entNode") as EntNodeResolver;
   if (!r) {
     throw new Error(`cannot resolve id when entNode not previously registered`);
   }


### PR DESCRIPTION
fixes https://github.com/lolopinto/ent/issues/824

not needed for clients which implement this interface and simplifies the API

needed for EntNodeResolver but that's fine