### PR TITLE
ability to differentiate builder.existingEnt in triggers/ observers/validators

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha12",
+        "@snowtop/ent": "^0.1.0-alpha13",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.0.1",
         "@snowtop/ent-password": "^0.0.1",
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha12.tgz",
-      "integrity": "sha512-TlpZBQ72Ji3Md5jGaMYzYsJpOwTii76HXFqyj/jmxUvU1apsjkWiRU6NDTL8nNbMjakhailfMb+SvmjxvTVn/Q==",
+      "version": "0.1.0-alpha13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha13.tgz",
+      "integrity": "sha512-07FAncCvc1ULXbFQW/AaqCR9LfKa6FRhvAiMxQSj9TAdYFM/WRPuzgfOavuD3KlzXiOne6jaQcZhL9oRhJUsAg==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6899,9 +6899,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha12.tgz",
-      "integrity": "sha512-TlpZBQ72Ji3Md5jGaMYzYsJpOwTii76HXFqyj/jmxUvU1apsjkWiRU6NDTL8nNbMjakhailfMb+SvmjxvTVn/Q==",
+      "version": "0.1.0-alpha13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha13.tgz",
+      "integrity": "sha512-07FAncCvc1ULXbFQW/AaqCR9LfKa6FRhvAiMxQSj9TAdYFM/WRPuzgfOavuD3KlzXiOne6jaQcZhL9oRhJUsAg==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha12",
+    "@snowtop/ent": "^0.1.0-alpha13",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.0.1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/src/ent/comment/actions/create_comment_action.ts
+++ b/examples/simple/src/ent/comment/actions/create_comment_action.ts
@@ -10,6 +10,7 @@ import {
   CommentCreateInput,
   CreateCommentActionBase,
 } from "../../generated/comment/actions/create_comment_action_base";
+import { Comment } from "../../../ent";
 
 export { CommentCreateInput };
 
