### PR TITLE
auto_schema: sort constraints in schema.sql consistently

### DIFF
--- a/examples/simple/src/schema/schema.sql
+++ b/examples/simple/src/schema/schema.sql
@@ -38,8 +38,8 @@ CREATE TABLE assoc_edge_config (
     created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
     updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
     CONSTRAINT assoc_edge_config_edge_type_pkey PRIMARY KEY (edge_type), 
-    CONSTRAINT assoc_edge_config_unique_edge_name UNIQUE (edge_name), 
-    CONSTRAINT assoc_edge_config_inverse_edge_type_fkey FOREIGN KEY(inverse_edge_type) REFERENCES assoc_edge_config (edge_type) ON DELETE RESTRICT
+    CONSTRAINT assoc_edge_config_inverse_edge_type_fkey FOREIGN KEY(inverse_edge_type) REFERENCES assoc_edge_config (edge_type) ON DELETE RESTRICT, 
+    CONSTRAINT assoc_edge_config_unique_edge_name UNIQUE (edge_name)
 );
 
 CREATE TABLE comments (
@@ -225,8 +225,8 @@ CREATE TABLE users (
     new_col TEXT, 
     new_col_2 TEXT, 
     CONSTRAINT users_id_pkey PRIMARY KEY (id), 
-    CONSTRAINT users_unique_phone_number UNIQUE (phone_number), 
-    CONSTRAINT users_unique_email_address UNIQUE (email_address)
+    CONSTRAINT users_unique_email_address UNIQUE (email_address), 
+    CONSTRAINT users_unique_phone_number UNIQUE (phone_number)
 );
 
 CREATE TABLE auth_codes (
@@ -238,9 +238,9 @@ CREATE TABLE auth_codes (
     email_address TEXT, 
     phone_number TEXT, 
     CONSTRAINT auth_codes_id_pkey PRIMARY KEY (id), 
-    CONSTRAINT "uniquePhoneCode" UNIQUE (phone_number, code), 
     CONSTRAINT auth_codes_user_id_fkey FOREIGN KEY(user_id) REFERENCES users (id) ON DELETE CASCADE, 
-    CONSTRAINT "uniqueCode" UNIQUE (email_address, code)
+    CONSTRAINT "uniqueCode" UNIQUE (email_address, code), 
+    CONSTRAINT "uniquePhoneCode" UNIQUE (phone_number, code)
 );
 
 CREATE INDEX auth_codes_user_id_idx ON auth_codes (user_id);

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -328,6 +328,13 @@ class Runner(object):
             },
         )
 
+        # let's do a consistent (not runtime dependent) sort of constraints by using name instead of _creation_order
+        @property
+        def sort_constraints_by_name(self):
+            return sorted(self.constraints, key=lambda c: c.name)
+
+        sa.Table._sorted_constraints = sort_constraints_by_name
+
         def invoke(op):
             if isinstance(op, alembicops.OpContainer):
                 for op2 in op.ops:


### PR DESCRIPTION
by using name instead of _creation_order which is currently what the logic does. this is so that running codegen multiple times with no schema changes ends with the same file