### PR TITLE
provide a way to resolve id fields for default values

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha10",
+        "@snowtop/ent": "^0.1.0-alpha11",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha10.tgz",
-      "integrity": "sha512-SsdhrUXCgMdrRiHWC2ULpSl9o2Gh3R2f04NcpP3ZkHWQ4x2EnypwCly5CQls/WUONt8ckhmWQZIECfjNaWbXeg==",
+      "version": "0.1.0-alpha11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha11.tgz",
+      "integrity": "sha512-radV+z+9tFV/Oqrmwkr5Bjlq2pDnnW73GxwBZL8tRE9AZEQ3Q8oLH3t7/5XI1W9azpC5SE09wMBxbOIQVX1MiQ==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6899,9 +6899,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha10.tgz",
-      "integrity": "sha512-SsdhrUXCgMdrRiHWC2ULpSl9o2Gh3R2f04NcpP3ZkHWQ4x2EnypwCly5CQls/WUONt8ckhmWQZIECfjNaWbXeg==",
+      "version": "0.1.0-alpha11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha11.tgz",
+      "integrity": "sha512-radV+z+9tFV/Oqrmwkr5Bjlq2pDnnW73GxwBZL8tRE9AZEQ3Q8oLH3t7/5XI1W9azpC5SE09wMBxbOIQVX1MiQ==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha10",
+    "@snowtop/ent": "^0.1.0-alpha11",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/src/ent/tests/contact.test.ts
+++ b/examples/simple/src/ent/tests/contact.test.ts
@@ -179,8 +179,6 @@ test("multiple emails", async () => {
     new IDViewer(user.id),
     input,
   ).saveX();
-  // reload contact
-  contact = await Contact.loadX(contact.viewer, contact.id);
 
   interface emailInfo {
     emailAddress: string;
@@ -222,8 +220,6 @@ test("multiple phonenumbers", async () => {
     new IDViewer(user.id),
     input,
   ).saveX();
-  // reload contact
-  contact = await Contact.loadX(contact.viewer, contact.id);
   interface phoneNmberInfo {
     phoneNumber: string;
     label: string;

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha10",
+  "version": "0.1.0-alpha11",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -236,22 +236,24 @@ export class SimpleBuilder<T extends Ent> implements Builder<T> {
         }
         return m;
       },
-      updateInput: (input: Data) => {
-        const knownFields = getFields(this.schema);
-        for (const k in input) {
-          if (knownFields.has(k)) {
-            this.fields.set(k, input[k]);
-          } else {
-            // related to #510. we do camelCase to pass fields in here but fields may be snakeCase and we want that to pass in tests
-            // we do camelCase in
-            const sc = snakeCase(k);
-            if (knownFields.has(sc)) {
-              this.fields.set(sc, input[k]);
-            }
-          }
-        }
-      },
+      updateInput: this.updateInput.bind(this),
     });
+  }
+
+  updateInput(input: Data) {
+    const knownFields = getFields(this.schema);
+    for (const k in input) {
+      if (knownFields.has(k)) {
+        this.fields.set(k, input[k]);
+      } else {
+        // related to #510. we do camelCase to pass fields in here but fields may be snakeCase and we want that to pass in tests
+        // we do camelCase in
+        const sc = snakeCase(k);
+        if (knownFields.has(sc)) {
+          this.fields.set(sc, input[k]);
+        }
+      }
+    }
   }
 
   build(): Promise<Changeset<T>> {


### PR DESCRIPTION
as seen in `create_contact_action`, it makes the resulting ent code much easier to read.

doesn't work for autoincrement ids

also fixed a bug where `getDefaultValueOnCreate` may get called multiple times and so may have one id at the start and another when it's time to write

fixes https://github.com/lolopinto/ent/issues/605 and https://github.com/lolopinto/ent/issues/574