### PR TITLE
s/overrideInput/deleteInputKey

### DIFF
--- a/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/generated/address_builder.ts
@@ -76,8 +76,8 @@ export class AddressBuilder implements Builder<Address> {
     };
   }
 
-  overrideInput(input: AddressInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -73,8 +73,8 @@ export class AuthCodeBuilder implements Builder<AuthCode> {
     };
   }
 
-  overrideInput(input: AuthCodeInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event/actions/generated/event_builder.ts
@@ -72,8 +72,8 @@ export class EventBuilder implements Builder<Event> {
     };
   }
 
-  overrideInput(input: EventInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/event_activity/actions/generated/event_activity_builder.ts
@@ -77,8 +77,8 @@ export class EventActivityBuilder implements Builder<EventActivity> {
     };
   }
 
-  overrideInput(input: EventActivityInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest/actions/generated/guest_builder.ts
@@ -74,8 +74,8 @@ export class GuestBuilder implements Builder<Guest> {
     };
   }
 
-  overrideInput(input: GuestInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_data/actions/generated/guest_data_builder.ts
@@ -74,8 +74,8 @@ export class GuestDataBuilder implements Builder<GuestData> {
     };
   }
 
-  overrideInput(input: GuestDataInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/guest_group/actions/generated/guest_group_builder.ts
@@ -72,8 +72,8 @@ export class GuestGroupBuilder implements Builder<GuestGroup> {
     };
   }
 
-  overrideInput(input: GuestGroupInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/ent-rsvp/backend/src/ent/user/actions/generated/user_builder.ts
@@ -73,8 +73,8 @@ export class UserBuilder implements Builder<User> {
     };
   }
 
-  overrideInput(input: UserInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/address/actions/generated/address_builder.ts
+++ b/examples/simple/src/ent/address/actions/generated/address_builder.ts
@@ -78,8 +78,8 @@ export class AddressBuilder implements Builder<Address> {
     };
   }
 
-  overrideInput(input: AddressInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/auth_code/actions/generated/auth_code_builder.ts
+++ b/examples/simple/src/ent/auth_code/actions/generated/auth_code_builder.ts
@@ -76,8 +76,8 @@ export class AuthCodeBuilder implements Builder<AuthCode> {
     };
   }
 
-  overrideInput(input: AuthCodeInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
+++ b/examples/simple/src/ent/comment/actions/generated/comment_builder.ts
@@ -76,8 +76,8 @@ export class CommentBuilder implements Builder<Comment> {
     };
   }
 
-  overrideInput(input: CommentInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/contact/actions/generated/contact_builder.ts
+++ b/examples/simple/src/ent/contact/actions/generated/contact_builder.ts
@@ -77,8 +77,8 @@ export class ContactBuilder implements Builder<Contact> {
     };
   }
 
-  overrideInput(input: ContactInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/contact_email/actions/generated/contact_email_builder.ts
+++ b/examples/simple/src/ent/contact_email/actions/generated/contact_email_builder.ts
@@ -76,8 +76,8 @@ export class ContactEmailBuilder implements Builder<ContactEmail> {
     };
   }
 
-  overrideInput(input: ContactEmailInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/contact_phone_number/actions/generated/contact_phone_number_builder.ts
+++ b/examples/simple/src/ent/contact_phone_number/actions/generated/contact_phone_number_builder.ts
@@ -76,8 +76,8 @@ export class ContactPhoneNumberBuilder implements Builder<ContactPhoneNumber> {
     };
   }
 
-  overrideInput(input: ContactPhoneNumberInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/event/actions/generated/event_builder.ts
+++ b/examples/simple/src/ent/event/actions/generated/event_builder.ts
@@ -78,8 +78,8 @@ export class EventBuilder implements Builder<Event> {
     };
   }
 
-  overrideInput(input: EventInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/holiday/actions/generated/holiday_builder.ts
+++ b/examples/simple/src/ent/holiday/actions/generated/holiday_builder.ts
@@ -76,8 +76,8 @@ export class HolidayBuilder implements Builder<Holiday> {
     };
   }
 
-  overrideInput(input: HolidayInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/hours_of_operation/actions/generated/hours_of_operation_builder.ts
+++ b/examples/simple/src/ent/hours_of_operation/actions/generated/hours_of_operation_builder.ts
@@ -77,8 +77,8 @@ export class HoursOfOperationBuilder implements Builder<HoursOfOperation> {
     };
   }
 
-  overrideInput(input: HoursOfOperationInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/simple/src/ent/user/actions/generated/user_builder.ts
+++ b/examples/simple/src/ent/user/actions/generated/user_builder.ts
@@ -98,8 +98,8 @@ export class UserBuilder implements Builder<User> {
     };
   }
 
-  overrideInput(input: UserInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/generated/account_builder.ts
@@ -73,8 +73,8 @@ export class AccountBuilder implements Builder<Account> {
     };
   }
 
-  overrideInput(input: AccountInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/todo-sqlite/src/ent/tag/actions/generated/tag_builder.ts
+++ b/examples/todo-sqlite/src/ent/tag/actions/generated/tag_builder.ts
@@ -74,8 +74,8 @@ export class TagBuilder implements Builder<Tag> {
     };
   }
 
-  overrideInput(input: TagInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/examples/todo-sqlite/src/ent/todo/actions/generated/todo_builder.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/generated/todo_builder.ts
@@ -73,8 +73,8 @@ export class TodoBuilder implements Builder<Todo> {
     };
   }
 
-  overrideInput(input: TodoInput) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -83,8 +83,8 @@ export class {{$builder}} implements {{useImport "Builder"}}<{{$node}}> {
     };
   }
 
-  overrideInput(input: {{.Node}}Input) {
-    this.input = input;
+  deleteInputKey(key: string) {
+    delete this.input[key];
   }
 
   // store data in Builder that can be retrieved by another validator, trigger, observer later in the action


### PR DESCRIPTION
`overrideInput` can easily be used incorrectly since it can be used in one trigger which overrides fields set in another trigger via `updateInput`

in practice, `deleteInputKey` isn't necessarily needed since a trigger can be written as:

```ts
changeset(b, _) {
  const input = builder.getInput();
  delete input[k];
}
```

follow-up to https://github.com/lolopinto/ent/pull/880