### PR TITLE
kill EvolvedIDField check in Field.TsType

### DIFF
--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -497,12 +497,6 @@ func (f *Field) CamelCaseName() string {
 }
 
 func (f *Field) TsType() string {
-	if f.EvolvedIDField() {
-		if f.Nullable() {
-			return (&enttype.NullableIDType{}).GetTSType()
-		}
-		return (&enttype.IDType{}).GetTSType()
-	}
 	return f.fieldType.GetTSType()
 }
 


### PR DESCRIPTION
seems weird. not used by any of the examples code and simplifies future changes

was originally added a while back in https://github.com/lolopinto/ent/pull/47 and doesn't seem relevant anymore