### PR TITLE
fix differences btw languages which causes weird issues

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha11",
+        "@snowtop/ent": "^0.1.0-alpha12",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha11.tgz",
-      "integrity": "sha512-radV+z+9tFV/Oqrmwkr5Bjlq2pDnnW73GxwBZL8tRE9AZEQ3Q8oLH3t7/5XI1W9azpC5SE09wMBxbOIQVX1MiQ==",
+      "version": "0.1.0-alpha12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha12.tgz",
+      "integrity": "sha512-TlpZBQ72Ji3Md5jGaMYzYsJpOwTii76HXFqyj/jmxUvU1apsjkWiRU6NDTL8nNbMjakhailfMb+SvmjxvTVn/Q==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6899,9 +6899,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha11.tgz",
-      "integrity": "sha512-radV+z+9tFV/Oqrmwkr5Bjlq2pDnnW73GxwBZL8tRE9AZEQ3Q8oLH3t7/5XI1W9azpC5SE09wMBxbOIQVX1MiQ==",
+      "version": "0.1.0-alpha12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha12.tgz",
+      "integrity": "sha512-TlpZBQ72Ji3Md5jGaMYzYsJpOwTii76HXFqyj/jmxUvU1apsjkWiRU6NDTL8nNbMjakhailfMb+SvmjxvTVn/Q==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha11",
+    "@snowtop/ent": "^0.1.0-alpha12",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/src/ent/generated/address/actions/address_builder.ts
+++ b/examples/simple/src/ent/generated/address/actions/address_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { Address, Event } from "../../..";
 import { EdgeType, NodeType } from "../../const";
