### PR TITLE
Field privacy

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.3.0",
         "@sentry/tracing": "^6.3.0",
-        "@snowtop/ent": "^0.0.38",
+        "@snowtop/ent": "^0.0.39-alpha14",
         "@snowtop/ent-email": "0.0.1",
         "@snowtop/ent-passport": "0.0.1",
         "@snowtop/ent-password": "0.0.1",
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.38.tgz",
-      "integrity": "sha512-MmdUSRE2/si5xRuEUkS5S69tZnIwoZgMD+h/osXQ4x+uxEfzecnELyTKuDZnlWLL5E/3yWVmG5fHtOrnEtvPAQ==",
+      "version": "0.0.39-alpha14",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
+      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -7313,9 +7313,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.38.tgz",
-      "integrity": "sha512-MmdUSRE2/si5xRuEUkS5S69tZnIwoZgMD+h/osXQ4x+uxEfzecnELyTKuDZnlWLL5E/3yWVmG5fHtOrnEtvPAQ==",
+      "version": "0.0.39-alpha14",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
+      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.3.0",
         "@sentry/tracing": "^6.3.0",
-        "@snowtop/ent": "^0.0.39-alpha14",
+        "@snowtop/ent": "^0.0.40-alpha",
         "@snowtop/ent-email": "0.0.1",
         "@snowtop/ent-passport": "0.0.1",
         "@snowtop/ent-password": "0.0.1",
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.39-alpha14",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
-      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
+      "version": "0.0.40-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.40-alpha.tgz",
+      "integrity": "sha512-e++eSrVLDr4nv/2BMT3lYInM4BrKTGePWeOaCt4CrtXd1QSevGRpdc/XsfENHezV2tzZTuN4xPV7dGwQjfRuWA==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -7313,9 +7313,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.39-alpha14",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
-      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
+      "version": "0.0.40-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.40-alpha.tgz",
+      "integrity": "sha512-e++eSrVLDr4nv/2BMT3lYInM4BrKTGePWeOaCt4CrtXd1QSevGRpdc/XsfENHezV2tzZTuN4xPV7dGwQjfRuWA==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "^6.3.0",
     "@sentry/tracing": "^6.3.0",
-    "@snowtop/ent": "^0.0.39-alpha14",
+    "@snowtop/ent": "^0.0.40-alpha",
     "@snowtop/ent-email": "0.0.1",
     "@snowtop/ent-passport": "0.0.1",
     "@snowtop/ent-password": "0.0.1",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "^6.3.0",
     "@sentry/tracing": "^6.3.0",
-    "@snowtop/ent": "^0.0.38",
+    "@snowtop/ent": "^0.0.39-alpha14",
     "@snowtop/ent-email": "0.0.1",
     "@snowtop/ent-passport": "0.0.1",
     "@snowtop/ent-password": "0.0.1",

--- a/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
@@ -114,7 +114,7 @@ export class AddressBuilder implements Builder<Address> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -111,7 +111,7 @@ export class AuthCodeBuilder implements Builder<AuthCode> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
@@ -110,7 +110,7 @@ export class EventBuilder implements Builder<Event> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
@@ -258,7 +258,7 @@ export class EventActivityBuilder implements Builder<EventActivity> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
@@ -184,6 +184,8 @@ export class AddressBase {
       fields: addressLoaderInfo.fields,
       ent: this,
       loaderFactory: addressLoader,
+      // if it has field Privacy, we specify this here and pass it on...
+      fieldPrivacy: new Map(),
     };
   }
 

--- a/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
@@ -184,8 +184,6 @@ export class AddressBase {
       fields: addressLoaderInfo.fields,
       ent: this,
       loaderFactory: addressLoader,
-      // if it has field Privacy, we specify this here and pass it on...
-      fieldPrivacy: new Map(),
     };
   }
 

--- a/examples/ent-rsvp/backend/src/ent/generated/event_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_query_base.ts
@@ -31,6 +31,7 @@ export const eventToEventActivitiesDataLoaderFactory = new IndexLoaderFactory(
     toPrime: [eventActivityLoader],
   },
 );
