### PR TITLE
Convert ent privacy policy

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha9",
+        "@snowtop/ent": "^0.1.0-alpha10",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha9",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha9.tgz",
-      "integrity": "sha512-jvikx6H7MbNdwQ/nwVC1mfjjf3YcTarfo1npVWvx7/gl8Cpp/D4PPa2eVFVz0tYnmS8tkOPeJAPzuKs0DQD73Q==",
+      "version": "0.1.0-alpha10",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha10.tgz",
+      "integrity": "sha512-SsdhrUXCgMdrRiHWC2ULpSl9o2Gh3R2f04NcpP3ZkHWQ4x2EnypwCly5CQls/WUONt8ckhmWQZIECfjNaWbXeg==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6899,9 +6899,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha9",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha9.tgz",
-      "integrity": "sha512-jvikx6H7MbNdwQ/nwVC1mfjjf3YcTarfo1npVWvx7/gl8Cpp/D4PPa2eVFVz0tYnmS8tkOPeJAPzuKs0DQD73Q==",
+      "version": "0.1.0-alpha10",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha10.tgz",
+      "integrity": "sha512-SsdhrUXCgMdrRiHWC2ULpSl9o2Gh3R2f04NcpP3ZkHWQ4x2EnypwCly5CQls/WUONt8ckhmWQZIECfjNaWbXeg==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha9",
+    "@snowtop/ent": "^0.1.0-alpha10",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/src/ent/address.ts
+++ b/examples/simple/src/ent/address.ts
@@ -1,7 +1,9 @@
-import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
+import { AlwaysAllowPrivacyPolicy, PrivacyPolicy } from "@snowtop/ent";
 import { AddressBase } from "./internal";
 
 // we're only writing this once except with --force and packageName provided
 export class Address extends AddressBase {
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 }

--- a/examples/simple/src/ent/auth_code.ts
+++ b/examples/simple/src/ent/auth_code.ts
@@ -7,7 +7,9 @@ import { AuthCodeBase } from "../ent/internal";
 
 // we're only writing this once except with --force and packageName provided
 export class AuthCode extends AuthCodeBase {
-  privacyPolicy: PrivacyPolicy = {
-    rules: [new AllowIfViewerIsRule("userID"), AlwaysDenyRule],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [new AllowIfViewerIsRule("userID"), AlwaysDenyRule],
+    };
+  }
 }

--- a/examples/simple/src/ent/comment.ts
+++ b/examples/simple/src/ent/comment.ts
@@ -2,9 +2,11 @@
  * Copyright whaa whaa
  */
 
-import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
+import { AlwaysAllowPrivacyPolicy, PrivacyPolicy } from "@snowtop/ent";
 import { CommentBase } from "./internal";
 
 export class Comment extends CommentBase {
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 }

--- a/examples/simple/src/ent/contact.ts
+++ b/examples/simple/src/ent/contact.ts
@@ -15,9 +15,11 @@ interface ContactPlusEmails {
 }
 
 export class Contact extends ContactBase {
-  privacyPolicy: PrivacyPolicy = {
-    rules: [new AllowIfViewerIsRule("userID"), AlwaysDenyRule],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [new AllowIfViewerIsRule("userID"), AlwaysDenyRule],
+    };
+  }
 
   @gqlField({
     type: GraphQLString,

--- a/examples/simple/src/ent/contact_email.ts
+++ b/examples/simple/src/ent/contact_email.ts
@@ -7,8 +7,10 @@ import { Contact } from ".";
 import { ContactEmailBase } from "./internal";
 
 export class ContactEmail extends ContactEmailBase {
-  privacyPolicy: PrivacyPolicy = new AllowIfEntIsVisiblePolicy(
-    this.contactID,
-    Contact.loaderOptions(),
-  );
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return new AllowIfEntIsVisiblePolicy(
+      this.contactID,
+      Contact.loaderOptions(),
+    );
+  }
 }

--- a/examples/simple/src/ent/contact_phone_number.ts
+++ b/examples/simple/src/ent/contact_phone_number.ts
@@ -7,8 +7,10 @@ import { Contact } from ".";
 import { ContactPhoneNumberBase } from "./internal";
 
 export class ContactPhoneNumber extends ContactPhoneNumberBase {
-  privacyPolicy: PrivacyPolicy = new AllowIfEntIsVisiblePolicy(
-    this.contactID,
-    Contact.loaderOptions(),
-  );
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return new AllowIfEntIsVisiblePolicy(
+      this.contactID,
+      Contact.loaderOptions(),
+    );
+  }
 }