+import { addressLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/address";
 
 export interface AddressInput {
@@ -63,6 +64,7 @@ export class AddressBuilder<TData extends AddressInput = AddressInput>
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: addressLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/auth_code/actions/auth_code_builder.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/auth_code_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { AuthCode, User } from "../../..";
 import { NodeType } from "../../const";
+import { authCodeLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/auth_code_schema";
 
 export interface AuthCodeInput {
@@ -61,6 +62,7 @@ export class AuthCodeBuilder<TData extends AuthCodeInput = AuthCodeInput>
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: authCodeLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/comment/actions/comment_builder.ts
+++ b/examples/simple/src/ent/generated/comment/actions/comment_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { Comment, User } from "../../..";
 import { EdgeType, NodeType } from "../../const";
+import { commentLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/comment_schema";
 
 export interface CommentInput {
@@ -61,6 +62,7 @@ export class CommentBuilder<TData extends CommentInput = CommentInput>
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: commentLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/contact/actions/contact_builder.ts
+++ b/examples/simple/src/ent/generated/contact/actions/contact_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { Comment, Contact, User } from "../../..";
 import { EdgeType, NodeType } from "../../const";
+import { contactLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/contact_schema";
 
 export interface ContactInput {
@@ -62,6 +63,7 @@ export class ContactBuilder<TData extends ContactInput = ContactInput>
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: contactLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/contact_email/actions/contact_email_builder.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/contact_email_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { Contact, ContactEmail } from "../../..";
 import { NodeType } from "../../const";
+import { contactEmailLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/contact_email_schema";
 
 export interface ContactEmailInput {
@@ -62,6 +63,7 @@ export class ContactEmailBuilder<
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: contactEmailLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/contact_phone_number_builder.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/contact_phone_number_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { Contact, ContactPhoneNumber } from "../../..";
 import { NodeType } from "../../const";
+import { contactPhoneNumberLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/contact_phone_number_schema";
 
 export interface ContactPhoneNumberInput {
@@ -62,6 +63,7 @@ export class ContactPhoneNumberBuilder<
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: contactPhoneNumberLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/event/actions/event_builder.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { Address, Event, User } from "../../..";
 import { EdgeType, NodeType } from "../../const";
+import { eventLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/event_schema";
 
 export interface EventInput {
@@ -63,6 +64,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: eventLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -88,7 +88,7 @@ export class EventBase {
     if (this._addressID === null) {
       return null;
     }
-    const m = getFieldsWithPrivacy(schema);
+    const m = getFieldsWithPrivacy(schema, eventLoaderInfo.fieldInfo);
     const p = m.get("address_id");
     if (!p) {
       throw new Error(`couldn't get field privacy policy for addressID`);

--- a/examples/simple/src/ent/generated/holiday/actions/holiday_builder.ts
+++ b/examples/simple/src/ent/generated/holiday/actions/holiday_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { DayOfWeek, DayOfWeekAlt, Holiday } from "../../..";
 import { NodeType } from "../../const";
+import { holidayLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/holiday_schema";
 
 export interface HolidayInput {
@@ -61,6 +62,7 @@ export class HolidayBuilder<TData extends HolidayInput = HolidayInput>
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: holidayLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/hours_of_operation/actions/hours_of_operation_builder.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation/actions/hours_of_operation_builder.ts
@@ -15,6 +15,7 @@ import {
 } from "@snowtop/ent/action";
 import { DayOfWeek, DayOfWeekAlt, HoursOfOperation } from "../../..";
 import { NodeType } from "../../const";
+import { hoursOfOperationLoaderInfo } from "../../loaders";
 import schema from "../../../../schema/hours_of_operation_schema";
 
 export interface HoursOfOperationInput {
@@ -63,6 +64,7 @@ export class HoursOfOperationBuilder<
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: hoursOfOperationLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/loaders.ts
+++ b/examples/simple/src/ent/generated/loaders.ts
@@ -30,6 +30,44 @@ export const addressLoaderInfo = {
   fields: addressFields,
   nodeType: NodeType.Address,
   loaderFactory: addressLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    street_name: {
+      dbCol: "street_name",
+      inputKey: "streetName",
+    },
+    city: {
+      dbCol: "city",
+      inputKey: "city",
+    },
+    state: {
+      dbCol: "state",
+      inputKey: "state",
+    },
+    zip: {
+      dbCol: "zip",
+      inputKey: "zip",
+    },
+    apartment: {
+      dbCol: "apartment",
+      inputKey: "apartment",
+    },
+    country: {
+      dbCol: "country",
+      inputKey: "country",
+    },
+  },
 };
 
 const authCodeTable = "auth_codes";
@@ -54,6 +92,36 @@ export const authCodeLoaderInfo = {
   fields: authCodeFields,
   nodeType: NodeType.AuthCode,
   loaderFactory: authCodeLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    code: {
+      dbCol: "code",
+      inputKey: "code",
+    },
+    userID: {
+      dbCol: "user_id",
+      inputKey: "userID",
+    },
+    emailAddress: {
+      dbCol: "email_address",
+      inputKey: "emailAddress",
+    },
+    phoneNumber: {
+      dbCol: "phone_number",
+      inputKey: "phoneNumber",
+    },
+  },
 };
 
 const commentTable = "comments";
@@ -78,6 +146,36 @@ export const commentLoaderInfo = {
   fields: commentFields,
   nodeType: NodeType.Comment,
   loaderFactory: commentLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    AuthorID: {
+      dbCol: "author_id",
+      inputKey: "authorID",
+    },
+    Body: {
+      dbCol: "body",
+      inputKey: "body",
+    },
+    ArticleID: {
+      dbCol: "article_id",
+      inputKey: "articleID",
+    },
+    ArticleType: {
+      dbCol: "article_type",
+      inputKey: "articleType",
+    },
+  },
 };
 
 const contactTable = "contacts";
@@ -103,6 +201,40 @@ export const contactLoaderInfo = {
   fields: contactFields,
   nodeType: NodeType.Contact,
   loaderFactory: contactLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    email_ids: {
+      dbCol: "email_ids",
+      inputKey: "emailIds",
+    },
+    phone_number_ids: {
+      dbCol: "phone_number_ids",
+      inputKey: "phoneNumberIds",
+    },
+    firstName: {
+      dbCol: "first_name",
+      inputKey: "firstName",
+    },
+    lastName: {
+      dbCol: "last_name",
+      inputKey: "lastName",
+    },
+    userID: {
+      dbCol: "user_id",
+      inputKey: "userID",
+    },
+  },
 };
 
 const contactEmailTable = "contact_emails";
@@ -126,6 +258,32 @@ export const contactEmailLoaderInfo = {
   fields: contactEmailFields,
   nodeType: NodeType.ContactEmail,
   loaderFactory: contactEmailLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    emailAddress: {
+      dbCol: "email_address",
+      inputKey: "emailAddress",
+    },
+    label: {
+      dbCol: "label",
+      inputKey: "label",
+    },
+    contactID: {
+      dbCol: "contact_id",
+      inputKey: "contactID",
+    },
+  },
 };
 
 const contactPhoneNumberTable = "contact_phone_numbers";
@@ -149,6 +307,32 @@ export const contactPhoneNumberLoaderInfo = {
   fields: contactPhoneNumberFields,
   nodeType: NodeType.ContactPhoneNumber,
   loaderFactory: contactPhoneNumberLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    phoneNumber: {
+      dbCol: "phone_number",
+      inputKey: "phoneNumber",
+    },
+    label: {
+      dbCol: "label",
+      inputKey: "label",
+    },
+    contactID: {
+      dbCol: "contact_id",
+      inputKey: "contactID",
+    },
+  },
 };
 
 const eventTable = "events";
@@ -175,6 +359,44 @@ export const eventLoaderInfo = {
   fields: eventFields,
   nodeType: NodeType.Event,
   loaderFactory: eventLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    name: {
+      dbCol: "name",
+      inputKey: "name",
+    },
+    creatorID: {
+      dbCol: "user_id",
+      inputKey: "creatorID",
+    },
+    start_time: {
+      dbCol: "start_time",
+      inputKey: "startTime",
+    },
+    end_time: {
+      dbCol: "end_time",
+      inputKey: "endTime",
+    },
+    location: {
+      dbCol: "location",
+      inputKey: "location",
+    },
+    addressID: {
+      dbCol: "address_id",
+      inputKey: "addressID",
+    },
+  },
 };
 
 const holidayTable = "holidays";
@@ -199,6 +421,36 @@ export const holidayLoaderInfo = {
   fields: holidayFields,
   nodeType: NodeType.Holiday,
   loaderFactory: holidayLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    dayOfWeek: {
+      dbCol: "day_of_week",
+      inputKey: "dayOfWeek",
+    },
+    dayOfWeekAlt: {
+      dbCol: "day_of_week_alt",
+      inputKey: "dayOfWeekAlt",
+    },
+    label: {
+      dbCol: "label",
+      inputKey: "label",
+    },
+    date: {
+      dbCol: "date",
+      inputKey: "date",
+    },
+  },
 };
 
 const hoursOfOperationTable = "hours_of_operations";
@@ -223,6 +475,36 @@ export const hoursOfOperationLoaderInfo = {
   fields: hoursOfOperationFields,
   nodeType: NodeType.HoursOfOperation,
   loaderFactory: hoursOfOperationLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    dayOfWeek: {
+      dbCol: "day_of_week",
+      inputKey: "dayOfWeek",
+    },
+    dayOfWeekAlt: {
+      dbCol: "day_of_week_alt",
+      inputKey: "dayOfWeekAlt",
+    },
+    open: {
+      dbCol: "open",
+      inputKey: "open",
+    },
+    close: {
+      dbCol: "close",
+      inputKey: "close",
+    },
+  },
 };
 
 const userTable = "users";
@@ -275,6 +557,100 @@ export const userLoaderInfo = {
   fields: userFields,
   nodeType: NodeType.User,
   loaderFactory: userLoader,
+  fieldInfo: {
+    ID: {
+      dbCol: "id",
+      inputKey: "id",
+    },
+    createdAt: {
+      dbCol: "created_at",
+      inputKey: "createdAt",
+    },
+    updatedAt: {
+      dbCol: "updated_at",
+      inputKey: "updatedAt",
+    },
+    FirstName: {
+      dbCol: "first_name",
+      inputKey: "firstName",
+    },
+    LastName: {
+      dbCol: "last_name",
+      inputKey: "lastName",
+    },
+    EmailAddress: {
+      dbCol: "email_address",
+      inputKey: "emailAddress",
+    },
+    PhoneNumber: {
+      dbCol: "phone_number",
+      inputKey: "phoneNumber",
+    },
+    Password: {
+      dbCol: "password",
+      inputKey: "password",
+    },
+    AccountStatus: {
+      dbCol: "account_status",
+      inputKey: "accountStatus",
+    },
+    emailVerified: {
+      dbCol: "email_verified",
+      inputKey: "emailVerified",
+    },
+    Bio: {
+      dbCol: "bio",
+      inputKey: "bio",
+    },
+    nicknames: {
+      dbCol: "nicknames",
+      inputKey: "nicknames",
+    },
+    prefs: {
+      dbCol: "prefs",
+      inputKey: "prefs",
+    },
+    prefsList: {
+      dbCol: "prefs_list",
+      inputKey: "prefsList",
+    },
+    prefs_diff: {
+      dbCol: "prefs_diff",
+      inputKey: "prefsDiff",
+    },
+    daysOff: {
+      dbCol: "days_off",
+      inputKey: "daysOff",
+    },
+    preferredShift: {
+      dbCol: "preferred_shift",
+      inputKey: "preferredShift",
+    },
+    timeInMs: {
+      dbCol: "time_in_ms",
+      inputKey: "timeInMs",
+    },
+    fun_uuids: {
+      dbCol: "fun_uuids",
+      inputKey: "funUuids",
+    },
+    new_col: {
+      dbCol: "new_col",
+      inputKey: "newCol",
+    },
+    new_col2: {
+      dbCol: "new_col_2",
+      inputKey: "newCol2",
+    },
+    superNestedObject: {
+      dbCol: "super_nested_object",
+      inputKey: "superNestedObject",
+    },
+    nestedList: {
+      dbCol: "nested_list",
+      inputKey: "nestedList",
+    },
+  },
 };
 
 userLoader.addToPrime(userEmailAddressLoader);

--- a/examples/simple/src/ent/generated/user/actions/user_builder.ts
+++ b/examples/simple/src/ent/generated/user/actions/user_builder.ts
@@ -22,6 +22,7 @@ import {
   UserPreferredShift,
 } from "../../..";
 import { EdgeType, NodeType } from "../../const";
+import { userLoaderInfo } from "../../loaders";
 import { UserNestedObjectList } from "../../user_nested_object_list";
 import { UserPrefsDiff } from "../../user_prefs_diff";
 import { UserPrefsStruct } from "../../user_prefs_struct";
@@ -89,6 +90,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
       schema,
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: userLoaderInfo.fieldInfo,
     });
   }
 

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -163,7 +163,7 @@ export class UserBase {
     if (this._accountStatus === null) {
       return null;
     }
-    const m = getFieldsWithPrivacy(schema);
+    const m = getFieldsWithPrivacy(schema, userLoaderInfo.fieldInfo);
     const p = m.get("account_status");
     if (!p) {
       throw new Error(`couldn't get field privacy policy for accountStatus`);
@@ -173,7 +173,7 @@ export class UserBase {
   }
 
   async emailVerified(): Promise<boolean | null> {
-    const m = getFieldsWithPrivacy(schema);
+    const m = getFieldsWithPrivacy(schema, userLoaderInfo.fieldInfo);
     const p = m.get("email_verified");
     if (!p) {
       throw new Error(`couldn't get field privacy policy for emailVerified`);
@@ -186,7 +186,7 @@ export class UserBase {
     if (this._prefs === null) {
       return null;
     }
-    const m = getFieldsWithPrivacy(schema);
+    const m = getFieldsWithPrivacy(schema, userLoaderInfo.fieldInfo);
     const p = m.get("prefs");
     if (!p) {
       throw new Error(`couldn't get field privacy policy for prefs`);
@@ -199,7 +199,7 @@ export class UserBase {
     if (this._prefsList === null) {
       return null;
     }
-    const m = getFieldsWithPrivacy(schema);
+    const m = getFieldsWithPrivacy(schema, userLoaderInfo.fieldInfo);
     const p = m.get("prefs_list");
     if (!p) {
       throw new Error(`couldn't get field privacy policy for prefsList`);
@@ -212,7 +212,7 @@ export class UserBase {
     if (this._prefsDiff === null) {
       return null;
     }
-    const m = getFieldsWithPrivacy(schema);
+    const m = getFieldsWithPrivacy(schema, userLoaderInfo.fieldInfo);
     const p = m.get("prefs_diff");
     if (!p) {
       throw new Error(`couldn't get field privacy policy for prefsDiff`);

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -312,7 +312,7 @@ export class {{$baseClass}} {
       ent: this,
       loaderFactory: {{useImport $loaderName}},
       {{if .OnEntLoadFieldPrivacy $cfg -}}
-        fieldPrivacy: {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}}),
+        fieldPrivacy: {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}}, {{useImport $loaderInfo}}.fieldInfo),
       {{end -}}
     };
   }

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -99,7 +99,7 @@ export class {{$baseClass}} {
             return null;
           }
         {{ end -}}
-        const m = {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}});
+        const m = {{useImport "getFieldsWithPrivacy"}}({{useImport "schema"}},{{useImport $loaderInfo}}.fieldInfo);
         const p = m.get("{{$field.GetDbColName}}");
         if (!p) {
           throw new Error(`couldn't get field privacy policy for {{$field.TSPublicAPIName}}`);

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -7,6 +7,8 @@
 {{ $schemaPath := .GetSchemaPath }}
 {{ reserveDefaultImport $schemaPath "schema"}}
 {{ reserveImport "src/ent/generated/const" "EdgeType" "NodeType" }}
+{{$loaderInfo := printf "%sLoaderInfo" .NodeInstance -}}
+{{ reserveImport "src/ent/generated/loaders" $loaderInfo -}}
 
 
 {{ range .GetImportPathsForDependencies -}}
@@ -67,6 +69,7 @@ export class {{$builder}}<TData extends {{$input}} = {{$input}}> implements {{us
       {{useImport "schema"}},
       editedFields: () => this.getEditedFields.apply(this),
       updateInput,
+      fieldInfo: {{useImport $loaderInfo}}.fieldInfo,
     });
   }
 

--- a/internal/tscode/loaders.tmpl
+++ b/internal/tscode/loaders.tmpl
@@ -36,6 +36,14 @@
     fields: {{$fields}},
     nodeType: {{useImport "NodeType"}}.{{.Node}},
     loaderFactory: {{printf "%sLoader" .NodeInstance }},
+    fieldInfo: {
+      {{range $field := .FieldInfo.Fields -}}
+      {{$field.FieldName}}: {
+        dbCol: '{{$field.GetDbColName}}',
+        inputKey: '{{$field.TsBuilderFieldName}}',
+        },
+      {{end}}
+    },
   }
 
   {{ range $loaders := $groups }}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha11",
+  "version": "0.1.0-alpha12",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/ent_complex.test.ts
+++ b/ts/src/core/ent_complex.test.ts
@@ -1,4 +1,9 @@
-import { User, SimpleAction, getTableName } from "../testutils/builder";
+import {
+  User,
+  SimpleAction,
+  getTableName,
+  getFieldInfo,
+} from "../testutils/builder";
 import {
   BaseEntSchema,
   BooleanType,
@@ -279,7 +284,7 @@ const userLoaderOptions = {
   fields: userFields,
   ent: User,
   loaderFactory: userLoaderFactory,
-  fieldPrivacy: getFieldsWithPrivacy(userSchema),
+  fieldPrivacy: getFieldsWithPrivacy(userSchema, getFieldInfo(userSchema)),
 };
 
 const accountSchema = new AccountSchema();
@@ -295,7 +300,10 @@ const accountLoaderOptions = {
   fields: userFields,
   ent: User,
   loaderFactory: accountLoaderFactory,
-  fieldPrivacy: getFieldsWithPrivacy(accountSchema),
+  fieldPrivacy: getFieldsWithPrivacy(
+    accountSchema,
+    getFieldInfo(accountSchema),
+  ),
 };
 
 let tdb: TempDB;

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -7,6 +7,15 @@ export declare type FieldMap = {
   [key: string]: Field;
 };
 
+interface FieldInfo {
+  dbCol: string;
+  inputKey: string;
+}
+
+export type FieldInfoMap = {
+  [key: string]: FieldInfo;
+};
+
 // Schema is the base for every schema in typescript
 export default interface Schema {
   // schema has list of fields that are unique to each node
@@ -449,6 +458,9 @@ export function getFields(value: SchemaInputType): Map<string, Field> {
   return m;
 }
 
+/**
+ * @deprecated should only be used by tests
+ */
 export function getStorageKey(field: Field, fieldName: string): string {
   return field.storageKey || snakeCase(fieldName);
 }
@@ -456,6 +468,7 @@ export function getStorageKey(field: Field, fieldName: string): string {
 // returns a mapping of storage key to field privacy
 export function getFieldsWithPrivacy(
   value: SchemaInputType,
+  fieldMap: FieldInfoMap,
 ): Map<string, PrivacyPolicy> {
   const schema = getSchema(value);
   function addFields(fields: FieldMap | Field[]) {
@@ -475,7 +488,11 @@ export function getFieldsWithPrivacy(
           } else {
             privacyPolicy = field.privacyPolicy;
           }
-          m.set(getStorageKey(field, name), privacyPolicy);
+          const info = fieldMap[name];
+          if (!info) {
+            throw new Error(`field with name ${name} not passed in fieldMap`);
+          }
+          m.set(info.dbCol, privacyPolicy);
         }
       }
     }
@@ -491,7 +508,11 @@ export function getFieldsWithPrivacy(
         } else {
           privacyPolicy = field.privacyPolicy;
         }
-        m.set(getStorageKey(field, name), privacyPolicy);
+        const info = fieldMap[name];
+        if (!info) {
+          throw new Error(`field with name ${name} not passed in fieldMap`);
+        }
+        m.set(info.dbCol, privacyPolicy);
       }
     }
   }


### PR DESCRIPTION
fixes https://github.com/lolopinto/ent/issues/510

```go
import (
	"fmt"

	"github.com/iancoleman/strcase"
)

func main() {
	fmt.Println(strcase.ToSnake("prefs2"))
}

// prefs_2 printed
```

```node
% node
Welcome to Node.js v17.0.1.
Type ".help" for more information.
> const s = require('snake-case')
undefined
> s.snakeCase('prefs2')
'prefs2'
> 
```

this difference in implementation leads to bugs when we run into one of these cases where the generated db col and what the JS thinks it is differ

now, we don't assume