+
 export const eventToGuestDataCountLoaderFactory = new RawCountLoaderFactory({
   ...GuestData.loaderOptions(),
   groupCol: "event_id",
@@ -42,6 +43,7 @@ export const eventToGuestDataDataLoaderFactory = new IndexLoaderFactory(
     toPrime: [guestDataLoader],
   },
 );
+
 export const eventToGuestGroupsCountLoaderFactory = new RawCountLoaderFactory({
   ...GuestGroup.loaderOptions(),
   groupCol: "event_id",
@@ -53,6 +55,7 @@ export const eventToGuestGroupsDataLoaderFactory = new IndexLoaderFactory(
     toPrime: [guestGroupLoader],
   },
 );
+
 export const eventToGuestsCountLoaderFactory = new RawCountLoaderFactory({
   ...Guest.loaderOptions(),
   groupCol: "event_id",

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_query_base.ts
@@ -53,6 +53,7 @@ export const guestToAuthCodesDataLoaderFactory = new IndexLoaderFactory(
     toPrime: [authCodeLoader],
   },
 );
+
 export const guestToGuestDataCountLoaderFactory = new RawCountLoaderFactory({
   ...GuestData.loaderOptions(),
   groupCol: "guest_id",

--- a/examples/ent-rsvp/backend/src/ent/generated/loaders.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/loaders.ts
@@ -22,6 +22,7 @@ export const addressLoader = new ObjectLoaderFactory({
   fields: addressFields,
   key: "id",
 });
+
 export const addressOwnerIDLoader = new ObjectLoaderFactory({
   tableName: addressTable,
   fields: addressFields,
@@ -54,6 +55,7 @@ export const authCodeLoader = new ObjectLoaderFactory({
   fields: authCodeFields,
   key: "id",
 });
+
 export const authCodeGuestIDLoader = new ObjectLoaderFactory({
   tableName: authCodeTable,
   fields: authCodeFields,
@@ -112,6 +114,7 @@ export const eventLoader = new ObjectLoaderFactory({
   fields: eventFields,
   key: "id",
 });
+
 export const eventSlugLoader = new ObjectLoaderFactory({
   tableName: eventTable,
   fields: eventFields,
@@ -215,6 +218,7 @@ export const userLoader = new ObjectLoaderFactory({
   fields: userFields,
   key: "id",
 });
+
 export const userEmailAddressLoader = new ObjectLoaderFactory({
   tableName: userTable,
   fields: userFields,

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
@@ -212,7 +212,7 @@ export class GuestBuilder implements Builder<Guest> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
@@ -112,7 +112,7 @@ export class GuestDataBuilder implements Builder<GuestData> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
@@ -167,7 +167,7 @@ export class GuestGroupBuilder implements Builder<GuestGroup> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
@@ -111,7 +111,7 @@ export class UserBuilder implements Builder<User> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/ent-rsvp/backend/src/schema/schema.py
+++ b/examples/ent-rsvp/backend/src/schema/schema.py
@@ -2,6 +2,7 @@
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+from auto_schema.schema_item import FullTextIndex
 
 metadata = sa.MetaData()
 

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.39-alpha12",
+        "@snowtop/ent": "^0.0.39-alpha13",
         "@snowtop/ent-email": "^0.0.1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.39-alpha12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha12.tgz",
-      "integrity": "sha512-SgX2gnBrSx4DjiH1Ff7Z33/zOUuQCbpvb6KLx6WxInxbLG58f9Bt441w3uz/ab2ss5Mnl5GvlUWLtbClg5/XRw==",
+      "version": "0.0.39-alpha13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha13.tgz",
+      "integrity": "sha512-5IpZTHUJ2SlvJQLSQgAD8cLnTHNxVE8z1nkNXbofWSYeMmXypYq8ag4NTT7+i2XtKX2ZlIMQT/EWUG+19GClKA==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6941,9 +6941,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.39-alpha12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha12.tgz",
-      "integrity": "sha512-SgX2gnBrSx4DjiH1Ff7Z33/zOUuQCbpvb6KLx6WxInxbLG58f9Bt441w3uz/ab2ss5Mnl5GvlUWLtbClg5/XRw==",
+      "version": "0.0.39-alpha13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha13.tgz",
+      "integrity": "sha512-5IpZTHUJ2SlvJQLSQgAD8cLnTHNxVE8z1nkNXbofWSYeMmXypYq8ag4NTT7+i2XtKX2ZlIMQT/EWUG+19GClKA==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.39-alpha14",
+        "@snowtop/ent": "^0.0.40-alpha",
         "@snowtop/ent-email": "^0.0.1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.39-alpha14",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
-      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
+      "version": "0.0.40-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.40-alpha.tgz",
+      "integrity": "sha512-e++eSrVLDr4nv/2BMT3lYInM4BrKTGePWeOaCt4CrtXd1QSevGRpdc/XsfENHezV2tzZTuN4xPV7dGwQjfRuWA==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6941,9 +6941,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.39-alpha14",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
-      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
+      "version": "0.0.40-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.40-alpha.tgz",
+      "integrity": "sha512-e++eSrVLDr4nv/2BMT3lYInM4BrKTGePWeOaCt4CrtXd1QSevGRpdc/XsfENHezV2tzZTuN4xPV7dGwQjfRuWA==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.39-alpha9",
+        "@snowtop/ent": "^0.0.39-alpha12",
         "@snowtop/ent-email": "^0.0.1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.39-alpha9",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha9.tgz",
-      "integrity": "sha512-CdGHZvh8maPzB7aofH3C3xTzMbb/gDTqDVoWGnN/nNUI+93Uk3QnmDCHVRkShdopKU97oPr8tGP04Y2dmARxUA==",
+      "version": "0.0.39-alpha12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha12.tgz",
+      "integrity": "sha512-SgX2gnBrSx4DjiH1Ff7Z33/zOUuQCbpvb6KLx6WxInxbLG58f9Bt441w3uz/ab2ss5Mnl5GvlUWLtbClg5/XRw==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6941,9 +6941,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.39-alpha9",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha9.tgz",
-      "integrity": "sha512-CdGHZvh8maPzB7aofH3C3xTzMbb/gDTqDVoWGnN/nNUI+93Uk3QnmDCHVRkShdopKU97oPr8tGP04Y2dmARxUA==",
+      "version": "0.0.39-alpha12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha12.tgz",
+      "integrity": "sha512-SgX2gnBrSx4DjiH1Ff7Z33/zOUuQCbpvb6KLx6WxInxbLG58f9Bt441w3uz/ab2ss5Mnl5GvlUWLtbClg5/XRw==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.39-alpha13",
+        "@snowtop/ent": "^0.0.39-alpha14",
         "@snowtop/ent-email": "^0.0.1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.39-alpha13",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha13.tgz",
-      "integrity": "sha512-5IpZTHUJ2SlvJQLSQgAD8cLnTHNxVE8z1nkNXbofWSYeMmXypYq8ag4NTT7+i2XtKX2ZlIMQT/EWUG+19GClKA==",
+      "version": "0.0.39-alpha14",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
+      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6941,9 +6941,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.39-alpha13",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha13.tgz",
-      "integrity": "sha512-5IpZTHUJ2SlvJQLSQgAD8cLnTHNxVE8z1nkNXbofWSYeMmXypYq8ag4NTT7+i2XtKX2ZlIMQT/EWUG+19GClKA==",
+      "version": "0.0.39-alpha14",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
+      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.39-alpha13",
+    "@snowtop/ent": "^0.0.39-alpha14",
     "@snowtop/ent-email": "^0.0.1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.39-alpha9",
+    "@snowtop/ent": "^0.0.39-alpha12",
     "@snowtop/ent-email": "^0.0.1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.39-alpha12",
+    "@snowtop/ent": "^0.0.39-alpha13",
     "@snowtop/ent-email": "^0.0.1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.39-alpha14",
+    "@snowtop/ent": "^0.0.40-alpha",
     "@snowtop/ent-email": "^0.0.1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/simple/src/ent/address/actions/generated/address_builder.ts
@@ -169,7 +169,7 @@ export class AddressBuilder implements Builder<Address> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -114,7 +114,7 @@ export class AuthCodeBuilder implements Builder<AuthCode> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
+++ b/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
@@ -168,7 +168,7 @@ export class CommentBuilder implements Builder<Comment> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/contact/actions/generated/contact_builder.ts
+++ b/examples/simple/src/ent/contact/actions/generated/contact_builder.ts
@@ -202,7 +202,7 @@ export class ContactBuilder implements Builder<Contact> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/contact_email/actions/generated/contact_email_builder.ts
+++ b/examples/simple/src/ent/contact_email/actions/generated/contact_email_builder.ts
@@ -114,7 +114,7 @@ export class ContactEmailBuilder implements Builder<ContactEmail> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/contact_phone_number/actions/generated/contact_phone_number_builder.ts
+++ b/examples/simple/src/ent/contact_phone_number/actions/generated/contact_phone_number_builder.ts
@@ -114,7 +114,7 @@ export class ContactPhoneNumberBuilder implements Builder<ContactPhoneNumber> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -167,8 +167,6 @@ export class EventBase {
       fields: eventLoaderInfo.fields,
       ent: this,
       loaderFactory: eventLoader,
-
-      //        fieldPrivacy: getFieldsWithPrivacy(schema),
     };
   }
 

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -84,7 +84,7 @@ export class UserBase {
   readonly phoneNumber: string | null;
   protected readonly password: string | null;
   protected readonly _accountStatus: string | null;
-  protected readonly _emailVerified: boolean | null;
+  protected readonly _emailVerified: boolean;
   readonly bio: string | null;
   readonly nicknames: string[] | null;
   protected readonly _prefs: UserPrefs | null;

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -354,8 +354,6 @@ export class UserBase {
       fields: userLoaderInfo.fields,
       ent: this,
       loaderFactory: userLoader,
-
-      //        fieldPrivacy: getFieldsWithPrivacy(schema),
     };
   }
 

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -137,9 +137,6 @@ export class UserBase {
   }
 
   async emailVerified(): Promise<boolean | null> {
-    if (this._emailVerified === null) {
-      return null;
-    }
     const m = getFieldsWithPrivacy(schema);
     const p = m.get("email_verified");
     if (!p) {

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -124,6 +124,9 @@ export class UserBase {
   privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
 
   async accountStatus(): Promise<string | null> {
+    if (this._accountStatus === null) {
+      return null;
+    }
     const m = getFieldsWithPrivacy(schema);
     const p = m.get("account_status");
     if (!p) {
@@ -134,6 +137,9 @@ export class UserBase {
   }
 
   async emailVerified(): Promise<boolean | null> {
+    if (this._emailVerified === null) {
+      return null;
+    }
     const m = getFieldsWithPrivacy(schema);
     const p = m.get("email_verified");
     if (!p) {
@@ -144,6 +150,9 @@ export class UserBase {
   }
 
   async prefs(): Promise<UserPrefs | null> {
+    if (this._prefs === null) {
+      return null;
+    }
     const m = getFieldsWithPrivacy(schema);
     const p = m.get("prefs");
     if (!p) {
@@ -154,6 +163,9 @@ export class UserBase {
   }
 
   async prefsList(): Promise<UserPrefs[] | null> {
+    if (this._prefsList === null) {
+      return null;
+    }
     const m = getFieldsWithPrivacy(schema);
     const p = m.get("prefs_list");
     if (!p) {
@@ -164,6 +176,9 @@ export class UserBase {
   }
 
   async prefsDiff(): Promise<any> {
+    if (this._prefsDiff === null) {
+      return null;
+    }
     const m = getFieldsWithPrivacy(schema);
     const p = m.get("prefs_diff");
     if (!p) {

--- a/examples/simple/src/ent/holiday/actions/generated/holiday_builder.ts
+++ b/examples/simple/src/ent/holiday/actions/generated/holiday_builder.ts
@@ -114,7 +114,7 @@ export class HolidayBuilder implements Builder<Holiday> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/hours_of_operation/actions/generated/hours_of_operation_builder.ts
+++ b/examples/simple/src/ent/hours_of_operation/actions/generated/hours_of_operation_builder.ts
@@ -115,7 +115,7 @@ export class HoursOfOperationBuilder implements Builder<HoursOfOperation> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/tests/event.test.ts
+++ b/examples/simple/src/ent/tests/event.test.ts
@@ -224,7 +224,7 @@ test("addressID privacy", async () => {
 
   eventFrom = await Event.loadX(user.viewer, event.id);
   // can now see address id
-  //  expect(await eventFrom.addressID()).toBe(address.id);
+  expect(await eventFrom.addressID()).toBe(address.id);
   const addressFrom = await eventFrom.loadAddress();
   expect(addressFrom).not.toBeNull();
   expect(addressFrom?.id).toBe(address.id);

--- a/examples/simple/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/simple/src/ent/user/actions/generated/user_builder.ts
@@ -597,7 +597,7 @@ export class UserBuilder implements Builder<User> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/simple/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/simple/src/ent/user/actions/generated/user_builder.ts
@@ -32,7 +32,7 @@ export interface UserInput {
   phoneNumber?: string | null;
   password?: string | null;
   accountStatus?: string | null;
-  emailVerified?: boolean | null;
+  emailVerified?: boolean;
   bio?: string | null;
   nicknames?: string[] | null;
   prefs?: UserPrefs | null;

--- a/examples/simple/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/simple/src/ent/user/actions/generated/user_builder.ts
@@ -32,7 +32,7 @@ export interface UserInput {
   phoneNumber?: string | null;
   password?: string | null;
   accountStatus?: string | null;
-  emailVerified?: boolean;
+  emailVerified?: boolean | null;
   bio?: string | null;
   nicknames?: string[] | null;
   prefs?: UserPrefs | null;
@@ -671,18 +671,12 @@ export class UserBuilder implements Builder<User> {
 
   // get value of AccountStatus. Retrieves it from the input if specified or takes it from existingEnt
   getNewAccountStatusValue(): string | null | undefined {
-    if (this.input.accountStatus !== undefined) {
-      return this.input.accountStatus;
-    }
-    return this.existingEnt?.accountStatus;
+    return this.input.accountStatus;
   }
 
   // get value of emailVerified. Retrieves it from the input if specified or takes it from existingEnt
-  getNewEmailVerifiedValue(): boolean | undefined {
-    if (this.input.emailVerified !== undefined) {
-      return this.input.emailVerified;
-    }
-    return this.existingEnt?.emailVerified;
+  getNewEmailVerifiedValue(): boolean | null | undefined {
+    return this.input.emailVerified;
   }
 
   // get value of Bio. Retrieves it from the input if specified or takes it from existingEnt
@@ -703,26 +697,17 @@ export class UserBuilder implements Builder<User> {
 
   // get value of prefs. Retrieves it from the input if specified or takes it from existingEnt
   getNewPrefsValue(): UserPrefs | null | undefined {
-    if (this.input.prefs !== undefined) {
-      return this.input.prefs;
-    }
-    return this.existingEnt?.prefs;
+    return this.input.prefs;
   }
 
   // get value of prefsList. Retrieves it from the input if specified or takes it from existingEnt
   getNewPrefsListValue(): UserPrefs[] | null | undefined {
-    if (this.input.prefsList !== undefined) {
-      return this.input.prefsList;
-    }
-    return this.existingEnt?.prefsList;
+    return this.input.prefsList;
   }
 
   // get value of prefs_diff. Retrieves it from the input if specified or takes it from existingEnt
   getNewPrefsDiffValue(): any | undefined {
-    if (this.input.prefsDiff !== undefined) {
-      return this.input.prefsDiff;
-    }
-    return this.existingEnt?.prefsDiff;
+    return this.input.prefsDiff;
   }
 
   // get value of daysOff. Retrieves it from the input if specified or takes it from existingEnt

--- a/examples/simple/src/graphql/resolvers/generated/user_type.ts
+++ b/examples/simple/src/graphql/resolvers/generated/user_type.ts
@@ -71,6 +71,9 @@ export const UserType = new GraphQLObjectType({
     },
     accountStatus: {
       type: GraphQLString,
+      resolve: async (user: User, args: {}, context: RequestContext) => {
+        return user.accountStatus();
+      },
     },
     bio: {
       type: GraphQLString,
@@ -80,12 +83,21 @@ export const UserType = new GraphQLObjectType({
     },
     prefs: {
       type: GraphQLJSON,
+      resolve: async (user: User, args: {}, context: RequestContext) => {
+        return user.prefs();
+      },
     },
     prefsList: {
       type: GraphQLList(GraphQLNonNull(GraphQLJSON)),
+      resolve: async (user: User, args: {}, context: RequestContext) => {
+        return user.prefsList();
+      },
     },
     prefsDiff: {
       type: GraphQLJSON,
+      resolve: async (user: User, args: {}, context: RequestContext) => {
+        return user.prefsDiff();
+      },
     },
     daysOff: {
       type: GraphQLList(GraphQLNonNull(DaysOffType)),

--- a/examples/simple/src/schema/event.ts
+++ b/examples/simple/src/schema/event.ts
@@ -1,6 +1,5 @@
 import {
   AllowIfViewerInboundEdgeExistsRule,
-  //  AllowIfViewerIsEntPropertyRule,
   AllowIfViewerIsRule,
   AlwaysDenyRule,
 } from "@snowtop/ent";
@@ -40,11 +39,11 @@ export default class Event extends BaseEntSchema implements Schema {
       graphqlName: "eventLocation",
     }),
     UUIDType({
-      // perfect, only creator or attendees can see event address
       name: "addressID",
       nullable: true,
       fieldEdge: { schema: "Address", inverseEdge: "hostedEvents" },
       privacyPolicy: {
+        // only creator or attendees can see event address
         rules: [
           new AllowIfViewerInboundEdgeExistsRule(
             EdgeType.UserToEventsAttending,

--- a/examples/simple/src/schema/event.ts
+++ b/examples/simple/src/schema/event.ts
@@ -1,4 +1,10 @@
 import {
+  AllowIfViewerInboundEdgeExistsRule,
+  //  AllowIfViewerIsEntPropertyRule,
+  AllowIfViewerIsRule,
+  AlwaysDenyRule,
+} from "@snowtop/ent";
+import {
   Schema,
   Action,
   Field,
@@ -10,6 +16,7 @@ import {
   UUIDType,
   AssocEdgeGroup,
 } from "@snowtop/ent/schema/";
+import { EdgeType } from "../ent/generated/const";
 
 /// explicit schema
 export default class Event extends BaseEntSchema implements Schema {
@@ -33,9 +40,19 @@ export default class Event extends BaseEntSchema implements Schema {
       graphqlName: "eventLocation",
     }),
     UUIDType({
+      // perfect, only creator or attendees can see event address
       name: "addressID",
       nullable: true,
       fieldEdge: { schema: "Address", inverseEdge: "hostedEvents" },
+      privacyPolicy: {
+        rules: [
+          new AllowIfViewerInboundEdgeExistsRule(
+            EdgeType.UserToEventsAttending,
+          ),
+          new AllowIfViewerIsRule("creatorID"),
+          AlwaysDenyRule,
+        ],
+      },
     }),
   ];
 

--- a/examples/simple/src/schema/user.ts
+++ b/examples/simple/src/schema/user.ts
@@ -22,6 +22,7 @@ import { PasswordType } from "@snowtop/ent-password";
 import { PhoneNumberType } from "@snowtop/ent-phonenumber";
 import { StringListType } from "@snowtop/ent/schema/field";
 import Feedback from "./patterns/feedback";
+import { AllowIfViewerPrivacyPolicy } from "@snowtop/ent";
 
 export default class User extends BaseEntSchema implements Schema {
   constructor() {
@@ -50,6 +51,7 @@ export default class User extends BaseEntSchema implements Schema {
       // allows scripts, internal tools etc to set this but not graphql
       disableUserGraphQLEditable: true,
       defaultValueOnCreate: () => "UNVERIFIED",
+      privacyPolicy: AllowIfViewerPrivacyPolicy,
     }),
     BooleanType({
       name: "emailVerified",
@@ -57,6 +59,7 @@ export default class User extends BaseEntSchema implements Schema {
       serverDefault: "FALSE",
       // not needed because we have serverDefault but can also set it here.
       defaultValueOnCreate: () => false,
+      privacyPolicy: AllowIfViewerPrivacyPolicy,
     }),
     StringType({ name: "Bio", nullable: true }),
     StringListType({ name: "nicknames", nullable: true }),
@@ -67,6 +70,7 @@ export default class User extends BaseEntSchema implements Schema {
         path: "src/ent/user_prefs",
         type: "UserPrefs",
       },
+      privacyPolicy: AllowIfViewerPrivacyPolicy,
     }),
     JSONBListType({
       name: "prefsList",
@@ -75,10 +79,12 @@ export default class User extends BaseEntSchema implements Schema {
         path: "src/ent/user_prefs",
         type: "UserPrefs",
       },
+      privacyPolicy: AllowIfViewerPrivacyPolicy,
     }),
     JSONType({
       name: "prefs_diff",
       nullable: true,
+      privacyPolicy: AllowIfViewerPrivacyPolicy,
       validator: (val: any) => {
         if (typeof val != "object") {
           return false;

--- a/examples/todo-sqlite/ent.yml
+++ b/examples/todo-sqlite/ent.yml
@@ -3,3 +3,5 @@ codegen:
   generateRootResolvers: true
   defaultGraphQLMutationName: VerbNoun
   defaultGraphQLFieldFormat: snake_case
+  fieldPrivacyEvaluated: at_ent_load
+

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.39-alpha14",
+        "@snowtop/ent": "^0.0.40-alpha",
         "@snowtop/ent-phonenumber": "^0.0.1",
         "@snowtop/ent-soft-delete": "^0.0.1",
         "@types/node": "^15.0.3",
@@ -993,9 +993,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.39-alpha14",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
-      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
+      "version": "0.0.40-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.40-alpha.tgz",
+      "integrity": "sha512-e++eSrVLDr4nv/2BMT3lYInM4BrKTGePWeOaCt4CrtXd1QSevGRpdc/XsfENHezV2tzZTuN4xPV7dGwQjfRuWA==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -7288,9 +7288,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.39-alpha14",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
-      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
+      "version": "0.0.40-alpha",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.40-alpha.tgz",
+      "integrity": "sha512-e++eSrVLDr4nv/2BMT3lYInM4BrKTGePWeOaCt4CrtXd1QSevGRpdc/XsfENHezV2tzZTuN4xPV7dGwQjfRuWA==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.0.39-alpha5",
+        "@snowtop/ent": "^0.0.39-alpha14",
         "@snowtop/ent-phonenumber": "^0.0.1",
         "@snowtop/ent-soft-delete": "^0.0.1",
         "@types/node": "^15.0.3",
@@ -993,9 +993,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.0.39-alpha5",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha5.tgz",
-      "integrity": "sha512-6ijwZsT7e9FNgQ4dnUdFRonl+zgjMycxU5/VcMaN/PlbMNsZlyhUfe9NPTmU1DK+LDDhptPtIRDAvbpVZ/Grqw==",
+      "version": "0.0.39-alpha14",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
+      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -7288,9 +7288,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.0.39-alpha5",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha5.tgz",
-      "integrity": "sha512-6ijwZsT7e9FNgQ4dnUdFRonl+zgjMycxU5/VcMaN/PlbMNsZlyhUfe9NPTmU1DK+LDDhptPtIRDAvbpVZ/Grqw==",
+      "version": "0.0.39-alpha14",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.0.39-alpha14.tgz",
+      "integrity": "sha512-41fXcfGMeXprbu/Uy7XUcKQ9ieQpxLYxSm3ENJhUp1pLJVg4zgDaF1gZJRdeLV/T8OvgbiC+BD0bWMrdnimYlw==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -35,7 +35,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.39-alpha5",
+    "@snowtop/ent": "^0.0.39-alpha14",
     "@snowtop/ent-phonenumber": "^0.0.1",
     "@snowtop/ent-soft-delete": "^0.0.1",
     "@types/node": "^15.0.3",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -35,7 +35,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.0.39-alpha14",
+    "@snowtop/ent": "^0.0.40-alpha",
     "@snowtop/ent-phonenumber": "^0.0.1",
     "@snowtop/ent-soft-delete": "^0.0.1",
     "@types/node": "^15.0.3",

--- a/examples/todo-sqlite/src/ent/account/actions/create_account_action.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/create_account_action.ts
@@ -1,4 +1,4 @@
-import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
+import { AlwaysAllowPrivacyPolicy, IDViewer, Data } from "@snowtop/ent";
 import {
   AccountCreateInput,
   CreateAccountActionBase,
@@ -9,5 +9,9 @@ export { AccountCreateInput };
 export default class CreateAccountAction extends CreateAccountActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
+  }
+
+  viewerForEntLoad(data: Data) {
+    return new IDViewer(data.id);
   }
 }

--- a/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
@@ -17,7 +17,7 @@ import schema from "src/schema/account";
 export interface AccountInput {
   deletedAt?: Date | null;
   name?: string;
-  phoneNumber?: string | null;
+  phoneNumber?: string;
   accountState?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
@@ -17,7 +17,7 @@ import schema from "src/schema/account";
 export interface AccountInput {
   deletedAt?: Date | null;
   name?: string;
-  phoneNumber?: string;
+  phoneNumber?: string | null;
   accountState?: AccountState | null;
 }
 
@@ -111,7 +111,7 @@ export class AccountBuilder implements Builder<Account> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();
@@ -146,7 +146,7 @@ export class AccountBuilder implements Builder<Account> {
   }
 
   // get value of PhoneNumber. Retrieves it from the input if specified or takes it from existingEnt
-  getNewPhoneNumberValue(): string | undefined {
+  getNewPhoneNumberValue(): string | null | undefined {
     if (this.input.phoneNumber !== undefined) {
       return this.input.phoneNumber;
     }

--- a/examples/todo-sqlite/src/ent/account/actions/generated/create_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/create_account_action_base.ts
@@ -14,7 +14,7 @@ import {
 
 export interface AccountCreateInput {
   name: string;
-  phoneNumber: string | null;
+  phoneNumber: string;
   accountState?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/ent/account/actions/generated/create_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/create_account_action_base.ts
@@ -14,7 +14,7 @@ import {
 
 export interface AccountCreateInput {
   name: string;
-  phoneNumber: string;
+  phoneNumber: string | null;
   accountState?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/ent/account/actions/generated/edit_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/edit_account_action_base.ts
@@ -15,7 +15,7 @@ import {
 
 export interface AccountEditInput {
   name?: string;
-  phoneNumber?: string | null;
+  phoneNumber?: string;
   accountState?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/ent/account/actions/generated/edit_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/edit_account_action_base.ts
@@ -15,7 +15,7 @@ import {
 
 export interface AccountEditInput {
   name?: string;
-  phoneNumber?: string;
+  phoneNumber?: string | null;
   accountState?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/ent/generated/account_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_base.ts
@@ -19,7 +19,7 @@ import {
   loadEntXViaKey,
   loadEnts,
 } from "@snowtop/ent";
-import { Field, getFields } from "@snowtop/ent/schema";
+import { Field, getFields, getFieldsWithPrivacy } from "@snowtop/ent/schema";
 import {
   accountLoader,
   accountLoaderInfo,
@@ -47,7 +47,7 @@ export class AccountBase {
   readonly updatedAt: Date;
   protected readonly deletedAt: Date | null;
   readonly name: string;
-  readonly phoneNumber: string;
+  readonly phoneNumber: string | null;
   readonly accountState: AccountState | null;
 
   constructor(public viewer: Viewer, protected data: Data) {
@@ -222,6 +222,7 @@ export class AccountBase {
       fields: accountLoaderInfo.fields,
       ent: this,
       loaderFactory: accountLoader,
+      fieldPrivacy: getFieldsWithPrivacy(schema),
     };
   }
 

--- a/examples/todo-sqlite/src/ent/tag/actions/generated/tag_builder.ts
+++ b/examples/todo-sqlite/src/ent/tag/actions/generated/tag_builder.ts
@@ -159,7 +159,7 @@ export class TagBuilder implements Builder<Tag> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/todo-sqlite/src/ent/tests/account.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/account.test.ts
@@ -4,6 +4,11 @@ import { Account } from "../internal";
 import { createAccount } from "../testutils/util";
 import { advanceTo } from "jest-date-mock";
 
+// TODO
+// tables don't exist for some reason
+// neither todo.db or todo22.db
+// also modify_edge loop forever
+// /# start with new auto_schema version
 test("create", async () => {
   await createAccount();
 });

--- a/examples/todo-sqlite/src/ent/tests/account.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/account.test.ts
@@ -4,13 +4,23 @@ import { Account } from "../internal";
 import { createAccount } from "../testutils/util";
 import { advanceTo } from "jest-date-mock";
 
-// TODO
-// tables don't exist for some reason
-// neither todo.db or todo22.db
-// also modify_edge loop forever
-// /# start with new auto_schema version
 test("create", async () => {
   await createAccount();
+});
+
+test("field privacy", async () => {
+  // viewer can see their own phone numbr and account state. no one else can
+  const account1 = await createAccount();
+  expect(account1.phoneNumber).not.toBeNull();
+  expect(account1.accountState).not.toBeNull();
+
+  const account2 = await createAccount();
+  expect(account2.phoneNumber).not.toBeNull();
+  expect(account2.accountState).not.toBeNull();
+
+  const fromOther = await Account.loadX(account1.viewer, account2.id);
+  expect(fromOther.phoneNumber).toBeNull();
+  expect(fromOther.accountState).toBeNull();
 });
 
 test("edit", async () => {

--- a/examples/todo-sqlite/src/ent/tests/account.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/account.test.ts
@@ -9,7 +9,7 @@ test("create", async () => {
 });
 
 test("field privacy", async () => {
-  // viewer can see their own phone numbr and account state. no one else can
+  // viewer can see their own phone number and account state. no one else can
   const account1 = await createAccount();
   expect(account1.phoneNumber).not.toBeNull();
   expect(account1.accountState).not.toBeNull();

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/todo_builder.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/todo_builder.ts
@@ -158,7 +158,7 @@ export class TodoBuilder implements Builder<Todo> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();

--- a/examples/todo-sqlite/src/graphql/generated/schema.gql
+++ b/examples/todo-sqlite/src/graphql/generated/schema.gql
@@ -255,3 +255,6 @@ type Mutation {
   renameTodo(input: RenameTodoInput!): RenameTodoPayload!
 }
 
+"""The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."""
+scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+

--- a/examples/todo-sqlite/src/graphql/generated/schema.gql
+++ b/examples/todo-sqlite/src/graphql/generated/schema.gql
@@ -255,6 +255,3 @@ type Mutation {
   renameTodo(input: RenameTodoInput!): RenameTodoPayload!
 }
 
-"""The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."""
-scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
-

--- a/examples/todo-sqlite/src/graphql/mutations/generated/account/create_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/account/create_account_type.ts
@@ -19,7 +19,7 @@ import { AccountStateType, AccountType } from "src/graphql/resolvers/";
 
 interface customCreateAccountInput
   extends Omit<AccountCreateInput, "phoneNumber" | "accountState"> {
-  phone_number: string;
+  phone_number: string | null;
   account_state?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/graphql/mutations/generated/account/create_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/account/create_account_type.ts
@@ -19,7 +19,7 @@ import { AccountStateType, AccountType } from "src/graphql/resolvers/";
 
 interface customCreateAccountInput
   extends Omit<AccountCreateInput, "phoneNumber" | "accountState"> {
-  phone_number: string | null;
+  phone_number: string;
   account_state?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/graphql/mutations/generated/account/edit_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/account/edit_account_type.ts
@@ -21,7 +21,7 @@ import { AccountStateType, AccountType } from "src/graphql/resolvers/";
 interface customEditAccountInput
   extends Omit<AccountEditInput, "phoneNumber" | "accountState"> {
   account_id: string;
-  phone_number?: string | null;
+  phone_number?: string;
   account_state?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/graphql/mutations/generated/account/edit_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/generated/account/edit_account_type.ts
@@ -21,7 +21,7 @@ import { AccountStateType, AccountType } from "src/graphql/resolvers/";
 interface customEditAccountInput
   extends Omit<AccountEditInput, "phoneNumber" | "accountState"> {
   account_id: string;
-  phone_number?: string;
+  phone_number?: string | null;
   account_state?: AccountState | null;
 }
 

--- a/examples/todo-sqlite/src/schema/account.ts
+++ b/examples/todo-sqlite/src/schema/account.ts
@@ -22,7 +22,6 @@ export default class Account extends BaseEntSchema {
       name: "PhoneNumber",
       unique: true,
       // only viewer can see their phone number
-
       // TODO: builder type needs to not change. needs to be non-nullable if original field wasn't nullable
       privacyPolicy: AllowIfViewerPrivacyPolicy,
     }),

--- a/examples/todo-sqlite/src/schema/account.ts
+++ b/examples/todo-sqlite/src/schema/account.ts
@@ -22,7 +22,6 @@ export default class Account extends BaseEntSchema {
       name: "PhoneNumber",
       unique: true,
       // only viewer can see their phone number
-      // TODO: builder type needs to not change. needs to be non-nullable if original field wasn't nullable
       privacyPolicy: AllowIfViewerPrivacyPolicy,
     }),
     EnumType({

--- a/examples/todo-sqlite/src/schema/account.ts
+++ b/examples/todo-sqlite/src/schema/account.ts
@@ -1,4 +1,5 @@
 import { EnumType } from "@snowtop/ent";
+import { AllowIfViewerPrivacyPolicy } from "@snowtop/ent";
 import {
   Action,
   ActionOperation,
@@ -17,7 +18,14 @@ export default class Account extends BaseEntSchema {
 
   fields: Field[] = [
     StringType({ name: "Name" }),
-    PhoneNumberType({ name: "PhoneNumber", unique: true }),
+    PhoneNumberType({
+      name: "PhoneNumber",
+      unique: true,
+      // only viewer can see their phone number
+
+      // TODO: builder type needs to not change. needs to be non-nullable if original field wasn't nullable
+      privacyPolicy: AllowIfViewerPrivacyPolicy,
+    }),
     EnumType({
       nullable: true,
       name: "accountState",
@@ -25,8 +33,11 @@ export default class Account extends BaseEntSchema {
       graphQLType: "AccountState",
       values: ["UNVERIFIED", "VERIFIED", "DEACTIVATED", "DISABLED"],
       defaultValueOnCreate: () => "UNVERIFIED",
+      // only viewer can see their account state
+      privacyPolicy: AllowIfViewerPrivacyPolicy,
     }),
   ];
+
   actions: Action[] = [
     {
       operation: ActionOperation.Mutations,

--- a/examples/todo-sqlite/src/schema/schema.py
+++ b/examples/todo-sqlite/src/schema/schema.py
@@ -6,85 +6,93 @@ from auto_schema.schema_item import FullTextIndex
 
 metadata = sa.MetaData()
 
- 
+
 sa.Table("accounts", metadata,
-    sa.Column("id", sa.Text(), nullable=False),
-    sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
-    sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
-    sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
-    sa.Column("name", sa.Text(), nullable=False),
-    sa.Column("phone_number", sa.Text(), nullable=False),
-    sa.Column("account_state", sa.Text(), nullable=True),
-    sa.Index("accounts_deleted_at_idx", "deleted_at"),
-    sa.PrimaryKeyConstraint("id", name="accounts_id_pkey"),
-    sa.UniqueConstraint("phone_number", name="accounts_unique_phone_number"),
-)
-   
+         sa.Column("id", sa.Text(), nullable=False),
+         sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+         sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
+         sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
+         sa.Column("name", sa.Text(), nullable=False),
+         sa.Column("phone_number", sa.Text(), nullable=False),
+         sa.Column("account_state", sa.Text(), nullable=True),
+         sa.Index("accounts_deleted_at_idx", "deleted_at"),
+         sa.PrimaryKeyConstraint("id", name="accounts_id_pkey"),
+         sa.UniqueConstraint(
+             "phone_number", name="accounts_unique_phone_number"),
+         )
+
 sa.Table("assoc_edge_config", metadata,
-    sa.Column("edge_type", sa.Text(), nullable=False),
-    sa.Column("edge_name", sa.Text(), nullable=False),
-    sa.Column("symmetric_edge", sa.Boolean(), nullable=False, server_default='false'),
-    sa.Column("inverse_edge_type", sa.Text(), nullable=True),
-    sa.Column("edge_table", sa.Text(), nullable=False),
-    sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
-    sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
-    sa.PrimaryKeyConstraint("edge_type", name="assoc_edge_config_edge_type_pkey"),
-    sa.UniqueConstraint("edge_name", name="assoc_edge_config_unique_edge_name"),
-    sa.ForeignKeyConstraint(["inverse_edge_type"], ["assoc_edge_config.edge_type"], name="assoc_edge_config_inverse_edge_type_fkey", ondelete="RESTRICT"),
-)
-   
+         sa.Column("edge_type", sa.Text(), nullable=False),
+         sa.Column("edge_name", sa.Text(), nullable=False),
+         sa.Column("symmetric_edge", sa.Boolean(),
+                   nullable=False, server_default='false'),
+         sa.Column("inverse_edge_type", sa.Text(), nullable=True),
+         sa.Column("edge_table", sa.Text(), nullable=False),
+         sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+         sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
+         sa.PrimaryKeyConstraint(
+             "edge_type", name="assoc_edge_config_edge_type_pkey"),
+         sa.UniqueConstraint(
+             "edge_name", name="assoc_edge_config_unique_edge_name"),
+         sa.ForeignKeyConstraint(["inverse_edge_type"], ["assoc_edge_config.edge_type"],
+                                 name="assoc_edge_config_inverse_edge_type_fkey", ondelete="RESTRICT"),
+         )
+
 sa.Table("tags", metadata,
-    sa.Column("id", sa.Text(), nullable=False),
-    sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
-    sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
-    sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
-    sa.Column("display_name", sa.Text(), nullable=False),
-    sa.Column("canonical_name", sa.Text(), nullable=False),
-    sa.Column("owner_id", sa.Text(), nullable=False),
-    sa.Column("related_tag_ids", sa.Text(), nullable=True),
-    sa.Index("tags_deleted_at_idx", "deleted_at"),
-    sa.Index("tags_owner_id_idx", "owner_id"),
-    sa.PrimaryKeyConstraint("id", name="tags_id_pkey"),
-    sa.ForeignKeyConstraint(["owner_id"], ["accounts.id"], name="tags_owner_id_fkey", ondelete="CASCADE"),
-    sa.UniqueConstraint("canonical_name", "owner_id", name="uniqueForOwner"),
-)
-   
+         sa.Column("id", sa.Text(), nullable=False),
+         sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+         sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
+         sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
+         sa.Column("display_name", sa.Text(), nullable=False),
+         sa.Column("canonical_name", sa.Text(), nullable=False),
+         sa.Column("owner_id", sa.Text(), nullable=False),
+         sa.Column("related_tag_ids", sa.Text(), nullable=True),
+         sa.Index("tags_deleted_at_idx", "deleted_at"),
+         sa.Index("tags_owner_id_idx", "owner_id"),
+         sa.PrimaryKeyConstraint("id", name="tags_id_pkey"),
+         sa.ForeignKeyConstraint(
+             ["owner_id"], ["accounts.id"], name="tags_owner_id_fkey", ondelete="CASCADE"),
+         sa.UniqueConstraint("canonical_name", "owner_id",
+                             name="uniqueForOwner"),
+         )
+
 sa.Table("todo_tags_edges", metadata,
-    sa.Column("id1", sa.Text(), nullable=False),
-    sa.Column("id1_type", sa.Text(), nullable=False),
-    sa.Column("edge_type", sa.Text(), nullable=False),
-    sa.Column("id2", sa.Text(), nullable=False),
-    sa.Column("id2_type", sa.Text(), nullable=False),
-    sa.Column("time", sa.TIMESTAMP(), nullable=False),
-    sa.Column("data", sa.Text(), nullable=True),
-    sa.PrimaryKeyConstraint("id1", "edge_type", "id2", name="todo_tags_edges_id1_edge_type_id2_pkey"),
-    sa.Index("todo_tags_edges_time_idx", "time"),
-)
-   
+         sa.Column("id1", sa.Text(), nullable=False),
+         sa.Column("id1_type", sa.Text(), nullable=False),
+         sa.Column("edge_type", sa.Text(), nullable=False),
+         sa.Column("id2", sa.Text(), nullable=False),
+         sa.Column("id2_type", sa.Text(), nullable=False),
+         sa.Column("time", sa.TIMESTAMP(), nullable=False),
+         sa.Column("data", sa.Text(), nullable=True),
+         sa.PrimaryKeyConstraint(
+             "id1", "edge_type", "id2", name="todo_tags_edges_id1_edge_type_id2_pkey"),
+         sa.Index("todo_tags_edges_time_idx", "time"),
+         )
+
 sa.Table("todos", metadata,
-    sa.Column("id", sa.Text(), nullable=False),
-    sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
-    sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
-    sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
-    sa.Column("text", sa.Text(), nullable=False),
-    sa.Column("completed", sa.Boolean(), nullable=False),
-    sa.Column("creator_id", sa.Text(), nullable=False),
-    sa.Index("todos_deleted_at_idx", "deleted_at"),
-    sa.Index("todos_completed_idx", "completed"),
-    sa.Index("todos_creator_id_idx", "creator_id"),
-    sa.PrimaryKeyConstraint("id", name="todos_id_pkey"),
-    sa.ForeignKeyConstraint(["creator_id"], ["accounts.id"], name="todos_creator_id_fkey", ondelete="CASCADE"),
-)
-  
+         sa.Column("id", sa.Text(), nullable=False),
+         sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+         sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
+         sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
+         sa.Column("text", sa.Text(), nullable=False),
+         sa.Column("completed", sa.Boolean(), nullable=False),
+         sa.Column("creator_id", sa.Text(), nullable=False),
+         sa.Index("todos_deleted_at_idx", "deleted_at"),
+         sa.Index("todos_completed_idx", "completed"),
+         sa.Index("todos_creator_id_idx", "creator_id"),
+         sa.PrimaryKeyConstraint("id", name="todos_id_pkey"),
+         sa.ForeignKeyConstraint(["creator_id"], [
+                                 "accounts.id"], name="todos_creator_id_fkey", ondelete="CASCADE"),
+         )
+
 
 metadata.info["edges"] = {
-  'public': {
-    'TagToTodosEdge': {"edge_name":"TagToTodosEdge", "edge_type":"79af8e13-22a1-4462-97e9-56832c053aaf", "edge_table":"todo_tags_edges", "symmetric_edge":False, "inverse_edge_type":"7197f874-e259-45d1-9c1a-b0967c964507"},
-    'TodoToTagsEdge': {"edge_name":"TodoToTagsEdge", "edge_type":"7197f874-e259-45d1-9c1a-b0967c964507", "edge_table":"todo_tags_edges", "symmetric_edge":False, "inverse_edge_type":"79af8e13-22a1-4462-97e9-56832c053aaf"},
-  }
+    'public': {
+        'TagToTodosEdge': {"edge_name": "TagToTodosEdge", "edge_type": "79af8e13-22a1-4462-97e9-56832c053aaf", "edge_table": "todo_tags_edges", "symmetric_edge": False, "inverse_edge_type": "7197f874-e259-45d1-9c1a-b0967c964507"},
+        'TodoToTagsEdge': {"edge_name": "TodoToTagsEdge", "edge_type": "7197f874-e259-45d1-9c1a-b0967c964507", "edge_table": "todo_tags_edges", "symmetric_edge": False, "inverse_edge_type": "79af8e13-22a1-4462-97e9-56832c053aaf"},
+    }
 }
 
 
-
 def get_metadata():
-  return metadata
+    return metadata

--- a/examples/todo-sqlite/src/testsetup/setup.ts
+++ b/examples/todo-sqlite/src/testsetup/setup.ts
@@ -1,7 +1,10 @@
-import { DB } from "@snowtop/ent";
+import { DB, loadConfig } from "@snowtop/ent";
 
 beforeAll(() => {
-  process.env.DB_CONNECTION_STRING = `sqlite:///todo22.db`;
+  process.env.DB_CONNECTION_STRING = `sqlite:///todo.db`;
+  loadConfig({
+    // log: "query",
+  });
 });
 
 afterAll(async () => {

--- a/examples/todo-sqlite/src/testsetup/setup.ts
+++ b/examples/todo-sqlite/src/testsetup/setup.ts
@@ -1,7 +1,7 @@
 import { DB } from "@snowtop/ent";
 
 beforeAll(() => {
-  process.env.DB_CONNECTION_STRING = `sqlite:///todo.db`;
+  process.env.DB_CONNECTION_STRING = `sqlite:///todo22.db`;
 });
 
 afterAll(async () => {

--- a/internal/action/interface.go
+++ b/internal/action/interface.go
@@ -56,7 +56,9 @@ type Action interface {
 
 type ActionField interface {
 	GetFieldType() enttype.EntType
-	TsFieldName() string
+	TsFieldName(cfg codegenapi.Config) string
+	TSPublicAPIName() string
+	TsBuilderFieldName() string
 	GetGraphQLName() string
 	ForceRequiredInAction() bool
 	ForceOptionalInAction() bool

--- a/internal/action/interface.go
+++ b/internal/action/interface.go
@@ -57,6 +57,7 @@ type Action interface {
 type ActionField interface {
 	GetFieldType() enttype.EntType
 	TsFieldName(cfg codegenapi.Config) string
+	TsBuilderType() string
 	TSPublicAPIName() string
 	TsBuilderFieldName() string
 	GetGraphQLName() string

--- a/internal/auto_schema/auto_schema.go
+++ b/internal/auto_schema/auto_schema.go
@@ -49,6 +49,7 @@ func RunPythonCommandWriter(cfg codegenapi.Config, w io.Writer, extraArgs ...str
 	if len(extraArgs) > 0 {
 		args = append(args, extraArgs...)
 	}
+
 	cmd := exec.Command(executable, args...)
 	if local {
 		cmd.Env = append(cmd.Env, "LOCAL_AUTO_SCHEMA=true")

--- a/internal/codegen/codegenapi/api.go
+++ b/internal/codegen/codegenapi/api.go
@@ -22,10 +22,18 @@ const (
 	SnakeCase GraphQLFieldFormat = "snake_case"
 )
 
+type FieldPrivacyEvaluated string
+
+const (
+	AtEntLoad FieldPrivacyEvaluated = "at_ent_load"
+	OnDemand  FieldPrivacyEvaluated = "on_demand"
+)
+
 // this file exists to simplify circular dependencies
 type Config interface {
 	DefaultGraphQLMutationName() GraphQLMutationName
 	DefaultGraphQLFieldFormat() GraphQLFieldFormat
+	FieldPrivacyEvaluated() FieldPrivacyEvaluated
 	GetRootPathToConfigs() string
 	DebugMode() bool
 }
@@ -48,6 +56,10 @@ func (cfg *DummyConfig) GetRootPathToConfigs() string {
 
 func (cfg *DummyConfig) DebugMode() bool {
 	return false
+}
+
+func (cfg DummyConfig) FieldPrivacyEvaluated() FieldPrivacyEvaluated {
+	return OnDemand
 }
 
 var _ Config = &DummyConfig{}

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -339,6 +339,15 @@ func (cfg *Config) DatabaseToCompareTo() string {
 	return ""
 }
 
+func (cfg *Config) FieldPrivacyEvaluated() codegenapi.FieldPrivacyEvaluated {
+	if codegen := cfg.getCodegenConfig(); codegen != nil {
+		if codegen.DefaultGraphQLFieldFormat != "" {
+			return codegen.FieldPrivacyEvaluated
+		}
+	}
+	return codegenapi.OnDemand
+}
+
 const DEFAULT_GLOB = "src/**/*.ts"
 const PRETTIER_FILE_CHUNKS = 20
 
@@ -473,18 +482,19 @@ func cloneConfig(cfg *config) *config {
 }
 
 type CodegenConfig struct {
-	DefaultEntPolicy           *PrivacyConfig                 `yaml:"defaultEntPolicy"`
-	DefaultActionPolicy        *PrivacyConfig                 `yaml:"defaultActionPolicy"`
-	Prettier                   *PrettierConfig                `yaml:"prettier"`
-	RelativeImports            bool                           `yaml:"relativeImports"`
-	DisableGraphQLRoot         bool                           `yaml:"disableGraphQLRoot"`
-	GeneratedHeader            string                         `yaml:"generatedHeader"`
-	DisableBase64Encoding      bool                           `yaml:"disableBase64Encoding"`
-	GenerateRootResolvers      bool                           `yaml:"generateRootResolvers"`
-	DefaultGraphQLMutationName codegenapi.GraphQLMutationName `yaml:"defaultGraphQLMutationName"`
-	DefaultGraphQLFieldFormat  codegenapi.GraphQLFieldFormat  `yaml:"defaultGraphQLFieldFormat"`
-	SchemaSQLFilePath          string                         `yaml:"schemaSQLFilePath"`
-	DatabaseToCompareTo        string                         `yaml:"databaseToCompareTo"`
+	DefaultEntPolicy           *PrivacyConfig                   `yaml:"defaultEntPolicy"`
+	DefaultActionPolicy        *PrivacyConfig                   `yaml:"defaultActionPolicy"`
+	Prettier                   *PrettierConfig                  `yaml:"prettier"`
+	RelativeImports            bool                             `yaml:"relativeImports"`
+	DisableGraphQLRoot         bool                             `yaml:"disableGraphQLRoot"`
+	GeneratedHeader            string                           `yaml:"generatedHeader"`
+	DisableBase64Encoding      bool                             `yaml:"disableBase64Encoding"`
+	GenerateRootResolvers      bool                             `yaml:"generateRootResolvers"`
+	DefaultGraphQLMutationName codegenapi.GraphQLMutationName   `yaml:"defaultGraphQLMutationName"`
+	DefaultGraphQLFieldFormat  codegenapi.GraphQLFieldFormat    `yaml:"defaultGraphQLFieldFormat"`
+	SchemaSQLFilePath          string                           `yaml:"schemaSQLFilePath"`
+	DatabaseToCompareTo        string                           `yaml:"databaseToCompareTo"`
+	FieldPrivacyEvaluated      codegenapi.FieldPrivacyEvaluated `yaml:"fieldPrivacyEvaluated"`
 }
 
 func cloneCodegen(cfg *CodegenConfig) *CodegenConfig {
@@ -508,6 +518,7 @@ func (cfg *CodegenConfig) Clone() *CodegenConfig {
 		DefaultGraphQLFieldFormat:  cfg.DefaultGraphQLFieldFormat,
 		SchemaSQLFilePath:          cfg.SchemaSQLFilePath,
 		DatabaseToCompareTo:        cfg.DatabaseToCompareTo,
+		FieldPrivacyEvaluated:      cfg.FieldPrivacyEvaluated,
 	}
 }
 

--- a/internal/db/db_schema.tmpl
+++ b/internal/db/db_schema.tmpl
@@ -2,7 +2,7 @@
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-from auto_schema.schema_item import FullTextIndex
+#from auto_schema.schema_item import FullTextIndex
 
 metadata = sa.MetaData()
 

--- a/internal/db/db_schema.tmpl
+++ b/internal/db/db_schema.tmpl
@@ -2,7 +2,7 @@
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-#from auto_schema.schema_item import FullTextIndex
+from auto_schema.schema_item import FullTextIndex
 
 metadata = sa.MetaData()
 

--- a/internal/field/compare_field.go
+++ b/internal/field/compare_field.go
@@ -78,6 +78,7 @@ func FieldEqual(existing, field *Field) bool {
 		existing.disableUserGraphQLEditable == field.disableUserGraphQLEditable &&
 		existing.hasDefaultValueOnCreate == field.hasDefaultValueOnCreate &&
 		existing.hasDefaultValueOnEdit == field.hasDefaultValueOnEdit &&
+		existing.hasFieldPrivacy == field.hasFieldPrivacy &&
 		existing.forceRequiredInAction == field.forceRequiredInAction &&
 		existing.forceOptionalInAction == field.forceOptionalInAction &&
 		existing.patternName == field.patternName

--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -213,8 +213,8 @@ func newFieldFromInput(cfg codegenapi.Config, f *input.Field) (*Field, error) {
 		ret.disableBuilderType = ret.polymorphic.DisableBuilderType
 	}
 
-	if ret.HasAsyncAccessor(cfg) {
-		//		spew.Dump("has any", ret.FieldName)
+	// if field privacy, whether on demand or ent load, the type here is nullable
+	if ret.hasFieldPrivacy {
 		nullableType, ok := ret.fieldType.(enttype.NullableType)
 		if ok {
 			if err := ret.setGraphQLFieldType(nullableType.GetNullableType()); err != nil {
@@ -522,11 +522,19 @@ func (f *Field) TsFieldName(cfg codegenapi.Config) string {
 }
 
 func (f *Field) TsBuilderFieldName() string {
+	// TODO need to solve these id issues generally
+	if f.FieldName == "ID" {
+		return "id"
+	}
 	return strcase.ToLowerCamel(f.FieldName)
 }
 
 // either async function name or public field
 func (f *Field) TSPublicAPIName() string {
+	// TODO need to solve these id issues generally
+	if f.FieldName == "ID" {
+		return "id"
+	}
 	return strcase.ToLowerCamel(f.FieldName)
 }
 

--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -26,7 +26,6 @@ type Field struct {
 	topLevelStructField bool       // id, updated_at, created_at no...
 	entType             types.Type // not all fields will have an entType. probably don't need this...
 
-	// TODO nullable version when privacy is nullable
 	fieldType enttype.TSGraphQLType // this is the underlying type for the field for graphql, db, etc
 	// in certain scenarios we need a different type for graphql vs typescript
 	graphqlFieldType enttype.TSGraphQLType

--- a/internal/field/field_type.go
+++ b/internal/field/field_type.go
@@ -548,6 +548,15 @@ func (f *Field) TsType() string {
 	return f.tsRawUnderlyingType()
 }
 
+// type of the field in the class e.g. readonly name type;
+func (f *Field) TsFieldType(cfg codegenapi.Config) string {
+	// there's a method that's nullable so return raw type
+	if f.HasAsyncAccessor(cfg) {
+		return f.tsRawUnderlyingType()
+	}
+	return f.TsType()
+}
+
 func (f *Field) tsRawUnderlyingType() string {
 	return f.fieldType.GetTSType()
 }

--- a/internal/field/non_ent_field.go
+++ b/internal/field/non_ent_field.go
@@ -56,6 +56,9 @@ func (f *NonEntField) GetTsType() string {
 	return f.fieldType.GetTSType()
 }
 
+func (f *NonEntField) TsBuilderType() string {
+	return f.fieldType.GetTSType()
+}
 func (f *NonEntField) GetFieldType() enttype.EntType {
 	return f.fieldType
 }

--- a/internal/field/non_ent_field.go
+++ b/internal/field/non_ent_field.go
@@ -59,6 +59,7 @@ func (f *NonEntField) GetTsType() string {
 func (f *NonEntField) TsBuilderType() string {
 	return f.fieldType.GetTSType()
 }
+
 func (f *NonEntField) GetFieldType() enttype.EntType {
 	return f.fieldType
 }

--- a/internal/field/non_ent_field.go
+++ b/internal/field/non_ent_field.go
@@ -64,7 +64,15 @@ func (f *NonEntField) GetGraphQLFieldType() enttype.TSGraphQLType {
 	return f.fieldType
 }
 
-func (f *NonEntField) TsFieldName() string {
+func (f *NonEntField) TsFieldName(cfg codegenapi.Config) string {
+	return strcase.ToLowerCamel(f.fieldName)
+}
+
+func (f *NonEntField) TsBuilderFieldName() string {
+	return strcase.ToLowerCamel(f.fieldName)
+}
+
+func (f *NonEntField) TSPublicAPIName() string {
 	return strcase.ToLowerCamel(f.fieldName)
 }
 

--- a/internal/field/ts_fields_test.go
+++ b/internal/field/ts_fields_test.go
@@ -1,0 +1,284 @@
+package field
+
+import (
+	"testing"
+
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
+	"github.com/lolopinto/ent/internal/schema/input"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// this is to test the different field type APIs introduced with https://github.com/lolopinto/ent/pull/867/files
+// maybe simpler in the future
+type expected struct {
+	private            bool
+	asyncAccessor      bool
+	tsFieldName        string
+	tsBuilderFieldName string
+	tsPublicAPIName    string
+	tsType             string
+	tsFieldType        string
+	tsBuilderType      string
+	// undefined added in builder.tmpl
+	tsBuilderUnionType string
+	//	graphqlType        string
+}
+
+func TestNonNullableField(t *testing.T) {
+	cfg := &codegenapi.DummyConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name: "name",
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string",
+		tsFieldType:        "string",
+		tsBuilderType:      "string",
+		tsBuilderUnionType: "string",
+		//		graphqlType:        "String!",
+	})
+}
+
+func TestNullableField(t *testing.T) {
+	cfg := &codegenapi.DummyConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name:     "name",
+		Nullable: true,
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string | null",
+		tsFieldType:        "string | null",
+		tsBuilderType:      "string | null",
+		tsBuilderUnionType: "string | null",
+	})
+}
+
+type onDemandConfig struct {
+	codegenapi.DummyConfig
+}
+
+func (cfg *onDemandConfig) FieldPrivacyEvaluated() codegenapi.FieldPrivacyEvaluated {
+	return codegenapi.OnDemand
+}
+
+type onEntLoadConfig struct {
+	codegenapi.DummyConfig
+}
+
+func (cfg *onEntLoadConfig) FieldPrivacyEvaluated() codegenapi.FieldPrivacyEvaluated {
+	return codegenapi.AtEntLoad
+}
+
+func TestNonNullableFieldOnDemand(t *testing.T) {
+	cfg := &onDemandConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name: "name",
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+		HasFieldPrivacy: true,
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            true,
+		asyncAccessor:      true,
+		tsFieldName:        "_name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string | null",
+		tsFieldType:        "string",
+		tsBuilderType:      "string",
+		tsBuilderUnionType: "string | null",
+	})
+}
+
+func TestNonNullableFieldOnDemandNoFieldPrivacy(t *testing.T) {
+	cfg := &onDemandConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name: "name",
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string",
+		tsFieldType:        "string",
+		tsBuilderType:      "string",
+		tsBuilderUnionType: "string",
+	})
+}
+
+func TestNullableFieldOnDemand(t *testing.T) {
+	cfg := &onDemandConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name:     "name",
+		Nullable: true,
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+		HasFieldPrivacy: true,
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            true,
+		asyncAccessor:      true,
+		tsFieldName:        "_name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string | null",
+		tsFieldType:        "string | null",
+		tsBuilderType:      "string | null",
+		tsBuilderUnionType: "string | null",
+	})
+}
+
+func TestNullableFieldOnDemandNoFieldPrivacy(t *testing.T) {
+	cfg := &onDemandConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name:     "name",
+		Nullable: true,
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string | null",
+		tsFieldType:        "string | null",
+		tsBuilderType:      "string | null",
+		tsBuilderUnionType: "string | null",
+	})
+}
+
+func TestNonNullableFieldOnEntLoad(t *testing.T) {
+	cfg := &onEntLoadConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name: "name",
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+		HasFieldPrivacy: true,
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string | null",
+		tsFieldType:        "string | null",
+		tsBuilderType:      "string",
+		tsBuilderUnionType: "string | null",
+	})
+}
+
+func TestNonNullableFieldOnEntLoadNoFieldPrivacy(t *testing.T) {
+	cfg := &onEntLoadConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name: "name",
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string",
+		tsFieldType:        "string",
+		tsBuilderType:      "string",
+		tsBuilderUnionType: "string",
+	})
+}
+
+func TestNullableFieldOnEntLoad(t *testing.T) {
+	cfg := &onEntLoadConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name:     "name",
+		Nullable: true,
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+		HasFieldPrivacy: true,
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string | null",
+		tsFieldType:        "string | null",
+		tsBuilderType:      "string | null",
+		tsBuilderUnionType: "string | null",
+	})
+}
+
+func TestNullableFieldOnEntLoadNoFieldPrivacy(t *testing.T) {
+	cfg := &onEntLoadConfig{}
+	f, err := newFieldFromInput(cfg, &input.Field{
+		Name:     "name",
+		Nullable: true,
+		Type: &input.FieldType{
+			DBType: input.String,
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "string | null",
+		tsFieldType:        "string | null",
+		tsBuilderType:      "string | null",
+		tsBuilderUnionType: "string | null",
+	})
+}
+
+func doTestField(t *testing.T, cfg codegenapi.Config, f *Field, exp *expected) {
+	assert.Equal(t, exp.private, f.Private(cfg))
+	assert.Equal(t, exp.asyncAccessor, f.HasAsyncAccessor(cfg))
+	assert.Equal(t, exp.tsFieldName, f.TsFieldName(cfg))
+	assert.Equal(t, exp.tsBuilderFieldName, f.TsBuilderFieldName())
+	assert.Equal(t, exp.tsPublicAPIName, f.TSPublicAPIName())
+	assert.Equal(t, exp.tsType, f.TsType())
+	assert.Equal(t, exp.tsFieldType, f.TsFieldType(cfg))
+	assert.Equal(t, exp.tsBuilderType, f.TsBuilderType())
+	assert.Equal(t, exp.tsBuilderUnionType, f.TsBuilderUnionType())
+}

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -1951,9 +1951,10 @@ func buildActionInputNode(processor *codegen.Processor, nodeData *schema.NodeDat
 					}
 				}
 				intType.Fields = append(intType.Fields, &interfaceField{
-					Name:       f.GetGraphQLName(),
-					Optional:   !action.IsRequiredField(a, f),
-					Type:       f.GetTsType(),
+					Name:     f.GetGraphQLName(),
+					Optional: !action.IsRequiredField(a, f),
+					// TODO we want the same types without the Builder part if it's an id field...
+					Type:       f.TsBuilderType(),
 					UseImports: useImports,
 				})
 			}

--- a/internal/schema/input/compare.go
+++ b/internal/schema/input/compare.go
@@ -58,6 +58,7 @@ func fieldEqual(existingField, field *Field) bool {
 		existingField.DisableUserEditable == field.DisableUserEditable &&
 		existingField.HasDefaultValueOnCreate == field.HasDefaultValueOnCreate &&
 		existingField.HasDefaultValueOnEdit == field.HasDefaultValueOnEdit &&
+		existingField.HasFieldPrivacy == field.HasFieldPrivacy &&
 
 		PolymorphicOptionsEqual(existingField.Polymorphic, field.Polymorphic) &&
 		existingField.DerivedWhenEmbedded == field.DerivedWhenEmbedded &&

--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -125,6 +125,7 @@ type Field struct {
 	DisableUserGraphQLEditable bool `json:"disableUserGraphQLEditable,omitempty"`
 	HasDefaultValueOnCreate    bool `json:"hasDefaultValueOnCreate,omitempty"`
 	HasDefaultValueOnEdit      bool `json:"hasDefaultValueOnEdit,omitempty"`
+	HasFieldPrivacy            bool `json:"hasFieldPrivacy"`
 
 	Polymorphic         *PolymorphicOptions `json:"polymorphic,omitempty"`
 	DerivedWhenEmbedded bool                `json:"derivedWhenEmbedded,omitempty"`

--- a/internal/schema/input/parse_ts_test.go
+++ b/internal/schema/input/parse_ts_test.go
@@ -51,6 +51,7 @@ type field struct {
 	disableUserGraphQLEditable bool
 	hasDefaultValueOnCreate    bool
 	hasDefaultValueOnEdit      bool
+	hasFieldPrivacy            bool
 	polymorphic                *input.PolymorphicOptions
 	derivedFields              []field
 }
@@ -217,6 +218,7 @@ func verifyField(t *testing.T, expField field, field *input.Field) {
 	assert.Equal(t, expField.disableUserGraphQLEditable, field.DisableUserGraphQLEditable)
 	assert.Equal(t, expField.hasDefaultValueOnCreate, field.HasDefaultValueOnCreate)
 	assert.Equal(t, expField.hasDefaultValueOnEdit, field.HasDefaultValueOnEdit)
+	assert.Equal(t, expField.hasFieldPrivacy, field.HasFieldPrivacy)
 
 	assert.Equal(t, expField.foreignKey, field.ForeignKey)
 	assert.Equal(t, expField.fieldEdge, field.FieldEdge)

--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -186,6 +186,13 @@ func (nodeData *NodeData) FieldsWithFieldPrivacy() bool {
 	return false
 }
 
+func (nodeData *NodeData) OnEntLoadFieldPrivacy(cfg codegenapi.Config) bool {
+	if !nodeData.FieldsWithFieldPrivacy() {
+		return false
+	}
+	return cfg.FieldPrivacyEvaluated() == codegenapi.AtEntLoad
+}
+
 // return the list of unique nodes at the end of an association
 // needed to import what's needed in generated code
 type uniqueNodeInfo struct {

--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/jinzhu/inflection"
 	"github.com/lolopinto/ent/internal/action"
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/codegen/nodeinfo"
 	"github.com/lolopinto/ent/internal/codepath"
 	"github.com/lolopinto/ent/internal/edge"
@@ -155,9 +156,9 @@ func (nodeData *NodeData) HasJSONField() bool {
 	return false
 }
 
-func (nodeData *NodeData) HasPrivateField() bool {
+func (nodeData *NodeData) HasPrivateField(cfg codegenapi.Config) bool {
 	for _, field := range nodeData.FieldInfo.Fields {
-		if field.Private() {
+		if field.Private(cfg) {
 			return true
 		}
 	}
@@ -174,6 +175,15 @@ func (nodeData *NodeData) HasAssocGroups() bool {
 		panic("TODO: fix EdgeGroupMuationBuilder to work for more than 1 assoc group")
 	}
 	return length > 0
+}
+
+func (nodeData *NodeData) FieldsWithFieldPrivacy() bool {
+	for _, f := range nodeData.FieldInfo.Fields {
+		if f.HasFieldPrivacy() {
+			return true
+		}
+	}
+	return false
 }
 
 // return the list of unique nodes at the end of an association

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -808,7 +808,7 @@ func (s *Schema) addLinkedEdges(cfg codegenapi.Config, info *NodeDataInfo) error
 			// so we want to add it to edges for
 			if err := edgeInfo.AddIndexedEdgeFromSource(
 				cfg,
-				f.TsFieldName(),
+				f.TsFieldName(cfg),
 				f.GetQuotedDBColName(),
 				nodeData.Node,
 				e.Polymorphic,
@@ -827,7 +827,7 @@ func (s *Schema) addLinkedEdges(cfg codegenapi.Config, info *NodeDataInfo) error
 						//						spew.Dump(nodeData.Node, foreign.NodeData.Node)
 						if err := fEdgeInfo.AddDestinationEdgeFromPolymorphicOptions(
 							cfg,
-							f.TsFieldName(),
+							f.TsFieldName(cfg),
 							f.GetQuotedDBColName(),
 							nodeData.Node,
 							e.Polymorphic,

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -34,17 +34,17 @@
         {{$ignore := useImport .Import -}}
       {{end -}}
       {{if $field.ForceRequiredInAction -}}
-        {{$field.TsFieldName}}: {{$type}};
+        {{$field.TsBuilderFieldName}}: {{$type}};
       {{else -}}
-        {{$field.TsFieldName}}?: {{$type}};
+        {{$field.TsBuilderFieldName}}?: {{$type}};
       {{end -}}
     {{end -}}
     {{ range $field := $int.NonEntFields -}}
       {{$type := $field.GetTsType -}}
       {{if $field.Required -}}
-        {{$field.TsFieldName}}: {{$type}};
+        {{$field.TsBuilderFieldName}}: {{$type}};
       {{else -}}
-        {{$field.TsFieldName}}?: {{$type}};
+        {{$field.TsBuilderFieldName}}?: {{$type}};
       {{end -}}
     {{end -}}
   }
@@ -67,18 +67,18 @@
         {{ $ignore := useImport .Import -}}
       {{end -}}
       {{if isRequiredField $action $field -}}
-        {{$field.TsFieldName}}: {{$type}};
+        {{$field.TsBuilderFieldName}}: {{$type}};
       {{else -}}
-        {{$field.TsFieldName}}?: {{$type}};
+        {{$field.TsBuilderFieldName}}?: {{$type}};
       {{end -}}
     {{end -}}
 
     {{ range $field := $action.GetNonEntFields -}}
       {{$type := $field.GetTsType -}}
       {{if $field.Required -}}
-        {{$field.TsFieldName}}: {{$type}};
+        {{$field.TsBuilderFieldName}}: {{$type}};
       {{else -}}
-        {{$field.TsFieldName}}?: {{$type}};
+        {{$field.TsBuilderFieldName}}?: {{$type}};
       {{end -}}
     {{end -}}
   }

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -78,6 +78,10 @@ export class {{$baseClass}} {
   {{range $field := .FieldInfo.Fields -}}
     {{ if $field.HasAsyncAccessor $cfg -}}
       async {{$field.TSPublicAPIName}}(): Promise<{{$field.TsType}}> {
+        {{/* need to check if this can actually be null */ -}}
+        if (this.{{$field.TsFieldName $cfg}} === null) {
+          return null;
+        }
         const m = {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}});
         const p = m.get("{{$field.GetDbColName}}");
         if (!p) {
@@ -451,14 +455,26 @@ export class {{$baseClass}} {
     {{ if $edge.NonPolymorphicList -}}
       {{with .NodeInfo -}}
         async load{{$edgeName}}(): Promise<{{useImport .Node}}|null> {
-          {{ if $edge.Nullable -}}
-            if (!this.{{$edge.TSFieldName}}) {
+          {{ $field := $nodeData.GetFieldByName $edge.FieldName -}}
+          {{ if and $field ($field.HasAsyncAccessor $cfg) -}}
+            const {{$edge.TSFieldName}} = await this.{{$edge.TSFieldName}}();
+            if (!{{$edge.TSFieldName}}) {
               return null;
             }
-          {{end -}}
+          {{ else -}}
+            {{ if $edge.Nullable -}}
+              if (!this.{{$edge.TSFieldName}}) {
+                return null;
+              }
+            {{end -}}
+          {{ end}}
           return {{useImport "loadEnt"}}(
             this.viewer, 
-            this.{{$edge.TSFieldName}},
+            {{ if and $field ($field.HasAsyncAccessor $cfg) -}}
+              {{$edge.TSFieldName}},
+            {{ else -}}
+              this.{{$edge.TSFieldName}},
+            {{end -}}
             {{useImport .Node}}.loaderOptions(),
           );
         }

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -286,9 +286,8 @@ export class {{$baseClass}} {
       fields: {{useImport $loaderInfo}}.fields,
       ent: this,
       loaderFactory: {{useImport $loaderName}},
-      {{/* TODO this is on-demand vs on-load */}}
-      {{if .FieldsWithFieldPrivacy -}}
-//        fieldPrivacy: {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}}),
+      {{if .OnEntLoadFieldPrivacy $cfg -}}
+        fieldPrivacy: {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}}),
       {{end -}}
     };
   }

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -48,11 +48,10 @@ export class {{$baseClass}} {
       {{end -}}
       {{$typ := useImportMaybe .Import -}}
     {{end -}}
-    {{/* TODO this needs to be originalTSType because some of these are non-nullable in the db... */ -}}
     {{ if $field.Private $cfg -}}
-      protected readonly {{$field.TsFieldName $cfg}}: {{$field.TsType}};
+      protected readonly {{$field.TsFieldName $cfg}}: {{$field.TsFieldType $cfg}};
     {{ else -}}
-      readonly {{$field.TsFieldName $cfg}}: {{$field.TsType}};
+      readonly {{$field.TsFieldName $cfg}}: {{$field.TsFieldType $cfg}};
     {{end -}}
   {{end}}
 

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -1,10 +1,11 @@
-{{ reserveImport .Package.PackagePath "loadEnt" "ID" "Data" "Viewer" "loadEntX" "loadEnts" "LoadEntOptions" "AssocEdge" "loadNodesByEdge" "loadRow" "loadRows" "loadRowX" "loadUniqueEdge" "loadUniqueNode" "AllowIfViewerPrivacyPolicy" "PrivacyPolicy" "query" "Ent" "getEdgeTypeInGroup" "ObjectLoaderFactory" "Context" "IndexLoaderFactory" "loadEntViaKey" "loadEntXViaKey" "CustomQuery" "loadCustomEnts" "loadCustomData"}}
-{{ reserveImport .Package.SchemaPackagePath "Field" "getFields"}}
+{{ reserveImport .Package.PackagePath "loadEnt" "ID" "Data" "Viewer" "loadEntX" "loadEnts" "LoadEntOptions" "AssocEdge" "loadNodesByEdge" "loadRow" "loadRows" "loadRowX" "loadUniqueEdge" "loadUniqueNode" "AllowIfViewerPrivacyPolicy" "PrivacyPolicy" "query" "Ent" "getEdgeTypeInGroup" "ObjectLoaderFactory" "Context" "IndexLoaderFactory" "loadEntViaKey" "loadEntXViaKey" "CustomQuery" "loadCustomEnts" "loadCustomData" "applyPrivacyPolicy"}}
+{{ reserveImport .Package.SchemaPackagePath "Field" "getFields" "getFieldsWithPrivacy"}}
 {{ reserveImport .Package.InternalImportPath "EdgeType" "NodeType" }}
 {{ reserveImport "src/ent/generated/loadAny" "loadEntByType" "loadEntXByType"}}
 {{ reserveImport .PrivacyConfig.Path .PrivacyConfig.PolicyName }}
 
 {{ $privacyCfg := .PrivacyConfig -}}
+{{ $cfg := .CodePath -}}
 
 {{with .NodeData -}}
 {{$loaderInfo := printf "%sLoaderInfo" .NodeInstance -}}
@@ -47,10 +48,11 @@ export class {{$baseClass}} {
       {{end -}}
       {{$typ := useImportMaybe .Import -}}
     {{end -}}
-    {{ if $field.Private -}}
-      protected readonly {{$field.TsFieldName}}: {{$field.TsType}};
+    {{/* TODO this needs to be originalTSType because some of these are non-nullable in the db... */ -}}
+    {{ if $field.Private $cfg -}}
+      protected readonly {{$field.TsFieldName $cfg}}: {{$field.TsType}};
     {{ else -}}
-      readonly {{$field.TsFieldName}}: {{$field.TsType}};
+      readonly {{$field.TsFieldName $cfg}}: {{$field.TsType}};
     {{end -}}
   {{end}}
 
@@ -60,9 +62,9 @@ export class {{$baseClass}} {
       {{$convertType := convertFunc $field.GetFieldType -}}
       {{if $convertType -}} 
         {{/* could be BigInt which isn't reserved */ -}}
-        this.{{$field.TsFieldName}} = {{useImportMaybe $convertType}}({{$val}});
+        this.{{$field.TsFieldName $cfg}} = {{useImportMaybe $convertType}}({{$val}});
       {{ else -}}
-        this.{{$field.TsFieldName}} = {{$val}};
+        this.{{$field.TsFieldName $cfg}} = {{$val}};
       {{end -}}
     {{end}}
   }
@@ -72,6 +74,20 @@ export class {{$baseClass}} {
   {{ else }}
     privacyPolicy: {{useImport "PrivacyPolicy"}} = {{useImport $privacyCfg.PolicyName}};
   {{ end }}
+
+  {{range $field := .FieldInfo.Fields -}}
+    {{ if $field.HasAsyncAccessor $cfg -}}
+      async {{$field.TSPublicAPIName}}(): Promise<{{$field.TsType}}> {
+        const m = {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}});
+        const p = m.get("{{$field.GetDbColName}}");
+        if (!p) {
+          throw new Error(`couldn't get field privacy policy for {{$field.TSPublicAPIName}}`);
+        }
+        const v = await {{useImport "applyPrivacyPolicy"}}(this.viewer, p, this);
+        return v ? this.{{$field.TsFieldName $cfg}} : null;
+      }
+    {{ end }}
+  {{ end -}}
 
   static async load<T extends {{$baseClass}}>(
     this: {{$thisType}},
@@ -201,11 +217,11 @@ export class {{$baseClass}} {
       static async loadFrom{{$field.CamelCaseName}}<T extends {{$baseClass}}>(
         this: {{$thisType}},
         viewer: {{$viewerType}},
-        {{$field.TsFieldName}}: {{$field.GetNotNullableTsType}},
+        {{$field.TsFieldName $cfg}}: {{$field.GetNotNullableTsType}},
       ): Promise<T | null> {
         return await {{useImport "loadEntViaKey"}}(
           viewer, 
-          {{$field.TsFieldName}},
+          {{$field.TsFieldName $cfg}},
           {
             ...{{$baseClass}}.loaderOptions.apply(this), 
             loaderFactory: {{$fieldLoader}},
@@ -216,11 +232,11 @@ export class {{$baseClass}} {
       static async loadFrom{{$field.CamelCaseName}}X<T extends {{$baseClass}}>(
         this: {{$thisType}},
         viewer: Viewer,
-        {{$field.TsFieldName}}: {{$field.GetNotNullableTsType}},
+        {{$field.TsFieldName $cfg}}: {{$field.GetNotNullableTsType}},
       ): Promise<T> {
         return await {{useImport "loadEntXViaKey"}}(
           viewer, 
-          {{$field.TsFieldName}},
+          {{$field.TsFieldName $cfg}},
           {
             ...{{$baseClass}}.loaderOptions.apply(this), 
             loaderFactory: {{$fieldLoader}},
@@ -230,19 +246,19 @@ export class {{$baseClass}} {
 
       static async loadIDFrom{{$field.CamelCaseName}}<T extends {{$baseClass}}>(
         this: {{$thisType}},
-        {{$field.TsFieldName}}: {{$field.GetNotNullableTsType}},
+        {{$field.TsFieldName $cfg}}: {{$field.GetNotNullableTsType}},
         context?: {{useImport "Context"}},
       ): Promise<{{$idType}} | undefined> {
-        const row = await {{$fieldLoader}}.createLoader(context).load({{$field.TsFieldName}});
+        const row = await {{$fieldLoader}}.createLoader(context).load({{$field.TsFieldName $cfg}});
         return row?.id;
       }
 
       static async loadRawDataFrom{{$field.CamelCaseName}}<T extends {{$baseClass}}>(
         this: {{$thisType}},
-        {{$field.TsFieldName}}: {{$field.GetNotNullableTsType}},
+        {{$field.TsFieldName $cfg}}: {{$field.GetNotNullableTsType}},
         context?: {{useImport "Context"}},
       ): Promise<{{$dataType}} | null> {
-        return {{$fieldLoader}}.createLoader(context).load({{$field.TsFieldName}});
+        return {{$fieldLoader}}.createLoader(context).load({{$field.TsFieldName $cfg}});
       }
     {{ else if $field.QueryFromEnt -}}
       {{$queryName := useImport ($this.GetFieldQueryName $field) -}}
@@ -266,6 +282,10 @@ export class {{$baseClass}} {
       fields: {{useImport $loaderInfo}}.fields,
       ent: this,
       loaderFactory: {{useImport $loaderName}},
+      {{/* TODO this is on-demand vs on-load */}}
+      {{if .FieldsWithFieldPrivacy -}}
+//        fieldPrivacy: {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}}),
+      {{end -}}
     };
   }
 

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -77,10 +77,12 @@ export class {{$baseClass}} {
   {{range $field := .FieldInfo.Fields -}}
     {{ if $field.HasAsyncAccessor $cfg -}}
       async {{$field.TSPublicAPIName}}(): Promise<{{$field.TsType}}> {
-        {{/* need to check if this can actually be null */ -}}
-        if (this.{{$field.TsFieldName $cfg}} === null) {
-          return null;
-        }
+        {{/* if underlying field can be null, we check for null */}}
+        {{ if $field.Nullable -}}
+          if (this.{{$field.TsFieldName $cfg}} === null) {
+            return null;
+          }
+        {{ end -}}
         const m = {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}});
         const p = m.get("{{$field.GetDbColName}}");
         if (!p) {

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -265,7 +265,7 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
   {{range $field := .FieldInfo.GetEditableFields}}
     {{$tsFieldName := $field.TsBuilderFieldName -}}
     // get value of {{$field.FieldName}}. Retrieves it from the input if specified or takes it from existingEnt
-    getNew{{$field.CamelCaseName}}Value(): {{$field.TsBuilderType}} | undefined {
+    getNew{{$field.CamelCaseName}}Value(): {{$field.TsBuilderUnionType}} | undefined {
     {{/** hmm not ideal for these accessors to not work...*/}}
       {{if $field.Private $cfg -}}
         return this.input.{{$tsFieldName}};

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -1,6 +1,8 @@
 {{reserveImport .Package.PackagePath "Viewer" "ID" "Ent" "AssocEdgeInputOptions"}}
 {{reserveImport .Package.ActionPackagePath "Action" "Builder" "WriteOperation" "Changeset" "saveBuilder" "saveBuilderX" "Orchestrator"}}
 
+{{ $cfg := .CodePath -}}
+
 {{with .NodeData -}}
 {{ $schemaPath := .GetSchemaPath }}
 {{ reserveDefaultImport $schemaPath "schema"}}
@@ -18,7 +20,7 @@ export interface {{.Node}}Input {
         {{ reserveImportPath . true -}}
         {{ $ignore := useImport .Import -}}
       {{end -}}
-    {{$field.TsFieldName}}?: {{$type}};
+    {{$field.TsBuilderFieldName}}?: {{$type}};
   {{end -}}
 }
 
@@ -218,7 +220,7 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
       }
     };
     {{range $field := .FieldInfo.GetEditableFields -}}
-      {{$tsFieldName := $field.TsFieldName -}}
+      {{$tsFieldName := $field.TsBuilderFieldName -}}
       addField("{{$field.FieldName}}", fields.{{$tsFieldName}});
       {{ $inverseEdge := $field.GetInverseEdge -}}
       {{ if $inverseEdge -}}
@@ -247,15 +249,17 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
   }
 
   {{range $field := .FieldInfo.GetEditableFields}}
+    {{$tsFieldName := $field.TsBuilderFieldName -}}
     // get value of {{$field.FieldName}}. Retrieves it from the input if specified or takes it from existingEnt
     getNew{{$field.CamelCaseName}}Value(): {{$field.TsBuilderType}} | undefined {
-      {{if $field.Private -}}
-        return this.input.{{$field.TsFieldName}};
+    {{/** hmm not ideal for these accessors to not work...*/}}
+      {{if $field.Private $cfg -}}
+        return this.input.{{$tsFieldName}};
       {{else -}}
-        if (this.input.{{$field.TsFieldName}} !== undefined) {
-          return this.input.{{$field.TsFieldName}}
+        if (this.input.{{$tsFieldName}} !== undefined) {
+          return this.input.{{$tsFieldName}}
         }
-        return this.existingEnt?.{{$field.TsFieldName}};
+        return this.existingEnt?.{{$tsFieldName}};
       {{end -}}
     }
 

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -209,7 +209,7 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
     return this.orchestrator.editedEntX();
   }
 
-  private getEditedFields(): Map<string, any> {
+  private async getEditedFields(): Promise<Map<string, any>> {
     const fields = this.input;
 
     const result = new Map<string, any>();
@@ -232,12 +232,26 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
               {{useImport "NodeType"}}.{{$inverseEdge.NodeInfo.Node}},
             );
           }
-          if (this.existingEnt && this.existingEnt.{{$tsFieldName}} && this.existingEnt.{{$tsFieldName}} !== fields.{{$tsFieldName}}) {
-            this.orchestrator.removeInboundEdge(
-              this.existingEnt.{{$tsFieldName}},
-              {{useImport "EdgeType"}}.{{$inverseEdge.TsEdgeConst}},
-            );
-          }
+          {{ if $field.HasAsyncAccessor $cfg -}}
+            // can't have this be dependent on privacy so need to fetch the raw data...
+            if (this.existingEnt) {
+              {{/* TODO eventually this needs to be smart enough and parallelize with any other possible fields here */ -}}
+              const rawData = await {{$node}}.loadRawData(this.existingEnt.id, this.viewer.context);
+              if (rawData && rawData.{{$field.GetDbColName}} !== null && rawData.{{$field.GetDbColName}} !== undefined) {
+                this.orchestrator.removeInboundEdge(
+                  rawData.{{$field.GetDbColName}},
+                  {{useImport "EdgeType"}}.{{$inverseEdge.TsEdgeConst}},
+                );
+              }
+            }
+          {{ else -}}
+            if (this.existingEnt && this.existingEnt.{{$tsFieldName}} && this.existingEnt.{{$tsFieldName}} !== fields.{{$tsFieldName}}) {
+              this.orchestrator.removeInboundEdge(
+                this.existingEnt.{{$tsFieldName}},
+                {{useImport "EdgeType"}}.{{$inverseEdge.TsEdgeConst}},
+              );
+            }
+          {{ end -}}
         }
       {{end -}}
     {{end -}}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.0.39",
+  "version": "0.0.40-alpha",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -493,8 +493,12 @@ export class Orchestrator<T extends Ent> {
 
     let validators = action?.validators || [];
 
+    // TODO not ideal we're calling this twice. fix...
+    // TODO add core test for softe delete with soft_delete package duplicated?
+    // to confirm it works and things like this don't break it.
+    const editedFields2 = await this.options.editedFields();
     await Promise.all([
-      this.formatAndValidateFields(schemaFields, editedFields),
+      this.formatAndValidateFields(schemaFields, editedFields2),
       this.validators(validators, action!, builder),
     ]);
   }

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -493,9 +493,8 @@ export class Orchestrator<T extends Ent> {
 
     let validators = action?.validators || [];
 
-    // TODO not ideal we're calling this twice. fix...
-    // TODO add core test for softe delete with soft_delete package duplicated?
-    // to confirm it works and things like this don't break it.
+    // not ideal we're calling this twice. fix...
+    // needed for now. may need to write somet of this?
     const editedFields2 = await this.options.editedFields();
     await Promise.all([
       this.formatAndValidateFields(schemaFields, editedFields2),
@@ -598,7 +597,7 @@ export class Orchestrator<T extends Ent> {
           this.defaultFieldsByTSName[camelCase(k)] = val;
           // hmm do we need this?
           // TODO how to do this for local tests?
-          //          this.defaultFieldsByFieldName[k] = val;
+          // this.defaultFieldsByFieldName[k] = val;
         }
       }
       this.actualOperation = this.getWriteOpForSQLStamentOp(transformed.op);

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -25,10 +25,10 @@ import {
   getTransformedUpdateOp,
   SQLStatementOperation,
   TransformedUpdateOperation,
+  getStorageKey,
 } from "../schema/schema";
 import { Changeset, Executor, Validator } from "../action/action";
 import { WriteOperation, Builder, Action } from "../action";
-import { snakeCase } from "snake-case";
 import { camelCase } from "camel-case";
 import { applyPrivacyPolicyX } from "../core/privacy";
 import { ListBasedExecutor, ComplexExecutor } from "./executor";
@@ -586,7 +586,7 @@ export class Orchestrator<T extends Ent> {
           if (field.format) {
             val = field.format(transformed.data[k]);
           }
-          let dbKey = field.storageKey || snakeCase(field.name);
+          let dbKey = getStorageKey(field);
           data[dbKey] = val;
           this.defaultFieldsByTSName[camelCase(k)] = val;
           // hmm do we need this?
@@ -605,7 +605,7 @@ export class Orchestrator<T extends Ent> {
     for (const [fieldName, field] of schemaFields) {
       let value = editedFields.get(fieldName);
       let defaultValue: any = undefined;
-      let dbKey = field.storageKey || snakeCase(field.name);
+      let dbKey = getStorageKey(field);
 
       if (value === undefined) {
         if (this.actualOperation === WriteOperation.Insert) {
@@ -738,7 +738,7 @@ export class Orchestrator<T extends Ent> {
         // null allowed
         value = this.defaultFieldsByFieldName[fieldName];
       }
-      let dbKey = field.storageKey || snakeCase(field.name);
+      let dbKey = getStorageKey(field);
 
       value = await this.transformFieldValue(field, dbKey, value);
 
@@ -755,7 +755,7 @@ export class Orchestrator<T extends Ent> {
         const defaultValue = this.defaultFieldsByFieldName[fieldName];
         let field = schemaFields.get(fieldName)!;
 
-        let dbKey = field.storageKey || snakeCase(field.name);
+        let dbKey = getStorageKey(field);
 
         // no value, let's just default
         if (data[dbKey] === undefined) {

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -164,12 +164,17 @@ interface LoadableEntOptions<T extends Ent> {
 export interface LoadEntOptions<T extends Ent>
   extends LoadableEntOptions<T>,
     // extending DataOptions and fields is to make APIs like loadEntsFromClause work until we come up with a cleaner API
-    SelectBaseDataOptions {}
+    SelectBaseDataOptions {
+  // if passed in, it means there's field privacy on the ents *and* we want to apply it at ent load
+  // if there's field privacy on the ent and not passed in, it'll be applied on demand when we try and load the ent
+  fieldPrivacy?: Map<string, PrivacyPolicy>;
+}
 
 export interface LoadCustomEntOptions<T extends Ent>
   // extending DataOptions and fields is to make APIs like loadEntsFromClause work until we come up with a cleaner API
   extends SelectBaseDataOptions {
   ent: EntConstructor<T>;
+  fieldPrivacy?: Map<string, PrivacyPolicy>;
 }
 
 export interface LoaderInfo {

--- a/ts/src/core/config.ts
+++ b/ts/src/core/config.ts
@@ -19,6 +19,11 @@ enum graphQLFieldFormat {
   SNAKE_CASE = "snake_case",
 }
 
+enum fieldPrivacyEvaluated {
+  AT_ENT_LOAD = "at_ent_load",
+  ON_DEMAND = "on_demand",
+}
+
 export interface Config {
   dbConnectionString?: string;
   dbFile?: string; // config/database.yml is default
@@ -87,6 +92,19 @@ interface CodegenConfig {
   // has changed. we need this because if no database is provided, we'd then try and compare
   // against database with same name as user
   databaseToCompareTo?: string;
+
+  // copied from schema.ts
+  // when field privacy is evaluated.
+  // field can have privacy policy
+  // there's 2 modes of how this is treated that can be configured in ent.yml because it affects codegen
+  // 1: evaluate at the time of ent load, we apply the privacy of each object and then apply the privacy of every
+  // field which has field privacy and set the property to null if the field is not visible to the viewer
+  // The underlying column is no longer in the `data` field of the object
+  // 2: generate accessors for the field and all callsites which reference that field will use that.
+  // the privacy will be evaluated on demand when needed
+
+  // default is on_demand
+  fieldPrivacyEvaluated?: fieldPrivacyEvaluated;
 }
 
 interface PrettierConfig {

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -382,7 +382,7 @@ async function applyPrivacyPolicyForEnt<T extends Ent>(
     if (!visible) {
       return null;
     }
-    return doFieldPrivcy(viewer, ent, data, fieldPrivacyOptions);
+    return doFieldPrivacy(viewer, ent, data, fieldPrivacyOptions);
   }
   return null;
 }
@@ -395,10 +395,10 @@ async function applyPrivacyPolicyForEntX<T extends Ent>(
 ): Promise<T> {
   // this will throw
   await applyPrivacyPolicyX(viewer, ent.privacyPolicy, ent);
-  return doFieldPrivcy(viewer, ent, data, options);
+  return doFieldPrivacy(viewer, ent, data, options);
 }
 
-async function doFieldPrivcy<T extends Ent>(
+async function doFieldPrivacy<T extends Ent>(
   viewer: Viewer,
   ent: T,
   data: Data,

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -24,6 +24,7 @@ import {
   CreateRowOptions,
   QueryDataOptions,
   EntConstructor,
+  PrivacyPolicy,
 } from "./base";
 
 import { applyPrivacyPolicy, applyPrivacyPolicyX } from "./privacy";
@@ -180,8 +181,7 @@ export async function loadEntXFromClause<T extends Ent>(
     context: viewer.context,
   };
   const row = await loadRowX(rowOptions);
-  const ent = new options.ent(viewer, row);
-  return await applyPrivacyPolicyForEntX(viewer, ent);
+  return await applyPrivacyPolicyForRowX(viewer, options, row);
 }
 
 export async function loadEnts<T extends Ent>(
@@ -269,7 +269,13 @@ export async function loadCustomEnts<T extends Ent>(
   await Promise.all(
     rows.map(async (row, idx) => {
       const ent = new options.ent(viewer, row);
-      let privacyEnt = await applyPrivacyPolicyForEnt(viewer, ent);
+      let privacyEnt = await applyPrivacyPolicyForEnt(
+        viewer,
+        ent,
+        row,
+        options,
+      );
+
       if (privacyEnt) {
         result[idx] = privacyEnt;
       }
@@ -344,7 +350,9 @@ export async function loadDerivedEnt<T extends Ent>(
   loader: new (viewer: Viewer, data: Data) => T,
 ): Promise<T | null> {
   const ent = new loader(viewer, data);
-  return await applyPrivacyPolicyForEnt(viewer, ent);
+  return await applyPrivacyPolicyForEnt(viewer, ent, data, {
+    ent: loader,
+  });
 }
 
 export async function loadDerivedEntX<T extends Ent>(
@@ -353,28 +361,70 @@ export async function loadDerivedEntX<T extends Ent>(
   loader: new (viewer: Viewer, data: Data) => T,
 ): Promise<T> {
   const ent = new loader(viewer, data);
-  return await applyPrivacyPolicyForEntX(viewer, ent);
+  return await applyPrivacyPolicyForEntX(viewer, ent, data, { ent: loader });
 }
 
-export async function applyPrivacyPolicyForEnt<T extends Ent>(
+interface FieldPrivacyOptions<T extends Ent> {
+  ent: EntConstructor<T>;
+  fieldPrivacy?: Map<string, PrivacyPolicy>;
+}
+
+// everything calls into this two so should be fine
+// TODO is there a smarter way to not instantiate two objects here?
+async function applyPrivacyPolicyForEnt<T extends Ent>(
   viewer: Viewer,
   ent: T | null,
+  data: Data,
+  fieldPrivacyOptions: FieldPrivacyOptions<T>,
 ): Promise<T | null> {
   if (ent) {
     const visible = await applyPrivacyPolicy(viewer, ent.privacyPolicy, ent);
-    if (visible) {
-      return ent;
+    if (!visible) {
+      return null;
     }
+    return doFieldPrivcy(viewer, ent, data, fieldPrivacyOptions);
   }
   return null;
 }
 
-export async function applyPrivacyPolicyForEntX<T extends Ent>(
+async function applyPrivacyPolicyForEntX<T extends Ent>(
   viewer: Viewer,
   ent: T,
+  data: Data,
+  options: FieldPrivacyOptions<T>,
 ): Promise<T> {
   // this will throw
   await applyPrivacyPolicyX(viewer, ent.privacyPolicy, ent);
+  return doFieldPrivcy(viewer, ent, data, options);
+}
+
+async function doFieldPrivcy<T extends Ent>(
+  viewer: Viewer,
+  ent: T,
+  data: Data,
+  options: FieldPrivacyOptions<T>,
+): Promise<T> {
+  if (!options.fieldPrivacy) {
+    return ent;
+  }
+  const promises: Promise<void>[] = [];
+  let somethingChanged = false;
+  for (const [k, policy] of options.fieldPrivacy) {
+    promises.push(
+      (async () => {
+        const r = await applyPrivacyPolicy(viewer, policy, ent);
+        if (!r) {
+          data[k] = null;
+          somethingChanged = true;
+        }
+      })(),
+    );
+  }
+  await Promise.all(promises);
+  if (somethingChanged) {
+    // have to create new instance
+    return new options.ent(viewer, data);
+  }
   return ent;
 }
 
@@ -1631,7 +1681,7 @@ export async function applyPrivacyPolicyForRow<T extends Ent>(
     return null;
   }
   const ent = new options.ent(viewer, row);
-  return await applyPrivacyPolicyForEnt(viewer, ent);
+  return await applyPrivacyPolicyForEnt(viewer, ent, row, options);
 }
 
 export async function applyPrivacyPolicyForRowX<T extends Ent>(
@@ -1640,7 +1690,7 @@ export async function applyPrivacyPolicyForRowX<T extends Ent>(
   row: Data,
 ): Promise<T> {
   const ent = new options.ent(viewer, row);
-  return await applyPrivacyPolicyForEntX(viewer, ent);
+  return await applyPrivacyPolicyForEntX(viewer, ent, row, options);
 }
 
 export async function applyPrivacyPolicyForRows<T extends Ent>(
@@ -1652,8 +1702,7 @@ export async function applyPrivacyPolicyForRows<T extends Ent>(
   // apply privacy logic
   await Promise.all(
     rows.map(async (row) => {
-      const ent = new options.ent(viewer, row);
-      let privacyEnt = await applyPrivacyPolicyForEnt(viewer, ent);
+      let privacyEnt = await applyPrivacyPolicyForRow(viewer, options, row);
       if (privacyEnt) {
         m.set(privacyEnt.id, privacyEnt);
       }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -10,8 +10,6 @@ export {
   loadDerivedEntX,
   loadEntViaKey,
   loadEntXViaKey,
-  applyPrivacyPolicyForEnt,
-  applyPrivacyPolicyForEntX,
   performRawQuery,
   // even these 3 need to change...
   loadRowX,

--- a/ts/src/parse_schema/parse.ts
+++ b/ts/src/parse_schema/parse.ts
@@ -14,6 +14,7 @@ function processFields(src: Field[], patternName?: string): ProcessedField[] {
     let f: ProcessedField = { ...field };
     f.hasDefaultValueOnCreate = field.defaultValueOnCreate != undefined;
     f.hasDefaultValueOnEdit = field.defaultValueOnEdit != undefined;
+    f.hasFieldPrivacy = field.privacyPolicy !== undefined;
     if (field.polymorphic) {
       // convert boolean into object
       // we keep boolean as an option to keep API simple
@@ -232,11 +233,12 @@ interface ProcessedPattern {
 
 type ProcessedField = Omit<
   Field,
-  "defaultValueOnEdit" | "defaultValueOnCreate"
+  "defaultValueOnEdit" | "defaultValueOnCreate" | "privacyPolicy"
 > & {
   hasDefaultValueOnCreate?: boolean;
   hasDefaultValueOnEdit?: boolean;
   patternName?: string;
+  hasFieldPrivacy?: boolean;
 };
 
 interface patternsDict {

--- a/ts/src/schema/index.ts
+++ b/ts/src/schema/index.ts
@@ -13,6 +13,7 @@ export {
   SchemaConstructor,
   SchemaInputType,
   getFields,
+  getFieldsWithPrivacy,
   ActionOperation,
   Action,
   EdgeAction,

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -434,7 +434,7 @@ export function getFieldsWithPrivacy(
         addFields(derivedFields);
       }
       if (field.privacyPolicy) {
-        m.set(field.name, field.privacyPolicy);
+        m.set(getStorageKey(field), field.privacyPolicy);
       }
     }
   }


### PR DESCRIPTION
adds ability to specify the privacy policy for a field on an ent.

2 modes for evaluation which can be configured via codegen and affect how the ent is evaluated

* evaluated at ent load 
when loading the ent, if the ent is visible, privacy is checked for every field which has field privacy configured 
if the viewer can't see said field, field is set to null. all accessors (ent and graphql) get the null value. if anyone wants the raw value, have to fetch the raw data
* evaluated on demand **(this is the default behavior)**
ent is loaded as usual
property for each field which has a privacy policy is set to protected (only visible within ent)
callers (ent and graphql) have to explicitly call an async function to get the privacy checked value of the field
this way, data for privacy only fetched if it's needed. however, API and callsites more complicated e.g. changing from non-privacy backed to privacy backed may need to dev having to update other (non-ent) callsites.

fixes https://github.com/lolopinto/ent/issues/465