### PR TITLE
[auto_schema] support for full text index

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -8,10 +8,10 @@ pytest = "*"
 autopep8 = ""
 
 [packages]
-alembic = "==1.7.6"
+alembic = "==1.7.7"
 datetime = "==4.3"
-sqlalchemy = "==1.4.31"
-psycopg2 = "==2.8.6"
+sqlalchemy = "==1.4.35"
+psycopg2 = "==2.9.3"
 autopep8 = "==1.5.4"
 python-dateutil= "==2.8.2"
 

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "33bd0bd100cd6c9c28e4e68b236b41901ae17108477cfb9aa07a7513d8148cff"
+            "sha256": "e81bad44ec571681eb79c75069d53dfb9a33e8c7a331a0844140c78db12f12b3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:6c0c05e9768a896d804387e20b299880fe01bc56484246b0dffe8075d6d3d847",
-                "sha256:ad842f2c3ab5c5d4861232730779c05e33db4ba880a08b85eb505e87c01095bc"
+                "sha256:29be0856ec7591c39f4e1cb10f198045d890e6e2274cf8da80cb5e721a09642b",
+                "sha256:4961248173ead7ce8a21efb3de378f13b8398e6630fab0eb258dc74a8af24c58"
             ],
             "index": "pypi",
-            "version": "==1.7.6"
+            "version": "==1.7.7"
         },
         "autopep8": {
             "hashes": [
@@ -41,123 +41,90 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c",
-                "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"
+                "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6",
+                "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"
             ],
             "markers": "python_version < '3.9'",
-            "version": "==4.11.1"
+            "version": "==4.11.3"
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45",
-                "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"
+                "sha256:9c4c12f9ef4329a00c1f72f30bddb4f10e582766b8705980bb76356b3ba8bc91",
+                "sha256:f6a4a9949f36ae289facec8dac1a899a54cbaf6a135cc8552d2c8b69209c06a3"
             ],
             "markers": "python_version < '3.9'",
