### PR TITLE
type Foo.loadRawData

### DIFF
--- a/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
@@ -29,6 +29,19 @@ import {
 import { NodeType } from "src/ent/internal";
 import schema from "src/schema/address";
 
+interface AddressDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  street: string;
+  city: string;
+  state: string;
+  zip_code: string;
+  apartment: string | null;
+  owner_id: ID;
+  owner_type: string;
+}
+
 export class AddressBase {
   readonly nodeType = NodeType.Address;
   readonly id: ID;
@@ -109,32 +122,36 @@ export class AddressBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<AddressDBData[]> {
+    return (await loadCustomData(
       AddressBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as AddressDBData[];
   }
 
   static async loadRawData<T extends AddressBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return addressLoader.createLoader(context).load(id);
+  ): Promise<AddressDBData | null> {
+    const row = await addressLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as AddressDBData;
   }
 
   static async loadRawDataX<T extends AddressBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<AddressDBData> {
     const row = await addressLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as AddressDBData;
   }
 
   static async loadFromOwnerID<T extends AddressBase>(
@@ -172,8 +189,12 @@ export class AddressBase {
     this: new (viewer: Viewer, data: Data) => T,
     ownerID: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return addressOwnerIDLoader.createLoader(context).load(ownerID);
+  ): Promise<AddressDBData | null> {
+    const row = await addressOwnerIDLoader.createLoader(context).load(ownerID);
+    if (!row) {
+      return null;
+    }
+    return row as AddressDBData;
   }
 
   static loaderOptions<T extends AddressBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
@@ -28,6 +28,16 @@ import {
 import { Guest, NodeType } from "src/ent/internal";
 import schema from "src/schema/auth_code";
 
+interface AuthCodeDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  code: string;
+  guest_id: ID;
+  email_address: string;
+  sent_code: boolean;
+}
+
 export class AuthCodeBase {
   readonly nodeType = NodeType.AuthCode;
   readonly id: ID;
@@ -102,32 +112,36 @@ export class AuthCodeBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<AuthCodeDBData[]> {
+    return (await loadCustomData(
       AuthCodeBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as AuthCodeDBData[];
   }
 
   static async loadRawData<T extends AuthCodeBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return authCodeLoader.createLoader(context).load(id);
+  ): Promise<AuthCodeDBData | null> {
+    const row = await authCodeLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as AuthCodeDBData;
   }
 
   static async loadRawDataX<T extends AuthCodeBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<AuthCodeDBData> {
     const row = await authCodeLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as AuthCodeDBData;
   }
 
   static async loadFromGuestID<T extends AuthCodeBase>(
@@ -165,8 +179,12 @@ export class AuthCodeBase {
     this: new (viewer: Viewer, data: Data) => T,
     guestID: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return authCodeGuestIDLoader.createLoader(context).load(guestID);
+  ): Promise<AuthCodeDBData | null> {
+    const row = await authCodeGuestIDLoader.createLoader(context).load(guestID);
+    if (!row) {
+      return null;
+    }
+    return row as AuthCodeDBData;
   }
 
   static loaderOptions<T extends AuthCodeBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
@@ -41,6 +41,19 @@ export enum EventActivityRsvpStatus {
   CannotRsvp = "cannotRsvp",
 }
 
+interface EventActivityDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  name: string;
+  event_id: ID;
+  start_time: Date;
+  end_time: Date | null;
+  location: string;
+  description: string | null;
+  invite_all_guests: boolean;
+}
+
 export class EventActivityBase {
   readonly nodeType = NodeType.EventActivity;
   readonly id: ID;
@@ -121,32 +134,36 @@ export class EventActivityBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<EventActivityDBData[]> {
+    return (await loadCustomData(
       EventActivityBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as EventActivityDBData[];
   }
 
   static async loadRawData<T extends EventActivityBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return eventActivityLoader.createLoader(context).load(id);
+  ): Promise<EventActivityDBData | null> {
+    const row = await eventActivityLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as EventActivityDBData;
   }
 
   static async loadRawDataX<T extends EventActivityBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<EventActivityDBData> {
     const row = await eventActivityLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as EventActivityDBData;
   }
 
   static loaderOptions<T extends EventActivityBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
@@ -34,6 +34,15 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/event";
 
+interface EventDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  name: string;
+  slug: string | null;
+  creator_id: ID;
+}
+
 export class EventBase {
   readonly nodeType = NodeType.Event;
   readonly id: ID;
@@ -106,28 +115,36 @@ export class EventBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(EventBase.loaderOptions.apply(this), query, context);
+  ): Promise<EventDBData[]> {
+    return (await loadCustomData(
+      EventBase.loaderOptions.apply(this),
+      query,
+      context,
+    )) as EventDBData[];
   }
 
   static async loadRawData<T extends EventBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return eventLoader.createLoader(context).load(id);
+  ): Promise<EventDBData | null> {
+    const row = await eventLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as EventDBData;
   }
 
   static async loadRawDataX<T extends EventBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<EventDBData> {
     const row = await eventLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as EventDBData;
   }
 
   static async loadFromSlug<T extends EventBase>(
@@ -165,8 +182,12 @@ export class EventBase {
     this: new (viewer: Viewer, data: Data) => T,
     slug: string,
     context?: Context,
-  ): Promise<Data | null> {
-    return eventSlugLoader.createLoader(context).load(slug);
+  ): Promise<EventDBData | null> {
+    const row = await eventSlugLoader.createLoader(context).load(slug);
+    if (!row) {
+      return null;
+    }
+    return row as EventDBData;
   }
 
   static loaderOptions<T extends EventBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
@@ -29,6 +29,17 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/guest";
 
+interface GuestDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  name: string;
+  event_id: ID;
+  email_address: string | null;
+  guest_group_id: ID;
+  title: string | null;
+}
+
 export class GuestBase {
   readonly nodeType = NodeType.Guest;
   readonly id: ID;
@@ -105,28 +116,36 @@ export class GuestBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(GuestBase.loaderOptions.apply(this), query, context);
+  ): Promise<GuestDBData[]> {
+    return (await loadCustomData(
+      GuestBase.loaderOptions.apply(this),
+      query,
+      context,
+    )) as GuestDBData[];
   }
 
   static async loadRawData<T extends GuestBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return guestLoader.createLoader(context).load(id);
+  ): Promise<GuestDBData | null> {
+    const row = await guestLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as GuestDBData;
   }
 
   static async loadRawDataX<T extends GuestBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<GuestDBData> {
     const row = await guestLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as GuestDBData;
   }
 
   static loaderOptions<T extends GuestBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
@@ -29,6 +29,16 @@ export enum GuestDataSource {
   HomePage = "home_page",
 }
 
+interface GuestDataDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  guest_id: ID;
+  event_id: ID;
+  dietary_restrictions: string;
+  source: GuestDataSource | null;
+}
+
 export class GuestDataBase {
   readonly nodeType = NodeType.GuestData;
   readonly id: ID;
@@ -103,32 +113,36 @@ export class GuestDataBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<GuestDataDBData[]> {
+    return (await loadCustomData(
       GuestDataBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as GuestDataDBData[];
   }
 
   static async loadRawData<T extends GuestDataBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return guestDataLoader.createLoader(context).load(id);
+  ): Promise<GuestDataDBData | null> {
+    const row = await guestDataLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as GuestDataDBData;
   }
 
   static async loadRawDataX<T extends GuestDataBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<GuestDataDBData> {
     const row = await guestDataLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as GuestDataDBData;
   }
 
   static loaderOptions<T extends GuestDataBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
@@ -29,6 +29,14 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/guest_group";
 
+interface GuestGroupDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  invitation_name: string;
+  event_id: ID;
+}
+
 export class GuestGroupBase {
   readonly nodeType = NodeType.GuestGroup;
   readonly id: ID;
@@ -99,32 +107,36 @@ export class GuestGroupBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<GuestGroupDBData[]> {
+    return (await loadCustomData(
       GuestGroupBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as GuestGroupDBData[];
   }
 
   static async loadRawData<T extends GuestGroupBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return guestGroupLoader.createLoader(context).load(id);
+  ): Promise<GuestGroupDBData | null> {
+    const row = await guestGroupLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as GuestGroupDBData;
   }
 
   static async loadRawDataX<T extends GuestGroupBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<GuestGroupDBData> {
     const row = await guestGroupLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as GuestGroupDBData;
   }
 
   static loaderOptions<T extends GuestGroupBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
@@ -27,6 +27,16 @@ import {
 import { NodeType, UserToEventsQuery } from "src/ent/internal";
 import schema from "src/schema/user";
 
+interface UserDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  first_name: string;
+  last_name: string;
+  email_address: string;
+  password: string;
+}
+
 export class UserBase {
   readonly nodeType = NodeType.User;
   readonly id: ID;
@@ -101,28 +111,36 @@ export class UserBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(UserBase.loaderOptions.apply(this), query, context);
+  ): Promise<UserDBData[]> {
+    return (await loadCustomData(
+      UserBase.loaderOptions.apply(this),
+      query,
+      context,
+    )) as UserDBData[];
   }
 
   static async loadRawData<T extends UserBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return userLoader.createLoader(context).load(id);
+  ): Promise<UserDBData | null> {
+    const row = await userLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as UserDBData;
   }
 
   static async loadRawDataX<T extends UserBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<UserDBData> {
     const row = await userLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as UserDBData;
   }
 
   static async loadFromEmailAddress<T extends UserBase>(
@@ -162,8 +180,14 @@ export class UserBase {
     this: new (viewer: Viewer, data: Data) => T,
     emailAddress: string,
     context?: Context,
-  ): Promise<Data | null> {
-    return userEmailAddressLoader.createLoader(context).load(emailAddress);
+  ): Promise<UserDBData | null> {
+    const row = await userEmailAddressLoader
+      .createLoader(context)
+      .load(emailAddress);
+    if (!row) {
+      return null;
+    }
+    return row as UserDBData;
   }
 
   static loaderOptions<T extends UserBase>(

--- a/examples/simple/src/ent/generated/address_base.ts
+++ b/examples/simple/src/ent/generated/address_base.ts
@@ -24,7 +24,7 @@ import { addressLoader, addressLoaderInfo } from "./loaders";
 import { AddressToHostedEventsQuery, NodeType } from "../internal";
 import schema from "../../schema/address";
 
-export interface AddressData {
+interface AddressDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -114,36 +114,36 @@ export class AddressBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<AddressData[]> {
+  ): Promise<AddressDBData[]> {
     return (await loadCustomData(
       AddressBase.loaderOptions.apply(this),
       query,
       context,
-    )) as AddressData[];
+    )) as AddressDBData[];
   }
 
   static async loadRawData<T extends AddressBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<AddressData | null> {
+  ): Promise<AddressDBData | null> {
     const row = await addressLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as AddressData;
+    return row as AddressDBData;
   }
 
   static async loadRawDataX<T extends AddressBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<AddressData> {
+  ): Promise<AddressDBData> {
     const row = await addressLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as AddressData;
+    return row as AddressDBData;
   }
 
   static loaderOptions<T extends AddressBase>(

--- a/examples/simple/src/ent/generated/address_base.ts
+++ b/examples/simple/src/ent/generated/address_base.ts
@@ -24,6 +24,18 @@ import { addressLoader, addressLoaderInfo } from "./loaders";
 import { AddressToHostedEventsQuery, NodeType } from "../internal";
 import schema from "../../schema/address";
 
+export interface AddressData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  street_name: string;
+  city: string;
+  state: string;
+  zip: string;
+  apartment: string | null;
+  country: string;
+}
+
 export class AddressBase {
   readonly nodeType = NodeType.Address;
   readonly id: ID;
@@ -102,32 +114,36 @@ export class AddressBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<AddressData[]> {
+    return (await loadCustomData(
       AddressBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as AddressData[];
   }
 
   static async loadRawData<T extends AddressBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return addressLoader.createLoader(context).load(id);
+  ): Promise<AddressData | null> {
+    const row = await addressLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as AddressData;
   }
 
   static async loadRawDataX<T extends AddressBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<AddressData> {
     const row = await addressLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as AddressData;
   }
 
   static loaderOptions<T extends AddressBase>(

--- a/examples/simple/src/ent/generated/auth_code_base.ts
+++ b/examples/simple/src/ent/generated/auth_code_base.ts
@@ -24,6 +24,16 @@ import { authCodeLoader, authCodeLoaderInfo } from "./loaders";
 import { NodeType, User } from "../internal";
 import schema from "../../schema/auth_code";
 
+export interface AuthCodeData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  code: string;
+  user_id: ID;
+  email_address: string | null;
+  phone_number: string | null;
+}
+
 export class AuthCodeBase {
   readonly nodeType = NodeType.AuthCode;
   readonly id: ID;
@@ -98,32 +108,36 @@ export class AuthCodeBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<AuthCodeData[]> {
+    return (await loadCustomData(
       AuthCodeBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as AuthCodeData[];
   }
 
   static async loadRawData<T extends AuthCodeBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return authCodeLoader.createLoader(context).load(id);
+  ): Promise<AuthCodeData | null> {
+    const row = await authCodeLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as AuthCodeData;
   }
 
   static async loadRawDataX<T extends AuthCodeBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<AuthCodeData> {
     const row = await authCodeLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as AuthCodeData;
   }
 
   static loaderOptions<T extends AuthCodeBase>(

--- a/examples/simple/src/ent/generated/auth_code_base.ts
+++ b/examples/simple/src/ent/generated/auth_code_base.ts
@@ -24,7 +24,7 @@ import { authCodeLoader, authCodeLoaderInfo } from "./loaders";
 import { NodeType, User } from "../internal";
 import schema from "../../schema/auth_code";
 
-export interface AuthCodeData {
+interface AuthCodeDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -108,36 +108,36 @@ export class AuthCodeBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<AuthCodeData[]> {
+  ): Promise<AuthCodeDBData[]> {
     return (await loadCustomData(
       AuthCodeBase.loaderOptions.apply(this),
       query,
       context,
-    )) as AuthCodeData[];
+    )) as AuthCodeDBData[];
   }
 
   static async loadRawData<T extends AuthCodeBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<AuthCodeData | null> {
+  ): Promise<AuthCodeDBData | null> {
     const row = await authCodeLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as AuthCodeData;
+    return row as AuthCodeDBData;
   }
 
   static async loadRawDataX<T extends AuthCodeBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<AuthCodeData> {
+  ): Promise<AuthCodeDBData> {
     const row = await authCodeLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as AuthCodeData;
+    return row as AuthCodeDBData;
   }
 
   static loaderOptions<T extends AuthCodeBase>(

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -31,7 +31,7 @@ import {
 } from "../internal";
 import schema from "../../schema/comment";
 
-export interface CommentData {
+interface CommentDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -115,36 +115,36 @@ export class CommentBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<CommentData[]> {
+  ): Promise<CommentDBData[]> {
     return (await loadCustomData(
       CommentBase.loaderOptions.apply(this),
       query,
       context,
-    )) as CommentData[];
+    )) as CommentDBData[];
   }
 
   static async loadRawData<T extends CommentBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<CommentData | null> {
+  ): Promise<CommentDBData | null> {
     const row = await commentLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as CommentData;
+    return row as CommentDBData;
   }
 
   static async loadRawDataX<T extends CommentBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<CommentData> {
+  ): Promise<CommentDBData> {
     const row = await commentLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as CommentData;
+    return row as CommentDBData;
   }
 
   static queryFromArticle<T extends CommentBase>(

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -31,6 +31,16 @@ import {
 } from "../internal";
 import schema from "../../schema/comment";
 
+export interface CommentData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  author_id: ID;
+  body: string;
+  article_id: ID;
+  article_type: string;
+}
+
 export class CommentBase {
   readonly nodeType = NodeType.Comment;
   readonly id: ID;
@@ -105,32 +115,36 @@ export class CommentBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<CommentData[]> {
+    return (await loadCustomData(
       CommentBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as CommentData[];
   }
 
   static async loadRawData<T extends CommentBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return commentLoader.createLoader(context).load(id);
+  ): Promise<CommentData | null> {
+    const row = await commentLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as CommentData;
   }
 
   static async loadRawDataX<T extends CommentBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<CommentData> {
     const row = await commentLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as CommentData;
   }
 
   static queryFromArticle<T extends CommentBase>(

--- a/examples/simple/src/ent/generated/contact_base.ts
+++ b/examples/simple/src/ent/generated/contact_base.ts
@@ -32,6 +32,17 @@ import {
 } from "../internal";
 import schema from "../../schema/contact";
 
+export interface ContactData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  email_ids: ID[];
+  phone_number_ids: ID[];
+  first_name: string;
+  last_name: string;
+  user_id: ID;
+}
+
 export class ContactBase {
   readonly nodeType = NodeType.Contact;
   readonly id: ID;
@@ -108,32 +119,36 @@ export class ContactBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<ContactData[]> {
+    return (await loadCustomData(
       ContactBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as ContactData[];
   }
 
   static async loadRawData<T extends ContactBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return contactLoader.createLoader(context).load(id);
+  ): Promise<ContactData | null> {
+    const row = await contactLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as ContactData;
   }
 
   static async loadRawDataX<T extends ContactBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<ContactData> {
     const row = await contactLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as ContactData;
   }
 
   static loaderOptions<T extends ContactBase>(

--- a/examples/simple/src/ent/generated/contact_base.ts
+++ b/examples/simple/src/ent/generated/contact_base.ts
@@ -32,7 +32,7 @@ import {
 } from "../internal";
 import schema from "../../schema/contact";
 
-export interface ContactData {
+interface ContactDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -119,36 +119,36 @@ export class ContactBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<ContactData[]> {
+  ): Promise<ContactDBData[]> {
     return (await loadCustomData(
       ContactBase.loaderOptions.apply(this),
       query,
       context,
-    )) as ContactData[];
+    )) as ContactDBData[];
   }
 
   static async loadRawData<T extends ContactBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactData | null> {
+  ): Promise<ContactDBData | null> {
     const row = await contactLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as ContactData;
+    return row as ContactDBData;
   }
 
   static async loadRawDataX<T extends ContactBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactData> {
+  ): Promise<ContactDBData> {
     const row = await contactLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as ContactData;
+    return row as ContactDBData;
   }
 
   static loaderOptions<T extends ContactBase>(

--- a/examples/simple/src/ent/generated/contact_email_base.ts
+++ b/examples/simple/src/ent/generated/contact_email_base.ts
@@ -24,7 +24,7 @@ import { contactEmailLoader, contactEmailLoaderInfo } from "./loaders";
 import { Contact, NodeType } from "../internal";
 import schema from "../../schema/contact_email";
 
-export interface ContactEmailData {
+interface ContactEmailDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -105,36 +105,36 @@ export class ContactEmailBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<ContactEmailData[]> {
+  ): Promise<ContactEmailDBData[]> {
     return (await loadCustomData(
       ContactEmailBase.loaderOptions.apply(this),
       query,
       context,
-    )) as ContactEmailData[];
+    )) as ContactEmailDBData[];
   }
 
   static async loadRawData<T extends ContactEmailBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactEmailData | null> {
+  ): Promise<ContactEmailDBData | null> {
     const row = await contactEmailLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as ContactEmailData;
+    return row as ContactEmailDBData;
   }
 
   static async loadRawDataX<T extends ContactEmailBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactEmailData> {
+  ): Promise<ContactEmailDBData> {
     const row = await contactEmailLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as ContactEmailData;
+    return row as ContactEmailDBData;
   }
 
   static loaderOptions<T extends ContactEmailBase>(

--- a/examples/simple/src/ent/generated/contact_email_base.ts
+++ b/examples/simple/src/ent/generated/contact_email_base.ts
@@ -24,6 +24,15 @@ import { contactEmailLoader, contactEmailLoaderInfo } from "./loaders";
 import { Contact, NodeType } from "../internal";
 import schema from "../../schema/contact_email";
 
+export interface ContactEmailData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  email_address: string;
+  label: string;
+  contact_id: ID;
+}
+
 export class ContactEmailBase {
   readonly nodeType = NodeType.ContactEmail;
   readonly id: ID;
@@ -96,32 +105,36 @@ export class ContactEmailBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<ContactEmailData[]> {
+    return (await loadCustomData(
       ContactEmailBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as ContactEmailData[];
   }
 
   static async loadRawData<T extends ContactEmailBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return contactEmailLoader.createLoader(context).load(id);
+  ): Promise<ContactEmailData | null> {
+    const row = await contactEmailLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as ContactEmailData;
   }
 
   static async loadRawDataX<T extends ContactEmailBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<ContactEmailData> {
     const row = await contactEmailLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as ContactEmailData;
   }
 
   static loaderOptions<T extends ContactEmailBase>(

--- a/examples/simple/src/ent/generated/contact_phone_number_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number_base.ts
@@ -27,6 +27,15 @@ import {
 import { Contact, NodeType } from "../internal";
 import schema from "../../schema/contact_phone_number";
 
+export interface ContactPhoneNumberData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  phone_number: string;
+  label: string;
+  contact_id: ID;
+}
+
 export class ContactPhoneNumberBase {
   readonly nodeType = NodeType.ContactPhoneNumber;
   readonly id: ID;
@@ -99,32 +108,36 @@ export class ContactPhoneNumberBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<ContactPhoneNumberData[]> {
+    return (await loadCustomData(
       ContactPhoneNumberBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as ContactPhoneNumberData[];
   }
 
   static async loadRawData<T extends ContactPhoneNumberBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return contactPhoneNumberLoader.createLoader(context).load(id);
+  ): Promise<ContactPhoneNumberData | null> {
+    const row = await contactPhoneNumberLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as ContactPhoneNumberData;
   }
 
   static async loadRawDataX<T extends ContactPhoneNumberBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<ContactPhoneNumberData> {
     const row = await contactPhoneNumberLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as ContactPhoneNumberData;
   }
 
   static loaderOptions<T extends ContactPhoneNumberBase>(

--- a/examples/simple/src/ent/generated/contact_phone_number_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number_base.ts
@@ -27,7 +27,7 @@ import {
 import { Contact, NodeType } from "../internal";
 import schema from "../../schema/contact_phone_number";
 
-export interface ContactPhoneNumberData {
+interface ContactPhoneNumberDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -108,36 +108,36 @@ export class ContactPhoneNumberBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<ContactPhoneNumberData[]> {
+  ): Promise<ContactPhoneNumberDBData[]> {
     return (await loadCustomData(
       ContactPhoneNumberBase.loaderOptions.apply(this),
       query,
       context,
-    )) as ContactPhoneNumberData[];
+    )) as ContactPhoneNumberDBData[];
   }
 
   static async loadRawData<T extends ContactPhoneNumberBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactPhoneNumberData | null> {
+  ): Promise<ContactPhoneNumberDBData | null> {
     const row = await contactPhoneNumberLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as ContactPhoneNumberData;
+    return row as ContactPhoneNumberDBData;
   }
 
   static async loadRawDataX<T extends ContactPhoneNumberBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactPhoneNumberData> {
+  ): Promise<ContactPhoneNumberDBData> {
     const row = await contactPhoneNumberLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as ContactPhoneNumberData;
+    return row as ContactPhoneNumberDBData;
   }
 
   static loaderOptions<T extends ContactPhoneNumberBase>(

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -44,7 +44,7 @@ export enum EventRsvpStatus {
   CanRsvp = "canRsvp",
 }
 
-export interface EventData {
+interface EventDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -147,36 +147,36 @@ export class EventBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<EventData[]> {
+  ): Promise<EventDBData[]> {
     return (await loadCustomData(
       EventBase.loaderOptions.apply(this),
       query,
       context,
-    )) as EventData[];
+    )) as EventDBData[];
   }
 
   static async loadRawData<T extends EventBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<EventData | null> {
+  ): Promise<EventDBData | null> {
     const row = await eventLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as EventData;
+    return row as EventDBData;
   }
 
   static async loadRawDataX<T extends EventBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<EventData> {
+  ): Promise<EventDBData> {
     const row = await eventLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as EventData;
+    return row as EventDBData;
   }
 
   static loaderOptions<T extends EventBase>(

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -44,6 +44,18 @@ export enum EventRsvpStatus {
   CanRsvp = "canRsvp",
 }
 
+export interface EventData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  name: string;
+  user_id: ID;
+  start_time: Date;
+  end_time: Date | null;
+  location: string;
+  address_id: ID | null;
+}
+
 export class EventBase {
   readonly nodeType = NodeType.Event;
   readonly id: ID;
@@ -135,28 +147,36 @@ export class EventBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(EventBase.loaderOptions.apply(this), query, context);
+  ): Promise<EventData[]> {
+    return (await loadCustomData(
+      EventBase.loaderOptions.apply(this),
+      query,
+      context,
+    )) as EventData[];
   }
 
   static async loadRawData<T extends EventBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return eventLoader.createLoader(context).load(id);
+  ): Promise<EventData | null> {
+    const row = await eventLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as EventData;
   }
 
   static async loadRawDataX<T extends EventBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<EventData> {
     const row = await eventLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as EventData;
   }
 
   static loaderOptions<T extends EventBase>(

--- a/examples/simple/src/ent/generated/holiday_base.ts
+++ b/examples/simple/src/ent/generated/holiday_base.ts
@@ -24,6 +24,16 @@ import { holidayLoader, holidayLoaderInfo } from "./loaders";
 import { DayOfWeek, DayOfWeekAlt, NodeType } from "../internal";
 import schema from "../../schema/holiday";
 
+export interface HolidayData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  day_of_week: DayOfWeek;
+  day_of_week_alt: DayOfWeekAlt | null;
+  label: string;
+  date: Date;
+}
+
 export class HolidayBase {
   readonly nodeType = NodeType.Holiday;
   readonly id: ID;
@@ -98,32 +108,36 @@ export class HolidayBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<HolidayData[]> {
+    return (await loadCustomData(
       HolidayBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as HolidayData[];
   }
 
   static async loadRawData<T extends HolidayBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return holidayLoader.createLoader(context).load(id);
+  ): Promise<HolidayData | null> {
+    const row = await holidayLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as HolidayData;
   }
 
   static async loadRawDataX<T extends HolidayBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<HolidayData> {
     const row = await holidayLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as HolidayData;
   }
 
   static loaderOptions<T extends HolidayBase>(

--- a/examples/simple/src/ent/generated/holiday_base.ts
+++ b/examples/simple/src/ent/generated/holiday_base.ts
@@ -24,7 +24,7 @@ import { holidayLoader, holidayLoaderInfo } from "./loaders";
 import { DayOfWeek, DayOfWeekAlt, NodeType } from "../internal";
 import schema from "../../schema/holiday";
 
-export interface HolidayData {
+interface HolidayDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -108,36 +108,36 @@ export class HolidayBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<HolidayData[]> {
+  ): Promise<HolidayDBData[]> {
     return (await loadCustomData(
       HolidayBase.loaderOptions.apply(this),
       query,
       context,
-    )) as HolidayData[];
+    )) as HolidayDBData[];
   }
 
   static async loadRawData<T extends HolidayBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<HolidayData | null> {
+  ): Promise<HolidayDBData | null> {
     const row = await holidayLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as HolidayData;
+    return row as HolidayDBData;
   }
 
   static async loadRawDataX<T extends HolidayBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<HolidayData> {
+  ): Promise<HolidayDBData> {
     const row = await holidayLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as HolidayData;
+    return row as HolidayDBData;
   }
 
   static loaderOptions<T extends HolidayBase>(

--- a/examples/simple/src/ent/generated/hours_of_operation_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation_base.ts
@@ -24,6 +24,16 @@ import { hoursOfOperationLoader, hoursOfOperationLoaderInfo } from "./loaders";
 import { DayOfWeek, DayOfWeekAlt, NodeType } from "../internal";
 import schema from "../../schema/hours_of_operation";
 
+export interface HoursOfOperationData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  day_of_week: DayOfWeek;
+  day_of_week_alt: DayOfWeekAlt | null;
+  open: string;
+  close: string;
+}
+
 export class HoursOfOperationBase {
   readonly nodeType = NodeType.HoursOfOperation;
   readonly id: ID;
@@ -98,32 +108,36 @@ export class HoursOfOperationBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<HoursOfOperationData[]> {
+    return (await loadCustomData(
       HoursOfOperationBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as HoursOfOperationData[];
   }
 
   static async loadRawData<T extends HoursOfOperationBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return hoursOfOperationLoader.createLoader(context).load(id);
+  ): Promise<HoursOfOperationData | null> {
+    const row = await hoursOfOperationLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as HoursOfOperationData;
   }
 
   static async loadRawDataX<T extends HoursOfOperationBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<HoursOfOperationData> {
     const row = await hoursOfOperationLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as HoursOfOperationData;
   }
 
   static loaderOptions<T extends HoursOfOperationBase>(

--- a/examples/simple/src/ent/generated/hours_of_operation_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation_base.ts
@@ -24,7 +24,7 @@ import { hoursOfOperationLoader, hoursOfOperationLoaderInfo } from "./loaders";
 import { DayOfWeek, DayOfWeekAlt, NodeType } from "../internal";
 import schema from "../../schema/hours_of_operation";
 
-export interface HoursOfOperationData {
+interface HoursOfOperationDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -108,36 +108,36 @@ export class HoursOfOperationBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<HoursOfOperationData[]> {
+  ): Promise<HoursOfOperationDBData[]> {
     return (await loadCustomData(
       HoursOfOperationBase.loaderOptions.apply(this),
       query,
       context,
-    )) as HoursOfOperationData[];
+    )) as HoursOfOperationDBData[];
   }
 
   static async loadRawData<T extends HoursOfOperationBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<HoursOfOperationData | null> {
+  ): Promise<HoursOfOperationDBData | null> {
     const row = await hoursOfOperationLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as HoursOfOperationData;
+    return row as HoursOfOperationDBData;
   }
 
   static async loadRawDataX<T extends HoursOfOperationBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<HoursOfOperationData> {
+  ): Promise<HoursOfOperationDBData> {
     const row = await hoursOfOperationLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as HoursOfOperationData;
+    return row as HoursOfOperationDBData;
   }
 
   static loaderOptions<T extends HoursOfOperationBase>(

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -77,6 +77,32 @@ export enum PreferredShift {
   Graveyard = "graveyard",
 }
 
+export interface UserData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  first_name: string;
+  last_name: string;
+  email_address: string;
+  phone_number: string | null;
+  password: string | null;
+  account_status: string | null;
+  email_verified: boolean | null;
+  bio: string | null;
+  nicknames: string[] | null;
+  prefs: UserPrefsStruct | null;
+  prefs_list: UserPrefsStruct2[] | null;
+  prefs_diff: UserPrefsDiff | null;
+  days_off: DaysOff[] | null;
+  preferred_shift: PreferredShift[] | null;
+  time_in_ms: BigInt | null;
+  fun_uuids: ID[] | null;
+  new_col: string | null;
+  new_col_2: string | null;
+  super_nested_object: UserSuperNestedObject | null;
+  nested_list: UserNestedObjectList[] | null;
+}
+
 export class UserBase {
   readonly nodeType = NodeType.User;
   readonly id: ID;
@@ -245,28 +271,36 @@ export class UserBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(UserBase.loaderOptions.apply(this), query, context);
+  ): Promise<UserData[]> {
+    return (await loadCustomData(
+      UserBase.loaderOptions.apply(this),
+      query,
+      context,
+    )) as UserData[];
   }
 
   static async loadRawData<T extends UserBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return userLoader.createLoader(context).load(id);
+  ): Promise<UserData | null> {
+    const row = await userLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as UserData;
   }
 
   static async loadRawDataX<T extends UserBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<UserData> {
     const row = await userLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as UserData;
   }
 
   static async loadFromEmailAddress<T extends UserBase>(
@@ -306,8 +340,14 @@ export class UserBase {
     this: new (viewer: Viewer, data: Data) => T,
     emailAddress: string,
     context?: Context,
-  ): Promise<Data | null> {
-    return userEmailAddressLoader.createLoader(context).load(emailAddress);
+  ): Promise<UserData | null> {
+    const row = await userEmailAddressLoader
+      .createLoader(context)
+      .load(emailAddress);
+    if (!row) {
+      return null;
+    }
+    return row as UserData;
   }
 
   static async loadFromPhoneNumber<T extends UserBase>(
@@ -347,8 +387,14 @@ export class UserBase {
     this: new (viewer: Viewer, data: Data) => T,
     phoneNumber: string,
     context?: Context,
-  ): Promise<Data | null> {
-    return userPhoneNumberLoader.createLoader(context).load(phoneNumber);
+  ): Promise<UserData | null> {
+    const row = await userPhoneNumberLoader
+      .createLoader(context)
+      .load(phoneNumber);
+    if (!row) {
+      return null;
+    }
+    return row as UserData;
   }
 
   static loaderOptions<T extends UserBase>(

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -77,7 +77,7 @@ export enum PreferredShift {
   Graveyard = "graveyard",
 }
 
-export interface UserData {
+interface UserDBData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -271,36 +271,36 @@ export class UserBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<UserData[]> {
+  ): Promise<UserDBData[]> {
     return (await loadCustomData(
       UserBase.loaderOptions.apply(this),
       query,
       context,
-    )) as UserData[];
+    )) as UserDBData[];
   }
 
   static async loadRawData<T extends UserBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<UserData | null> {
+  ): Promise<UserDBData | null> {
     const row = await userLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as UserData;
+    return row as UserDBData;
   }
 
   static async loadRawDataX<T extends UserBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<UserData> {
+  ): Promise<UserDBData> {
     const row = await userLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as UserData;
+    return row as UserDBData;
   }
 
   static async loadFromEmailAddress<T extends UserBase>(
@@ -340,14 +340,14 @@ export class UserBase {
     this: new (viewer: Viewer, data: Data) => T,
     emailAddress: string,
     context?: Context,
-  ): Promise<UserData | null> {
+  ): Promise<UserDBData | null> {
     const row = await userEmailAddressLoader
       .createLoader(context)
       .load(emailAddress);
     if (!row) {
       return null;
     }
-    return row as UserData;
+    return row as UserDBData;
   }
 
   static async loadFromPhoneNumber<T extends UserBase>(
@@ -387,14 +387,14 @@ export class UserBase {
     this: new (viewer: Viewer, data: Data) => T,
     phoneNumber: string,
     context?: Context,
-  ): Promise<UserData | null> {
+  ): Promise<UserDBData | null> {
     const row = await userPhoneNumberLoader
       .createLoader(context)
       .load(phoneNumber);
     if (!row) {
       return null;
     }
-    return row as UserData;
+    return row as UserDBData;
   }
 
   static loaderOptions<T extends UserBase>(

--- a/examples/todo-sqlite/src/ent/generated/account_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_base.ts
@@ -40,6 +40,16 @@ export enum AccountState {
   DISABLED = "DISABLED",
 }
 
+interface AccountDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  name: string;
+  phone_number: string | null;
+  account_state: AccountState | null;
+}
+
 export class AccountBase {
   readonly nodeType = NodeType.Account;
   readonly id: ID;
@@ -143,32 +153,36 @@ export class AccountBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(
+  ): Promise<AccountDBData[]> {
+    return (await loadCustomData(
       AccountBase.loaderOptions.apply(this),
       query,
       context,
-    );
+    )) as AccountDBData[];
   }
 
   static async loadRawData<T extends AccountBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return accountLoader.createLoader(context).load(id);
+  ): Promise<AccountDBData | null> {
+    const row = await accountLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as AccountDBData;
   }
 
   static async loadRawDataX<T extends AccountBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<AccountDBData> {
     const row = await accountLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as AccountDBData;
   }
 
   // TODO index deleted_at not id... we want an indexQueryLoader...
@@ -210,8 +224,14 @@ export class AccountBase {
     this: new (viewer: Viewer, data: Data) => T,
     phoneNumber: string,
     context?: Context,
-  ): Promise<Data | null> {
-    return accountPhoneNumberLoader.createLoader(context).load(phoneNumber);
+  ): Promise<AccountDBData | null> {
+    const row = await accountPhoneNumberLoader
+      .createLoader(context)
+      .load(phoneNumber);
+    if (!row) {
+      return null;
+    }
+    return row as AccountDBData;
   }
 
   static loaderOptions<T extends AccountBase>(

--- a/examples/todo-sqlite/src/ent/generated/tag_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_base.ts
@@ -27,6 +27,17 @@ import {
 import { Account, NodeType, TagToTodosQuery } from "src/ent/internal";
 import schema from "src/schema/tag";
 
+interface TagDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  display_name: string;
+  canonical_name: string;
+  owner_id: ID;
+  related_tag_ids: ID[] | null;
+}
+
 export class TagBase {
   readonly nodeType = NodeType.Tag;
   readonly id: ID;
@@ -128,28 +139,36 @@ export class TagBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(TagBase.loaderOptions.apply(this), query, context);
+  ): Promise<TagDBData[]> {
+    return (await loadCustomData(
+      TagBase.loaderOptions.apply(this),
+      query,
+      context,
+    )) as TagDBData[];
   }
 
   static async loadRawData<T extends TagBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return tagLoader.createLoader(context).load(id);
+  ): Promise<TagDBData | null> {
+    const row = await tagLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as TagDBData;
   }
 
   static async loadRawDataX<T extends TagBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<TagDBData> {
     const row = await tagLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as TagDBData;
   }
 
   // TODO index deleted_at not id... we want an indexQueryLoader...

--- a/examples/todo-sqlite/src/ent/generated/todo_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_base.ts
@@ -27,6 +27,16 @@ import {
 import { Account, NodeType, TodoToTagsQuery } from "src/ent/internal";
 import schema from "src/schema/todo";
 
+interface TodoDBData {
+  id: ID;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  text: string;
+  completed: boolean;
+  creator_id: ID;
+}
+
 export class TodoBase {
   readonly nodeType = NodeType.Todo;
   readonly id: ID;
@@ -130,28 +140,36 @@ export class TodoBase {
     this: new (viewer: Viewer, data: Data) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<Data[]> {
-    return loadCustomData(TodoBase.loaderOptions.apply(this), query, context);
+  ): Promise<TodoDBData[]> {
+    return (await loadCustomData(
+      TodoBase.loaderOptions.apply(this),
+      query,
+      context,
+    )) as TodoDBData[];
   }
 
   static async loadRawData<T extends TodoBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data | null> {
-    return todoLoader.createLoader(context).load(id);
+  ): Promise<TodoDBData | null> {
+    const row = await todoLoader.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as TodoDBData;
   }
 
   static async loadRawDataX<T extends TodoBase>(
     this: new (viewer: Viewer, data: Data) => T,
     id: ID,
     context?: Context,
-  ): Promise<Data> {
+  ): Promise<TodoDBData> {
     const row = await todoLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as TodoDBData;
   }
 
   // TODO index deleted_at not id... we want an indexQueryLoader...

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -28,8 +28,7 @@
 {{$this := .}}
 
 {{$baseClass := printf "%sBase" .Node -}}
-{{$constructor := "arg: new (viewer: Viewer, data: Data) => T"}}
-{{$thisType := "new (viewer: Viewer, data: Data) => T"}}
+{{$thisType := "new (viewer: Viewer, data: Data) => T" }}
 
 {{ range .GetTSEnums -}}
   {{if not .Imported -}}
@@ -37,6 +36,21 @@
   {{end -}}
 {{ end}}
 {{$nodeData := .}}
+
+{{$dataType := printf "%sData" .Node -}}
+
+export interface {{.Node}}Data {
+  {{range $field := .FieldInfo.Fields -}}
+    {{ range $field.GetTsTypeImports -}}
+      {{ if ($nodeData.ForeignImport .Import) -}}
+        {{ reserveImportPath . false -}}
+      {{end -}}
+      {{$typ := useImportMaybe .Import -}}
+    {{end -}}
+
+    {{$field.GetDbColName}}: {{$field.TsType}};
+  {{ end -}}
+}
 
 export class {{$baseClass}} {
 
@@ -55,7 +69,7 @@ export class {{$baseClass}} {
     {{end -}}
   {{end}}
 
-  constructor(public viewer: {{$viewerType}}, protected data:{{$dataType}}) {
+  constructor(public viewer: {{$viewerType}}, protected data:Data) {
     {{range $field := .FieldInfo.Fields -}}
       {{$val := printf "data.%s" $field.GetDbColName -}}
       {{$convertType := convertFunc ($field.GetTSFieldType $cfg) -}}
@@ -187,12 +201,12 @@ export class {{$baseClass}} {
     this: {{$thisType}},
     query: {{useImport "CustomQuery"}},
     context?: {{useImport "Context"}}
-  ): Promise<Data[]> {
-    return {{useImport "loadCustomData"}}(
+  ): Promise<{{$dataType}}[]> {
+    return  await {{useImport "loadCustomData"}}(
       {{$baseClass}}.loaderOptions.apply(this),
       query,
       context,
-    );
+    ) as {{$dataType}}[];
   }
 
   static async loadRawData<T extends {{$baseClass}}>(
@@ -200,7 +214,11 @@ export class {{$baseClass}} {
     id: ID,
     context?: {{useImport "Context"}},
   ): Promise<{{$dataType}} | null> {
-    return {{useImport $loaderName}}.createLoader(context).load(id);
+    const row = await {{useImport $loaderName}}.createLoader(context).load(id);
+    if (!row) {
+      return null;
+    }
+    return row as {{$dataType}};
   }
 
   static async loadRawDataX<T extends {{$baseClass}}>(
@@ -212,7 +230,7 @@ export class {{$baseClass}} {
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row;
+    return row as {{$dataType}};
   }
 
 
@@ -263,7 +281,11 @@ export class {{$baseClass}} {
         {{$field.TsFieldName $cfg}}: {{$field.GetNotNullableTsType}},
         context?: {{useImport "Context"}},
       ): Promise<{{$dataType}} | null> {
-        return {{$fieldLoader}}.createLoader(context).load({{$field.TsFieldName $cfg}});
+        const row = await {{$fieldLoader}}.createLoader(context).load({{$field.TsFieldName $cfg}});
+        if (!row) {
+          return null;
+        }
+        return row as {{$dataType}};
       }
     {{ else if $field.QueryFromEnt -}}
       {{$queryName := useImport ($this.GetFieldQueryName $field) -}}

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -24,10 +24,10 @@
 
 {{$viewerType := useImport "Viewer"}}
 {{$idType := useImport "ID" }}
-{{$dataType := useImport "Data" }}
 {{$this := .}}
 
 {{$baseClass := printf "%sBase" .Node -}}
+{{$ignore := useImport "Data" -}}
 {{$thisType := "new (viewer: Viewer, data: Data) => T" }}
 
 {{ range .GetTSEnums -}}
@@ -37,9 +37,9 @@
 {{ end}}
 {{$nodeData := .}}
 
-{{$dataType := printf "%sData" .Node -}}
+{{$dataType := printf "%sDBData" .Node -}}
 
-export interface {{.Node}}Data {
+interface {{$dataType}} {
   {{range $field := .FieldInfo.Fields -}}
     {{ range $field.GetTsTypeImports -}}
       {{ if ($nodeData.ForeignImport .Import) -}}


### PR DESCRIPTION
fixes https://github.com/lolopinto/ent/issues/887

had a different version that typed everything (including the ent APIs) but it became too complicated so simplified to only type the public APIs 