### PR TITLE
nodejs 18: update test suites

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -40,7 +40,7 @@ import DB from "./core/db";
 export * from "./core/loaders";
 export { DB };
 
-// TODO figure out if this should be its own
+// TODO figure out if this should be its own import path e.g. @snowtop/ent/privacy
 export {
   EntPrivacyError,
   AlwaysAllowRule,


### PR DESCRIPTION
to support 14, 16, 17, 18

will drop 17 later

https://nodejs.org/en/blog/announcements/v18-release-announce/
nodejs release cycle always confuses https://nodejs.org/en/about/releases/

will update docker images later when new build is coming out