-            "version": "==5.4.0"
+            "version": "==5.7.0"
         },
         "mako": {
             "hashes": [
-                "sha256:4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2",
-                "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"
+                "sha256:23aab11fdbbb0f1051b93793a58323ff937e98e34aece1c4219675122e57e4ba",
+                "sha256:9a7c7e922b87db3686210cf49d5d767033a41d4010b284e747682c92bddd8b39"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.0"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
-                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
-                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
-                "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194",
-                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
-                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
-                "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
-                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
-                "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
-                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
-                "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
-                "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a",
-                "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
-                "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
-                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
-                "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38",
-                "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
-                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
-                "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
-                "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047",
-                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
-                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
-                "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b",
-                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
-                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
-                "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
-                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
-                "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1",
-                "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
-                "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
-                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
-                "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee",
-                "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f",
-                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
-                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
-                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
-                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
-                "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
-                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
-                "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86",
-                "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6",
-                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
-                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
-                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
-                "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
-                "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e",
-                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
-                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
-                "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f",
-                "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
-                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
-                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
-                "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145",
-                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
-                "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
-                "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
-                "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a",
-                "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207",
-                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
-                "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
-                "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd",
-                "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
-                "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
-                "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9",
-                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
-                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
-                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
-                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
-                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.1"
         },
         "psycopg2": {
             "hashes": [
-                "sha256:00195b5f6832dbf2876b8bf77f12bdce648224c89c880719c745b90515233301",
-                "sha256:068115e13c70dc5982dfc00c5d70437fe37c014c808acce119b5448361c03725",
-                "sha256:26e7fd115a6db75267b325de0fba089b911a4a12ebd3d0b5e7acb7028bc46821",
-                "sha256:2c93d4d16933fea5bbacbe1aaf8fa8c1348740b2e50b3735d1b0bf8154cbf0f3",
-                "sha256:56007a226b8e95aa980ada7abdea6b40b75ce62a433bd27cec7a8178d57f4051",
-                "sha256:56fee7f818d032f802b8eed81ef0c1232b8b42390df189cab9cfa87573fe52c5",
-                "sha256:6a3d9efb6f36f1fe6aa8dbb5af55e067db802502c55a9defa47c5a1dad41df84",
-                "sha256:a49833abfdede8985ba3f3ec641f771cca215479f41523e99dace96d5b8cce2a",
-                "sha256:ad2fe8a37be669082e61fb001c185ffb58867fdbb3e7a6b0b0d2ffe232353a3e",
-                "sha256:b8cae8b2f022efa1f011cc753adb9cbadfa5a184431d09b273fb49b4167561ad",
-                "sha256:d160744652e81c80627a909a0e808f3c6653a40af435744de037e3172cf277f5",
-                "sha256:d5062ae50b222da28253059880a871dc87e099c25cb68acf613d9d227413d6f7",
-                "sha256:f22ea9b67aea4f4a1718300908a2fb62b3e4276cf00bd829a97ab5894af42ea3",
-                "sha256:f974c96fca34ae9e4f49839ba6b78addf0346777b46c4da27a7bf54f48d3057d",
-                "sha256:fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543"
+                "sha256:06f32425949bd5fe8f625c49f17ebb9784e1e4fe928b7cce72edc36fb68e4c0c",
+                "sha256:0762c27d018edbcb2d34d51596e4346c983bd27c330218c56c4dc25ef7e819bf",
+                "sha256:083707a696e5e1c330af2508d8fab36f9700b26621ccbcb538abe22e15485362",
+                "sha256:34b33e0162cfcaad151f249c2649fd1030010c16f4bbc40a604c1cb77173dcf7",
+                "sha256:4295093a6ae3434d33ec6baab4ca5512a5082cc43c0505293087b8a46d108461",
+                "sha256:8cf3878353cc04b053822896bc4922b194792df9df2f1ad8da01fb3043602126",
+                "sha256:8e841d1bf3434da985cc5ef13e6f75c8981ced601fd70cc6bf33351b91562981",
+                "sha256:9572e08b50aed176ef6d66f15a21d823bb6f6d23152d35e8451d7d2d18fdac56",
+                "sha256:a81e3866f99382dfe8c15a151f1ca5fde5815fde879348fe5a9884a7c092a305",
+                "sha256:cb10d44e6694d763fa1078a26f7f6137d69f555a78ec85dc2ef716c37447e4b2",
+                "sha256:d3ca6421b942f60c008f81a3541e8faf6865a28d5a9b48544b0ee4f40cac7fca"
             ],
             "index": "pypi",
-            "version": "==2.8.6"
+            "version": "==2.9.3"
         },
         "pycodestyle": {
             "hashes": [
@@ -177,10 +144,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
-                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
+                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
             ],
-            "version": "==2021.3"
+            "version": "==2022.1"
         },
         "six": {
             "hashes": [
@@ -192,45 +159,45 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:05fa14f279d43df68964ad066f653193187909950aa0163320b728edfc400167",
-                "sha256:0ddc5e5ccc0160e7ad190e5c61eb57560f38559e22586955f205e537cda26034",
-                "sha256:15a03261aa1e68f208e71ae3cd845b00063d242cbf8c87348a0c2c0fc6e1f2ac",
-                "sha256:289465162b1fa1e7a982f8abe59d26a8331211cad4942e8031d2b7db1f75e649",
-                "sha256:2e216c13ecc7fcdcbb86bb3225425b3ed338e43a8810c7089ddb472676124b9b",
-                "sha256:2fd4d3ca64c41dae31228b80556ab55b6489275fb204827f6560b65f95692cf3",
-                "sha256:330eb45395874cc7787214fdd4489e2afb931bc49e0a7a8f9cd56d6e9c5b1639",
-                "sha256:3c7ed6c69debaf6198fadb1c16ae1253a29a7670bbf0646f92582eb465a0b999",
-                "sha256:4ad31cec8b49fd718470328ad9711f4dc703507d434fd45461096da0a7135ee0",
-                "sha256:57205844f246bab9b666a32f59b046add8995c665d9ecb2b7b837b087df90639",
-                "sha256:582b59d1e5780a447aada22b461e50b404a9dc05768da1d87368ad8190468418",
-                "sha256:5e9c7b3567edbc2183607f7d9f3e7e89355b8f8984eec4d2cd1e1513c8f7b43f",
-                "sha256:6a01ec49ca54ce03bc14e10de55dfc64187a2194b3b0e5ac0fdbe9b24767e79e",
-                "sha256:6f22c040d196f841168b1456e77c30a18a3dc16b336ddbc5a24ce01ab4e95ae0",
-                "sha256:81f2dd355b57770fdf292b54f3e0a9823ec27a543f947fa2eb4ec0df44f35f0d",
-                "sha256:85e4c244e1de056d48dae466e9baf9437980c19fcde493e0db1a0a986e6d75b4",
-                "sha256:8d0949b11681380b4a50ac3cd075e4816afe9fa4a8c8ae006c1ca26f0fa40ad8",
-                "sha256:975f5c0793892c634c4920057da0de3a48bbbbd0a5c86f5fcf2f2fedf41b76da",
-                "sha256:9e4fb2895b83993831ba2401b6404de953fdbfa9d7d4fa6a4756294a83bbc94f",
-                "sha256:b35dca159c1c9fa8a5f9005e42133eed82705bf8e243da371a5e5826440e65ca",
-                "sha256:b7b20c88873675903d6438d8b33fba027997193e274b9367421e610d9da76c08",
-                "sha256:bb4b15fb1f0aafa65cbdc62d3c2078bea1ceecbfccc9a1f23a2113c9ac1191fa",
-                "sha256:c0c7171aa5a57e522a04a31b84798b6c926234cb559c0939840c3235cf068813",
-                "sha256:c317ddd7c586af350a6aef22b891e84b16bff1a27886ed5b30f15c1ed59caeaa",
-                "sha256:c3abc34fed19fdeaead0ced8cf56dd121f08198008c033596aa6aae7cc58f59f",
-                "sha256:ca68c52e3cae491ace2bf39b35fef4ce26c192fd70b4cd90f040d419f70893b5",
-                "sha256:cf2cd387409b12d0a8b801610d6336ee7d24043b6dd965950eaec09b73e7262f",
-                "sha256:d046a9aeba9bc53e88a41e58beb72b6205abb9a20f6c136161adf9128e589db5",
-                "sha256:d5c20c8415173b119762b6110af64448adccd4d11f273fb9f718a9865b88a99c",
-                "sha256:d86132922531f0dc5a4f424c7580a472a924dd737602638e704841c9cb24aea2",
-                "sha256:dccff41478050e823271642837b904d5f9bda3f5cf7d371ce163f00a694118d6",
-                "sha256:de85c26a5a1c72e695ab0454e92f60213b4459b8d7c502e0be7a6369690eeb1a",
-                "sha256:e3a86b59b6227ef72ffc10d4b23f0fe994bef64d4667eab4fb8cd43de4223bec",
-                "sha256:e79e73d5ee24196d3057340e356e6254af4d10e1fc22d3207ea8342fc5ffb977",
-                "sha256:ea8210090a816d48a4291a47462bac750e3bc5c2442e6d64f7b8137a7c3f9ac5",
-                "sha256:f3b7ec97e68b68cb1f9ddb82eda17b418f19a034fa8380a0ac04e8fe01532875"
+                "sha256:093b3109c2747d5dc0fa4314b1caf4c7ca336d5c8c831e3cfbec06a7e861e1e6",
+                "sha256:186cb3bd77abf2ddcf722f755659559bfb157647b3fd3f32ea1c70e8311e8f6b",
+                "sha256:1b4eac3933c335d7f375639885765722534bb4e52e51cdc01a667eea822af9b6",
+                "sha256:1ff9f84b2098ef1b96255a80981ee10f4b5d49b6cfeeccf9632c2078cd86052e",
+                "sha256:28aa2ef06c904729620cc735262192e622db9136c26d8587f71f29ec7715628a",
+                "sha256:28b17ebbaee6587013be2f78dc4f6e95115e1ec8dd7647c4e7be048da749e48b",
+                "sha256:2c6c411d8c59afba95abccd2b418f30ade674186660a2d310d364843049fb2c1",
+                "sha256:2ffc813b01dc6473990f5e575f210ca5ac2f5465ace3908b78ffd6d20058aab5",
+                "sha256:48036698f20080462e981b18d77d574631a3d1fc2c33b416c6df299ec1d10b99",
+                "sha256:48f0eb5bcc87a9b2a95b345ed18d6400daaa86ca414f6840961ed85c342af8f4",
+                "sha256:4ba2c1f368bcf8551cdaa27eac525022471015633d5bdafbc4297e0511f62f51",
+                "sha256:53c7469b86a60fe2babca4f70111357e6e3d5150373bc85eb3b914356983e89a",
+                "sha256:6204d06bfa85f87625e1831ca663f9dba91ac8aec24b8c65d02fb25cbaf4b4d7",
+                "sha256:63c82c9e8ccc2fb4bfd87c24ffbac320f70b7c93b78f206c1f9c441fa3013a5f",
+                "sha256:70e571ae9ee0ff36ed37e2b2765445d54981e4d600eccdf6fe3838bc2538d157",
+                "sha256:95411abc0e36d18f54fa5e24d42960ea3f144fb16caaa5a8c2e492b5424cc82c",
+                "sha256:9837133b89ad017e50a02a3b46419869cf4e9aa02743e911b2a9e25fa6b05403",
+                "sha256:9bec63b1e20ef69484f530fb4b4837e050450637ff9acd6dccc7003c5013abf8",
+                "sha256:9d8edfb09ed2b865485530c13e269833dab62ab2d582fde21026c9039d4d0e62",
+                "sha256:9dac1924611698f8fe5b2e58601156c01da2b6c0758ba519003013a78280cf4d",
+                "sha256:9e1a72197529ea00357640f21d92ffc7024e156ef9ac36edf271c8335facbc1a",
+                "sha256:9e7094cf04e6042c4210a185fa7b9b8b3b789dd6d1de7b4f19452290838e48bd",
+                "sha256:a4efb70a62cbbbc052c67dc66b5448b0053b509732184af3e7859d05fdf6223c",
+                "sha256:a5dbdbb39c1b100df4d182c78949158073ca46ba2850c64fe02ffb1eb5b70903",
+                "sha256:aeea6ace30603ca9a8869853bb4a04c7446856d7789e36694cd887967b7621f6",
+                "sha256:b2489e70bfa2356f2d421106794507daccf6cc8711753c442fc97272437fc606",
+                "sha256:babd63fb7cb6b0440abb6d16aca2be63342a6eea3dc7b613bb7a9357dc36920f",
+                "sha256:c6fb6b9ed1d0be7fa2c90be8ad2442c14cbf84eb0709dd1afeeff1e511550041",
+                "sha256:cfd8e4c64c30a5219032e64404d468c425bdbc13b397da906fc9bee6591fc0dd",
+                "sha256:d17316100fcd0b6371ac9211351cb976fd0c2e12a859c1a57965e3ef7f3ed2bc",
+                "sha256:d38a49aa75a5759d0d118e26701d70c70a37b896379115f8386e91b0444bfa70",
+                "sha256:da25e75ba9f3fabc271673b6b413ca234994e6d3453424bea36bb5549c5bbaec",
+                "sha256:e255a8dd5572b0c66d6ee53597d36157ad6cf3bc1114f61c54a65189f996ab03",
+                "sha256:e8b09e2d90267717d850f2e2323919ea32004f55c40e5d53b41267e382446044",
+                "sha256:ecc81336b46e31ae9c9bdfa220082079914e31a476d088d3337ecf531d861228",
+                "sha256:effadcda9a129cc56408dd5b2ea20ee9edcea24bd58e6a1489fa27672d733182"
             ],
             "index": "pypi",
-            "version": "==1.4.31"
+            "version": "==1.4.35"
         },
         "toml": {
             "hashes": [
@@ -242,11 +209,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d",
-                "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"
+                "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
+                "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==3.7.0"
+            "version": "==3.8.0"
         },
         "zope.interface": {
             "hashes": [
@@ -363,19 +330,19 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "pytest": {
             "hashes": [
-                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
-                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
+                "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63",
+                "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"
             ],
             "index": "pypi",
-            "version": "==7.0.1"
+            "version": "==7.1.1"
         },
         "toml": {
             "hashes": [

--- a/python/auto_schema/auto_schema/change_type.py
+++ b/python/auto_schema/auto_schema/change_type.py
@@ -10,6 +10,9 @@ class ChangeType(str, Enum):
     DROP_COLUMN = "drop_column"
     CREATE_INDEX = "create_index"
     DROP_INDEX = "drop_index"
+    # TODO update go?
+    CREATE_FULL_TEXT_INDEX = "create_full_text_index"
+    DROP_FULL_TEXT_INDEX = "drop_full_text_index"
     CREATE_FOREIGN_KEY = "create_foreign_key"
     ALTER_COLUMN = "alter_column"
     CREATE_UNIQUE_CONSTRAINT = "create_unique_constraint"

--- a/python/auto_schema/auto_schema/compare.py
+++ b/python/auto_schema/auto_schema/compare.py
@@ -495,6 +495,7 @@ index_regex = re.compile('CREATE INDEX (.+) USING (gin|btree)(.+)')
 
 # sqlalchemy doesn't reflect postgres indexes that have expressions in them so have to manually
 # fetch these indices from pg_indices to find them
+# warning: "Skipped unsupported reflection of expression-based index accounts_full_text_idx"
 def _get_raw_db_indexes(autogen_context: AutogenContext, conn_table: Optional[sa.Table]):
     if conn_table is None or _dialect_name(autogen_context) != 'postgresql':
         return {}
@@ -527,6 +528,8 @@ def _get_raw_db_indexes(autogen_context: AutogenContext, conn_table: Optional[sa
     return ret
 
 
+# use a cache so we only hit the db once for each table
+# @functools.lru_cache()
 def get_db_indexes_for_table(connection: sa.engine.Connection, tname: str):
     res = connection.execute(
         "SELECT indexname, indexdef from pg_indexes where tablename = '%s'" % tname)

--- a/python/auto_schema/auto_schema/compare.py
+++ b/python/auto_schema/auto_schema/compare.py
@@ -479,7 +479,6 @@ def _compare_indexes(autogen_context: AutogenContext,
 
             # find existing create index op and replace with ours
             if idx is not None:
-
                 modify_table_ops.ops[idx] = ops.CreateFullTextIndexOp(
                     index.name,
                     index.table.name,
@@ -522,7 +521,7 @@ def _get_raw_db_indexes(autogen_context: AutogenContext, conn_table: Optional[sa
             ret[name] = {
                 'postgresql_using': r[1],
                 'postgresql_using_internals': r[2],
-
+                # TODO don't have columns|column to pass to FullTextIndex
             }
 
     return ret

--- a/python/auto_schema/auto_schema/diff.py
+++ b/python/auto_schema/auto_schema/diff.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from sqlalchemy.sql.sqltypes import String
 from .clause_text import get_clause_text
 from .change_type import ChangeType
-from .ops import MigrateOpInterface
+from .ops import MigrateOpInterface, DropFullTextIndexOp, CreateFullTextIndexOp
 
 import alembic.operations.ops as alembicops
 
@@ -40,6 +40,8 @@ class Diff(object):
             'DropColumnOp': self._drop_column,
             'CreateIndexOp': self._create_index,
             'DropIndexOp': self._drop_index,
+            'CreateFullTextIndexOp': self._create_full_text_index,
+            'DropFullTextIndexOp': self._drop_full_text_index,
             'CreateForeignKeyOp': self._create_foreign_key,
             'AlterColumnOp': self._alter_column,
             'CreateUniqueConstraintOp': self._create_unique_constraint,
@@ -99,6 +101,18 @@ class Diff(object):
         self._append_change(op.table_name, {
             "change": ChangeType.DROP_INDEX,
             "desc": 'drop index %s from %s' % (op.index_name, op.table_name),
+        })
+
+    def _create_full_text_index(self: Diff, op: CreateFullTextIndexOp):
+        self._append_change(op.table_name, {
+            "change": ChangeType.CREATE_FULL_TEXT_INDEX,
+            "desc": 'add full text index %s to %s' % (op.index_name, op.table_name),
+        })
+
+    def _drop_full_text_index(self: Diff, op: DropFullTextIndexOp):
+        self._append_change(op.table_name, {
+            "change": ChangeType.DROP_FULL_TEXT_INDEX,
+            "desc": 'drop full text index %s from %s' % (op.index_name, op.table_name),
         })
 
     def _create_foreign_key(self: Diff, op: alembicops.CreateForeignKeyOp):

--- a/python/auto_schema/auto_schema/ops.py
+++ b/python/auto_schema/auto_schema/ops.py
@@ -364,7 +364,6 @@ class OurDropConstraintOp(MigrateOpInterface, alembicops.DropConstraintOp):
         return self.table_name
 
 
-# the real solution here is this doesn't need columns since we'll get all the information needed from
 @Operations.register_operation("create_full_text_index")
 class CreateFullTextIndexOp(MigrateOpInterface):
 
@@ -415,11 +414,6 @@ class CreateFullTextIndexOp(MigrateOpInterface):
     ):
         idx = FullTextIndex(
             self.index_name,
-            #            self.table_name,
-            #            "",
-            # TODO
-
-            #            schema=self.schema,
             unique=self.unique,
             **self.kw,
         )
@@ -479,15 +473,11 @@ class DropFullTextIndexOp(MigrateOpInterface):
 
     @classmethod
     def from_index(cls, index: FullTextIndex):
-        # whelp....
-        # index.table is None...
-        # start from here...
         assert index.table is not None
         return cls(
             index.name,
             index.table.name,
-            #            schema=index.table.schema,
-            schema=None,
+            schema=index.table.schema,
             info=index.info,
         )
 
@@ -497,11 +487,6 @@ class DropFullTextIndexOp(MigrateOpInterface):
 
         idx = FullTextIndex(
             self.index_name,
-            #            self.table_name,
-            # TODO
-            #            "",
-            #            schema=self.schema,
-
             **self.kw,
         )
         if self.table is not None:

--- a/python/auto_schema/auto_schema/ops.py
+++ b/python/auto_schema/auto_schema/ops.py
@@ -377,7 +377,6 @@ class CreateFullTextIndexOp(MigrateOpInterface):
         table: Optional[sa.Table] = None,
         **kw
     ) -> None:
-        print('constructor', index_name, table_name, schema, unique, kw)
         self.index_name = index_name
         self.table_name = table_name
         self.schema = schema
@@ -386,7 +385,6 @@ class CreateFullTextIndexOp(MigrateOpInterface):
         self.table = table
 
     def get_revision_message(self) -> String:
-        print("rev message", self.index_name, self.table_name)
         return 'add full text index %s to %s' % (self.index_name, self.table_name)
 
     def get_change_type(self) -> ChangeType:
@@ -409,13 +407,12 @@ class CreateFullTextIndexOp(MigrateOpInterface):
             index.table.name,
             schema=index.table.schema,
             unique=index.unique,
-            **index.kwargs,
+            info=index.info
         )
 
     def to_index(
         self, migration_context=None
     ):
-        print("to_index in reverse", self.table_name, self.schema)
         idx = FullTextIndex(
             self.index_name,
             #            self.table_name,
@@ -440,6 +437,7 @@ class CreateFullTextIndexOp(MigrateOpInterface):
         unique: bool = False,
         **kw
     ):
+        # table_name here so can't make it table?
         op = cls(
             index_name, table_name, schema=schema, unique=unique, **kw
         )
@@ -449,6 +447,7 @@ class CreateFullTextIndexOp(MigrateOpInterface):
 @Operations.register_operation("drop_full_text_index")
 class DropFullTextIndexOp(MigrateOpInterface):
 
+    # TODO kill table_name and make it table?
     def __init__(
         self,
         index_name: str,
@@ -476,8 +475,6 @@ class DropFullTextIndexOp(MigrateOpInterface):
         return self.table_name
 
     def reverse(self) -> CreateFullTextIndexOp:
-        print("pre-to-index")
-        print("to_index", self.to_index())
         return CreateFullTextIndexOp.from_index(self.to_index())
 
     @classmethod
@@ -491,14 +488,13 @@ class DropFullTextIndexOp(MigrateOpInterface):
             index.table.name,
             #            schema=index.table.schema,
             schema=None,
-            **index.kwargs,
+            info=index.info,
         )
 
     def to_index(
         self, migration_context=None
     ):
 
-        print("to_index end", self.kw)
         idx = FullTextIndex(
             self.index_name,
             #            self.table_name,

--- a/python/auto_schema/auto_schema/ops.py
+++ b/python/auto_schema/auto_schema/ops.py
@@ -1,8 +1,12 @@
+from typing import Any, Optional, Tuple
 import alembic.operations.ops as alembicops
 from alembic.operations import Operations, MigrateOperation
 import abc
+import sqlalchemy as sa
 
 from sqlalchemy.sql.sqltypes import String
+
+from auto_schema.schema_item import FullTextIndex
 from .change_type import ChangeType
 
 
@@ -323,6 +327,7 @@ class DropEnumOp(MigrateOpInterface):
 # alembic for some reason doesn't have it...
 
 
+# TODO rename these from Our to AutoSchema or reuse the same names if we don't care about names being unique
 class OurCreateCheckConstraintOp(MigrateOpInterface, alembicops.CreateCheckConstraintOp):
 
     def get_revision_message(self) -> String:
@@ -357,3 +362,165 @@ class OurDropConstraintOp(MigrateOpInterface, alembicops.DropConstraintOp):
 
     def get_table_name(self) -> String:
         return self.table_name
+
+
+# the real solution here is this doesn't need columns since we'll get all the information needed from
+@Operations.register_operation("create_full_text_index")
+class CreateFullTextIndexOp(MigrateOpInterface):
+
+    def __init__(
+        self,
+        index_name: str,
+        table_name: str,
+        schema: Optional[Any] = None,
+        unique: bool = False,
+        table: Optional[sa.Table] = None,
+        **kw
+    ) -> None:
+        print('constructor', index_name, table_name, schema, unique, kw)
+        self.index_name = index_name
+        self.table_name = table_name
+        self.schema = schema
+        self.unique = unique
+        self.kw = kw
+        self.table = table
+
+    def get_revision_message(self) -> String:
+        print("rev message", self.index_name, self.table_name)
+        return 'add full text index %s to %s' % (self.index_name, self.table_name)
+
+    def get_change_type(self) -> ChangeType:
+        return ChangeType.CREATE_FULL_TEXT_INDEX
+
+    def get_table_name(self) -> String:
+        return self.table_name
+
+    def reverse(self):
+        return DropFullTextIndexOp.from_index(self.to_index())
+
+    def to_diff_tuple(self) -> Tuple[str, FullTextIndex]:
+        return ("add_full_text_index", self.to_index())
+
+    @classmethod
+    def from_index(cls, index: FullTextIndex):
+        assert index.table is not None
+        return cls(
+            index.name,
+            index.table.name,
+            schema=index.table.schema,
+            unique=index.unique,
+            **index.kwargs,
+        )
+
+    def to_index(
+        self, migration_context=None
+    ):
+        print("to_index in reverse", self.table_name, self.schema)
+        idx = FullTextIndex(
+            self.index_name,
+            #            self.table_name,
+            #            "",
+            # TODO
+
+            #            schema=self.schema,
+            unique=self.unique,
+            **self.kw,
+        )
+        if self.table is not None:
+            idx._set_parent(self.table)
+        return idx
+
+    @classmethod
+    def create_full_text_index(
+        cls,
+        operations: Operations,
+        index_name: str,
+        table_name: str,
+        schema=None,
+        unique: bool = False,
+        **kw
+    ):
+        op = cls(
+            index_name, table_name, schema=schema, unique=unique, **kw
+        )
+        return operations.invoke(op)
+
+
+@Operations.register_operation("drop_full_text_index")
+class DropFullTextIndexOp(MigrateOpInterface):
+
+    def __init__(
+        self,
+        index_name: str,
+        table_name: Optional[str] = None,
+        schema: Optional[Any] = None,
+        table: Optional[sa.Table] = None,
+        **kw
+    ) -> None:
+        self.index_name = index_name
+        self.table_name = table_name
+        self.schema = schema
+        self.table = table
+        self.kw = kw
+
+    def to_diff_tuple(self) -> Tuple[str, FullTextIndex]:
+        return ("remove_full_text_index", self.to_index())
+
+    def get_revision_message(self) -> String:
+        return 'drop full text index %s from %s' % (self.index_name, self.table_name)
+
+    def get_change_type(self) -> ChangeType:
+        return ChangeType.DROP_FULL_TEXT_INDEX
+
+    def get_table_name(self) -> String:
+        return self.table_name
+
+    def reverse(self) -> CreateFullTextIndexOp:
+        print("pre-to-index")
+        print("to_index", self.to_index())
+        return CreateFullTextIndexOp.from_index(self.to_index())
+
+    @classmethod
+    def from_index(cls, index: FullTextIndex):
+        # whelp....
+        # index.table is None...
+        # start from here...
+        assert index.table is not None
+        return cls(
+            index.name,
+            index.table.name,
+            #            schema=index.table.schema,
+            schema=None,
+            **index.kwargs,
+        )
+
+    def to_index(
+        self, migration_context=None
+    ):
+
+        print("to_index end", self.kw)
+        idx = FullTextIndex(
+            self.index_name,
+            #            self.table_name,
+            # TODO
+            #            "",
+            #            schema=self.schema,
+
+            **self.kw,
+        )
+        if self.table is not None:
+            idx._set_parent(self.table)
+        return idx
+
+    @classmethod
+    def drop_full_text_index(
+        cls,
+        operations: "Operations",
+        index_name: str,
+        table_name=None,
+        schema=None,
+        **kw
+    ):
+        op = cls(index_name, table_name=table_name,
+                 schema=schema, **kw)
+        return operations.invoke(op)

--- a/python/auto_schema/auto_schema/ops_impl.py
+++ b/python/auto_schema/auto_schema/ops_impl.py
@@ -143,3 +143,29 @@ def add_enum_type(operations: ops.Operations, operation: ops.AddEnumOp):
 def drop_enum_type(operations: ops.Operations, operation: ops.DropEnumOp):
     postgresql.ENUM(*operation.values, name=operation.enum_name).drop(
         operations.get_bind())
+
+
+@Operations.implementation_for(ops.CreateFullTextIndexOp)
+def create_full_text_index(operations: ops.Operations, operation: ops.CreateFullTextIndexOp):
+    connection = operations.get_bind()
+    # TODO
+    # print("kw", operation.kw, operation.columns,
+    #       operation.unique, operation.kw, operation.info)
+
+    connection.execute(
+        "CREATE INDEX %(index_name)s ON %(table_name)s USING %(using)s (%(using_internals)s);" % {
+            'index_name': operation.index_name,
+            'table_name': operation.table_name,
+            'using': operation.kw.get('info').get('postgresql_using'),
+            # TODO should this work if empty?
+            'using_internals': operation.kw.get('info').get('postgresql_using_internals'),
+        }
+    )
+
+
+@Operations.implementation_for(ops.DropFullTextIndexOp)
+def create_full_text_index(operations: ops.Operations, operation: ops.CreateFullTextIndexOp):
+    connection = operations.get_bind()
+    connection.execute(
+        "DROP INDEX %s" % operation.index_name
+    )

--- a/python/auto_schema/auto_schema/ops_impl.py
+++ b/python/auto_schema/auto_schema/ops_impl.py
@@ -148,10 +148,6 @@ def drop_enum_type(operations: ops.Operations, operation: ops.DropEnumOp):
 @Operations.implementation_for(ops.CreateFullTextIndexOp)
 def create_full_text_index(operations: ops.Operations, operation: ops.CreateFullTextIndexOp):
     connection = operations.get_bind()
-    # TODO
-    # print("kw", operation.kw, operation.columns,
-    #       operation.unique, operation.kw, operation.info)
-
     connection.execute(
         "CREATE INDEX %(index_name)s ON %(table_name)s USING %(using)s (%(using_internals)s);" % {
             'index_name': operation.index_name,

--- a/python/auto_schema/auto_schema/renderers.py
+++ b/python/auto_schema/auto_schema/renderers.py
@@ -179,18 +179,12 @@ def _render_kw_args(d):
 
 @renderers.dispatch_for(ops.CreateFullTextIndexOp)
 def render_full_text_index(autogen_context: AutogenContext, op: ops.CreateFullTextIndexOp) -> str:
-    #    print(op.columns)
-    #    cols = [col for col in op.columns]
-    #    print("rendereer", op.info, op.kw)
-    # ignore info
-    # need unique=False and add kw
+
     return (
         "op.create_full_text_index('%(index_name)s', '%(table_name)s', "
         "unique=%(unique)r, %(kwargs)s)" % {
             "index_name": op.index_name,
             "table_name": op.table_name,
-            # not plural?
-            #            "columns": "'%s'" % op.columns,
             "unique": op.unique or False,
             "kwargs": _render_kw_args(op.kw),
         }

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -1,5 +1,7 @@
 import json
 from collections.abc import Mapping
+
+from auto_schema.schema_item import FullTextIndex
 from .diff import Diff
 from .clause_text import get_clause_text
 import sqlalchemy as sa
@@ -90,6 +92,15 @@ class Runner(object):
     @classmethod
     def include_object(cls, object, name, type, reflected, compare_to):
         exclude_tables = Runner.exclude_tables().split(',')
+
+        # if we return false here, can we keep track of this and use this later?
+        # can't do this because it removes it completely. you'd assume reflected is what we want but alas
+        if type == "index" and isinstance(object, FullTextIndex):
+            # print("include_index false")
+            #     # print("yes")
+            # print(cls, object, name, reflected, compare_to)
+            #     # will handle this later
+            return True
 
         if type == "table" and name in exclude_tables:
             return False

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -1,7 +1,6 @@
 import json
 from collections.abc import Mapping
 
-from auto_schema.schema_item import FullTextIndex
 from .diff import Diff
 from .clause_text import get_clause_text
 import sqlalchemy as sa
@@ -92,15 +91,6 @@ class Runner(object):
     @classmethod
     def include_object(cls, object, name, type, reflected, compare_to):
         exclude_tables = Runner.exclude_tables().split(',')
-
-        # if we return false here, can we keep track of this and use this later?
-        # can't do this because it removes it completely. you'd assume reflected is what we want but alas
-        if type == "index" and isinstance(object, FullTextIndex):
-            # print("include_index false")
-            #     # print("yes")
-            # print(cls, object, name, reflected, compare_to)
-            #     # will handle this later
-            return True
 
         if type == "table" and name in exclude_tables:
             return False

--- a/python/auto_schema/auto_schema/schema_item.py
+++ b/python/auto_schema/auto_schema/schema_item.py
@@ -5,13 +5,17 @@ from sqlalchemy import exc
 # simplified version
 # postgresql_using
 # posgresqql_using_internals
+# need our own Index class because
 class FullTextIndex(Index):
 
     def __init__(self, name: str, **kw) -> None:
-        # TODO make it required
+        # TODO make column|columns required
+        # not currently required because of _get_raw_db_indexes
+        # we don't use it anyways so fine. just passed to super() because we need to pass something
         cols = ['id']
-        if 'columns' in kw:
-            cols = kw.get('columns')
-        elif 'column' in kw:
-            cols = [kw.get('column')]
+        info = kw.get('info', {})
+        if 'columns' in info:
+            cols = info.get('columns')
+        elif 'column' in info:
+            cols = [info.get('column')]
         super().__init__(name, *cols, **kw)

--- a/python/auto_schema/auto_schema/schema_item.py
+++ b/python/auto_schema/auto_schema/schema_item.py
@@ -8,5 +8,10 @@ from sqlalchemy import exc
 class FullTextIndex(Index):
 
     def __init__(self, name: str, **kw) -> None:
-        # no columns
-        super().__init__(name, kw.get('column', "id"), **kw)
+        # TODO make it required
+        cols = ['id']
+        if 'columns' in kw:
+            cols = kw.get('columns')
+        elif 'column' in kw:
+            cols = [kw.get('column')]
+        super().__init__(name, *cols, **kw)

--- a/python/auto_schema/auto_schema/schema_item.py
+++ b/python/auto_schema/auto_schema/schema_item.py
@@ -10,24 +10,3 @@ class FullTextIndex(Index):
     def __init__(self, name: str, **kw) -> None:
         # no columns
         super().__init__(name, kw.get('column', "id"), **kw)
-        # self.name = name
-        # self.unique = kw.pop("unique", False)
-        # self.table = None
-        # if "info" in kw:
-        #     self.info = kw.pop("info")
-        # if "table" in kw:
-        #     self.table = kw.pop("table")
-
-#        super().__init__()
-
-    # def _set_parent(self, table, **kw):
-    #     #        ColumnCollectionMixin._set_parent(self, table)
-
-    #     if self.table is not None and table is not self.table:
-    #         raise exc.ArgumentError(
-    #             "Index '%s' is against table '%s', and "
-    #             "cannot be associated with table '%s'."
-    #             % (self.name, self.table.description, table.description)
-    #         )
-    #     self.table = table
-    #     table.indexes.add(self)

--- a/python/auto_schema/auto_schema/schema_item.py
+++ b/python/auto_schema/auto_schema/schema_item.py
@@ -1,0 +1,33 @@
+from sqlalchemy.sql.schema import Index
+from sqlalchemy import exc
+
+
+# simplified version
+# postgresql_using
+# posgresqql_using_internals
+class FullTextIndex(Index):
+
+    def __init__(self, name: str, **kw) -> None:
+        # no columns
+        super().__init__(name, kw.get('column', "id"), **kw)
+        # self.name = name
+        # self.unique = kw.pop("unique", False)
+        # self.table = None
+        # if "info" in kw:
+        #     self.info = kw.pop("info")
+        # if "table" in kw:
+        #     self.table = kw.pop("table")
+
+#        super().__init__()
+
+    # def _set_parent(self, table, **kw):
+    #     #        ColumnCollectionMixin._set_parent(self, table)
+
+    #     if self.table is not None and table is not self.table:
+    #         raise exc.ArgumentError(
+    #             "Index '%s' is against table '%s', and "
+    #             "cannot be associated with table '%s'."
+    #             % (self.name, self.table.description, table.description)
+    #         )
+    #     self.table = table
+    #     table.indexes.add(self)

--- a/python/auto_schema/auto_schema/script.py.mako
+++ b/python/auto_schema/auto_schema/script.py.mako
@@ -12,6 +12,7 @@ import sqlalchemy as sa
 ## TODO: for down commans when removing edges, we add "UUID()" which is broken and unncessary :(
 ## from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.dialects import postgresql
+## TODO add custom import. this is where we'll add our own index...
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.

--- a/python/auto_schema/auto_schema/script.py.mako
+++ b/python/auto_schema/auto_schema/script.py.mako
@@ -12,7 +12,6 @@ import sqlalchemy as sa
 ## TODO: for down commans when removing edges, we add "UUID()" which is broken and unncessary :(
 ## from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.dialects import postgresql
-## TODO add custom import. this is where we'll add our own index...
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -425,8 +425,6 @@ def metadata_with_multi_column_index(metadata_with_table):
              )
     return metadata_with_table
 
-# doesn't seem like we can do it  with schema so have to detect it and do op.add_Edge
-
 
 def metadata_with_fulltext_search_index(metadata_with_table):
     sa.Table('accounts',

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -457,13 +457,56 @@ def metadata_with_multicolumn_fulltext_search_index(metadata_with_table):
     return metadata_with_table
 
 
+@pytest.fixture
+def metadata_with_multicolumn_fulltext_search():
+    metadata = metadata_with_base_table_restored()
+    sa.Table('accounts',
+             metadata,
+             FullTextIndex("accounts_full_text_idx",
+                           info={
+                               'postgresql_using': 'gin',
+                               'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
+                               'columns': ['first_name', 'last_name'],
+                           }
+                           ),
+             extend_existing=True
+             )
+    return metadata
+
+
+def metadata_with_multicolumn_fulltext_search_index_btree(metadata_with_table):
+    sa.Table('accounts',
+             metadata_with_table,
+             FullTextIndex("accounts_full_text_idx",
+                           info={
+                               'postgresql_using': 'btree',
+                               'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
+                               'columns': ['first_name', 'last_name'],
+                           }
+                           ),
+             extend_existing=True
+             )
+    return metadata_with_table
+
+
 def metadata_with_generated_col_fulltext_search_index(metadata_with_table):
-    # this is the correct way to modify a table!
     sa.Table('accounts', metadata_with_table,
              sa.Column('full_name', postgresql.TSVECTOR(), sa.Computed(
                  "to_tsvector('english', first_name || ' ' || last_name)")),
              sa.Index('accounts_full_text_idx',
                       'full_name', postgresql_using='gin'),
+
+             extend_existing=True)
+
+    return metadata_with_table
+
+
+def metadata_with_generated_col_fulltext_search_index_btree(metadata_with_table):
+    sa.Table('accounts', metadata_with_table,
+             sa.Column('full_name', postgresql.TSVECTOR(), sa.Computed(
+                 "to_tsvector('english', first_name || ' ' || last_name)")),
+             sa.Index('accounts_full_text_idx',
+                      'full_name', postgresql_using='btree'),
 
              extend_existing=True)
 

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -425,27 +425,32 @@ def metadata_with_multi_column_index(metadata_with_table):
 def metadata_with_fulltext_search_index(metadata_with_table):
     return _add_index_to_metadata(
         metadata_with_table,
-        # index the first and last name because we support searching by that
-        FullTextIndex("accounts_full_text_idx",
-                      # let's do just one col for now
-                      # TODO get rid of this...
-                      #                      "first_name",
-                      #                 func.to_tsvector(first_name).label(vectorized_name),
-                      # using postgresql_using so it keeps failing without FullTextIndex and we know our class does something...
-                      #                      postgresql_using='gin',
+        FullTextIndex("accounts_first_name_idx",
                       info={
                           'postgresql_using': 'gin',
                           'postgresql_using_internals': "to_tsvector('english', first_name)",
                           'column': 'first_name',
-                          #                          'colums': ['first_name', 'last_name']
                       }
-                      #  postgresql_using="gin(to_tsvector('english', first_name))",
-                      #  postgresql_ops={
-                      #      'vectorized_name': "to_tsvector('english', first_name)"
-                      #  }
                       ),
 
     )
+
+
+def metadata_with_multicolumn_fulltext_search_index(metadata_with_table):
+    return _add_index_to_metadata(
+        metadata_with_table,
+        FullTextIndex("accounts_full_text_idx",
+                      info={
+                          'postgresql_using': 'gin',
+                          'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
+                          'columns': ['first_name', 'last_name'],
+                      }
+                      ),
+
+    )
+
+
+# TODO generated stored column
 
 
 @ pytest.fixture

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -15,6 +15,7 @@ from auto_schema import runner
 from typing import List
 
 from auto_schema.schema_item import FullTextIndex
+from auto_schema import compare
 
 
 class Postgres:
@@ -117,8 +118,8 @@ def new_test_runner(request):
             path = r.get_schema_path()
 
             # delete temp directory which was created
-            # if os.path.isdir(path):
-            #     shutil.rmtree(path)
+            if os.path.isdir(path):
+                shutil.rmtree(path)
 
         request.addfinalizer(delete_path)
 

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -432,11 +432,12 @@ def metadata_with_fulltext_search_index(metadata_with_table):
                       #                      "first_name",
                       #                 func.to_tsvector(first_name).label(vectorized_name),
                       # using postgresql_using so it keeps failing without FullTextIndex and we know our class does something...
-                      postgresql_using='gin',
+                      #                      postgresql_using='gin',
                       info={
                           'postgresql_using': 'gin',
                           'postgresql_using_internals': "to_tsvector('english', first_name)",
                           'column': 'first_name',
+                          #                          'colums': ['first_name', 'last_name']
                       }
                       #  postgresql_using="gin(to_tsvector('english', first_name))",
                       #  postgresql_ops={

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -450,7 +450,20 @@ def metadata_with_multicolumn_fulltext_search_index(metadata_with_table):
     )
 
 
-# TODO generated stored column
+def metadata_with_generated_col_fulltext_search_index(metadata_with_table):
+    # this is the correct way to modify a table!
+    sa.Table('accounts', metadata_with_table,
+             sa.Column('full_name', postgresql.TSVECTOR(), sa.Computed(
+                 "to_tsvector('english', first_name || ' ' || last_name)")),
+             extend_existing=True)
+
+    return _add_index_to_metadata(
+        metadata_with_table,
+        # when it's mapping to a generated column, let's just use regular sa.Index
+        # don't need the complexity we provide
+        sa.Index('accounts_full_text_idx',
+                 'full_name', postgresql_using='gin'),
+    )
 
 
 @ pytest.fixture

--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -1057,7 +1057,16 @@ class TestPostgresRunner(BaseTestRunner):
             validate_schema=False
         )
 
-    # TODO need to test with this from the start
+    @pytest.mark.usefixtures("metadata_with_multicolumn_fulltext_search")
+    # TODO this is failed because of index comparisons
+    # this doesn't work because indexes are wrong. why we have validate false in
+    # make_changes_and_restore
+    @pytest.mark.xfail()
+    def test_multi_col_full_text_create(self, new_test_runner, metadata_with_multicolumn_fulltext_search):
+        r = new_test_runner(
+            metadata_with_multicolumn_fulltext_search)
+        testingutils.run_and_validate_with_standard_metadata_tables(
+            r, metadata_with_multicolumn_fulltext_search)
 
     @pytest.mark.usefixtures("metadata_with_table")
     def test_multi_col_full_text_index_added_and_removed(self, new_test_runner, metadata_with_table):
@@ -1072,11 +1081,35 @@ class TestPostgresRunner(BaseTestRunner):
         )
 
     @pytest.mark.usefixtures("metadata_with_table")
+    def test_multi_col_full_text_index_added_and_removed_btree(self, new_test_runner, metadata_with_table):
+        testingutils.make_changes_and_restore(
+            new_test_runner,
+            metadata_with_table,
+            conftest.metadata_with_multicolumn_fulltext_search_index_btree,
+            "add full text index accounts_full_text_idx to accounts",
+            "drop full text index accounts_full_text_idx from accounts",
+            # skip validation because of complications with idx
+            validate_schema=False
+        )
+
+    @pytest.mark.usefixtures("metadata_with_table")
     def test_full_text_index_with_generated_column(self, new_test_runner, metadata_with_table):
         testingutils.make_changes_and_restore(
             new_test_runner,
             metadata_with_table,
             conftest.metadata_with_generated_col_fulltext_search_index,
+            "add column full_name to table accounts\nadd index accounts_full_text_idx to accounts",
+            "drop index accounts_full_text_idx from accounts\ndrop column full_name from table accounts",
+            # skip validation because of complications with idx
+            validate_schema=False
+        )
+
+    @pytest.mark.usefixtures("metadata_with_table")
+    def test_full_text_index_with_generated_column_btree(self, new_test_runner, metadata_with_table):
+        testingutils.make_changes_and_restore(
+            new_test_runner,
+            metadata_with_table,
+            conftest.metadata_with_generated_col_fulltext_search_index_btree,
             "add column full_name to table accounts\nadd index accounts_full_text_idx to accounts",
             "drop index accounts_full_text_idx from accounts\ndrop column full_name from table accounts",
             # skip validation because of complications with idx

--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -1066,7 +1066,6 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.run_and_validate_with_standard_metadata_tables(
             r, metadata_with_json, new_table_names=['tbl'])
 
-    # TODO only
     @pytest.mark.usefixtures("metadata_with_table")
     def test_full_text_index_added_and_removed(self, new_test_runner, metadata_with_table):
         r = new_test_runner(metadata_with_table)
@@ -1075,6 +1074,45 @@ class TestPostgresRunner(BaseTestRunner):
 
         r2 = testingutils.recreate_with_new_metadata(
             r, new_test_runner, metadata_with_table, conftest.metadata_with_fulltext_search_index)
+
+        message = r2.revision_message()
+        assert message == "add full text index accounts_first_name_idx to accounts"
+
+        r2.run()
+        testingutils.assert_num_files(r2, 2)
+        testingutils.assert_num_tables(r2, 2)
+
+        # downgrade and upgrade back should work
+        r2.downgrade(delete_files=False, revision='-1')
+        r2.upgrade()
+
+        r3 = testingutils.recreate_metadata_fixture(
+            new_test_runner, conftest.metadata_with_base_table_restored(), r2)
+
+        message = r3.revision_message()
+        assert message == "drop full text index accounts_first_name_idx from accounts"
+
+        r3.run()
+        testingutils.assert_num_files(r3, 3)
+        testingutils.assert_num_tables(r3, 2)
+
+        # downgrade and upgrade back should work
+        r3.downgrade(delete_files=False, revision='-1')
+        r3.upgrade()
+
+    # TODO abstract this out. common pattern
+    # start with something, make a change, restore it
+    # downgrade and upgrade along the way
+
+    # TODO need to test with this from the start
+    @pytest.mark.usefixtures("metadata_with_table")
+    def test_multi_col_full_text_index_added_and_removed(self, new_test_runner, metadata_with_table):
+        r = new_test_runner(metadata_with_table)
+        testingutils.run_and_validate_with_standard_metadata_tables(
+            r, metadata_with_table)
+
+        r2 = testingutils.recreate_with_new_metadata(
+            r, new_test_runner, metadata_with_table, conftest.metadata_with_multicolumn_fulltext_search_index)
 
         message = r2.revision_message()
         assert message == "add full text index accounts_full_text_idx to accounts"

--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -1083,6 +1083,10 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 2)
         testingutils.assert_num_tables(r2, 2)
 
+        # downgrade and upgrade back should work
+        r2.downgrade(delete_files=False, revision='-1')
+        r2.upgrade()
+
         r3 = testingutils.recreate_metadata_fixture(
             new_test_runner, conftest.metadata_with_base_table_restored(), r2)
 
@@ -1093,7 +1097,9 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r3, 3)
         testingutils.assert_num_tables(r3, 2)
 
-        # TODO need to successfully downgrade because the generated create is wrong
+        # downgrade and upgrade back should work
+        r3.downgrade(delete_files=False, revision='-1')
+        r3.upgrade()
 
 
 class TestSqliteRunner(BaseTestRunner):

--- a/python/auto_schema/tests/testingutils.py
+++ b/python/auto_schema/tests/testingutils.py
@@ -427,7 +427,15 @@ def _setup_assoc_edge_config(new_test_runner, metadata_with_assoc_edge_config):
     return r
 
 
-def make_changes_and_restore(new_test_runner, metadata_with_table, metadata_change_func, r2_message, r3_message, validate_schema=True):
+def make_changes_and_restore(
+    new_test_runner,
+    metadata_with_table,
+    metadata_change_func,
+    r2_message,
+    r3_message,
+    validate_schema=True,
+    post_r2_func=None,
+):
     r = new_test_runner(metadata_with_table)
     run_and_validate_with_standard_metadata_tables(
         r, metadata_with_table)
@@ -443,6 +451,9 @@ def make_changes_and_restore(new_test_runner, metadata_with_table, metadata_chan
     # should have the expected files with the expected tables
     assert_num_files(r2, 2)
     assert_num_tables(r2, 2, ['accounts', 'alembic_version'])
+
+    if post_r2_func is not None:
+        post_r2_func(r2)
 
     # downgrade and upgrade back should work
     r2.downgrade(delete_files=False, revision='-1')

--- a/python/auto_schema/tests/testingutils.py
+++ b/python/auto_schema/tests/testingutils.py
@@ -5,6 +5,8 @@ from sqlalchemy.dialects import postgresql
 from auto_schema.clause_text import get_clause_text
 from auto_schema import runner
 from sqlalchemy.sql.sqltypes import String
+
+from auto_schema import compare
 from . import conftest
 
 


### PR DESCRIPTION
addresses https://github.com/lolopinto/ent/issues/466

alembic autogenerate doesn't support full text search. we want to support this an option in ent and make it possible to configure access

currently only supports in postgres

docs: https://www.postgresql.org/docs/current/textsearch.html
https://www.postgresql.org/docs/current/textsearch-intro.html
https://www.postgresql.org/docs/current/textsearch-tables.html

also relevant reads https://blog.crunchydata.com/blog/postgres-full-text-search-a-search-engine-in-a-database, http://rachbelaid.com/postgres-full-text-search-is-good-enough/ for how it may want to be used

still need support in schema and help querying

high level things here:
* support adding index, removing index once in schema
* support index on stored generated column
* support indices on tsvectors of columns (either 1 or more columns)