@@ -18,7 +19,12 @@ export default class CreateCommentAction extends CreateCommentActionBase {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  triggers: Trigger<CommentBuilder, CommentCreateInput>[] = [
+  triggers: Trigger<
+    Comment,
+    CommentBuilder<Comment, Comment>,
+    CommentCreateInput,
+    Comment
+  >[] = [
     {
       changeset(builder, input) {
         // creating the comment automatically adds the needed edges

--- a/examples/simple/src/ent/contact/actions/create_contact_action.ts
+++ b/examples/simple/src/ent/contact/actions/create_contact_action.ts
@@ -34,7 +34,7 @@ export default class CreateContactAction extends CreateContactActionBase {
     };
   }
 
-  triggers: Trigger<ContactBuilder, ContactCreateInput>[] = [
+  triggers: Trigger<Contact, ContactBuilder, ContactCreateInput>[] = [
     {
       async changeset(builder, input) {
         if (!input.emails) {
@@ -93,7 +93,7 @@ export default class CreateContactAction extends CreateContactActionBase {
     },
   ];
 
-  observers: Observer<ContactBuilder, ContactCreateInput>[] = [
+  observers: Observer<Contact, ContactBuilder, ContactCreateInput>[] = [
     new EntCreationObserver<Contact>(),
   ];
 

--- a/examples/simple/src/ent/event/actions/create_event_action.ts
+++ b/examples/simple/src/ent/event/actions/create_event_action.ts
@@ -6,6 +6,7 @@ import { Trigger, Validator } from "@snowtop/ent/action";
 import { SharedValidators } from "./event_validators";
 import { EventBuilder } from "../../generated/event/actions/event_builder";
 import { AlwaysAllowPrivacyPolicy, PrivacyPolicy } from "@snowtop/ent";
+import { Event } from "../../../ent";
 
 export { EventCreateInput };
 
@@ -17,11 +18,11 @@ export default class CreateEventAction extends CreateEventActionBase {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  validators: Validator<EventBuilder, EventCreateInput>[] = [
+  validators: Validator<Event, EventBuilder, EventCreateInput>[] = [
     ...SharedValidators,
   ];
 
-  triggers: Trigger<EventBuilder, EventCreateInput>[] = [
+  triggers: Trigger<Event, EventBuilder, EventCreateInput>[] = [
     {
       changeset(
         builder: EventBuilder<EventCreateInput>,

--- a/examples/simple/src/ent/event/actions/edit_event_action.ts
+++ b/examples/simple/src/ent/event/actions/edit_event_action.ts
@@ -10,12 +10,15 @@ import {
   PrivacyPolicy,
 } from "@snowtop/ent";
 import { EventBuilder } from "../../generated/event/actions/event_builder";
+import { Event } from "../../../ent";
 
 export { EventEditInput };
 
 // we're only writing this once except with --force and packageName provided
 export default class EditEventAction extends EditEventActionBase {
-  validators: Validator<EventBuilder, EventEditInput>[] = [...SharedValidators];
+  validators: Validator<Event, EventBuilder, EventEditInput>[] = [
+    ...SharedValidators,
+  ];
 
   getPrivacyPolicy(): PrivacyPolicy {
     return {

--- a/examples/simple/src/ent/event/actions/event_validators.ts
+++ b/examples/simple/src/ent/event/actions/event_validators.ts
@@ -3,8 +3,11 @@ import {
   EventBuilder,
   EventInput,
 } from "../../generated/event/actions/event_builder";
+import { Event } from "../../../ent";
 
-export class EventTimeValidator implements Validator<EventBuilder, EventInput> {
+export class EventTimeValidator
+  implements Validator<Event, EventBuilder, EventInput>
+{
   validate(builder: EventBuilder): void {
     const startTime = builder.getNewStartTimeValue();
     const endTime = builder.getNewEndTimeValue();

--- a/examples/simple/src/ent/generated/address/actions/create_address_action_base.ts
+++ b/examples/simple/src/ent/generated/address/actions/create_address_action_base.ts
@@ -23,16 +23,26 @@ export interface AddressCreateInput {
 
 export class CreateAddressActionBase
   implements
-    Action<Address, AddressBuilder<AddressCreateInput>, AddressCreateInput>
+    Action<
+      Address,
+      AddressBuilder<AddressCreateInput, Address | null>,
+      AddressCreateInput,
+      Address | null
+    >
 {
-  public readonly builder: AddressBuilder<AddressCreateInput>;
+  public readonly builder: AddressBuilder<AddressCreateInput, Address | null>;
   public readonly viewer: Viewer;
   protected input: AddressCreateInput;
 
   constructor(viewer: Viewer, input: AddressCreateInput) {
     this.viewer = viewer;
     this.input = input;
-    this.builder = new AddressBuilder(this.viewer, WriteOperation.Insert, this);
+    this.builder = new AddressBuilder(
+      this.viewer,
+      WriteOperation.Insert,
+      this,
+      null,
+    );
   }
 
   getPrivacyPolicy(): PrivacyPolicy<Address> {

--- a/examples/simple/src/ent/generated/auth_code/actions/auth_code_builder.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/auth_code_builder.ts
@@ -31,21 +31,26 @@ function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class AuthCodeBuilder<TData extends AuthCodeInput = AuthCodeInput>
-  implements Builder<AuthCode>
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
+export class AuthCodeBuilder<
+  TInput extends AuthCodeInput = AuthCodeInput,
+  TExistingEnt extends TMaybleNullableEnt<AuthCode> = AuthCode | null,
+> implements Builder<AuthCode, TExistingEnt>
 {
-  orchestrator: Orchestrator<AuthCode, TData>;
+  orchestrator: Orchestrator<AuthCode, TInput>;
   readonly placeholderID: ID;
   readonly ent = AuthCode;
   readonly nodeType = NodeType.AuthCode;
-  private input: TData;
+  private input: TInput;
   private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: Action<AuthCode, Builder<AuthCode>, TData>,
-    public readonly existingEnt?: AuthCode | undefined,
+    action: Action<AuthCode, Builder<AuthCode, TExistingEnt>, TInput>,
+    public readonly existingEnt: TExistingEnt,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-AuthCode`;
     this.input = action.getInput();
@@ -66,7 +71,7 @@ export class AuthCodeBuilder<TData extends AuthCodeInput = AuthCodeInput>
     });
   }
 
-  getInput(): TData {
+  getInput(): TInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
@@ -27,9 +27,17 @@ export interface AuthCodeCreateInput {
 
 export class CreateAuthCodeActionBase
   implements
-    Action<AuthCode, AuthCodeBuilder<AuthCodeCreateInput>, AuthCodeCreateInput>
+    Action<
+      AuthCode,
+      AuthCodeBuilder<AuthCodeCreateInput, AuthCode | null>,
+      AuthCodeCreateInput,
+      AuthCode | null
+    >
 {
-  public readonly builder: AuthCodeBuilder<AuthCodeCreateInput>;
+  public readonly builder: AuthCodeBuilder<
+    AuthCodeCreateInput,
+    AuthCode | null
+  >;
   public readonly viewer: Viewer;
   protected input: AuthCodeCreateInput;
 
@@ -40,6 +48,7 @@ export class CreateAuthCodeActionBase
       this.viewer,
       WriteOperation.Insert,
       this,
+      null,
     );
   }
 

--- a/examples/simple/src/ent/generated/auth_code/actions/delete_auth_code_action_base.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/delete_auth_code_action_base.ts
@@ -14,9 +14,15 @@ import { AuthCode } from "../../..";
 import { AuthCodeBuilder, AuthCodeInput } from "./auth_code_builder";
 
 export class DeleteAuthCodeActionBase
-  implements Action<AuthCode, AuthCodeBuilder<AuthCodeInput>, AuthCodeInput>
+  implements
+    Action<
+      AuthCode,
+      AuthCodeBuilder<AuthCodeInput, AuthCode>,
+      AuthCodeInput,
+      AuthCode
+    >
 {
-  public readonly builder: AuthCodeBuilder<AuthCodeInput>;
+  public readonly builder: AuthCodeBuilder<AuthCodeInput, AuthCode>;
   public readonly viewer: Viewer;
   protected authCode: AuthCode;
 

--- a/examples/simple/src/ent/generated/comment/actions/create_comment_action_base.ts
+++ b/examples/simple/src/ent/generated/comment/actions/create_comment_action_base.ts
@@ -28,16 +28,26 @@ export interface CommentCreateInput {
 
 export class CreateCommentActionBase
   implements
-    Action<Comment, CommentBuilder<CommentCreateInput>, CommentCreateInput>
+    Action<
+      Comment,
+      CommentBuilder<CommentCreateInput, Comment | null>,
+      CommentCreateInput,
+      Comment | null
+    >
 {
-  public readonly builder: CommentBuilder<CommentCreateInput>;
+  public readonly builder: CommentBuilder<CommentCreateInput, Comment | null>;
   public readonly viewer: Viewer;
   protected input: CommentCreateInput;
 
   constructor(viewer: Viewer, input: CommentCreateInput) {
     this.viewer = viewer;
     this.input = input;
-    this.builder = new CommentBuilder(this.viewer, WriteOperation.Insert, this);
+    this.builder = new CommentBuilder(
+      this.viewer,
+      WriteOperation.Insert,
+      this,
+      null,
+    );
   }
 
   getPrivacyPolicy(): PrivacyPolicy<Comment> {

--- a/examples/simple/src/ent/generated/contact/actions/create_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/create_contact_action_base.ts
@@ -38,16 +38,26 @@ export interface ContactCreateInput {
 
 export class CreateContactActionBase
   implements
-    Action<Contact, ContactBuilder<ContactCreateInput>, ContactCreateInput>
+    Action<
+      Contact,
+      ContactBuilder<ContactCreateInput, Contact | null>,
+      ContactCreateInput,
+      Contact | null
+    >
 {
-  public readonly builder: ContactBuilder<ContactCreateInput>;
+  public readonly builder: ContactBuilder<ContactCreateInput, Contact | null>;
   public readonly viewer: Viewer;
   protected input: ContactCreateInput;
 
   constructor(viewer: Viewer, input: ContactCreateInput) {
     this.viewer = viewer;
     this.input = input;
-    this.builder = new ContactBuilder(this.viewer, WriteOperation.Insert, this);
+    this.builder = new ContactBuilder(
+      this.viewer,
+      WriteOperation.Insert,
+      this,
+      null,
+    );
   }
 
   getPrivacyPolicy(): PrivacyPolicy<Contact> {

--- a/examples/simple/src/ent/generated/contact/actions/delete_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/delete_contact_action_base.ts
@@ -14,9 +14,15 @@ import { Contact } from "../../..";
 import { ContactBuilder, ContactInput } from "./contact_builder";
 
 export class DeleteContactActionBase
-  implements Action<Contact, ContactBuilder<ContactInput>, ContactInput>
+  implements
+    Action<
+      Contact,
+      ContactBuilder<ContactInput, Contact>,
+      ContactInput,
+      Contact
+    >
 {
-  public readonly builder: ContactBuilder<ContactInput>;
+  public readonly builder: ContactBuilder<ContactInput, Contact>;
   public readonly viewer: Viewer;
   protected contact: Contact;
 

--- a/examples/simple/src/ent/generated/contact/actions/edit_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/edit_contact_action_base.ts
@@ -28,9 +28,14 @@ export interface ContactEditInput {
 
 export class EditContactActionBase
   implements
-    Action<Contact, ContactBuilder<ContactEditInput>, ContactEditInput>
+    Action<
+      Contact,
+      ContactBuilder<ContactEditInput, Contact>,
+      ContactEditInput,
+      Contact
+    >
 {
-  public readonly builder: ContactBuilder<ContactEditInput>;
+  public readonly builder: ContactBuilder<ContactEditInput, Contact>;
   public readonly viewer: Viewer;
   protected input: ContactEditInput;
   protected contact: Contact;

--- a/examples/simple/src/ent/generated/contact_email/actions/contact_email_builder.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/contact_email_builder.ts
@@ -30,22 +30,26 @@ function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
 export class ContactEmailBuilder<
-  TData extends ContactEmailInput = ContactEmailInput,
-> implements Builder<ContactEmail>
+  TInput extends ContactEmailInput = ContactEmailInput,
+  TExistingEnt extends TMaybleNullableEnt<ContactEmail> = ContactEmail | null,
+> implements Builder<ContactEmail, TExistingEnt>
 {
-  orchestrator: Orchestrator<ContactEmail, TData>;
+  orchestrator: Orchestrator<ContactEmail, TInput>;
   readonly placeholderID: ID;
   readonly ent = ContactEmail;
   readonly nodeType = NodeType.ContactEmail;
-  private input: TData;
+  private input: TInput;
   private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: Action<ContactEmail, Builder<ContactEmail>, TData>,
-    public readonly existingEnt?: ContactEmail | undefined,
+    action: Action<ContactEmail, Builder<ContactEmail, TExistingEnt>, TInput>,
+    public readonly existingEnt: TExistingEnt,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-ContactEmail`;
     this.input = action.getInput();
@@ -67,7 +71,7 @@ export class ContactEmailBuilder<
     });
   }
 
-  getInput(): TData {
+  getInput(): TInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/generated/contact_email/actions/create_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/create_contact_email_action_base.ts
@@ -28,11 +28,15 @@ export class CreateContactEmailActionBase
   implements
     Action<
       ContactEmail,
-      ContactEmailBuilder<ContactEmailCreateInput>,
-      ContactEmailCreateInput
+      ContactEmailBuilder<ContactEmailCreateInput, ContactEmail | null>,
+      ContactEmailCreateInput,
+      ContactEmail | null
     >
 {
-  public readonly builder: ContactEmailBuilder<ContactEmailCreateInput>;
+  public readonly builder: ContactEmailBuilder<
+    ContactEmailCreateInput,
+    ContactEmail | null
+  >;
   public readonly viewer: Viewer;
   protected input: ContactEmailCreateInput;
 
@@ -43,6 +47,7 @@ export class CreateContactEmailActionBase
       this.viewer,
       WriteOperation.Insert,
       this,
+      null,
     );
   }
 

--- a/examples/simple/src/ent/generated/contact_email/actions/delete_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/delete_contact_email_action_base.ts
@@ -20,11 +20,12 @@ export class DeleteContactEmailActionBase
   implements
     Action<
       ContactEmail,
-      ContactEmailBuilder<ContactEmailInput>,
-      ContactEmailInput
+      ContactEmailBuilder<ContactEmailInput, ContactEmail>,
+      ContactEmailInput,
+      ContactEmail
     >
 {
-  public readonly builder: ContactEmailBuilder<ContactEmailInput>;
+  public readonly builder: ContactEmailBuilder<ContactEmailInput, ContactEmail>;
   public readonly viewer: Viewer;
   protected contactEmail: ContactEmail;
 

--- a/examples/simple/src/ent/generated/contact_email/actions/edit_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/edit_contact_email_action_base.ts
@@ -28,11 +28,15 @@ export class EditContactEmailActionBase
   implements
     Action<
       ContactEmail,
-      ContactEmailBuilder<ContactEmailEditInput>,
-      ContactEmailEditInput
+      ContactEmailBuilder<ContactEmailEditInput, ContactEmail>,
+      ContactEmailEditInput,
+      ContactEmail
     >
 {
-  public readonly builder: ContactEmailBuilder<ContactEmailEditInput>;
+  public readonly builder: ContactEmailBuilder<
+    ContactEmailEditInput,
+    ContactEmail
+  >;
   public readonly viewer: Viewer;
   protected input: ContactEmailEditInput;
   protected contactEmail: ContactEmail;

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/contact_phone_number_builder.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/contact_phone_number_builder.ts
@@ -30,22 +30,30 @@ function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
 export class ContactPhoneNumberBuilder<
-  TData extends ContactPhoneNumberInput = ContactPhoneNumberInput,
-> implements Builder<ContactPhoneNumber>
+  TInput extends ContactPhoneNumberInput = ContactPhoneNumberInput,
+  TExistingEnt extends TMaybleNullableEnt<ContactPhoneNumber> = ContactPhoneNumber | null,
+> implements Builder<ContactPhoneNumber, TExistingEnt>
 {
-  orchestrator: Orchestrator<ContactPhoneNumber, TData>;
+  orchestrator: Orchestrator<ContactPhoneNumber, TInput>;
   readonly placeholderID: ID;
   readonly ent = ContactPhoneNumber;
   readonly nodeType = NodeType.ContactPhoneNumber;
-  private input: TData;
+  private input: TInput;
   private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: Action<ContactPhoneNumber, Builder<ContactPhoneNumber>, TData>,
-    public readonly existingEnt?: ContactPhoneNumber | undefined,
+    action: Action<
+      ContactPhoneNumber,
+      Builder<ContactPhoneNumber, TExistingEnt>,
+      TInput
+    >,
+    public readonly existingEnt: TExistingEnt,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-ContactPhoneNumber`;
     this.input = action.getInput();
@@ -67,7 +75,7 @@ export class ContactPhoneNumberBuilder<
     });
   }
 
-  getInput(): TData {
+  getInput(): TInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/create_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/create_contact_phone_number_action_base.ts
@@ -28,11 +28,18 @@ export class CreateContactPhoneNumberActionBase
   implements
     Action<
       ContactPhoneNumber,
-      ContactPhoneNumberBuilder<ContactPhoneNumberCreateInput>,
-      ContactPhoneNumberCreateInput
+      ContactPhoneNumberBuilder<
+        ContactPhoneNumberCreateInput,
+        ContactPhoneNumber | null
+      >,
+      ContactPhoneNumberCreateInput,
+      ContactPhoneNumber | null
     >
 {
-  public readonly builder: ContactPhoneNumberBuilder<ContactPhoneNumberCreateInput>;
+  public readonly builder: ContactPhoneNumberBuilder<
+    ContactPhoneNumberCreateInput,
+    ContactPhoneNumber | null
+  >;
   public readonly viewer: Viewer;
   protected input: ContactPhoneNumberCreateInput;
 
@@ -43,6 +50,7 @@ export class CreateContactPhoneNumberActionBase
       this.viewer,
       WriteOperation.Insert,
       this,
+      null,
     );
   }
 

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/delete_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/delete_contact_phone_number_action_base.ts
@@ -20,11 +20,15 @@ export class DeleteContactPhoneNumberActionBase
   implements
     Action<
       ContactPhoneNumber,
-      ContactPhoneNumberBuilder<ContactPhoneNumberInput>,
-      ContactPhoneNumberInput
+      ContactPhoneNumberBuilder<ContactPhoneNumberInput, ContactPhoneNumber>,
+      ContactPhoneNumberInput,
+      ContactPhoneNumber
     >
 {
-  public readonly builder: ContactPhoneNumberBuilder<ContactPhoneNumberInput>;
+  public readonly builder: ContactPhoneNumberBuilder<
+    ContactPhoneNumberInput,
+    ContactPhoneNumber
+  >;
   public readonly viewer: Viewer;
   protected contactPhoneNumber: ContactPhoneNumber;
 

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/edit_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/edit_contact_phone_number_action_base.ts
@@ -28,11 +28,18 @@ export class EditContactPhoneNumberActionBase
   implements
     Action<
       ContactPhoneNumber,
-      ContactPhoneNumberBuilder<ContactPhoneNumberEditInput>,
-      ContactPhoneNumberEditInput
+      ContactPhoneNumberBuilder<
+        ContactPhoneNumberEditInput,
+        ContactPhoneNumber
+      >,
+      ContactPhoneNumberEditInput,
+      ContactPhoneNumber
     >
 {
-  public readonly builder: ContactPhoneNumberBuilder<ContactPhoneNumberEditInput>;
+  public readonly builder: ContactPhoneNumberBuilder<
+    ContactPhoneNumberEditInput,
+    ContactPhoneNumber
+  >;
   public readonly viewer: Viewer;
   protected input: ContactPhoneNumberEditInput;
   protected contactPhoneNumber: ContactPhoneNumber;

--- a/examples/simple/src/ent/generated/event/actions/create_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/create_event_action_base.ts
@@ -28,16 +28,27 @@ export interface EventCreateInput {
 }
 
 export class CreateEventActionBase
-  implements Action<Event, EventBuilder<EventCreateInput>, EventCreateInput>
+  implements
+    Action<
+      Event,
+      EventBuilder<EventCreateInput, Event | null>,
+      EventCreateInput,
+      Event | null
+    >
 {
-  public readonly builder: EventBuilder<EventCreateInput>;
+  public readonly builder: EventBuilder<EventCreateInput, Event | null>;
   public readonly viewer: Viewer;
   protected input: EventCreateInput;
 
   constructor(viewer: Viewer, input: EventCreateInput) {
     this.viewer = viewer;
     this.input = input;
-    this.builder = new EventBuilder(this.viewer, WriteOperation.Insert, this);
+    this.builder = new EventBuilder(
+      this.viewer,
+      WriteOperation.Insert,
+      this,
+      null,
+    );
   }
 
   getPrivacyPolicy(): PrivacyPolicy<Event> {

--- a/examples/simple/src/ent/generated/event/actions/delete_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/delete_event_action_base.ts
@@ -14,9 +14,9 @@ import { Event } from "../../..";
 import { EventBuilder, EventInput } from "./event_builder";
 
 export class DeleteEventActionBase
-  implements Action<Event, EventBuilder<EventInput>, EventInput>
+  implements Action<Event, EventBuilder<EventInput, Event>, EventInput, Event>
 {
-  public readonly builder: EventBuilder<EventInput>;
+  public readonly builder: EventBuilder<EventInput, Event>;
   public readonly viewer: Viewer;
   protected event: Event;
 

--- a/examples/simple/src/ent/generated/event/actions/edit_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/edit_event_action_base.ts
@@ -28,9 +28,10 @@ export interface EventEditInput {
 }
 
 export class EditEventActionBase
-  implements Action<Event, EventBuilder<EventEditInput>, EventEditInput>
+  implements
+    Action<Event, EventBuilder<EventEditInput, Event>, EventEditInput, Event>
 {
-  public readonly builder: EventBuilder<EventEditInput>;
+  public readonly builder: EventBuilder<EventEditInput, Event>;
   public readonly viewer: Viewer;
   protected input: EventEditInput;
   protected event: Event;

--- a/examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts
@@ -33,11 +33,12 @@ export class EditEventRsvpStatusActionBase
   implements
     Action<
       Event,
-      EventBuilder<EditEventRsvpStatusInput>,
-      EditEventRsvpStatusInput
+      EventBuilder<EditEventRsvpStatusInput, Event>,
+      EditEventRsvpStatusInput,
+      Event
     >
 {
-  public readonly builder: EventBuilder<EditEventRsvpStatusInput>;
+  public readonly builder: EventBuilder<EditEventRsvpStatusInput, Event>;
   public readonly viewer: Viewer;
   protected input: EditEventRsvpStatusInput;
   protected event: Event;

--- a/examples/simple/src/ent/generated/event/actions/event_add_host_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_add_host_action_base.ts
@@ -20,9 +20,9 @@ import { Event, User } from "../../..";
 import { EventBuilder, EventInput } from "./event_builder";
 
 export class EventAddHostActionBase
-  implements Action<Event, EventBuilder<EventInput>, EventInput>
+  implements Action<Event, EventBuilder<EventInput, Event>, EventInput, Event>
 {
-  public readonly builder: EventBuilder<EventInput>;
+  public readonly builder: EventBuilder<EventInput, Event>;
   public readonly viewer: Viewer;
   protected event: Event;
 

--- a/examples/simple/src/ent/generated/event/actions/event_builder.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_builder.ts
@@ -33,21 +33,26 @@ function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class EventBuilder<TData extends EventInput = EventInput>
-  implements Builder<Event>
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
+export class EventBuilder<
+  TInput extends EventInput = EventInput,
+  TExistingEnt extends TMaybleNullableEnt<Event> = Event | null,
+> implements Builder<Event, TExistingEnt>
 {
-  orchestrator: Orchestrator<Event, TData>;
+  orchestrator: Orchestrator<Event, TInput>;
   readonly placeholderID: ID;
   readonly ent = Event;
   readonly nodeType = NodeType.Event;
-  private input: TData;
+  private input: TInput;
   private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: Action<Event, Builder<Event>, TData>,
-    public readonly existingEnt?: Event | undefined,
+    action: Action<Event, Builder<Event, TExistingEnt>, TInput>,
+    public readonly existingEnt: TExistingEnt,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Event`;
     this.input = action.getInput();
@@ -68,7 +73,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
     });
   }
 
-  getInput(): TData {
+  getInput(): TInput {
     return this.input;
   }
 
@@ -104,7 +109,9 @@ export class EventBuilder<TData extends EventInput = EventInput>
     this.orchestrator.clearInputEdges(edgeType, op, id);
   }
 
-  addAttending(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
+  addAttending(
+    ...nodes: (ID | User | Builder<User>)[]
+  ): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addAttendingID(node);
@@ -120,7 +127,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
   addAttendingID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder<TData> {
+  ): EventBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToAttending,
@@ -130,7 +137,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  removeAttending(...nodes: (ID | User)[]): EventBuilder<TData> {
+  removeAttending(...nodes: (ID | User)[]): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -144,7 +151,9 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  addDeclined(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
+  addDeclined(
+    ...nodes: (ID | User | Builder<User>)[]
+  ): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addDeclinedID(node);
@@ -160,7 +169,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
   addDeclinedID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder<TData> {
+  ): EventBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToDeclined,
@@ -170,7 +179,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  removeDeclined(...nodes: (ID | User)[]): EventBuilder<TData> {
+  removeDeclined(...nodes: (ID | User)[]): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.EventToDeclined);
@@ -181,7 +190,9 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  addHost(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
+  addHost(
+    ...nodes: (ID | User | Builder<User>)[]
+  ): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addHostID(node);
@@ -197,7 +208,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
   addHostID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder<TData> {
+  ): EventBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToHosts,
@@ -207,7 +218,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  removeHost(...nodes: (ID | User)[]): EventBuilder<TData> {
+  removeHost(...nodes: (ID | User)[]): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.EventToHosts);
@@ -218,7 +229,9 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  addInvited(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
+  addInvited(
+    ...nodes: (ID | User | Builder<User>)[]
+  ): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addInvitedID(node);
@@ -234,7 +247,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
   addInvitedID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder<TData> {
+  ): EventBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToInvited,
@@ -244,7 +257,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  removeInvited(...nodes: (ID | User)[]): EventBuilder<TData> {
+  removeInvited(...nodes: (ID | User)[]): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.EventToInvited);
@@ -255,7 +268,9 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  addMaybe(...nodes: (ID | User | Builder<User>)[]): EventBuilder<TData> {
+  addMaybe(
+    ...nodes: (ID | User | Builder<User>)[]
+  ): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addMaybeID(node);
@@ -271,7 +286,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
   addMaybeID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): EventBuilder<TData> {
+  ): EventBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.EventToMaybe,
@@ -281,7 +296,7 @@ export class EventBuilder<TData extends EventInput = EventInput>
     return this;
   }
 
-  removeMaybe(...nodes: (ID | User)[]): EventBuilder<TData> {
+  removeMaybe(...nodes: (ID | User)[]): EventBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.EventToMaybe);

--- a/examples/simple/src/ent/generated/event/actions/event_remove_host_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_remove_host_action_base.ts
@@ -14,9 +14,9 @@ import { Event, User } from "../../..";
 import { EventBuilder, EventInput } from "./event_builder";
 
 export class EventRemoveHostActionBase
-  implements Action<Event, EventBuilder<EventInput>, EventInput>
+  implements Action<Event, EventBuilder<EventInput, Event>, EventInput, Event>
 {
-  public readonly builder: EventBuilder<EventInput>;
+  public readonly builder: EventBuilder<EventInput, Event>;
   public readonly viewer: Viewer;
   protected event: Event;
 

--- a/examples/simple/src/ent/generated/holiday/actions/create_holiday_action_base.ts
+++ b/examples/simple/src/ent/generated/holiday/actions/create_holiday_action_base.ts
@@ -21,16 +21,26 @@ export interface HolidayCreateInput {
 
 export class CreateHolidayActionBase
   implements
-    Action<Holiday, HolidayBuilder<HolidayCreateInput>, HolidayCreateInput>
+    Action<
+      Holiday,
+      HolidayBuilder<HolidayCreateInput, Holiday | null>,
+      HolidayCreateInput,
+      Holiday | null
+    >
 {
-  public readonly builder: HolidayBuilder<HolidayCreateInput>;
+  public readonly builder: HolidayBuilder<HolidayCreateInput, Holiday | null>;
   public readonly viewer: Viewer;
   protected input: HolidayCreateInput;
 
   constructor(viewer: Viewer, input: HolidayCreateInput) {
     this.viewer = viewer;
     this.input = input;
-    this.builder = new HolidayBuilder(this.viewer, WriteOperation.Insert, this);
+    this.builder = new HolidayBuilder(
+      this.viewer,
+      WriteOperation.Insert,
+      this,
+      null,
+    );
   }
 
   getPrivacyPolicy(): PrivacyPolicy<Holiday> {

--- a/examples/simple/src/ent/generated/holiday/actions/holiday_builder.ts
+++ b/examples/simple/src/ent/generated/holiday/actions/holiday_builder.ts
@@ -31,21 +31,26 @@ function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class HolidayBuilder<TData extends HolidayInput = HolidayInput>
-  implements Builder<Holiday>
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
+export class HolidayBuilder<
+  TInput extends HolidayInput = HolidayInput,
+  TExistingEnt extends TMaybleNullableEnt<Holiday> = Holiday | null,
+> implements Builder<Holiday, TExistingEnt>
 {
-  orchestrator: Orchestrator<Holiday, TData>;
+  orchestrator: Orchestrator<Holiday, TInput>;
   readonly placeholderID: ID;
   readonly ent = Holiday;
   readonly nodeType = NodeType.Holiday;
-  private input: TData;
+  private input: TInput;
   private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: Action<Holiday, Builder<Holiday>, TData>,
-    public readonly existingEnt?: Holiday | undefined,
+    action: Action<Holiday, Builder<Holiday, TExistingEnt>, TInput>,
+    public readonly existingEnt: TExistingEnt,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-Holiday`;
     this.input = action.getInput();
@@ -66,7 +71,7 @@ export class HolidayBuilder<TData extends HolidayInput = HolidayInput>
     });
   }
 
-  getInput(): TData {
+  getInput(): TInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/generated/hours_of_operation/actions/create_hours_of_operation_action_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation/actions/create_hours_of_operation_action_base.ts
@@ -23,11 +23,18 @@ export class CreateHoursOfOperationActionBase
   implements
     Action<
       HoursOfOperation,
-      HoursOfOperationBuilder<HoursOfOperationCreateInput>,
-      HoursOfOperationCreateInput
+      HoursOfOperationBuilder<
+        HoursOfOperationCreateInput,
+        HoursOfOperation | null
+      >,
+      HoursOfOperationCreateInput,
+      HoursOfOperation | null
     >
 {
-  public readonly builder: HoursOfOperationBuilder<HoursOfOperationCreateInput>;
+  public readonly builder: HoursOfOperationBuilder<
+    HoursOfOperationCreateInput,
+    HoursOfOperation | null
+  >;
   public readonly viewer: Viewer;
   protected input: HoursOfOperationCreateInput;
 
@@ -38,6 +45,7 @@ export class CreateHoursOfOperationActionBase
       this.viewer,
       WriteOperation.Insert,
       this,
+      null,
     );
   }
 

--- a/examples/simple/src/ent/generated/hours_of_operation/actions/hours_of_operation_builder.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation/actions/hours_of_operation_builder.ts
@@ -31,22 +31,30 @@ function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
 export class HoursOfOperationBuilder<
-  TData extends HoursOfOperationInput = HoursOfOperationInput,
-> implements Builder<HoursOfOperation>
+  TInput extends HoursOfOperationInput = HoursOfOperationInput,
+  TExistingEnt extends TMaybleNullableEnt<HoursOfOperation> = HoursOfOperation | null,
+> implements Builder<HoursOfOperation, TExistingEnt>
 {
-  orchestrator: Orchestrator<HoursOfOperation, TData>;
+  orchestrator: Orchestrator<HoursOfOperation, TInput>;
   readonly placeholderID: ID;
   readonly ent = HoursOfOperation;
   readonly nodeType = NodeType.HoursOfOperation;
-  private input: TData;
+  private input: TInput;
   private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: Action<HoursOfOperation, Builder<HoursOfOperation>, TData>,
-    public readonly existingEnt?: HoursOfOperation | undefined,
+    action: Action<
+      HoursOfOperation,
+      Builder<HoursOfOperation, TExistingEnt>,
+      TInput
+    >,
+    public readonly existingEnt: TExistingEnt,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-HoursOfOperation`;
     this.input = action.getInput();
@@ -68,7 +76,7 @@ export class HoursOfOperationBuilder<
     });
   }
 
-  getInput(): TData {
+  getInput(): TInput {
     return this.input;
   }
 

--- a/examples/simple/src/ent/generated/user/actions/confirm_edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/confirm_edit_email_address_action_base.ts
@@ -22,11 +22,12 @@ export class ConfirmEditEmailAddressActionBase
   implements
     Action<
       User,
-      UserBuilder<ConfirmEditEmailAddressInput>,
-      ConfirmEditEmailAddressInput
+      UserBuilder<ConfirmEditEmailAddressInput, User>,
+      ConfirmEditEmailAddressInput,
+      User
     >
 {
-  public readonly builder: UserBuilder<ConfirmEditEmailAddressInput>;
+  public readonly builder: UserBuilder<ConfirmEditEmailAddressInput, User>;
   public readonly viewer: Viewer;
   protected input: ConfirmEditEmailAddressInput;
   protected user: User;

--- a/examples/simple/src/ent/generated/user/actions/confirm_edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/confirm_edit_phone_number_action_base.ts
@@ -22,11 +22,12 @@ export class ConfirmEditPhoneNumberActionBase
   implements
     Action<
       User,
-      UserBuilder<ConfirmEditPhoneNumberInput>,
-      ConfirmEditPhoneNumberInput
+      UserBuilder<ConfirmEditPhoneNumberInput, User>,
+      ConfirmEditPhoneNumberInput,
+      User
     >
 {
-  public readonly builder: UserBuilder<ConfirmEditPhoneNumberInput>;
+  public readonly builder: UserBuilder<ConfirmEditPhoneNumberInput, User>;
   public readonly viewer: Viewer;
   protected input: ConfirmEditPhoneNumberInput;
   protected user: User;

--- a/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
@@ -37,16 +37,27 @@ export interface UserCreateInput {
 }
 
 export class CreateUserActionBase
-  implements Action<User, UserBuilder<UserCreateInput>, UserCreateInput>
+  implements
+    Action<
+      User,
+      UserBuilder<UserCreateInput, User | null>,
+      UserCreateInput,
+      User | null
+    >
 {
-  public readonly builder: UserBuilder<UserCreateInput>;
+  public readonly builder: UserBuilder<UserCreateInput, User | null>;
   public readonly viewer: Viewer;
   protected input: UserCreateInput;
 
   constructor(viewer: Viewer, input: UserCreateInput) {
     this.viewer = viewer;
     this.input = input;
-    this.builder = new UserBuilder(this.viewer, WriteOperation.Insert, this);
+    this.builder = new UserBuilder(
+      this.viewer,
+      WriteOperation.Insert,
+      this,
+      null,
+    );
   }
 
   getPrivacyPolicy(): PrivacyPolicy<User> {

--- a/examples/simple/src/ent/generated/user/actions/delete_user_action_2_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/delete_user_action_2_base.ts
@@ -18,9 +18,10 @@ export interface DeleteUserInput2 {
 }
 
 export class DeleteUserAction2Base
-  implements Action<User, UserBuilder<DeleteUserInput2>, DeleteUserInput2>
+  implements
+    Action<User, UserBuilder<DeleteUserInput2, User>, DeleteUserInput2, User>
 {
-  public readonly builder: UserBuilder<DeleteUserInput2>;
+  public readonly builder: UserBuilder<DeleteUserInput2, User>;
   public readonly viewer: Viewer;
   protected input: DeleteUserInput2;
   protected user: User;

--- a/examples/simple/src/ent/generated/user/actions/delete_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/delete_user_action_base.ts
@@ -14,9 +14,9 @@ import { User } from "../../..";
 import { UserBuilder, UserInput } from "./user_builder";
 
 export class DeleteUserActionBase
-  implements Action<User, UserBuilder<UserInput>, UserInput>
+  implements Action<User, UserBuilder<UserInput, User>, UserInput, User>
 {
-  public readonly builder: UserBuilder<UserInput>;
+  public readonly builder: UserBuilder<UserInput, User>;
   public readonly viewer: Viewer;
   protected user: User;
 

--- a/examples/simple/src/ent/generated/user/actions/edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_email_address_action_base.ts
@@ -19,9 +19,14 @@ export interface EditEmailAddressInput {
 
 export class EditEmailAddressActionBase
   implements
-    Action<User, UserBuilder<EditEmailAddressInput>, EditEmailAddressInput>
+    Action<
+      User,
+      UserBuilder<EditEmailAddressInput, User>,
+      EditEmailAddressInput,
+      User
+    >
 {
-  public readonly builder: UserBuilder<EditEmailAddressInput>;
+  public readonly builder: UserBuilder<EditEmailAddressInput, User>;
   public readonly viewer: Viewer;
   protected input: EditEmailAddressInput;
   protected user: User;

--- a/examples/simple/src/ent/generated/user/actions/edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_phone_number_action_base.ts
@@ -19,9 +19,14 @@ export interface EditPhoneNumberInput {
 
 export class EditPhoneNumberActionBase
   implements
-    Action<User, UserBuilder<EditPhoneNumberInput>, EditPhoneNumberInput>
+    Action<
+      User,
+      UserBuilder<EditPhoneNumberInput, User>,
+      EditPhoneNumberInput,
+      User
+    >
 {
-  public readonly builder: UserBuilder<EditPhoneNumberInput>;
+  public readonly builder: UserBuilder<EditPhoneNumberInput, User>;
   public readonly viewer: Viewer;
   protected input: EditPhoneNumberInput;
   protected user: User;

--- a/examples/simple/src/ent/generated/user/actions/edit_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_user_action_base.ts
@@ -19,9 +19,10 @@ export interface UserEditInput {
 }
 
 export class EditUserActionBase
-  implements Action<User, UserBuilder<UserEditInput>, UserEditInput>
+  implements
+    Action<User, UserBuilder<UserEditInput, User>, UserEditInput, User>
 {
-  public readonly builder: UserBuilder<UserEditInput>;
+  public readonly builder: UserBuilder<UserEditInput, User>;
   public readonly viewer: Viewer;
   protected input: UserEditInput;
   protected user: User;

--- a/examples/simple/src/ent/generated/user/actions/user_builder.ts
+++ b/examples/simple/src/ent/generated/user/actions/user_builder.ts
@@ -59,21 +59,26 @@ function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
 
-export class UserBuilder<TData extends UserInput = UserInput>
-  implements Builder<User>
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
+export class UserBuilder<
+  TInput extends UserInput = UserInput,
+  TExistingEnt extends TMaybleNullableEnt<User> = User | null,
+> implements Builder<User, TExistingEnt>
 {
-  orchestrator: Orchestrator<User, TData>;
+  orchestrator: Orchestrator<User, TInput>;
   readonly placeholderID: ID;
   readonly ent = User;
   readonly nodeType = NodeType.User;
-  private input: TData;
+  private input: TInput;
   private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: Viewer,
     public readonly operation: WriteOperation,
-    action: Action<User, Builder<User>, TData>,
-    public readonly existingEnt?: User | undefined,
+    action: Action<User, Builder<User, TExistingEnt>, TInput>,
+    public readonly existingEnt: TExistingEnt,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-User`;
     this.input = action.getInput();
@@ -94,7 +99,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
     });
   }
 
-  getInput(): TData {
+  getInput(): TInput {
     return this.input;
   }
 
@@ -132,7 +137,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
 
   addComment(
     ...nodes: (ID | Comment | Builder<Comment>)[]
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addCommentID(node);
@@ -148,7 +153,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addCommentID(
     id: ID | Builder<Comment>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.ObjectToComments,
@@ -158,7 +163,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeComment(...nodes: (ID | Comment)[]): UserBuilder<TData> {
+  removeComment(...nodes: (ID | Comment)[]): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -174,7 +179,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
 
   addCreatedEvent(
     ...nodes: (ID | Event | Builder<Event>)[]
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addCreatedEventID(node);
@@ -190,7 +195,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addCreatedEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToCreatedEvents,
@@ -200,7 +205,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeCreatedEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
+  removeCreatedEvent(
+    ...nodes: (ID | Event)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -219,7 +226,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
 
   addDeclinedEvent(
     ...nodes: (ID | Event | Builder<Event>)[]
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addDeclinedEventID(node);
@@ -235,7 +242,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addDeclinedEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToDeclinedEvents,
@@ -245,7 +252,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeDeclinedEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
+  removeDeclinedEvent(
+    ...nodes: (ID | Event)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -264,7 +273,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
 
   addEventsAttending(
     ...nodes: (ID | Event | Builder<Event>)[]
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addEventsAttendingID(node);
@@ -280,7 +289,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addEventsAttendingID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToEventsAttending,
@@ -290,7 +299,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeEventsAttending(...nodes: (ID | Event)[]): UserBuilder<TData> {
+  removeEventsAttending(
+    ...nodes: (ID | Event)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -307,7 +318,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  addFriend(...nodes: (ID | User | Builder<User>)[]): UserBuilder<TData> {
+  addFriend(
+    ...nodes: (ID | User | Builder<User>)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addFriendID(node);
@@ -323,7 +336,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addFriendID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToFriends,
@@ -333,7 +346,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeFriend(...nodes: (ID | User)[]): UserBuilder<TData> {
+  removeFriend(...nodes: (ID | User)[]): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.UserToFriends);
@@ -346,7 +359,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
 
   addInvitedEvent(
     ...nodes: (ID | Event | Builder<Event>)[]
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addInvitedEventID(node);
@@ -362,7 +375,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addInvitedEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToInvitedEvents,
@@ -372,7 +385,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeInvitedEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
+  removeInvitedEvent(
+    ...nodes: (ID | Event)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -389,7 +404,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  addLiker(...nodes: (ID | User | Builder<User>)[]): UserBuilder<TData> {
+  addLiker(
+    ...nodes: (ID | User | Builder<User>)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addLikerID(node);
@@ -405,7 +422,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addLikerID(
     id: ID | Builder<User>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.ObjectToLikers,
@@ -415,7 +432,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeLiker(...nodes: (ID | User)[]): UserBuilder<TData> {
+  removeLiker(...nodes: (ID | User)[]): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.ObjectToLikers);
@@ -426,7 +443,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  addLike(...nodes: (Ent | Builder<Ent>)[]): UserBuilder<TData> {
+  addLike(...nodes: (Ent | Builder<Ent>)[]): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.orchestrator.addOutboundEdge(
@@ -450,7 +467,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
     id: ID | Builder<Ent>,
     nodeType: NodeType,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToLikes,
@@ -460,7 +477,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeLike(...nodes: (ID | Ent)[]): UserBuilder<TData> {
+  removeLike(...nodes: (ID | Ent)[]): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, EdgeType.UserToLikes);
@@ -471,7 +488,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  addMaybeEvent(...nodes: (ID | Event | Builder<Event>)[]): UserBuilder<TData> {
+  addMaybeEvent(
+    ...nodes: (ID | Event | Builder<Event>)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addMaybeEventID(node);
@@ -487,7 +506,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addMaybeEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToMaybeEvents,
@@ -497,7 +516,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeMaybeEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
+  removeMaybeEvent(
+    ...nodes: (ID | Event)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -513,7 +534,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
 
   addSelfContact(
     ...nodes: (ID | Contact | Builder<Contact>)[]
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addSelfContactID(node);
@@ -529,7 +550,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addSelfContactID(
     id: ID | Builder<Contact>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToSelfContact,
@@ -539,7 +560,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeSelfContact(...nodes: (ID | Contact)[]): UserBuilder<TData> {
+  removeSelfContact(
+    ...nodes: (ID | Contact)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(
@@ -555,7 +578,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
 
   addUserToHostedEvent(
     ...nodes: (ID | Event | Builder<Event>)[]
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (this.isBuilder(node)) {
         this.addUserToHostedEventID(node);
@@ -571,7 +594,7 @@ export class UserBuilder<TData extends UserInput = UserInput>
   addUserToHostedEventID(
     id: ID | Builder<Event>,
     options?: AssocEdgeInputOptions,
-  ): UserBuilder<TData> {
+  ): UserBuilder<TInput, TExistingEnt> {
     this.orchestrator.addOutboundEdge(
       id,
       EdgeType.UserToHostedEvents,
@@ -581,7 +604,9 @@ export class UserBuilder<TData extends UserInput = UserInput>
     return this;
   }
 
-  removeUserToHostedEvent(...nodes: (ID | Event)[]): UserBuilder<TData> {
+  removeUserToHostedEvent(
+    ...nodes: (ID | Event)[]
+  ): UserBuilder<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(

--- a/examples/simple/src/ent/user/actions/confirm_edit_email_address_action.ts
+++ b/examples/simple/src/ent/user/actions/confirm_edit_email_address_action.ts
@@ -23,7 +23,7 @@ async function findAuthCode(
 }
 
 export default class ConfirmEditEmailAddressAction extends ConfirmEditEmailAddressActionBase {
-  validators: Validator<UserBuilder, ConfirmEditEmailAddressInput>[] = [
+  validators: Validator<User, UserBuilder, ConfirmEditEmailAddressInput>[] = [
     {
       async validate(builder, input) {
         const authCode = await findAuthCode(
@@ -38,7 +38,7 @@ export default class ConfirmEditEmailAddressAction extends ConfirmEditEmailAddre
     },
   ];
 
-  triggers: Trigger<UserBuilder, ConfirmEditEmailAddressInput>[] = [
+  triggers: Trigger<User, UserBuilder, ConfirmEditEmailAddressInput>[] = [
     {
       async changeset(builder, input) {
         const authCode = await findAuthCode(

--- a/examples/simple/src/ent/user/actions/confirm_edit_phone_number_action.ts
+++ b/examples/simple/src/ent/user/actions/confirm_edit_phone_number_action.ts
@@ -22,7 +22,7 @@ async function findAuthCode(
 }
 // we're only writing this once except with --force and packageName provided
 export default class ConfirmEditPhoneNumberAction extends ConfirmEditPhoneNumberActionBase {
-  validators: Validator<UserBuilder, ConfirmEditPhoneNumberInput>[] = [
+  validators: Validator<User, UserBuilder, ConfirmEditPhoneNumberInput>[] = [
     {
       async validate(builder, input) {
         const authCode = await findAuthCode(
@@ -37,7 +37,7 @@ export default class ConfirmEditPhoneNumberAction extends ConfirmEditPhoneNumber
     },
   ];
 
-  triggers: Trigger<UserBuilder, ConfirmEditPhoneNumberInput>[] = [
+  triggers: Trigger<User, UserBuilder, ConfirmEditPhoneNumberInput>[] = [
     {
       async changeset(builder, input) {
         const authCode = await findAuthCode(

--- a/examples/simple/src/graphql/mutations/import_contact.ts
+++ b/examples/simple/src/graphql/mutations/import_contact.ts
@@ -1,4 +1,4 @@
-import { ID, RequestContext, Ent, Data } from "@snowtop/ent";
+import { ID, RequestContext } from "@snowtop/ent";
 import {
   gqlArg,
   gqlContextType,
@@ -8,12 +8,10 @@ import {
 import { GraphQLID } from "graphql";
 import { FileUpload } from "graphql-upload";
 import parse from "csv-parse";
-import { Action } from "@snowtop/ent/action";
 import { BaseAction } from "@snowtop/ent/action/experimental_action";
 import { User } from "../../ent";
 import CreateContactAction from "../../ent/contact/actions/create_contact_action";
 import { UserBuilder } from "../../ent/generated/user/actions/user_builder";
-import { ContactBuilder } from "../../ent/generated/contact/actions/contact_builder";
 
 export class ImportContactResolver {
   @gqlMutation({ type: User })
@@ -25,7 +23,7 @@ export class ImportContactResolver {
     const file2 = await file;
 
     const user = await User.loadX(context.getViewer(), userID);
-    let actions: Action<Ent, ContactBuilder, Data>[] = [];
+    let actions: CreateContactAction[] = [];
 
     const parser = file2.createReadStream().pipe(
       parse({

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -90,8 +90,15 @@
   {{ $inputData = useImport $inputData -}}
 {{ end -}}
 
-export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}, {{useImport $builderName}}<{{$inputData}}>, {{$inputData}}> {
-  public readonly builder: {{useImport $builderName}}<{{$inputData}}>;
+{{ $existingEnt := "" -}}
+{{ if $action.MutatingExistingObject -}}
+  {{$existingEnt = $node}}
+{{ else -}}
+  {{$existingEnt = printf "%s | null" $node}}
+{{ end -}}
+
+export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}, {{useImport $builderName}}<{{$inputData}}, {{$existingEnt}}>, {{$inputData}}, {{$existingEnt}}> {
+  public readonly builder: {{useImport $builderName}}<{{$inputData}}, {{$existingEnt}}>;
   public readonly viewer: {{$viewer}}
   {{ if $hasInput -}}
     protected input: {{$inputName}};
@@ -111,6 +118,8 @@ export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}, {{useI
       this,
       {{ if $action.MutatingExistingObject -}}
         {{$instance}},
+      {{ else -}}
+        null,
       {{end -}}
     );
     {{if $action.MutatingExistingObject -}}

--- a/internal/tscode/builder.tmpl
+++ b/internal/tscode/builder.tmpl
@@ -40,19 +40,25 @@ function randomNum(): string {
 
 {{$node := useImport .Node}}
 
-export class {{$builder}}<TData extends {{$input}} = {{$input}}> implements {{useImport "Builder"}}<{{$node}}> {
-  orchestrator: {{useImport "Orchestrator"}}<{{$node}}, TData>;
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
+export class {{$builder}}<
+  TInput extends {{$input}} = {{$input}},
+  TExistingEnt extends TMaybleNullableEnt<{{$node}}> = {{$node}} | null,
+> implements {{useImport "Builder"}}<{{$node}}, TExistingEnt> {
+  orchestrator: {{useImport "Orchestrator"}}<{{$node}}, TInput>;
   readonly placeholderID: {{useImport "ID"}};
   readonly ent = {{$node}};
   readonly nodeType = {{useImport "NodeType"}}.{{$node}};
-  private input: TData;
+  private input: TInput;
   private m: Map<string, any> = new Map();
 
   public constructor(
     public readonly viewer: {{useImport "Viewer"}},
     public readonly operation: {{useImport "WriteOperation"}},
-    action: {{useImport "Action"}}<{{$node}}, {{useImport "Builder"}}<{{$node}}>, TData>,
-    public readonly existingEnt?: {{$node}} | undefined,
+    action: {{useImport "Action"}}<{{$node}}, {{useImport "Builder"}}<{{$node}}, TExistingEnt>, TInput>,
+    public readonly existingEnt: TExistingEnt,
   ) {
     this.placeholderID = `$ent.idPlaceholderID$ ${randomNum()}-{{$node}}`;
     this.input = action.getInput();
@@ -73,7 +79,7 @@ export class {{$builder}}<TData extends {{$input}} = {{$input}}> implements {{us
     });
   }
 
-  getInput(): TData {
+  getInput(): TInput {
     return this.input;
   }
 
@@ -116,10 +122,10 @@ export class {{$builder}}<TData extends {{$input}} = {{$input}}> implements {{us
     {{ $node := useImport .Node -}}
     {{ $polymorphicEdge := $edge.Edge.PolymorphicEdge -}}
   {{ if $polymorphicEdge -}}
-    {{$edge.TSAddMethodName}}(...nodes: ({{$node}} | Builder<{{$node}}>)[]): {{$builder}}<TData> {
+    {{$edge.TSAddMethodName}}(...nodes: ({{$node}} | Builder<{{$node}}>)[]): {{$builder}}<TInput, TExistingEnt> {
   {{ else -}}
   {{/* for PolymorphicEdges, this API doesn't work since we don't know the type. callers should call addLikerID in a map */}}  
-    {{$edge.TSAddMethodName}}(...nodes: (ID | {{$node}} | Builder<{{$node}}>)[]): {{$builder}}<TData> {
+    {{$edge.TSAddMethodName}}(...nodes: (ID | {{$node}} | Builder<{{$node}}>)[]): {{$builder}}<TInput, TExistingEnt> {
   {{ end -}}
     for (const node of nodes) {
       {{ if $polymorphicEdge -}}
@@ -156,7 +162,7 @@ export class {{$builder}}<TData extends {{$input}} = {{$input}}> implements {{us
       nodeType: {{useImport "NodeType"}},
     {{ end -}}
     options?: {{useImport "AssocEdgeInputOptions"}}
-  ): {{$builder}}<TData> {
+  ): {{$builder}}<TInput, TExistingEnt> {
     {{/* TODO need inbound edges also */}}
     this.orchestrator.addOutboundEdge(
       id, 
@@ -171,7 +177,7 @@ export class {{$builder}}<TData extends {{$input}} = {{$input}}> implements {{us
     return this;
   }
 
-  {{$edge.TSRemoveMethodName}}(...nodes: (ID | {{$node}})[]): {{$builder}}<TData> {
+  {{$edge.TSRemoveMethodName}}(...nodes: (ID | {{$node}})[]): {{$builder}}<TInput, TExistingEnt> {
     for (const node of nodes) {
       if (typeof node === "object") {
         this.orchestrator.removeOutboundEdge(node.id, {{useImport "EdgeType"}}.{{$edge.TSEdgeConst}});

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha12",
+  "version": "0.1.0-alpha13",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/action.test.ts
+++ b/ts/src/action/action.test.ts
@@ -106,6 +106,8 @@ function getUserCreateBuilder(): SimpleBuilder<User> {
       ["id", "{id}"],
       ["foo", "bar"],
     ]),
+    WriteOperation.Insert,
+    null,
   );
 }
 

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -116,11 +116,11 @@ export interface Action<
   observers?: Observer<TBuilder, TData>[];
   validators?: Validator<TBuilder, TData>[];
   getInput(): TData; // this input is passed to Triggers, Observers, Validators
-  transformWrite?: <T2 extends Ent>(
-    stmt: UpdateOperation<T2>,
+  transformWrite?: (
+    stmt: UpdateOperation<TEnt>,
   ) =>
-    | Promise<TransformedUpdateOperation<T2>>
-    | TransformedUpdateOperation<T2>
+    | Promise<TransformedUpdateOperation<TEnt>>
+    | TransformedUpdateOperation<TEnt>
     | null;
 
   valid(): Promise<boolean>;

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -100,8 +100,9 @@ export interface Validator<TBuilder extends Builder<Ent>, TData extends Data> {
 
 export interface Action<
   TEnt extends Ent,
-  TBuilder extends Builder<TEnt>,
-  TData extends Data,
+  TBuilder extends Builder<TEnt, TExistingEnt>,
+  TInput extends Data,
+  TExistingEnt extends TMaybleNullableEnt<TEnt> = MaybeNull<TEnt>,
 > {
   readonly viewer: Viewer;
   changeset(): Promise<Changeset<TEnt>>;
@@ -112,10 +113,10 @@ export interface Action<
   // TODO consider making these methods. maybe they'll be easier to use then?
   // performance implications of methods being called multiple times and new instances?
   // even when declared in base class, if overriden in subclasses, still need to type it...
-  triggers?: Trigger<TBuilder, TData>[];
-  observers?: Observer<TBuilder, TData>[];
-  validators?: Validator<TBuilder, TData>[];
-  getInput(): TData; // this input is passed to Triggers, Observers, Validators
+  triggers?: Trigger<TBuilder, TInput>[];
+  observers?: Observer<TBuilder, TInput>[];
+  validators?: Validator<TBuilder, TInput>[];
+  getInput(): TInput; // this input is passed to Triggers, Observers, Validators
   transformWrite?: (
     stmt: UpdateOperation<TEnt>,
   ) =>

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -77,25 +77,40 @@ export type TriggerReturn =
   | Promise<Changeset<Ent> | void | (Changeset<Ent> | void)[]>
   | Promise<Changeset<Ent>>[];
 
-export interface Trigger<TBuilder extends Builder<Ent>, TData extends Data> {
+export interface Trigger<
+  TEnt extends Ent,
+  TBuilder extends Builder<TEnt, TExistingEnt>,
+  TInput extends Data = Data,
+  TExistingEnt extends TMaybleNullableEnt<TEnt> = MaybeNull<TEnt>,
+> {
   // TODO: way in the future. detect any writes happening in changesets and optionally throw if configured to do so
   // can throw if it wants. not expected to throw tho.
   // input passed in here !== builder.getInput()
   // builder.getInput() can have other default fields
-  changeset(builder: TBuilder, input: TData): TriggerReturn;
+  changeset(builder: TBuilder, input: TInput): TriggerReturn;
 }
 
-export interface Observer<TBuilder extends Builder<Ent>, TData extends Data> {
+export interface Observer<
+  TEnt extends Ent,
+  TBuilder extends Builder<TEnt, TExistingEnt>,
+  TInput extends Data = Data,
+  TExistingEnt extends TMaybleNullableEnt<TEnt> = MaybeNull<TEnt>,
+> {
   // input passed in here !== builder.getInput()
   // builder.getInput() can have other default fields
-  observe(builder: TBuilder, input: TData): void | Promise<void>;
+  observe(builder: TBuilder, input: TInput): void | Promise<void>;
 }
 
-export interface Validator<TBuilder extends Builder<Ent>, TData extends Data> {
+export interface Validator<
+  TEnt extends Ent,
+  TBuilder extends Builder<TEnt, TExistingEnt>,
+  TInput extends Data,
+  TExistingEnt extends TMaybleNullableEnt<TEnt> = MaybeNull<TEnt>,
+> {
   // can throw if it wants
   // input passed in here !== builder.getInput()
   // builder.getInput() can have other default fields
-  validate(builder: TBuilder, input: TData): Promise<void> | void;
+  validate(builder: TBuilder, input: TInput): Promise<void> | void;
 }
 
 export interface Action<
@@ -113,9 +128,9 @@ export interface Action<
   // TODO consider making these methods. maybe they'll be easier to use then?
   // performance implications of methods being called multiple times and new instances?
   // even when declared in base class, if overriden in subclasses, still need to type it...
-  triggers?: Trigger<TBuilder, TInput>[];
-  observers?: Observer<TBuilder, TInput>[];
-  validators?: Validator<TBuilder, TInput>[];
+  triggers?: Trigger<TEnt, TBuilder, TInput, TExistingEnt>[];
+  observers?: Observer<TEnt, TBuilder, TInput, TExistingEnt>[];
+  validators?: Validator<TEnt, TBuilder, TInput, TExistingEnt>[];
   getInput(): TInput; // this input is passed to Triggers, Observers, Validators
   transformWrite?: (
     stmt: UpdateOperation<TEnt>,

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -23,8 +23,14 @@ export enum WriteOperation {
   Delete = "delete",
 }
 
-export interface Builder<T extends Ent> {
-  existingEnt?: T;
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
+export interface Builder<
+  T extends Ent,
+  TExistingEnt extends TMaybleNullableEnt<T> = MaybeNull<T>,
+> {
+  existingEnt: TExistingEnt;
   ent: EntConstructor<T>;
   placeholderID: ID;
   readonly viewer: Viewer;
@@ -115,7 +121,7 @@ export interface Action<
   ) =>
     | Promise<TransformedUpdateOperation<T2>>
     | TransformedUpdateOperation<T2>
-    | undefined;
+    | null;
 
   valid(): Promise<boolean>;
   // throws if invalid

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -294,7 +294,7 @@ class MessageAction extends SimpleAction<Message> {
     super(viewer, MessageSchema, fields, operation, existingEnt);
   }
 
-  triggers: Trigger<SimpleBuilder<Message>, Data>[] = [
+  triggers: Trigger<Message, SimpleBuilder<Message>>[] = [
     {
       changeset: (builder, _input): void => {
         let sender = builder.fields.get("sender");
@@ -310,7 +310,7 @@ class MessageAction extends SimpleAction<Message> {
     },
   ];
 
-  observers: Observer<SimpleBuilder<Message>, Data>[] = [
+  observers: Observer<Message, SimpleBuilder<Message>>[] = [
     new EntCreationObserver<Message>(),
   ];
 }
@@ -327,7 +327,7 @@ class UserAction extends SimpleAction<User> {
     super(viewer, UserSchema, fields, operation, existingEnt);
   }
 
-  triggers: Trigger<SimpleBuilder<User>, Data>[] = [
+  triggers: Trigger<User, SimpleBuilder<User>, Data>[] = [
     {
       changeset: (builder): Promise<Changeset<Contact>> => {
         let firstName = builder.fields.get("FirstName");
@@ -356,7 +356,7 @@ class UserAction extends SimpleAction<User> {
     },
   ];
 
-  observers: Observer<SimpleBuilder<User>, Data>[] = [
+  observers: Observer<User, SimpleBuilder<User>, Data>[] = [
     new EntCreationObserver<User>(),
   ];
 }
@@ -366,7 +366,9 @@ type getMembershipFunction = (
   edge: EdgeInputData,
 ) => SimpleAction<Ent>;
 
-class GroupMembershipTrigger implements Trigger<SimpleBuilder<Group>, Data> {
+class GroupMembershipTrigger
+  implements Trigger<Group, SimpleBuilder<Group>, Data>
+{
   constructor(private getter: getMembershipFunction) {}
   changeset(builder: SimpleBuilder<Group>, input: Data): TriggerReturn {
     const inputEdges = builder.orchestrator.getInputEdges(

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -289,7 +289,7 @@ class MessageAction extends SimpleAction<Message> {
     viewer: Viewer,
     fields: Map<string, any>,
     operation: WriteOperation,
-    existingEnt?: Message,
+    existingEnt: Message | null,
   ) {
     super(viewer, MessageSchema, fields, operation, existingEnt);
   }
@@ -322,7 +322,7 @@ class UserAction extends SimpleAction<User> {
     viewer: Viewer,
     fields: Map<string, any>,
     operation: WriteOperation,
-    existingEnt?: User,
+    existingEnt: User | null,
   ) {
     super(viewer, UserSchema, fields, operation, existingEnt);
   }
@@ -341,6 +341,7 @@ class UserAction extends SimpleAction<User> {
             ["UserID", builder],
           ]),
           WriteOperation.Insert,
+          null,
         );
 
         this.contactAction.observers = [new EntCreationObserver<Contact>()];
@@ -492,6 +493,7 @@ function commonTests() {
         ["LastName", "Snow"],
       ]),
       WriteOperation.Insert,
+      null,
     );
     const user = await action.saveX();
     expect(operations.length).toBe(1);
@@ -542,6 +544,7 @@ function commonTests() {
         ["LastName", "Snow"],
       ]),
       WriteOperation.Insert,
+      null,
     );
 
     const exec = await executeAction(action, ListBasedExecutor);
@@ -628,6 +631,7 @@ function commonTests() {
         ["LastName", "Snow"],
       ]),
       WriteOperation.Insert,
+      null,
     );
     let firstName = userBuilder.fields.get("FirstName");
     let lastName = userBuilder.fields.get("LastName");
@@ -640,6 +644,7 @@ function commonTests() {
         ["UserID", userBuilder],
       ]),
       WriteOperation.Insert,
+      null,
     );
 
     try {
@@ -662,6 +667,7 @@ function commonTests() {
         ["LastName", "Snow"],
       ]),
       WriteOperation.Insert,
+      null,
     );
 
     // expect ComplexExecutor because of complexity of what we have here
@@ -770,6 +776,7 @@ function commonTests() {
               ["EmailAddress", userInfo.emailAddress],
             ]),
             WriteOperation.Insert,
+            null,
           );
 
           for (let channel of autoJoinChannels) {
@@ -799,6 +806,7 @@ function commonTests() {
               ["expiresAt", new Date().setTime(new Date().getTime() + 86400)],
             ]),
             WriteOperation.Insert,
+            null,
           );
 
           return await Promise.all([
@@ -923,6 +931,7 @@ function commonTests() {
                 ["log", input],
               ]),
               WriteOperation.Insert,
+              null,
             );
             builder.orchestrator.addOutboundEdge(
               clAction.builder,
@@ -955,6 +964,7 @@ function commonTests() {
             ["notificationsEnabled", true],
           ]),
           WriteOperation.Insert,
+          null,
         );
       },
     );
@@ -991,6 +1001,7 @@ function commonTests() {
                 ["log", input],
               ]),
               WriteOperation.Insert,
+              null,
             );
             builder.orchestrator.addInboundEdge(
               clAction.builder,
@@ -1023,6 +1034,7 @@ function commonTests() {
             ["notificationsEnabled", true],
           ]),
           WriteOperation.Insert,
+          null,
         );
       },
     );
@@ -1078,6 +1090,7 @@ function commonTests() {
                 ["log", input],
               ]),
               WriteOperation.Insert,
+              null,
             );
             builder.orchestrator.addOutboundEdge(
               clAction.builder,
@@ -1112,6 +1125,7 @@ function commonTests() {
             ["notificationsEnabled", true],
           ]),
           WriteOperation.Insert,
+          null,
         );
       },
     );
@@ -1152,6 +1166,7 @@ function commonTests() {
         ["EmailAddress", randomEmail()],
       ]),
       WriteOperation.Insert,
+      null,
     );
 
     async function doNothing(): Promise<void> {}
@@ -1234,6 +1249,7 @@ function commonTests() {
       AccountSchema,
       new Map([]),
       WriteOperation.Insert,
+      null,
     );
 
     const actions: SimpleAction<Ent>[] = inputs.map(
@@ -1246,6 +1262,7 @@ function commonTests() {
             ["AccountID", accountAction.builder],
           ]),
           WriteOperation.Insert,
+          null,
         ),
     );
     actions.push(accountAction);
@@ -1255,7 +1272,7 @@ function commonTests() {
         viewer: Viewer,
         operation: WriteOperation,
         action: SimpleAction<Group>,
-        existingEnt?: Group,
+        existingEnt: Group | null,
       ) {
         super(viewer, GroupSchema, new Map(), operation, existingEnt, action);
       }
@@ -1274,6 +1291,7 @@ function commonTests() {
           ["expiresAt", new Date().setTime(new Date().getTime() + 86400)],
         ]),
         WriteOperation.Insert,
+        null,
       ),
     );
 

--- a/ts/src/action/experimental_action.ts
+++ b/ts/src/action/experimental_action.ts
@@ -56,7 +56,7 @@ export class BaseAction<TEnt extends Ent, TData extends Data>
       viewer,
       operation,
       this,
-      options?.existingEnt || undefined,
+      options?.existingEnt || null,
     );
   }
 
@@ -121,7 +121,7 @@ interface BuilderConstructor<TEnt extends Ent, TData extends Data> {
     viewer: Viewer,
     operation: WriteOperation,
     action: Action<TEnt, EntBuilder<TEnt>, TData>,
-    existingEnt?: TEnt | undefined,
+    existingEnt: TEnt | null,
   ): EntBuilder<TEnt>;
 }
 

--- a/ts/src/action/experimental_action.ts
+++ b/ts/src/action/experimental_action.ts
@@ -30,9 +30,9 @@ export class BaseAction<TEnt extends Ent, TData extends Data>
 {
   builder: EntBuilder<TEnt>;
   private input: TData;
-  triggers: Trigger<EntBuilder<TEnt>, TData>[] = [];
-  observers: Observer<EntBuilder<TEnt>, TData>[] = [];
-  validators: Validator<EntBuilder<TEnt>, TData>[] = [];
+  triggers: Trigger<TEnt, EntBuilder<TEnt>, TData>[] = [];
+  observers: Observer<TEnt, EntBuilder<TEnt>, TData>[] = [];
+  validators: Validator<TEnt, EntBuilder<TEnt>, TData>[] = [];
 
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -333,11 +333,29 @@ const SensitiveValuesSchema = getBuilderSchemaFromFields(
   SensitiveUser,
 );
 
+function getInsertUserAction(
+  map: Map<string, any>,
+  viewer: Viewer = new LoggedOutViewer(),
+) {
+  return new SimpleAction(viewer, UserSchema, map, WriteOperation.Insert, null);
+}
+
+function getInsertUserBuilder(
+  map: Map<string, any>,
+  viewer: Viewer = new LoggedOutViewer(),
+) {
+  return new SimpleBuilder(
+    viewer,
+    UserSchema,
+    map,
+    WriteOperation.Insert,
+    null,
+  );
+}
+
 function commonTests() {
   test("schema on create", async () => {
-    const builder = new SimpleBuilder(
-      new LoggedOutViewer(),
-      UserSchema,
+    const builder = getInsertUserBuilder(
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
@@ -351,9 +369,7 @@ function commonTests() {
   });
 
   test("missing required field", async () => {
-    const builder = new SimpleBuilder(
-      new LoggedOutViewer(),
-      UserSchema,
+    const builder = getInsertUserBuilder(
       new Map([
         ["FirstName", "Jon"],
         // non-nullable field set to null
@@ -375,11 +391,7 @@ function commonTests() {
   // if somehow builder logic doesn't handle this, we still catch this for create
   // should this be default and simplify builders?
   test("required field not set", async () => {
-    const builder = new SimpleBuilder(
-      new LoggedOutViewer(),
-      UserSchema,
-      new Map([["FirstName", "Jon"]]),
-    );
+    const builder = getInsertUserBuilder(new Map([["FirstName", "Jon"]]));
 
     try {
       await builder.build();
@@ -397,6 +409,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
 
     await builder.build();
@@ -410,6 +424,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
 
     await builder.build();
@@ -423,6 +439,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
 
     await builder.build();
@@ -436,6 +454,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
 
     try {
@@ -496,6 +516,8 @@ function commonTests() {
       new LoggedOutViewer(),
       SchemaWithNullFields,
       new Map([["startTime", d]]),
+      WriteOperation.Insert,
+      null,
     );
 
     const fields = await getFieldsFromBuilder(builder);
@@ -511,6 +533,8 @@ function commonTests() {
         ["startTime", d],
         ["endTime", null],
       ]),
+      WriteOperation.Insert,
+      null,
     );
     const fields2 = await getFieldsFromBuilder(builder2);
     expect(fields2["start_time"]).toBeDefined();
@@ -531,6 +555,8 @@ function commonTests() {
       new LoggedOutViewer(),
       SchemaWithOverridenDBKey,
       new Map([["emailAddress", "test@email.com"]]),
+      WriteOperation.Insert,
+      null,
     );
 
     const fields = await getFieldsFromBuilder(builder);
@@ -547,6 +573,8 @@ function commonTests() {
           ["username", "lolopinto"],
           ["zip", "94114"],
         ]),
+        WriteOperation.Insert,
+        null,
       );
 
       const fields = await getFieldsFromBuilder(builder);
@@ -563,6 +591,8 @@ function commonTests() {
           ["username", "LOLOPINTO"],
           ["zip", "94114"],
         ]),
+        WriteOperation.Insert,
+        null,
       );
 
       const fields = await getFieldsFromBuilder(builder);
@@ -579,6 +609,8 @@ function commonTests() {
           ["username", "LOLOPINTO"],
           ["zip", "941"],
         ]),
+        WriteOperation.Insert,
+        null,
       );
 
       try {
@@ -903,27 +935,21 @@ function commonTests() {
         ]),
       );
 
-      const action = new SimpleAction(
-        new LoggedOutViewer(),
-        UserSchema,
+      const action = getInsertUserAction(
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
         ]),
-        WriteOperation.Insert,
       );
       action.builder.orchestrator.addInboundEdge(user.id, "edge", "User");
       action.triggers = [
         {
           changeset: (builder: SimpleBuilder<User>) => {
-            const derivedAction = new SimpleAction(
-              new LoggedOutViewer(),
-              UserSchema,
+            const derivedAction = getInsertUserAction(
               new Map([
                 ["FirstName", "Sansa"],
                 ["LastName", "Stark"],
               ]),
-              WriteOperation.Insert,
             );
 
             // take the edges and write it as 3 edge
@@ -990,14 +1016,11 @@ function commonTests() {
         ]),
       );
 
-      const action = new SimpleAction(
-        new LoggedOutViewer(),
-        UserSchema,
+      const action = getInsertUserAction(
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
         ]),
-        WriteOperation.Insert,
       );
       action.builder.orchestrator.addInboundEdge(
         user.id,
@@ -1007,14 +1030,11 @@ function commonTests() {
       action.triggers = [
         {
           changeset: (builder: SimpleBuilder<User>) => {
-            const derivedAction = new SimpleAction(
-              new LoggedOutViewer(),
-              UserSchema,
+            const derivedAction = getInsertUserAction(
               new Map([
                 ["FirstName", "Sansa"],
                 ["LastName", "Stark"],
               ]),
-              WriteOperation.Insert,
             );
 
             // take the edges and write it as 3 edge
@@ -1391,27 +1411,21 @@ function commonTests() {
         ]),
       );
 
-      const action = new SimpleAction(
-        new LoggedOutViewer(),
-        UserSchema,
+      const action = getInsertUserAction(
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
         ]),
-        WriteOperation.Insert,
       );
       action.builder.orchestrator.addOutboundEdge(user.id, "edge", "User");
       action.triggers = [
         {
           changeset: (builder: SimpleBuilder<User>) => {
-            const derivedAction = new SimpleAction(
-              new LoggedOutViewer(),
-              UserSchema,
+            const derivedAction = getInsertUserAction(
               new Map([
                 ["FirstName", "Sansa"],
                 ["LastName", "Stark"],
               ]),
-              WriteOperation.Insert,
             );
 
             // take the edges and write it as 3 edge
@@ -1480,14 +1494,11 @@ function commonTests() {
       ]),
     );
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
-      UserSchema,
+    const action = getInsertUserAction(
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
-      WriteOperation.Insert,
     );
     action.builder.orchestrator.addOutboundEdge(
       user.id,
@@ -1497,14 +1508,11 @@ function commonTests() {
     action.triggers = [
       {
         changeset: (builder: SimpleBuilder<User>) => {
-          const derivedAction = new SimpleAction(
-            new LoggedOutViewer(),
-            UserSchema,
+          const derivedAction = getInsertUserAction(
             new Map([
               ["FirstName", "Sansa"],
               ["LastName", "Stark"],
             ]),
-            WriteOperation.Insert,
           );
 
           // take the edges and write it as 3 edge
@@ -1684,6 +1692,7 @@ function commonTests() {
         UserSchema,
         new Map(),
         WriteOperation.Edit,
+        null,
       );
       builder.orchestrator.removeInboundEdge("2", "edge");
 
@@ -1741,6 +1750,7 @@ function commonTests() {
         UserSchema,
         new Map(),
         WriteOperation.Edit,
+        null,
       );
       builder.orchestrator.removeOutboundEdge("2", "edge");
 
@@ -1783,6 +1793,7 @@ function commonTests() {
           ["endTime", yesterday],
         ]),
         WriteOperation.Insert,
+        null,
       );
       action.validators = validators;
 
@@ -1806,6 +1817,7 @@ function commonTests() {
           ["endTime", now],
         ]),
         WriteOperation.Insert,
+        null,
       );
       action.validators = validators;
 
@@ -1818,14 +1830,11 @@ function commonTests() {
 
   describe("privacyPolicy", () => {
     test("valid", async () => {
-      let action = new SimpleAction(
-        new LoggedOutViewer(),
-        UserSchema,
+      let action = getInsertUserAction(
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
         ]),
-        WriteOperation.Insert,
       );
       action.getPrivacyPolicy = () => {
         return {
@@ -1838,14 +1847,12 @@ function commonTests() {
 
     test("invalid", async () => {
       const viewer = new IDViewer("1");
-      const action = new SimpleAction(
-        viewer,
-        UserSchema,
+      const action = getInsertUserAction(
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
         ]),
-        WriteOperation.Insert,
+        viewer,
       );
       action.getPrivacyPolicy = () => {
         return {
@@ -1858,14 +1865,12 @@ function commonTests() {
 
     test("invalidX. create", async () => {
       const viewer = new IDViewer("1");
-      const action = new SimpleAction(
-        viewer,
-        UserSchema,
+      const action = getInsertUserAction(
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
         ]),
-        WriteOperation.Insert,
+        viewer,
       );
       action.getPrivacyPolicy = () => {
         return {
@@ -1964,14 +1969,11 @@ function commonTests() {
     });
 
     test("unsafe ent in creation. valid", async () => {
-      let action = new SimpleAction(
-        new LoggedOutViewer(),
-        UserSchema,
+      let action = getInsertUserAction(
         new Map([
           ["FirstName", "Jon"],
           ["LastName", "Snow"],
         ]),
-        WriteOperation.Insert,
       );
       action.getPrivacyPolicy = () => {
         return {
@@ -1986,14 +1988,11 @@ function commonTests() {
     });
 
     test("unsafe ent in creation. invalid", async () => {
-      let action = new SimpleAction(
-        new LoggedOutViewer(),
-        UserSchema,
+      let action = getInsertUserAction(
         new Map([
           ["FirstName", "Sansa"],
           ["LastName", "Snow"],
         ]),
-        WriteOperation.Insert,
       );
       action.getPrivacyPolicy = () => {
         return {
@@ -2029,6 +2028,7 @@ function commonTests() {
           ["LastName", "Snow"],
         ]),
         WriteOperation.Insert,
+        null,
       );
 
       action.triggers = triggers;
@@ -2060,6 +2060,7 @@ function commonTests() {
           ["LastName", "Snow"],
         ]),
         WriteOperation.Insert,
+        null,
       );
       // also create a contact when we create a user
       action.triggers = [
@@ -2079,6 +2080,7 @@ function commonTests() {
                 ["UserID", builder],
               ]),
               WriteOperation.Insert,
+              null,
             );
             return contactAction.changeset();
           },
@@ -2134,6 +2136,7 @@ function commonTests() {
           ["account_status", "UNVERIFIED"],
         ]),
         WriteOperation.Insert,
+        null,
       );
       action.observers = [sendEmailObserver];
 
@@ -2166,6 +2169,7 @@ function commonTests() {
           ["account_status", "UNVERIFIED"],
         ]),
         WriteOperation.Insert,
+        null,
       );
       action.observers = [sendEmailObserver];
 
@@ -2203,6 +2207,7 @@ function commonTests() {
           ["account_status", "UNVERIFIED"],
         ]),
         WriteOperation.Insert,
+        null,
       );
       action.observers = [sendEmailObserverAsync];
 
@@ -2238,6 +2243,7 @@ function commonTests() {
         UserSchemaExtended,
         fields,
         WriteOperation.Insert,
+        null,
       );
       action.triggers = [
         {
@@ -2379,6 +2385,8 @@ function commonTests() {
         ["OwnerID", user.id],
         ["OwnerType", user.nodeType],
       ]),
+      WriteOperation.Insert,
+      null,
     );
 
     const fields = await getFieldsFromBuilder(builder);
@@ -2396,6 +2404,7 @@ function commonTests() {
           ["LastName", "Snow"],
         ]),
         WriteOperation.Insert,
+        null,
       );
       action.viewerForEntLoad = (data: Data) => {
         // load the created ent using a VC of the newly created user.
@@ -2423,6 +2432,7 @@ function commonTests() {
           ["LastName", "Snow"],
         ]),
         WriteOperation.Insert,
+        null,
       );
       try {
         await action.saveX();
@@ -2496,6 +2506,7 @@ function commonTests() {
           ["LastName", "Snow"],
         ]),
         WriteOperation.Insert,
+        null,
       );
       await action.saveX();
       expect(mockLog.logs.length).toBeGreaterThanOrEqual(1);
@@ -2515,6 +2526,7 @@ function commonTests() {
           ["LastName", "Snow"],
         ]),
         WriteOperation.Insert,
+        null,
       );
       await action.saveX();
       expect(mockLog.logs.length).toBeGreaterThanOrEqual(1);
@@ -2534,6 +2546,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
     await builder.saveX();
     const user = await builder.editedEntX();
@@ -2545,6 +2559,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
 
     await builder2.saveX();
@@ -2558,6 +2574,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
     // logged out viewer with null viewer throws since it's still required
     try {
@@ -2576,6 +2594,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
     await builder.saveX();
     const user = await builder.editedEntX();
@@ -2587,6 +2607,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
 
     await builder2.saveX();
@@ -2600,6 +2622,8 @@ function commonTests() {
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
+      WriteOperation.Insert,
+      null,
     );
     // logged out viewer with null viewer throws since it's still required
     try {
@@ -2626,6 +2650,7 @@ function commonTests() {
         ["LastName", "Snow"],
       ]),
       WriteOperation.Insert,
+      null,
     );
     action.triggers = [
       {
@@ -2642,6 +2667,7 @@ function commonTests() {
                   ["email", `foo${v}@bar.com`],
                 ]),
                 WriteOperation.Insert,
+                null,
               );
               const data = await action2.builder.orchestrator.getEditedData();
               emailIDs.push(data.id);
@@ -2684,6 +2710,7 @@ function commonTests() {
         ["LastName", "Snow"],
       ]),
       WriteOperation.Insert,
+      null,
     );
     const unsafe =
       await action.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
@@ -2710,6 +2737,7 @@ function commonTests() {
         ["LastName", "Snow"],
       ]),
       WriteOperation.Insert,
+      null,
     );
 
     let idInTrigger: string | undefined;
@@ -2746,6 +2774,7 @@ const getCreateBuilder = (map: Map<string, any>) => {
     UserSchema,
     map,
     WriteOperation.Insert,
+    null,
   );
 };
 

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -1764,7 +1764,7 @@ function commonTests() {
   });
 
   describe("validators", () => {
-    const validators: Validator<SimpleBuilder<Event>, Data>[] = [
+    const validators: Validator<Event, SimpleBuilder<Event>, Data>[] = [
       {
         validate: async (builder): Promise<void> => {
           let startTime: Date = builder.fields.get("startTime");
@@ -2010,7 +2010,11 @@ function commonTests() {
   describe("trigger", () => {
     let now = new Date();
 
-    const accountStatusTrigger: Trigger<SimpleBuilder<UserWithStatus>, Data> = {
+    const accountStatusTrigger: Trigger<
+      UserWithStatus,
+      SimpleBuilder<UserWithStatus>,
+      Data
+    > = {
       changeset: (builder: SimpleBuilder<UserWithStatus>): void => {
         builder.fields.set("account_status", "VALID");
       },
@@ -2846,7 +2850,7 @@ async function getEdgeOpFromBuilder<T extends Ent>(
   throw new Error(`could not find edge operation with edgeType ${edgeType}`);
 }
 
-let sendEmailObserver: Observer<SimpleBuilder<User>, Data> = {
+let sendEmailObserver: Observer<User, SimpleBuilder<User>, Data> = {
   observe: (builder): void => {
     let email = builder.fields.get("EmailAddress");
     if (!email) {
@@ -2863,7 +2867,7 @@ let sendEmailObserver: Observer<SimpleBuilder<User>, Data> = {
   },
 };
 
-let sendEmailObserverAsync: Observer<SimpleBuilder<User>, Data> = {
+let sendEmailObserverAsync: Observer<User, SimpleBuilder<User>, Data> = {
   observe: async (builder) => {
     let email = builder.fields.get("EmailAddress");
     if (!email) {

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -629,7 +629,7 @@ export class Orchestrator<
     // if action transformations. always do it
     // if disable transformations set, don't do schema transform and just do the right thing
     // else apply schema tranformation if it exists
-    let transformed: TransformedUpdateOperation<TEnt> | null;
+    let transformed: TransformedUpdateOperation<TEnt> | null = null;
 
     if (action?.transformWrite) {
       transformed = await action.transformWrite({
@@ -639,7 +639,7 @@ export class Orchestrator<
         existingEnt: this.existingEnt,
       });
     } else if (!this.disableTransformations) {
-      transformed = getTransformedUpdateOp(this.options.schema, {
+      transformed = getTransformedUpdateOp<TEnt>(this.options.schema, {
         viewer: builder.viewer,
         op: this.getSQLStatementOperation(),
         data: editedFields,
@@ -667,6 +667,7 @@ export class Orchestrator<
       }
       this.actualOperation = this.getWriteOpForSQLStamentOp(transformed.op);
       if (transformed.existingEnt) {
+        // @ts-ignore
         this.existingEnt = transformed.existingEnt;
       }
     }

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -564,7 +564,7 @@ export class Orchestrator<
   private async triggers(
     action: Action<TEnt, Builder<TEnt>, TData>,
     builder: Builder<TEnt>,
-    triggers: Trigger<Builder<TEnt>, TData>[],
+    triggers: Trigger<TEnt, Builder<TEnt>, TData>[],
   ): Promise<void> {
     await Promise.all(
       triggers.map(async (trigger) => {
@@ -587,7 +587,7 @@ export class Orchestrator<
   }
 
   private async validators(
-    validators: Validator<Builder<TEnt>, TData>[],
+    validators: Validator<TEnt, Builder<TEnt>, TData>[],
     action: Action<TEnt, Builder<TEnt>, TData>,
     builder: Builder<TEnt>,
   ): Promise<void> {

--- a/ts/src/action/transformed_orchestrator.test.ts
+++ b/ts/src/action/transformed_orchestrator.test.ts
@@ -102,7 +102,7 @@ class DeletedAtPattern implements Pattern {
 
   transformWrite<T extends Ent>(
     stmt: UpdateOperation<T>,
-  ): TransformedUpdateOperation<T> | undefined {
+  ): TransformedUpdateOperation<T> | null {
     switch (stmt.op) {
       case SQLStatementOperation.Delete:
         return {
@@ -113,6 +113,7 @@ class DeletedAtPattern implements Pattern {
           },
         };
     }
+    return null;
   }
 }
 
@@ -133,7 +134,7 @@ class DeletedAtSnakeCasePattern implements Pattern {
 
   transformWrite<T extends Ent>(
     stmt: UpdateOperation<T>,
-  ): TransformedUpdateOperation<T> | undefined {
+  ): TransformedUpdateOperation<T> | null {
     switch (stmt.op) {
       case SQLStatementOperation.Delete:
         return {
@@ -144,6 +145,7 @@ class DeletedAtSnakeCasePattern implements Pattern {
           },
         };
     }
+    return null;
   }
 }
 

--- a/ts/src/action/transformed_orchestrator.test.ts
+++ b/ts/src/action/transformed_orchestrator.test.ts
@@ -1,6 +1,6 @@
 import { advanceTo } from "jest-date-mock";
 import { WriteOperation } from "../action";
-import { Data, Ent } from "../core/base";
+import { Data, Ent, Viewer } from "../core/base";
 import { LoggedOutViewer } from "../core/viewer";
 import { StringType, TimestampType } from "../schema/field";
 import {
@@ -230,16 +230,39 @@ function transformDeletedAt(row: Data | null) {
   return row;
 }
 
+function getInsertUserAction(
+  map: Map<string, any>,
+  viewer: Viewer = new LoggedOutViewer(),
+) {
+  return new SimpleAction(
+    viewer,
+    new UserSchema(),
+    map,
+    WriteOperation.Insert,
+    null,
+  );
+}
+
+function getInsertContactAction(
+  map: Map<string, any>,
+  viewer: Viewer = new LoggedOutViewer(),
+) {
+  return new SimpleAction(
+    viewer,
+    new ContactSchema(),
+    map,
+    WriteOperation.Insert,
+    null,
+  );
+}
+
 function commonTests() {
   test("delete -> update", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
-      new UserSchema(),
+    const action = getInsertUserAction(
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
-      WriteOperation.Insert,
     );
     const user = await action.saveX();
     const loader = getNewLoader();
@@ -280,14 +303,11 @@ function commonTests() {
   });
 
   test("really delete", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
-      new UserSchema(),
+    const action = getInsertUserAction(
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
-      WriteOperation.Insert,
     );
     const user = await action.saveX();
     const loader = getNewLoader();
@@ -330,14 +350,11 @@ function commonTests() {
       expect(users.length).toBe(ct);
     };
     verifyPostgres(0);
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
-      new UserSchema(),
+    const action = getInsertUserAction(
       new Map([
         ["FirstName", "Jon"],
         ["LastName", "Snow"],
       ]),
-      WriteOperation.Insert,
     );
     const user = await action.saveX();
     verifyPostgres(1);
@@ -370,14 +387,11 @@ function commonTests() {
       }
     };
 
-    const action2 = new SimpleAction(
-      new LoggedOutViewer(),
-      new UserSchema(),
+    const action2 = getInsertUserAction(
       new Map([
         ["FirstName", "Aegon"],
         ["LastName", "Targaryen"],
       ]),
-      WriteOperation.Insert,
     );
     // @ts-ignore
     action2.transformWrite = tranformJonToAegon;
@@ -388,14 +402,11 @@ function commonTests() {
     expect(user2.data.last_name).toBe("Targaryen");
     verifyPostgres(1);
 
-    const action3 = new SimpleAction(
-      new LoggedOutViewer(),
-      new UserSchema(),
+    const action3 = getInsertUserAction(
       new Map([
         ["FirstName", "Sansa"],
         ["LastName", "Stark"],
       ]),
-      WriteOperation.Insert,
     );
     // @ts-ignore
     action3.transformWrite = tranformJonToAegon;
@@ -409,14 +420,11 @@ function commonTests() {
   });
 
   test("delete -> update. snake_case", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
-      new ContactSchema(),
+    const action = getInsertContactAction(
       new Map([
         ["first_name", "Jon"],
         ["last_name", "Snow"],
       ]),
-      WriteOperation.Insert,
     );
     const contact = await action.saveX();
     const loader = getContactNewLoader();
@@ -457,14 +465,11 @@ function commonTests() {
   });
 
   test("really delete. snake_case", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
-      new ContactSchema(),
+    const action = getInsertContactAction(
       new Map([
         ["first_name", "Jon"],
         ["last_name", "Snow"],
       ]),
-      WriteOperation.Insert,
     );
     const contact = await action.saveX();
     const loader = getContactNewLoader();
@@ -507,14 +512,11 @@ function commonTests() {
       expect(contacts.length).toBe(ct);
     };
     verifyPostgres(0);
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
-      new ContactSchema(),
+    const action = getInsertContactAction(
       new Map([
         ["first_name", "Jon"],
         ["last_name", "Snow"],
       ]),
-      WriteOperation.Insert,
     );
     const contact = await action.saveX();
     verifyPostgres(1);
@@ -547,14 +549,11 @@ function commonTests() {
       }
     };
 
-    const action2 = new SimpleAction(
-      new LoggedOutViewer(),
-      new ContactSchema(),
+    const action2 = getInsertContactAction(
       new Map([
         ["first_name", "Aegon"],
         ["last_name", "Targaryen"],
       ]),
-      WriteOperation.Insert,
     );
     // @ts-ignore
     action2.transformWrite = tranformJonToAegon;
@@ -565,14 +564,11 @@ function commonTests() {
     expect(contact2.data.last_name).toBe("Targaryen");
     verifyPostgres(1);
 
-    const action3 = new SimpleAction(
-      new LoggedOutViewer(),
-      new ContactSchema(),
+    const action3 = getInsertContactAction(
       new Map([
         ["first_name", "Sansa"],
         ["last_name", "Stark"],
       ]),
-      WriteOperation.Insert,
     );
     // @ts-ignore
     action3.transformWrite = tranformJonToAegon;

--- a/ts/src/core/ent.test.ts
+++ b/ts/src/core/ent.test.ts
@@ -59,6 +59,8 @@ function getUserCreateBuilder(): SimpleBuilder<User> {
       ["id", "{id}"],
       ["foo", "bar"],
     ]),
+    WriteOperation.Insert,
+    null,
   );
 }
 
@@ -357,6 +359,8 @@ function commonTests() {
           ["id", "{id}"],
           ["foo", "bar"],
         ]),
+        WriteOperation.Insert,
+        null,
       );
       action.viewerForEntLoad = (data: Data) => {
         return new IDViewer(data.id);

--- a/ts/src/core/ent_complex.test.ts
+++ b/ts/src/core/ent_complex.test.ts
@@ -353,6 +353,7 @@ async function createUser(email: string) {
       ["birthday", "jan 1"],
     ]),
     WriteOperation.Insert,
+    null,
   );
   return action.saveX();
 }
@@ -371,6 +372,7 @@ async function createAccount(email: string) {
       ["birthday", "jan 1"],
     ]),
     WriteOperation.Insert,
+    null,
   );
   return action.saveX();
 }

--- a/ts/src/schema/postgres_schema_live.test.ts
+++ b/ts/src/schema/postgres_schema_live.test.ts
@@ -14,6 +14,7 @@ import {
   SimpleAction,
   getBuilderSchemaFromFields,
   getBuilderSchemaTZFromFields,
+  BuilderSchema,
 } from "../testutils/builder";
 import {
   table,
@@ -32,6 +33,7 @@ import { AlwaysAllowPrivacyPolicy } from "../core/privacy";
 import { ID, Ent, Viewer, Data, PrivacyPolicy } from "../core/base";
 import * as fs from "fs";
 import * as path from "path";
+import { WriteOperation } from "../action";
 
 const UserSchema = getBuilderSchemaFromFields(
   {
@@ -123,6 +125,19 @@ afterEach(async () => {
   await tdb.drop("users");
 });
 
+function getInsertAction<T extends Ent>(
+  schema: BuilderSchema<T>,
+  map: Map<string, any>,
+) {
+  return new SimpleAction(
+    new LoggedOutViewer(),
+    schema,
+    map,
+    WriteOperation.Insert,
+    null,
+  );
+}
+
 describe("timestamp", () => {
   beforeEach(async () => {
     await createRegUsers();
@@ -130,8 +145,7 @@ describe("timestamp", () => {
 
   test("standard", async () => {
     const date = new Date();
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       UserSchema,
       new Map<string, any>([
         ["FirstName", "Jon"],
@@ -153,8 +167,7 @@ describe("timestamp", () => {
 
   test("no setTypeParser", async () => {
     const date = new Date();
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       UserSchema,
       new Map<string, any>([
         ["FirstName", "Jon"],
@@ -195,8 +208,7 @@ describe("timestamp", () => {
 
   test("no toISO formattting", async () => {
     const date = new Date();
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new UserWithTimestampNoFormatSchema(),
       new Map<string, any>([
         ["FirstName", "Jon"],
@@ -217,8 +229,7 @@ describe("timestamp", () => {
 
   test("neither toISO formatting nor new parser", async () => {
     const date = new Date();
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new UserWithTimestampNoFormatSchema(),
       new Map<string, any>([
         ["FirstName", "Jon"],
@@ -249,8 +260,7 @@ describe("timestamp", () => {
 test("timestamptz", async () => {
   await createUsersWithTZ();
   const date = new Date();
-  const action = new SimpleAction(
-    new LoggedOutViewer(),
+  const action = getInsertAction(
     UserWithTimezoneSchema,
     new Map<string, any>([
       ["FirstName", "Jon"],
@@ -325,8 +335,7 @@ describe("time", () => {
 
     const close = new Date();
     close.setHours(17, 0, 0, 0);
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       HoursSchema,
       new Map<string, any>([
         ["dayOfWeek", "sunday"],
@@ -341,8 +350,7 @@ describe("time", () => {
   });
 
   test("time format", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       HoursSchema,
       new Map<string, any>([
         ["dayOfWeek", "sunday"],
@@ -391,8 +399,7 @@ describe("timetz", () => {
     close.setMinutes(0);
     close.setSeconds(0);
     close.setMilliseconds(0);
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       HoursTZSchema,
       new Map<string, any>([
         ["dayOfWeek", "sunday"],
@@ -409,8 +416,7 @@ describe("timetz", () => {
   });
 
   test("time format", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       HoursSchema,
       new Map<string, any>([
         ["dayOfWeek", "sunday"],
@@ -474,8 +480,7 @@ describe("date", () => {
   };
 
   test("date object", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       HolidaySchema,
       new Map<string, any>([
         ["label", "inaugaration"],
@@ -489,8 +494,7 @@ describe("date", () => {
   });
 
   test("date format", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       HolidaySchema,
       new Map<string, any>([
         ["label", "inaugaration"],

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -204,7 +204,7 @@ export enum SQLStatementOperation {
 
 export interface UpdateOperation<T extends Ent> {
   op: SQLStatementOperation;
-  existingEnt?: T;
+  existingEnt: T | null;
   viewer: Viewer;
   data?: Map<string, any>;
 }
@@ -216,7 +216,7 @@ export interface TransformedUpdateOperation<T extends Ent> {
 
   // if changing to an update, we want to return the ent
   // TODO don't have a way to delete the ent e.g. update -> insert
-  existingEnt?: T;
+  existingEnt: T | null;
 }
 
 // we want --strictNullChecks flag so nullable is used to type graphql, ts, db

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -173,7 +173,7 @@ export interface Pattern {
   transformRead?: () => Clause;
   transformWrite?: <T extends Ent>(
     stmt: UpdateOperation<T>,
-  ) => TransformedUpdateOperation<T> | undefined;
+  ) => TransformedUpdateOperation<T> | null;
 
   // can only have one pattern in an object which transforms each
   // if we do, it throws an Error
@@ -216,7 +216,7 @@ export interface TransformedUpdateOperation<T extends Ent> {
 
   // if changing to an update, we want to return the ent
   // TODO don't have a way to delete the ent e.g. update -> insert
-  existingEnt: T | null;
+  existingEnt?: T | null;
 }
 
 // we want --strictNullChecks flag so nullable is used to type graphql, ts, db
@@ -564,16 +564,17 @@ export function getObjectLoaderProperties(
 export function getTransformedUpdateOp<T extends Ent>(
   value: SchemaInputType,
   stmt: UpdateOperation<T>,
-): TransformedUpdateOperation<T> | undefined {
+): TransformedUpdateOperation<T> | null {
   const schema = getSchema(value);
   if (!schema.patterns) {
-    return;
+    return null;
   }
   for (const p of schema.patterns) {
     if (p.transformWrite) {
       return p.transformWrite(stmt);
     }
   }
+  return null;
 }
 
 // this maps to ActionOperation in ent/action.go

--- a/ts/src/schema/schema_json.test.ts
+++ b/ts/src/schema/schema_json.test.ts
@@ -10,6 +10,7 @@ import { loadConfig } from "../core/config";
 import { convertJSON } from "../core/convert";
 import { JSONType, JSONBType } from "./json_field";
 import { FieldMap } from "./schema";
+import { WriteOperation } from "../action";
 
 let tdb: TempDB;
 
@@ -42,6 +43,19 @@ async function createTables(...schemas: BuilderSchema<Ent>[]) {
   for (const schema of schemas) {
     await tdb.create(getSchemaTable(schema, DB.getDialect()));
   }
+}
+
+function getInsertAction<T extends Ent>(
+  schema: BuilderSchema<T>,
+  map: Map<string, any>,
+) {
+  return new SimpleAction(
+    new LoggedOutViewer(),
+    schema,
+    map,
+    WriteOperation.Insert,
+    null,
+  );
 }
 
 describe("postgres", () => {
@@ -94,8 +108,7 @@ function commonTests() {
   }
 
   test("json", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new NotificationSchema(),
       new Map<string, any>([
         [
@@ -118,8 +131,7 @@ function commonTests() {
   });
 
   test("json. invalid", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new NotificationSchema(),
       new Map<string, any>([
         [
@@ -142,8 +154,7 @@ function commonTests() {
   });
 
   test("jsonb", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new NotificationJSONBSchema(),
       new Map<string, any>([
         [
@@ -166,8 +177,7 @@ function commonTests() {
   });
 
   test("jsonb. invalid", async () => {
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new NotificationJSONBSchema(),
       new Map<string, any>([
         [

--- a/ts/src/schema/schema_list.test.ts
+++ b/ts/src/schema/schema_list.test.ts
@@ -28,6 +28,7 @@ import {
   convertList,
   convertJSON,
 } from "../core/convert";
+import { WriteOperation } from "../action";
 let tdb: TempDB;
 async function setupTempDB(dialect: Dialect, connString?: string) {
   beforeAll(async () => {
@@ -60,6 +61,19 @@ async function createTables(...schemas: BuilderSchema<Ent>[]) {
   }
 }
 
+function getInsertAction<T extends Ent>(
+  schema: BuilderSchema<T>,
+  map: Map<string, any>,
+) {
+  return new SimpleAction(
+    new LoggedOutViewer(),
+    schema,
+    map,
+    WriteOperation.Insert,
+    null,
+  );
+}
+
 describe("postgres", () => {
   setupTempDB(Dialect.Postgres);
   commonTests();
@@ -82,8 +96,7 @@ function commonTests() {
 
     const n = ["Lord Snow", "The Prince That was Promised"];
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new AccountSchema(),
       new Map<string, any>([["Nicknames", n]]),
     );
@@ -105,8 +118,7 @@ function commonTests() {
     const input = ["US", "Uk", "fr"];
     const output = input.map((f) => f.toLowerCase());
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new CountryCodeSchema(),
       new Map<string, any>([["codes", input]]),
     );
@@ -127,8 +139,7 @@ function commonTests() {
 
     const n = [4, 8, 15, 16, 23, 42];
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new LotterySchema(),
       new Map<string, any>([["numbers", n]]),
     );
@@ -149,8 +160,7 @@ function commonTests() {
 
     const n = [98.0, 97.6, 93.2, 92.1];
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new TempHistorySchema(),
       new Map<string, any>([["temps", n]]),
     );
@@ -174,8 +184,7 @@ function commonTests() {
     const holidays = ["2020-12-25", "2020-12-26", "2021-01-01"];
     const expected = holidays.map(convertDate);
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new HolidaySchema(),
       new Map<string, any>([
         ["id", v4()],
@@ -201,8 +210,7 @@ function commonTests() {
     // TODO we don't support complicated time formats...
     const times = ["08:00:00", "10:00:00", "11:30:00"];
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new AppointmentSchema(),
       new Map<string, any>([["availableTimes", times]]),
     );
@@ -235,8 +243,7 @@ function commonTests() {
     const times = [newDate(8), newDate(10), newDate(11, 30)];
     const expected = times.map((time) => TimeType().format(time));
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new AppointmentSchema(),
       new Map<string, any>([["availableTimes", times]]),
     );
@@ -257,8 +264,7 @@ function commonTests() {
 
     const satisfied = [true, false, true];
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new SurveySchema(),
       new Map<string, any>([["satisfied", satisfied]]),
     );
@@ -286,8 +292,7 @@ function commonTests() {
     ];
     const expected = visits.map(convertDate);
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new VisitSchema(),
       new Map<string, any>([["visits", visits]]),
     );
@@ -318,8 +323,7 @@ function commonTests() {
   test("enum list", async () => {
     const weekend = ["Saturday", "Sunday"];
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new AvailableSchema(),
       new Map<string, any>([["days", weekend]]),
     );
@@ -332,8 +336,7 @@ function commonTests() {
   test("invalid enum value", async () => {
     const weekend = ["red", "Tuesday"];
 
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new AvailableSchema(),
       new Map<string, any>([["days", weekend]]),
     );
@@ -417,8 +420,7 @@ function commonTests() {
         bar3: null,
       },
     ];
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new PreferencesSchema(),
       new Map<string, any>([["prefsList", prefsList]]),
     );
@@ -444,8 +446,7 @@ function commonTests() {
         bar3: null,
       },
     ];
-    const action = new SimpleAction(
-      new LoggedOutViewer(),
+    const action = getInsertAction(
       new PreferencesJSONSchema(),
       new Map<string, any>([["prefsList", prefsList]]),
     );

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -314,12 +314,12 @@ interface viewerEntLoadFunc {
 export class SimpleAction<
   T extends Ent,
   TExistingEnt extends TMaybleNullableEnt<T> = MaybeNull<T>,
-> implements Action<T, SimpleBuilder<T>, Data>
+> implements Action<T, SimpleBuilder<T, TExistingEnt>, Data, TExistingEnt>
 {
-  builder: SimpleBuilder<T>;
-  validators: Validator<SimpleBuilder<T>, Data>[] = [];
-  triggers: Trigger<SimpleBuilder<T>, Data>[] = [];
-  observers: Observer<SimpleBuilder<T>, Data>[] = [];
+  builder: SimpleBuilder<T, TExistingEnt>;
+  validators: Validator<T, SimpleBuilder<T>, Data>[] = [];
+  triggers: Trigger<T, SimpleBuilder<T>, Data>[] = [];
+  observers: Observer<T, SimpleBuilder<T>, Data>[] = [];
   viewerForEntLoad: viewerEntLoadFunc | undefined;
 
   constructor(
@@ -329,7 +329,7 @@ export class SimpleAction<
     operation: WriteOperation = WriteOperation.Insert,
     existingEnt: TExistingEnt,
   ) {
-    this.builder = new SimpleBuilder<T>(
+    this.builder = new SimpleBuilder<T, TExistingEnt>(
       this.viewer,
       schema,
       fields,

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -175,8 +175,15 @@ export function getFieldInfo(value: BuilderSchema<Ent>) {
   return ret;
 }
 
+type MaybeNull<T extends Ent> = T | null;
+type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
+
 // reuses orchestrator and standard things
-export class SimpleBuilder<T extends Ent> implements Builder<T> {
+export class SimpleBuilder<
+  T extends Ent,
+  TExistingEnt extends TMaybleNullableEnt<T> = MaybeNull<T>,
+> implements Builder<T>
+{
   ent: EntConstructor<T>;
   placeholderID: ID;
   public orchestrator: Orchestrator<T, Data>;
@@ -188,7 +195,7 @@ export class SimpleBuilder<T extends Ent> implements Builder<T> {
     private schema: BuilderSchema<T>,
     fields: Map<string, any>,
     public operation: WriteOperation = WriteOperation.Insert,
-    public existingEnt: T | undefined = undefined,
+    public existingEnt: TExistingEnt,
     action?: Action<T, SimpleBuilder<T>, Data> | undefined,
   ) {
     // create dynamic placeholder
@@ -304,8 +311,10 @@ interface viewerEntLoadFunc {
   (data: Data): Viewer | Promise<Viewer>;
 }
 
-export class SimpleAction<T extends Ent>
-  implements Action<T, SimpleBuilder<T>, Data>
+export class SimpleAction<
+  T extends Ent,
+  TExistingEnt extends TMaybleNullableEnt<T> = MaybeNull<T>,
+> implements Action<T, SimpleBuilder<T>, Data>
 {
   builder: SimpleBuilder<T>;
   validators: Validator<SimpleBuilder<T>, Data>[] = [];
@@ -318,7 +327,7 @@ export class SimpleAction<T extends Ent>
     schema: BuilderSchema<T>,
     private fields: Map<string, any>,
     operation: WriteOperation = WriteOperation.Insert,
-    existingEnt: T | undefined = undefined,
+    existingEnt: TExistingEnt,
   ) {
     this.builder = new SimpleBuilder<T>(
       this.viewer,

--- a/ts/src/testutils/fake_data/fake_contact.ts
+++ b/ts/src/testutils/fake_data/fake_contact.ts
@@ -14,6 +14,7 @@ import { NodeType } from "./const";
 import { table, uuid, text, timestamptz } from "../db/test_db";
 import { ObjectLoaderFactory } from "../../core/loaders";
 import { convertDate } from "../../core/convert";
+import { WriteOperation } from "../../action";
 
 export class FakeContact implements Ent {
   readonly id: ID;
@@ -117,7 +118,13 @@ export function getContactBuilder(viewer: Viewer, input: ContactCreateInput) {
   m.set("createdAt", new Date());
   m.set("updatedAt", new Date());
 
-  return new SimpleBuilder(viewer, FakeContactSchema, m);
+  return new SimpleBuilder(
+    viewer,
+    FakeContactSchema,
+    m,
+    WriteOperation.Insert,
+    null,
+  );
 }
 
 export async function createContact(viewer: Viewer, input: ContactCreateInput) {

--- a/ts/src/testutils/fake_data/fake_event.ts
+++ b/ts/src/testutils/fake_data/fake_event.ts
@@ -14,6 +14,7 @@ import { NodeType } from "./const";
 import { table, uuid, text, timestamptz } from "../db/test_db";
 import { ObjectLoaderFactory } from "../../core/loaders";
 import { convertDate, convertNullableDate } from "../../core/convert";
+import { WriteOperation } from "../../action";
 
 export class FakeEvent implements Ent {
   readonly id: ID;
@@ -130,7 +131,13 @@ export function getEventBuilder(viewer: Viewer, input: EventCreateInput) {
   for (const key in input) {
     m.set(key, input[key]);
   }
-  return new SimpleBuilder(viewer, FakeEventSchema, m);
+  return new SimpleBuilder(
+    viewer,
+    FakeEventSchema,
+    m,
+    WriteOperation.Insert,
+    null,
+  );
 }
 
 export async function createEvent(viewer: Viewer, input: EventCreateInput) {

--- a/ts/src/testutils/fake_data/fake_user.ts
+++ b/ts/src/testutils/fake_data/fake_user.ts
@@ -21,6 +21,7 @@ import { IDViewer, IDViewerOptions } from "../../core/viewer";
 import { table, uuid, text, timestamptz } from "../db/test_db";
 import { ObjectLoaderFactory } from "../../core/loaders";
 import { convertDate } from "../../core/convert";
+import { WriteOperation } from "../../action";
 
 interface TokenOptions extends IDViewerOptions {
   tokens?: {};
@@ -165,7 +166,13 @@ export function getUserAction(viewer: Viewer, input: UserCreateInput) {
   for (const key in input) {
     m.set(key, input[key]);
   }
-  const action = new SimpleAction(viewer, FakeUserSchema, m);
+  const action = new SimpleAction(
+    viewer,
+    FakeUserSchema,
+    m,
+    WriteOperation.Insert,
+    null,
+  );
   action.viewerForEntLoad = (data: Data) => {
     // load the created ent using a VC of the newly created user.
     return new IDViewer(data.id);


### PR DESCRIPTION
`builder.existingEnt` is non-nullable in edit/delete actions

fixes https://github.com/lolopinto/ent/issues/767