--- a/examples/simple/src/ent/event.ts
+++ b/examples/simple/src/ent/event.ts
@@ -3,7 +3,9 @@ import { PrivacyPolicy, AlwaysAllowRule } from "@snowtop/ent";
 
 // we're only writing this once except with --force and packageName provided
 export class Event extends EventBase {
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AlwaysAllowRule],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [AlwaysAllowRule],
+    };
+  }
 }

--- a/examples/simple/src/ent/generated/address_base.ts
+++ b/examples/simple/src/ent/generated/address_base.ts
@@ -60,7 +60,9 @@ export class AddressBase {
     this.country = data.country;
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   static async load<T extends AddressBase>(
     this: new (viewer: Viewer, data: Data) => T,

--- a/examples/simple/src/ent/generated/auth_code_base.ts
+++ b/examples/simple/src/ent/generated/auth_code_base.ts
@@ -54,7 +54,9 @@ export class AuthCodeBase {
     this.phoneNumber = data.phone_number;
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   static async load<T extends AuthCodeBase>(
     this: new (viewer: Viewer, data: Data) => T,

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -61,7 +61,9 @@ export class CommentBase {
     this.articleType = data.article_type;
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   static async load<T extends CommentBase>(
     this: new (viewer: Viewer, data: Data) => T,

--- a/examples/simple/src/ent/generated/contact_base.ts
+++ b/examples/simple/src/ent/generated/contact_base.ts
@@ -65,7 +65,9 @@ export class ContactBase {
     this.userID = data.user_id;
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   static async load<T extends ContactBase>(
     this: new (viewer: Viewer, data: Data) => T,

--- a/examples/simple/src/ent/generated/contact_email_base.ts
+++ b/examples/simple/src/ent/generated/contact_email_base.ts
@@ -51,7 +51,9 @@ export class ContactEmailBase {
     this.contactID = data.contact_id;
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   static async load<T extends ContactEmailBase>(
     this: new (viewer: Viewer, data: Data) => T,

--- a/examples/simple/src/ent/generated/contact_phone_number_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number_base.ts
@@ -54,7 +54,9 @@ export class ContactPhoneNumberBase {
     this.contactID = data.contact_id;
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   static async load<T extends ContactPhoneNumberBase>(
     this: new (viewer: Viewer, data: Data) => T,

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -80,7 +80,9 @@ export class EventBase {
     this._addressID = data.address_id;
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   async addressID(): Promise<ID | null> {
     if (this._addressID === null) {

--- a/examples/simple/src/ent/generated/holiday_base.ts
+++ b/examples/simple/src/ent/generated/holiday_base.ts
@@ -54,7 +54,9 @@ export class HolidayBase {
     this.date = convertDate(data.date);
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   static async load<T extends HolidayBase>(
     this: new (viewer: Viewer, data: Data) => T,

--- a/examples/simple/src/ent/generated/hours_of_operation_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation_base.ts
@@ -54,7 +54,9 @@ export class HoursOfOperationBase {
     this.close = data.close;
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   static async load<T extends HoursOfOperationBase>(
     this: new (viewer: Viewer, data: Data) => T,

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -155,7 +155,9 @@ export class UserBase {
     this.nestedList = convertNullableJSONList(data.nested_list);
   }
 
-  privacyPolicy: PrivacyPolicy = AllowIfViewerPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AllowIfViewerPrivacyPolicy;
+  }
 
   async accountStatus(): Promise<string | null> {
     if (this._accountStatus === null) {

--- a/examples/simple/src/ent/holiday.ts
+++ b/examples/simple/src/ent/holiday.ts
@@ -1,7 +1,9 @@
-import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
+import { AlwaysAllowPrivacyPolicy, PrivacyPolicy } from "@snowtop/ent";
 import { HolidayBase } from "./internal";
 
 // we're only writing this once except with --force and packageName provided
 export class Holiday extends HolidayBase {
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 }

--- a/examples/simple/src/ent/hours_of_operation.ts
+++ b/examples/simple/src/ent/hours_of_operation.ts
@@ -1,7 +1,9 @@
-import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
+import { AlwaysAllowPrivacyPolicy, PrivacyPolicy } from "@snowtop/ent";
 import { HoursOfOperationBase } from "./internal";
 
 // we're only writing this once except with --force and packageName provided
 export class HoursOfOperation extends HoursOfOperationBase {
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 }

--- a/examples/simple/src/ent/user.ts
+++ b/examples/simple/src/ent/user.ts
@@ -4,6 +4,7 @@ import {
   AlwaysDenyRule,
   AllowIfViewerInboundEdgeExistsRule,
   Data,
+  PrivacyPolicy,
 } from "@snowtop/ent";
 import { AllowIfOmniRule } from "./../privacy/omni";
 import { GraphQLString } from "graphql";
@@ -12,14 +13,16 @@ import * as bcrypt from "bcryptjs";
 
 // we're only writing this once except with --force and packageName provided
 export class User extends UserBase {
-  privacyPolicy = {
-    rules: [
-      AllowIfOmniRule,
-      AllowIfViewerRule,
-      new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToFriends),
-      AlwaysDenyRule,
-    ],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [
+        AllowIfOmniRule,
+        AllowIfViewerRule,
+        new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToFriends),
+        AlwaysDenyRule,
+      ],
+    };
+  }
 
   @gqlField({
     type: GraphQLString,

--- a/examples/simple/src/ent/user.ts
+++ b/examples/simple/src/ent/user.ts
@@ -1,6 +1,5 @@
 import { UserBase, Contact, EdgeType } from "./internal";
 import {
-  PrivacyPolicy,
   AllowIfViewerRule,
   AlwaysDenyRule,
   AllowIfViewerInboundEdgeExistsRule,
@@ -13,7 +12,7 @@ import * as bcrypt from "bcryptjs";
 
 // we're only writing this once except with --force and packageName provided
 export class User extends UserBase {
-  privacyPolicy: PrivacyPolicy = {
+  privacyPolicy = {
     rules: [
       AllowIfOmniRule,
       AllowIfViewerRule,

--- a/examples/simple/src/privacy/omni.ts
+++ b/examples/simple/src/privacy/omni.ts
@@ -5,7 +5,7 @@ interface OmniViewer extends Viewer {
 }
 
 export const AllowIfOmniRule = {
-  async apply(v: Viewer, ent: Ent): Promise<PrivacyResult> {
+  async apply(v: Viewer, ent?: Ent): Promise<PrivacyResult> {
     if (
       (v as OmniViewer).isOmniscient !== undefined &&
       (v as OmniViewer).isOmniscient()

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -81,12 +81,14 @@ export class {{$baseClass}} {
       {{end -}}
     {{end}}
   }
-
-  {{ if $privacyCfg.Class }}
-    privacyPolicy: {{useImport "PrivacyPolicy"}} = new {{useImport $privacyCfg.PolicyName}}();
-  {{ else }}
-    privacyPolicy: {{useImport "PrivacyPolicy"}} = {{useImport $privacyCfg.PolicyName}};
-  {{ end }}
+  
+  getPrivacyPolicy(): {{useImport "PrivacyPolicy"}}<this> {
+    {{ if $privacyCfg.Class }}
+      return new {{useImport $privacyCfg.PolicyName}}();
+    {{ else }}
+      return {{useImport $privacyCfg.PolicyName}};
+    {{ end }}
+  }
 
   {{range $field := .FieldInfo.Fields -}}
     {{ if $field.HasAsyncAccessor $cfg -}}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha9",
+  "version": "0.1.0-alpha10",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -1,4 +1,4 @@
-import { Ent, ID, Viewer, Data } from "../core/base";
+import { Ent, ID, Viewer, Data, PrivacyPolicy } from "../core/base";
 import { DataOperation, loadEdges, loadEnts, loadRows } from "../core/ent";
 import * as clause from "../core/clause";
 import { ObjectLoaderFactory } from "../core/loaders/object_loader";
@@ -203,7 +203,9 @@ class Account implements Ent {
   id: ID;
   accountID: string = "";
   nodeType = "Account";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;
@@ -232,7 +234,9 @@ const GroupSchema = getBuilderSchemaFromFields(
 class GroupMembership implements Ent {
   id: ID;
   nodeType = "GroupMembership";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;
@@ -251,7 +255,9 @@ const GroupMembershipSchema = getBuilderSchemaFromFields(
 class Changelog implements Ent {
   id: ID;
   nodeType = "Changelog";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -252,9 +252,11 @@ class CustomUser implements Ent {
   id: ID;
   accountID: string = "";
   nodeType = "User";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AllowIfViewerRule, AlwaysDenyRule],
-  };
+  getPrivacyPolicy() {
+    return {
+      rules: [AllowIfViewerRule, AlwaysDenyRule],
+    };
+  }
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;
   }

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -92,7 +92,7 @@ export interface Viewer {
 export interface Ent {
   id: ID;
   viewer: Viewer;
-  privacyPolicy: PrivacyPolicy<this>;
+  getPrivacyPolicy(): PrivacyPolicy<this>;
   nodeType: string;
 }
 

--- a/ts/src/core/ent.test.ts
+++ b/ts/src/core/ent.test.ts
@@ -111,9 +111,11 @@ class DerivedUser implements Ent {
   id: ID;
   accountID: string;
   nodeType = "User";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AllowIfViewerRule, AlwaysDenyRule],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [AllowIfViewerRule, AlwaysDenyRule],
+    };
+  }
   constructor(public viewer: Viewer, data: Data) {
     this.id = data["id"];
   }
@@ -328,9 +330,11 @@ function commonTests() {
       id: ID;
       accountID: string;
       nodeType = "User2";
-      privacyPolicy = {
-        rules: [AllowIfViewerRule, AlwaysDenyRule],
-      };
+      getPrivacyPolicy() {
+        return {
+          rules: [AllowIfViewerRule, AlwaysDenyRule],
+        };
+      }
 
       constructor(public viewer: Viewer, public data: Data) {
         this.id = data.id;

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -385,7 +385,11 @@ async function applyPrivacyPolicyForEnt<T extends Ent>(
   fieldPrivacyOptions: FieldPrivacyOptions<T>,
 ): Promise<T | null> {
   if (ent) {
-    const visible = await applyPrivacyPolicy(viewer, ent.privacyPolicy, ent);
+    const visible = await applyPrivacyPolicy(
+      viewer,
+      ent.getPrivacyPolicy(),
+      ent,
+    );
     if (!visible) {
       return null;
     }
@@ -401,7 +405,7 @@ async function applyPrivacyPolicyForEntX<T extends Ent>(
   options: FieldPrivacyOptions<T>,
 ): Promise<T> {
   // this will throw
-  await applyPrivacyPolicyX(viewer, ent.privacyPolicy, ent);
+  await applyPrivacyPolicyX(viewer, ent.getPrivacyPolicy(), ent);
   return doFieldPrivacy(viewer, ent, data, options);
 }
 

--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -64,24 +64,26 @@ class User implements Ent {
   id: ID;
   accountID: string;
   nodeType = "User";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [
-      {
-        async apply(v: Viewer, ent?: Ent): Promise<PrivacyResult> {
-          if (!v.viewerID) {
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [
+        {
+          async apply(v: Viewer, ent?: Ent): Promise<PrivacyResult> {
+            if (!v.viewerID) {
+              return Skip();
+            }
+            // can see each other if same modulus because we crazy
+            const vNum = v.viewerID as number;
+            if (vNum % 2 === (ent?.id as number) % 2) {
+              return Allow();
+            }
             return Skip();
-          }
-          // can see each other if same modulus because we crazy
-          const vNum = v.viewerID as number;
-          if (vNum % 2 === (ent?.id as number) % 2) {
-            return Allow();
-          }
-          return Skip();
+          },
         },
-      },
-      AlwaysDenyRule,
-    ],
-  };
+        AlwaysDenyRule,
+      ],
+    };
+  }
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data["id"];
   }

--- a/ts/src/core/ent_data.test.ts
+++ b/ts/src/core/ent_data.test.ts
@@ -53,9 +53,11 @@ class User implements Ent {
   foo: string | null;
   accountID: string;
   nodeType = "User";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AllowIfViewerRule, AlwaysDenyRule],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [AllowIfViewerRule, AlwaysDenyRule],
+    };
+  }
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data["bar"];
     this.baz = data["baz"];
@@ -86,9 +88,11 @@ class Contact implements Ent {
   foo: string | null;
   accountID: string;
   nodeType = "Contact";
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AllowIfViewerRule, AlwaysDenyRule],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [AllowIfViewerRule, AlwaysDenyRule],
+    };
+  }
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data["bar"];
     this.baz = data["baz"];

--- a/ts/src/core/privacy.test.ts
+++ b/ts/src/core/privacy.test.ts
@@ -37,7 +37,9 @@ const loggedOutViewer = new LoggedOutViewer();
 class User implements Ent {
   id: ID;
   accountID: string;
-  privacyPolicy: PrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return { rules: [] };
+  }
   nodeType = "User";
   // TODO add policy here
   constructor(public viewer: Viewer, data: Data) {
@@ -52,7 +54,9 @@ const getUser = function (
   accountID: string = "2",
 ): User {
   const user = new User(v, { id });
-  user.privacyPolicy = privacyPolicy;
+  user.getPrivacyPolicy = () => {
+    return privacyPolicy;
+  };
   user.accountID = accountID;
   return user;
 };
@@ -285,9 +289,11 @@ async function createUser() {
 }
 
 class DefinedUser extends User {
-  privacyPolicy: PrivacyPolicy = {
-    rules: [AllowIfViewerRule, AlwaysDenyRule],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [AllowIfViewerRule, AlwaysDenyRule],
+    };
+  }
   static loaderOptions(): LoadEntOptions<DefinedUser> {
     return {
       tableName: "users",

--- a/ts/src/core/privacy.ts
+++ b/ts/src/core/privacy.ts
@@ -314,7 +314,7 @@ export class AllowIfEdgeExistsRule implements PrivacyPolicyRule {
 export class AllowIfViewerInboundEdgeExistsRule implements PrivacyPolicyRule {
   constructor(private edgeType: string) {}
 
-  async apply(v: Viewer, ent: Ent): Promise<PrivacyResult> {
+  async apply(v: Viewer, ent?: Ent): Promise<PrivacyResult> {
     return allowIfEdgeExistsRule(v.viewerID, ent?.id, this.edgeType, v.context);
   }
 }

--- a/ts/src/schema/postgres_schema_live.test.ts
+++ b/ts/src/schema/postgres_schema_live.test.ts
@@ -29,7 +29,7 @@ import pg from "pg";
 import { defaultTimestampParser, Dialect } from "../core/db";
 import { DBType, FieldMap } from "./schema";
 import { AlwaysAllowPrivacyPolicy } from "../core/privacy";
-import { ID, Ent, Viewer, Data } from "../core/base";
+import { ID, Ent, Viewer, Data, PrivacyPolicy } from "../core/base";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -277,7 +277,9 @@ class Hours implements Ent {
   id: ID;
   accountID: string;
   nodeType = "Hours";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;
@@ -430,8 +432,9 @@ class Holiday implements Ent {
   id: ID;
   accountID: string;
   nodeType = "Holiday";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
-
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;
   }

--- a/ts/src/scripts/transform_code.ts
+++ b/ts/src/scripts/transform_code.ts
@@ -37,9 +37,6 @@ async function main() {
       if (!classInfo || classInfo.extends !== classInfo.name + "Base") {
         return;
       }
-      if (classInfo.name !== "ContactEmail") {
-        return;
-      }
 
       // need to check for PrivacyPolicy import...
       traversed = true;

--- a/ts/src/scripts/transform_code.ts
+++ b/ts/src/scripts/transform_code.ts
@@ -5,7 +5,7 @@ import {
   getTarget,
   createSourceFile,
 } from "../tsc/compilerOptions";
-import { getClassInfo, transformImport } from "../tsc/ast";
+import { getClassInfo, getPreText, transformImport } from "../tsc/ast";
 import { execSync } from "child_process";
 import * as fs from "fs";
 
@@ -35,6 +35,9 @@ async function main() {
       let classInfo = getClassInfo(contents, sourceFile, node);
       // only do classes which extend a base class e.g. User extends UserBase
       if (!classInfo || classInfo.extends !== classInfo.name + "Base") {
+        return;
+      }
+      if (classInfo.name !== "ContactEmail") {
         return;
       }
 
@@ -75,7 +78,7 @@ async function main() {
     for (const node of nodes) {
       if (node.node) {
         if (ts.isImportDeclaration(node.node)) {
-          let transformed = transformImport(node.node, sourceFile, {
+          let transformed = transformImport(contents, node.node, sourceFile, {
             newImports: ["PrivacyPolicy"],
           });
           if (transformed) {

--- a/ts/src/scripts/transform_code.ts
+++ b/ts/src/scripts/transform_code.ts
@@ -1,0 +1,75 @@
+import { glob } from "glob";
+import ts from "typescript";
+import {
+  readCompilerOptions,
+  getTarget,
+  createSourceFile,
+} from "../tsc/compilerOptions";
+
+async function main() {
+  const options = readCompilerOptions(".");
+  let files = glob.sync("src/ent/*.ts");
+  const target = getTarget(options.target?.toString());
+
+  files.forEach((file) => {
+    // go through the file and print everything back if not starting immediately after other position
+    let { contents, sourceFile } = createSourceFile(target, file);
+
+    ts.forEachChild(sourceFile, function (node: ts.Node) {
+      if (!ts.isClassDeclaration(node) || !node.heritageClauses) {
+        return;
+      }
+      if (!node.heritageClauses) {
+        return;
+      }
+      const klass = node.name?.getFullText(sourceFile).trim();
+      if (!klass) {
+        return;
+      }
+
+      const bases = node.heritageClauses
+        .filter((hc) => hc.token === ts.SyntaxKind.ExtendsKeyword)
+        .map((hc) =>
+          hc.types.map((type) => type.expression.getText(sourceFile)),
+        )
+        // @ts-ignore why is this missing?
+        .flat(1);
+      if (bases.length !== 1) {
+        return;
+      }
+
+      if (bases[0] !== klass + "Base") {
+        return;
+      }
+
+      const pp = node.members.filter((mm) => {
+        const v =
+          mm.kind === ts.SyntaxKind.PropertyDeclaration &&
+          (mm.name as ts.Identifier).escapedText === "privacyPolicy";
+        if (!v) {
+          return false;
+        }
+        const property = mm as ts.PropertyDeclaration;
+        return (
+          property.initializer?.kind === ts.SyntaxKind.ObjectLiteralExpression
+        );
+      });
+      if (pp.length !== 1) {
+        return;
+      }
+      const property = pp[0] as ts.PropertyDeclaration;
+      const initializer = property.initializer as ts.ObjectLiteralExpression;
+      console.debug(klass, initializer.properties);
+      //      console.debug(pp);
+    });
+  });
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/ts/src/scripts/transform_schema.ts
+++ b/ts/src/scripts/transform_schema.ts
@@ -1,47 +1,21 @@
 import { glob } from "glob";
 import ts from "typescript";
 import * as fs from "fs";
-import { readCompilerOptions } from "../tsc/compilerOptions";
+import {
+  readCompilerOptions,
+  getTarget,
+  createSourceFile,
+} from "../tsc/compilerOptions";
 import { execSync } from "child_process";
 import { Data } from "../core/base";
 import path from "path";
-
-function getTarget(target: string) {
-  switch (target.toLowerCase()) {
-    case "es2015":
-      return ts.ScriptTarget.ES2015;
-    case "es2016":
-      return ts.ScriptTarget.ES2016;
-    case "es2017":
-      return ts.ScriptTarget.ES2017;
-    case "es2018":
-      return ts.ScriptTarget.ES2018;
-    case "es2019":
-      return ts.ScriptTarget.ES2019;
-    case "es2020":
-      return ts.ScriptTarget.ES2020;
-    case "es2021":
-      return ts.ScriptTarget.ES2021;
-    case "es3":
-      return ts.ScriptTarget.ES3;
-    case "es5":
-      return ts.ScriptTarget.ES5;
-    case "esnext":
-      return ts.ScriptTarget.ESNext;
-    default:
-      return ts.ScriptTarget.ESNext;
-  }
-}
 
 async function main() {
   // this assumes this is being run from root of directory
   const options = readCompilerOptions(".");
   let files = glob.sync("src/schema/*.ts");
 
-  const target = options.target
-    ? // @ts-ignore
-      getTarget(options.target)
-    : ts.ScriptTarget.ESNext;
+  const target = getTarget(options.target?.toString());
 
   // filter to only event.ts e.g. for comments and whitespace...
   //  files = files.filter((f) => f.endsWith("event.ts"));
@@ -56,16 +30,9 @@ async function main() {
     // const writeFile = file;
     //    console.debug(file, writeFile);
 
-    let contents = fs.readFileSync(file).toString();
-
     // go through the file and print everything back if not starting immediately after other position
-    const sourceFile = ts.createSourceFile(
-      file,
-      contents,
-      target,
-      false,
-      ts.ScriptKind.TS,
-    );
+    let { contents, sourceFile } = createSourceFile(target, file);
+
     const nodes: NodeInfo[] = [];
     let updateImport = false;
     let removeImports: string[] = [];

--- a/ts/src/scripts/transform_schema.ts
+++ b/ts/src/scripts/transform_schema.ts
@@ -59,10 +59,15 @@ async function main() {
     for (const node of nodes) {
       if (updateImport && node.importNode) {
         const importNode = node.node as ts.ImportDeclaration;
-        const transformedImport = transformImport(importNode, sourceFile, {
-          removeImports,
-          transform: transformSchema,
-        });
+        const transformedImport = transformImport(
+          contents,
+          importNode,
+          sourceFile,
+          {
+            removeImports,
+            transform: transformSchema,
+          },
+        );
         if (transformedImport) {
           newContents += transformedImport;
           continue;

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -1,4 +1,11 @@
-import { Ent, ID, Viewer, Data, EntConstructor } from "../core/base";
+import {
+  Ent,
+  ID,
+  Viewer,
+  Data,
+  EntConstructor,
+  PrivacyPolicy,
+} from "../core/base";
 import { AlwaysAllowPrivacyPolicy } from "../core/privacy";
 import { Orchestrator } from "../action/orchestrator";
 import {
@@ -29,7 +36,9 @@ export class User implements Ent {
   id: ID;
   accountID: string = "";
   nodeType = "User";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
   firstName: string;
 
   constructor(public viewer: Viewer, public data: Data) {
@@ -44,7 +53,9 @@ export class Event implements Ent {
   id: ID;
   accountID: string = "";
   nodeType = "Event";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;
@@ -55,7 +66,9 @@ export class Contact implements Ent {
   id: ID;
   accountID: string = "";
   nodeType = "Contact";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.data.created_at = convertDate(data.created_at);
@@ -68,7 +81,9 @@ export class Group implements Ent {
   id: ID;
   accountID: string = "";
   nodeType = "Group";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;
@@ -79,7 +94,9 @@ export class Message implements Ent {
   id: ID;
   accountID: string = "";
   nodeType = "Message";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;
@@ -90,7 +107,9 @@ export class Address implements Ent {
   id: ID;
   accountID: string = "";
   nodeType = "Address";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;

--- a/ts/src/testutils/db/test_db_helpers.test.ts
+++ b/ts/src/testutils/db/test_db_helpers.test.ts
@@ -12,7 +12,9 @@ class Account implements Ent {
   id: ID;
   accountID: string;
   nodeType = "Account";
-  privacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy() {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, public data: Data) {
     this.id = data.id;

--- a/ts/src/testutils/fake_data/fake_contact.ts
+++ b/ts/src/testutils/fake_data/fake_contact.ts
@@ -26,9 +26,11 @@ export class FakeContact implements Ent {
   readonly emailAddress: string;
   readonly userID: ID;
 
-  privacyPolicy: PrivacyPolicy = {
-    rules: [new AllowIfViewerIsRule("userID"), AlwaysDenyRule],
-  };
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [new AllowIfViewerIsRule("userID"), AlwaysDenyRule],
+    };
+  }
 
   constructor(public viewer: Viewer, data: Data) {
     this.data = data;

--- a/ts/src/testutils/fake_data/fake_event.ts
+++ b/ts/src/testutils/fake_data/fake_event.ts
@@ -28,7 +28,9 @@ export class FakeEvent implements Ent {
   readonly description: string | null;
   readonly userID: ID;
 
-  privacyPolicy: PrivacyPolicy = AlwaysAllowPrivacyPolicy;
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return AlwaysAllowPrivacyPolicy;
+  }
 
   constructor(public viewer: Viewer, data: Data) {
     this.data = data;

--- a/ts/src/testutils/fake_data/fake_user.ts
+++ b/ts/src/testutils/fake_data/fake_user.ts
@@ -49,30 +49,32 @@ export class FakeUser implements Ent {
   readonly phoneNumber: string | null;
   protected readonly password: string | null;
 
-  privacyPolicy: PrivacyPolicy = {
-    rules: [
-      AllowIfViewerRule,
-      //can view user if friends
-      new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToFriends),
-      //can view user if following
-      new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToFollowing),
-      new AllowIfConditionAppliesRule((viewer: Viewer, ent: Ent) => {
-        if (!(viewer instanceof ViewerWithAccessToken)) {
-          return false;
-        }
+  getPrivacyPolicy(): PrivacyPolicy<this> {
+    return {
+      rules: [
+        AllowIfViewerRule,
+        //can view user if friends
+        new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToFriends),
+        //can view user if following
+        new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToFollowing),
+        new AllowIfConditionAppliesRule((viewer: Viewer, ent: Ent) => {
+          if (!(viewer instanceof ViewerWithAccessToken)) {
+            return false;
+          }
 
-        return viewer.hasToken("allow_outbound_friend_request");
-      }, new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToFriendRequests)),
-      new AllowIfConditionAppliesRule((viewer: Viewer, ent: Ent) => {
-        if (!(viewer instanceof ViewerWithAccessToken)) {
-          return false;
-        }
+          return viewer.hasToken("allow_outbound_friend_request");
+        }, new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToFriendRequests)),
+        new AllowIfConditionAppliesRule((viewer: Viewer, ent: Ent) => {
+          if (!(viewer instanceof ViewerWithAccessToken)) {
+            return false;
+          }
 
-        return viewer.hasToken("allow_incoming_friend_request");
-      }, new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToIncomingFriendRequests)),
-      AlwaysDenyRule,
-    ],
-  };
+          return viewer.hasToken("allow_incoming_friend_request");
+        }, new AllowIfViewerInboundEdgeExistsRule(EdgeType.UserToIncomingFriendRequests)),
+        AlwaysDenyRule,
+      ],
+    };
+  }
 
   constructor(public viewer: Viewer, data: Data) {
     this.data = data;

--- a/ts/src/tsc/ast.ts
+++ b/ts/src/tsc/ast.ts
@@ -110,6 +110,7 @@ interface transformOpts {
 }
 
 export function transformImport(
+  fileContents: string,
   importNode: ts.ImportDeclaration,
   sourceFile: ts.SourceFile,
   opts?: transformOpts,
@@ -142,9 +143,6 @@ export function transformImport(
   }
   let finalImports = new Set<string>();
 
-  if (opts?.newImports) {
-    opts.newImports.forEach((imp) => finalImports.add(imp));
-  }
   for (let i = 0; i < imports.length; i++) {
     let imp = imports[i].trim();
     if (opts?.transform) {
@@ -155,8 +153,14 @@ export function transformImport(
     }
     finalImports.add(imp);
   }
+  if (opts?.newImports) {
+    opts.newImports.forEach((imp) => finalImports.add(imp));
+  }
+
+  const comment = getPreText(fileContents, importNode, sourceFile);
 
   return (
+    comment +
     "import " +
     importText.substring(0, start + 1) +
     Array.from(finalImports).join(", ") +

--- a/ts/src/tsc/ast.ts
+++ b/ts/src/tsc/ast.ts
@@ -145,6 +145,9 @@ export function transformImport(
 
   for (let i = 0; i < imports.length; i++) {
     let imp = imports[i].trim();
+    if (imp === "") {
+      continue;
+    }
     if (opts?.transform) {
       imp = opts.transform(imp);
     }

--- a/ts/src/tsc/ast.ts
+++ b/ts/src/tsc/ast.ts
@@ -1,0 +1,101 @@
+import ts from "typescript";
+
+export function getPreText(
+  fileContents: string,
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+): string {
+  return fileContents.substring(node.getFullStart(), node.getStart(sourceFile));
+}
+
+export interface ClassInfo {
+  extends?: string;
+  comment: string;
+  name: string;
+  export?: boolean;
+  default?: boolean;
+  //  implementsSchema?: boolean;
+  implements?: string[];
+  wrapClassContents(inner: string): string;
+}
+
+export function getClassInfo(
+  fileContents: string,
+  sourceFile: ts.SourceFile,
+  node: ts.ClassDeclaration,
+): ClassInfo | undefined {
+  let className = node.name?.text;
+
+  let classExtends: string | undefined;
+  let impl: string[] = [];
+  if (node.heritageClauses) {
+    for (const hc of node.heritageClauses) {
+      switch (hc.token) {
+        case ts.SyntaxKind.ImplementsKeyword:
+          for (const type of hc.types) {
+            impl.push(type.expression.getText(sourceFile));
+          }
+          break;
+
+        case ts.SyntaxKind.ExtendsKeyword:
+          // can only extend one class
+          for (const type of hc.types) {
+            const text = type.expression.getText(sourceFile);
+            classExtends = text;
+          }
+          break;
+      }
+    }
+  }
+
+  // we probably still don't need all of this...
+  if (!className || !node.heritageClauses || !classExtends) {
+    return undefined;
+  }
+
+  let hasExport = false;
+  let hasDefault = false;
+  let comment = getPreText(fileContents, node, sourceFile);
+
+  const wrapClassContents = (inner: string) => {
+    let ret = `${comment}`;
+    if (hasExport) {
+      ret += "export ";
+    }
+    if (hasDefault) {
+      ret += "default ";
+    }
+    ret += `class ${className} `;
+    if (classExtends) {
+      ret += `extends ${classExtends} `;
+    }
+    if (impl.length) {
+      ret += `implements ${impl.join(", ")}`;
+    }
+
+    return `${ret}{
+      ${inner}
+    }`;
+  };
+
+  if (node.modifiers) {
+    for (const mod of node.modifiers) {
+      const text = mod.getText(sourceFile);
+      if (text === "export") {
+        hasExport = true;
+      } else if (text === "default") {
+        hasDefault = true;
+      }
+    }
+  }
+
+  return {
+    name: className,
+    extends: classExtends,
+    comment,
+    implements: impl,
+    wrapClassContents,
+    export: hasExport,
+    default: hasDefault,
+  };
+}

--- a/ts/src/tsc/compilerOptions.ts
+++ b/ts/src/tsc/compilerOptions.ts
@@ -37,3 +37,44 @@ export function readCompilerOptions(filePath: string) {
   }
   return options;
 }
+
+export function getTarget(target?: string) {
+  switch (target?.toLowerCase()) {
+    case "es2015":
+      return ts.ScriptTarget.ES2015;
+    case "es2016":
+      return ts.ScriptTarget.ES2016;
+    case "es2017":
+      return ts.ScriptTarget.ES2017;
+    case "es2018":
+      return ts.ScriptTarget.ES2018;
+    case "es2019":
+      return ts.ScriptTarget.ES2019;
+    case "es2020":
+      return ts.ScriptTarget.ES2020;
+    case "es2021":
+      return ts.ScriptTarget.ES2021;
+    case "es3":
+      return ts.ScriptTarget.ES3;
+    case "es5":
+      return ts.ScriptTarget.ES5;
+    case "esnext":
+      return ts.ScriptTarget.ESNext;
+    default:
+      return ts.ScriptTarget.ESNext;
+  }
+}
+
+export function createSourceFile(target: ts.ScriptTarget, file: string) {
+  let contents = fs.readFileSync(file).toString();
+
+  // go through the file and print everything back if not starting immediately after other position
+  const sourceFile = ts.createSourceFile(
+    file,
+    contents,
+    target,
+    false,
+    ts.ScriptKind.TS,
+  );
+  return { contents, sourceFile };
+}


### PR DESCRIPTION
Convert `Ent.privacyPolicy` to `Ent.getPrivacyPolicy` to be consistent with actions and queries

also includes a `transform_code.ts` file which transforms ents similar to `transform_schema.ts`. 

will eventually combine into one script which needs to be run which does all the transformations from v0 to v1.

fixes https://github.com/lolopinto/ent/issues/709