### PR TITLE
change Actions API

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha15",
+        "@snowtop/ent": "^0.1.0-alpha16",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha1",
         "@snowtop/ent-password": "^0.0.1",
@@ -950,9 +950,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha15",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha15.tgz",
-      "integrity": "sha512-UTrHKSzK9LjcsqtDaL08ynyIqly8bDZplupCTqo1vmwQZL/FrIjMDNfOu2wW+wjEQvl9upEASfbdU4sGcANbMg==",
+      "version": "0.1.0-alpha16",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha16.tgz",
+      "integrity": "sha512-G4hDcfGbbFajkdrtUGbFnyklY5mNX1ikQshkXbEGqohfByiETXAciRV4CWYoXz2ax5CMBJOK1RAmCFofk1yqJg==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6512,9 +6512,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha15",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha15.tgz",
-      "integrity": "sha512-UTrHKSzK9LjcsqtDaL08ynyIqly8bDZplupCTqo1vmwQZL/FrIjMDNfOu2wW+wjEQvl9upEASfbdU4sGcANbMg==",
+      "version": "0.1.0-alpha16",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha16.tgz",
+      "integrity": "sha512-G4hDcfGbbFajkdrtUGbFnyklY5mNX1ikQshkXbEGqohfByiETXAciRV4CWYoXz2ax5CMBJOK1RAmCFofk1yqJg==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha15",
+    "@snowtop/ent": "^0.1.0-alpha16",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha1",
     "@snowtop/ent-password": "^0.0.1",

--- a/examples/simple/src/ent/auth_code/actions/create_auth_code_action.ts
+++ b/examples/simple/src/ent/auth_code/actions/create_auth_code_action.ts
@@ -5,23 +5,34 @@ import {
 import { AuthCodeBuilder } from "../../generated/auth_code/actions/auth_code_builder";
 
 export { AuthCodeCreateInput };
+import { ExampleViewer } from "../../../viewer/viewer";
+import { AuthCode } from "../../";
+import { Validator } from "@snowtop/ent/action";
 
 // we're only writing this once except with --force and packageName provided
 export default class CreateAuthCodeAction extends CreateAuthCodeActionBase {
-  validators = [
-    {
-      validate(builder: AuthCodeBuilder, input: AuthCodeCreateInput) {
-        if (
-          !(
-            (input.emailAddress || input.phoneNumber) &&
-            !(input.emailAddress && input.phoneNumber)
-          )
-        ) {
-          throw new Error(
-            `exactly one of phoneNumber and emailAddress needs to be provided`,
-          );
-        }
+  getValidators(): Validator<
+    AuthCode,
+    AuthCodeBuilder<AuthCodeCreateInput, AuthCode | null>,
+    ExampleViewer,
+    AuthCodeCreateInput,
+    AuthCode | null
+  >[] {
+    return [
+      {
+        validate(builder: AuthCodeBuilder, input: AuthCodeCreateInput) {
+          if (
+            !(
+              (input.emailAddress || input.phoneNumber) &&
+              !(input.emailAddress && input.phoneNumber)
+            )
+          ) {
+            throw new Error(
+              `exactly one of phoneNumber and emailAddress needs to be provided`,
+            );
+          }
+        },
       },
-    },
-  ];
+    ];
+  }
 }

--- a/examples/simple/src/ent/comment/actions/create_comment_action.ts
+++ b/examples/simple/src/ent/comment/actions/create_comment_action.ts
@@ -14,7 +14,6 @@ import { Comment } from "../../../ent";
 import { ExampleViewer } from "../../../viewer/viewer";
 
 export { CommentCreateInput };
-import { Comment } from "../../";
 
 export default class CreateCommentAction extends CreateCommentActionBase {
   getPrivacyPolicy() {

--- a/examples/simple/src/ent/comment/actions/create_comment_action.ts
+++ b/examples/simple/src/ent/comment/actions/create_comment_action.ts
@@ -14,24 +14,27 @@ import { Comment } from "../../../ent";
 import { ExampleViewer } from "../../../viewer/viewer";
 
 export { CommentCreateInput };
+import { Comment } from "../../";
 
 export default class CreateCommentAction extends CreateCommentActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  triggers: Trigger<
+  getTriggers(): Trigger<
     Comment,
-    CommentBuilder<Comment, Comment>,
+    CommentBuilder<CommentCreateInput, Comment | null>,
     ExampleViewer,
     CommentCreateInput,
-    Comment
-  >[] = [
-    {
-      changeset(builder, input) {
-        // creating the comment automatically adds the needed edges
-        builder.addPostID(input.articleID, input.articleType as NodeType);
+    Comment | null
+  >[] {
+    return [
+      {
+        changeset(builder, input) {
+          // creating the comment automatically adds the needed edges
+          builder.addPostID(input.articleID, input.articleType as NodeType);
+        },
       },
-    },
-  ];
+    ];
+  }
 }

--- a/examples/simple/src/ent/contact/actions/create_contact_action.ts
+++ b/examples/simple/src/ent/contact/actions/create_contact_action.ts
@@ -35,76 +35,82 @@ export default class CreateContactAction extends CreateContactActionBase {
     };
   }
 
-  triggers: Trigger<
+  getTriggers(): Trigger<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactCreateInput, Contact | null>,
     ExampleViewer,
-    ContactCreateInput
-  >[] = [
-    {
-      async changeset(builder, input) {
-        if (!input.emails) {
-          return;
-        }
-        const emailIds: ID[] = [];
-        const changesets = await Promise.all(
-          input.emails.map(async (email) => {
-            const action = CreateContactEmailAction.create(builder.viewer, {
-              emailAddress: email.emailAddress,
-              label: email.label,
-              contactID: builder,
-            });
-            // use getPossibleUnsafeEntForPrivacy for this
-            const unsafe =
-              await action.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
-            emailIds.push(unsafe!.id);
-            return action.changeset();
-          }),
-        );
-
-        builder.updateInput({
-          emailIds,
-        });
-        return changesets;
-      },
-    },
-    {
-      async changeset(builder, input) {
-        if (!input.phoneNumbers) {
-          return;
-        }
-        const phoneNumberIds: ID[] = [];
-        const changesets = await Promise.all(
-          input.phoneNumbers.map(async (phone) => {
-            const action = CreateContactPhoneNumberAction.create(
-              builder.viewer,
-              {
-                phoneNumber: phone.phoneNumber,
-                label: phone.label,
+    ContactCreateInput,
+    Contact | null
+  >[] {
+    return [
+      {
+        async changeset(builder, input) {
+          if (!input.emails) {
+            return;
+          }
+          const emailIds: ID[] = [];
+          const changesets = await Promise.all(
+            input.emails.map(async (email) => {
+              const action = CreateContactEmailAction.create(builder.viewer, {
+                emailAddress: email.emailAddress,
+                label: email.label,
                 contactID: builder,
-              },
-            );
-            const edited = await action.builder.orchestrator.getEditedData();
-            phoneNumberIds.push(edited.id);
-            return action.changeset();
-          }),
-        );
+              });
+              // use getPossibleUnsafeEntForPrivacy for this
+              const unsafe =
+                await action.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
+              emailIds.push(unsafe!.id);
+              return action.changeset();
+            }),
+          );
 
-        builder.updateInput({
-          phoneNumberIds,
-        });
-
-        return changesets;
+          builder.updateInput({
+            emailIds,
+          });
+          return changesets;
+        },
       },
-    },
-  ];
+      {
+        async changeset(builder, input) {
+          if (!input.phoneNumbers) {
+            return;
+          }
+          const phoneNumberIds: ID[] = [];
+          const changesets = await Promise.all(
+            input.phoneNumbers.map(async (phone) => {
+              const action = CreateContactPhoneNumberAction.create(
+                builder.viewer,
+                {
+                  phoneNumber: phone.phoneNumber,
+                  label: phone.label,
+                  contactID: builder,
+                },
+              );
+              const edited = await action.builder.orchestrator.getEditedData();
+              phoneNumberIds.push(edited.id);
+              return action.changeset();
+            }),
+          );
 
-  observers: Observer<
+          builder.updateInput({
+            phoneNumberIds,
+          });
+
+          return changesets;
+        },
+      },
+    ];
+  }
+
+  getObservers(): Observer<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactCreateInput, Contact | null>,
     ExampleViewer,
-    ContactCreateInput
-  >[] = [new EntCreationObserver()];
+    ContactCreateInput,
+    Contact | null
+  >[] {
+    return [new EntCreationObserver()];
+  }
 
   viewerForEntLoad(data: Data) {
     // needed if created in user action and we want to make sure this

--- a/examples/simple/src/ent/event/actions/create_event_action.ts
+++ b/examples/simple/src/ent/event/actions/create_event_action.ts
@@ -10,6 +10,7 @@ import { Event } from "../../../ent";
 import { ExampleViewer } from "../../../viewer/viewer";
 
 export { EventCreateInput };
+import { Event } from "../../";
 
 // we're only writing this once except with --force and packageName provided
 export default class CreateEventAction extends CreateEventActionBase {
@@ -19,21 +20,32 @@ export default class CreateEventAction extends CreateEventActionBase {
     return AlwaysAllowPrivacyPolicy;
   }
 
-  validators: Validator<
+  getValidators(): Validator<
     Event,
-    EventBuilder,
+    EventBuilder<EventCreateInput, Event | null>,
     ExampleViewer,
-    EventCreateInput
-  >[] = [...SharedValidators];
+    EventCreateInput,
+    Event | null
+  >[] {
+    return [...SharedValidators];
+  }
 
-  triggers: Trigger<Event, EventBuilder, ExampleViewer, EventCreateInput>[] = [
-    {
-      changeset(
-        builder: EventBuilder<EventCreateInput>,
-        input: EventCreateInput,
-      ) {
-        builder.addHostID(input.creatorID);
+  getTriggers(): Trigger<
+    Event,
+    EventBuilder<EventCreateInput, Event | null>,
+    ExampleViewer,
+    EventCreateInput,
+    Event | null
+  >[] {
+    return [
+      {
+        changeset(
+          builder: EventBuilder<EventCreateInput>,
+          input: EventCreateInput,
+        ) {
+          builder.addHostID(input.creatorID);
+        },
       },
-    },
-  ];
+    ];
+  }
 }

--- a/examples/simple/src/ent/event/actions/create_event_action.ts
+++ b/examples/simple/src/ent/event/actions/create_event_action.ts
@@ -10,7 +10,6 @@ import { Event } from "../../../ent";
 import { ExampleViewer } from "../../../viewer/viewer";
 
 export { EventCreateInput };
-import { Event } from "../../";
 
 // we're only writing this once except with --force and packageName provided
 export default class CreateEventAction extends CreateEventActionBase {

--- a/examples/simple/src/ent/event/actions/edit_event_action.ts
+++ b/examples/simple/src/ent/event/actions/edit_event_action.ts
@@ -14,11 +14,20 @@ import { Event } from "../../../ent";
 import { ExampleViewer } from "../../../viewer/viewer";
 
 export { EventEditInput };
+import { Event } from "../../";
 
 // we're only writing this once except with --force and packageName provided
 export default class EditEventAction extends EditEventActionBase {
-  validators: Validator<Event, EventBuilder, ExampleViewer, EventEditInput>[] =
+  getValidators(): Validator<
+    Event,
+    EventBuilder<EventEditInput, Event>,
+    ExampleViewer,
+    EventEditInput,
+    Event
+  >[] {
+    return;
     [...SharedValidators];
+  }
 
   getPrivacyPolicy(): PrivacyPolicy {
     return {

--- a/examples/simple/src/ent/event/actions/edit_event_action.ts
+++ b/examples/simple/src/ent/event/actions/edit_event_action.ts
@@ -14,7 +14,6 @@ import { Event } from "../../../ent";
 import { ExampleViewer } from "../../../viewer/viewer";
 
 export { EventEditInput };
-import { Event } from "../../";
 
 // we're only writing this once except with --force and packageName provided
 export default class EditEventAction extends EditEventActionBase {
@@ -25,8 +24,7 @@ export default class EditEventAction extends EditEventActionBase {
     EventEditInput,
     Event
   >[] {
-    return;
-    [...SharedValidators];
+    return [...SharedValidators];
   }
 
   getPrivacyPolicy(): PrivacyPolicy {

--- a/examples/simple/src/ent/generated/address/actions/create_address_action_base.ts
+++ b/examples/simple/src/ent/generated/address/actions/create_address_action_base.ts
@@ -59,7 +59,7 @@ export class CreateAddressActionBase
 
   getTriggers(): Trigger<
     Address,
-    AddressBuilder,
+    AddressBuilder<AddressCreateInput, Address | null>,
     ExampleViewer,
     AddressCreateInput,
     Address | null
@@ -69,7 +69,7 @@ export class CreateAddressActionBase
 
   getObservers(): Observer<
     Address,
-    AddressBuilder,
+    AddressBuilder<AddressCreateInput, Address | null>,
     ExampleViewer,
     AddressCreateInput,
     Address | null
@@ -79,7 +79,7 @@ export class CreateAddressActionBase
 
   getValidators(): Validator<
     Address,
-    AddressBuilder,
+    AddressBuilder<AddressCreateInput, Address | null>,
     ExampleViewer,
     AddressCreateInput,
     Address | null

--- a/examples/simple/src/ent/generated/address/actions/create_address_action_base.ts
+++ b/examples/simple/src/ent/generated/address/actions/create_address_action_base.ts
@@ -7,7 +7,14 @@ import {
   AllowIfViewerHasIdentityPrivacyPolicy,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { Address } from "../../..";
 import { AddressBuilder } from "./address_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -48,6 +55,36 @@ export class CreateAddressActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Address> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Address,
+    AddressBuilder,
+    ExampleViewer,
+    AddressCreateInput,
+    Address | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Address,
+    AddressBuilder,
+    ExampleViewer,
+    AddressCreateInput,
+    Address | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Address,
+    AddressBuilder,
+    ExampleViewer,
+    AddressCreateInput,
+    Address | null
+  >[] {
+    return [];
   }
 
   getInput(): AddressCreateInput {

--- a/examples/simple/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
@@ -62,7 +62,7 @@ export class CreateAuthCodeActionBase
 
   getTriggers(): Trigger<
     AuthCode,
-    AuthCodeBuilder,
+    AuthCodeBuilder<AuthCodeCreateInput, AuthCode | null>,
     ExampleViewer,
     AuthCodeCreateInput,
     AuthCode | null
@@ -72,7 +72,7 @@ export class CreateAuthCodeActionBase
 
   getObservers(): Observer<
     AuthCode,
-    AuthCodeBuilder,
+    AuthCodeBuilder<AuthCodeCreateInput, AuthCode | null>,
     ExampleViewer,
     AuthCodeCreateInput,
     AuthCode | null
@@ -82,7 +82,7 @@ export class CreateAuthCodeActionBase
 
   getValidators(): Validator<
     AuthCode,
-    AuthCodeBuilder,
+    AuthCodeBuilder<AuthCodeCreateInput, AuthCode | null>,
     ExampleViewer,
     AuthCodeCreateInput,
     AuthCode | null

--- a/examples/simple/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { AuthCode, User } from "../../..";
@@ -55,6 +58,36 @@ export class CreateAuthCodeActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<AuthCode> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    AuthCode,
+    AuthCodeBuilder,
+    ExampleViewer,
+    AuthCodeCreateInput,
+    AuthCode | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    AuthCode,
+    AuthCodeBuilder,
+    ExampleViewer,
+    AuthCodeCreateInput,
+    AuthCode | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    AuthCode,
+    AuthCodeBuilder,
+    ExampleViewer,
+    AuthCodeCreateInput,
+    AuthCode | null
+  >[] {
+    return [];
   }
 
   getInput(): AuthCodeCreateInput {

--- a/examples/simple/src/ent/generated/auth_code/actions/delete_auth_code_action_base.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/delete_auth_code_action_base.ts
@@ -51,7 +51,7 @@ export class DeleteAuthCodeActionBase
 
   getTriggers(): Trigger<
     AuthCode,
-    AuthCodeBuilder,
+    AuthCodeBuilder<AuthCodeInput, AuthCode>,
     ExampleViewer,
     AuthCodeInput,
     AuthCode
@@ -61,7 +61,7 @@ export class DeleteAuthCodeActionBase
 
   getObservers(): Observer<
     AuthCode,
-    AuthCodeBuilder,
+    AuthCodeBuilder<AuthCodeInput, AuthCode>,
     ExampleViewer,
     AuthCodeInput,
     AuthCode
@@ -71,7 +71,7 @@ export class DeleteAuthCodeActionBase
 
   getValidators(): Validator<
     AuthCode,
-    AuthCodeBuilder,
+    AuthCodeBuilder<AuthCodeInput, AuthCode>,
     ExampleViewer,
     AuthCodeInput,
     AuthCode

--- a/examples/simple/src/ent/generated/auth_code/actions/delete_auth_code_action_base.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/delete_auth_code_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { AuthCode } from "../../..";
 import { AuthCodeBuilder, AuthCodeInput } from "./auth_code_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -40,6 +47,36 @@ export class DeleteAuthCodeActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<AuthCode> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    AuthCode,
+    AuthCodeBuilder,
+    ExampleViewer,
+    AuthCodeInput,
+    AuthCode
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    AuthCode,
+    AuthCodeBuilder,
+    ExampleViewer,
+    AuthCodeInput,
+    AuthCode
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    AuthCode,
+    AuthCodeBuilder,
+    ExampleViewer,
+    AuthCodeInput,
+    AuthCode
+  >[] {
+    return [];
   }
 
   getInput(): AuthCodeInput {

--- a/examples/simple/src/ent/generated/comment/actions/create_comment_action_base.ts
+++ b/examples/simple/src/ent/generated/comment/actions/create_comment_action_base.ts
@@ -60,7 +60,7 @@ export class CreateCommentActionBase
 
   getTriggers(): Trigger<
     Comment,
-    CommentBuilder,
+    CommentBuilder<CommentCreateInput, Comment | null>,
     ExampleViewer,
     CommentCreateInput,
     Comment | null
@@ -70,7 +70,7 @@ export class CreateCommentActionBase
 
   getObservers(): Observer<
     Comment,
-    CommentBuilder,
+    CommentBuilder<CommentCreateInput, Comment | null>,
     ExampleViewer,
     CommentCreateInput,
     Comment | null
@@ -80,7 +80,7 @@ export class CreateCommentActionBase
 
   getValidators(): Validator<
     Comment,
-    CommentBuilder,
+    CommentBuilder<CommentCreateInput, Comment | null>,
     ExampleViewer,
     CommentCreateInput,
     Comment | null

--- a/examples/simple/src/ent/generated/comment/actions/create_comment_action_base.ts
+++ b/examples/simple/src/ent/generated/comment/actions/create_comment_action_base.ts
@@ -13,6 +13,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Comment, User } from "../../..";
@@ -53,6 +56,36 @@ export class CreateCommentActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Comment> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Comment,
+    CommentBuilder,
+    ExampleViewer,
+    CommentCreateInput,
+    Comment | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Comment,
+    CommentBuilder,
+    ExampleViewer,
+    CommentCreateInput,
+    Comment | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Comment,
+    CommentBuilder,
+    ExampleViewer,
+    CommentCreateInput,
+    Comment | null
+  >[] {
+    return [];
   }
 
   getInput(): CommentCreateInput {

--- a/examples/simple/src/ent/generated/contact/actions/create_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/create_contact_action_base.ts
@@ -69,7 +69,7 @@ export class CreateContactActionBase
 
   getTriggers(): Trigger<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactCreateInput, Contact | null>,
     ExampleViewer,
     ContactCreateInput,
     Contact | null
@@ -79,7 +79,7 @@ export class CreateContactActionBase
 
   getObservers(): Observer<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactCreateInput, Contact | null>,
     ExampleViewer,
     ContactCreateInput,
     Contact | null
@@ -89,7 +89,7 @@ export class CreateContactActionBase
 
   getValidators(): Validator<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactCreateInput, Contact | null>,
     ExampleViewer,
     ContactCreateInput,
     Contact | null

--- a/examples/simple/src/ent/generated/contact/actions/create_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/create_contact_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Contact, User } from "../../..";
@@ -62,6 +65,36 @@ export class CreateContactActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Contact> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactCreateInput,
+    Contact | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactCreateInput,
+    Contact | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactCreateInput,
+    Contact | null
+  >[] {
+    return [];
   }
 
   getInput(): ContactCreateInput {

--- a/examples/simple/src/ent/generated/contact/actions/delete_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/delete_contact_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { Contact } from "../../..";
 import { ContactBuilder, ContactInput } from "./contact_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -40,6 +47,36 @@ export class DeleteContactActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Contact> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactInput,
+    Contact
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactInput,
+    Contact
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactInput,
+    Contact
+  >[] {
+    return [];
   }
 
   getInput(): ContactInput {

--- a/examples/simple/src/ent/generated/contact/actions/delete_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/delete_contact_action_base.ts
@@ -51,7 +51,7 @@ export class DeleteContactActionBase
 
   getTriggers(): Trigger<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactInput, Contact>,
     ExampleViewer,
     ContactInput,
     Contact
@@ -61,7 +61,7 @@ export class DeleteContactActionBase
 
   getObservers(): Observer<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactInput, Contact>,
     ExampleViewer,
     ContactInput,
     Contact
@@ -71,7 +71,7 @@ export class DeleteContactActionBase
 
   getValidators(): Validator<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactInput, Contact>,
     ExampleViewer,
     ContactInput,
     Contact

--- a/examples/simple/src/ent/generated/contact/actions/edit_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/edit_contact_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Contact, User } from "../../..";
@@ -59,6 +62,36 @@ export class EditContactActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Contact> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactEditInput,
+    Contact
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactEditInput,
+    Contact
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Contact,
+    ContactBuilder,
+    ExampleViewer,
+    ContactEditInput,
+    Contact
+  >[] {
+    return [];
   }
 
   getInput(): ContactEditInput {

--- a/examples/simple/src/ent/generated/contact/actions/edit_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/edit_contact_action_base.ts
@@ -66,7 +66,7 @@ export class EditContactActionBase
 
   getTriggers(): Trigger<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactEditInput, Contact>,
     ExampleViewer,
     ContactEditInput,
     Contact
@@ -76,7 +76,7 @@ export class EditContactActionBase
 
   getObservers(): Observer<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactEditInput, Contact>,
     ExampleViewer,
     ContactEditInput,
     Contact
@@ -86,7 +86,7 @@ export class EditContactActionBase
 
   getValidators(): Validator<
     Contact,
-    ContactBuilder,
+    ContactBuilder<ContactEditInput, Contact>,
     ExampleViewer,
     ContactEditInput,
     Contact

--- a/examples/simple/src/ent/generated/contact_email/actions/create_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/create_contact_email_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Contact, ContactEmail } from "../../..";
@@ -54,6 +57,36 @@ export class CreateContactEmailActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<ContactEmail> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailCreateInput,
+    ContactEmail | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailCreateInput,
+    ContactEmail | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailCreateInput,
+    ContactEmail | null
+  >[] {
+    return [];
   }
 
   getInput(): ContactEmailCreateInput {

--- a/examples/simple/src/ent/generated/contact_email/actions/create_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/create_contact_email_action_base.ts
@@ -61,7 +61,7 @@ export class CreateContactEmailActionBase
 
   getTriggers(): Trigger<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailCreateInput, ContactEmail | null>,
     ExampleViewer,
     ContactEmailCreateInput,
     ContactEmail | null
@@ -71,7 +71,7 @@ export class CreateContactEmailActionBase
 
   getObservers(): Observer<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailCreateInput, ContactEmail | null>,
     ExampleViewer,
     ContactEmailCreateInput,
     ContactEmail | null
@@ -81,7 +81,7 @@ export class CreateContactEmailActionBase
 
   getValidators(): Validator<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailCreateInput, ContactEmail | null>,
     ExampleViewer,
     ContactEmailCreateInput,
     ContactEmail | null

--- a/examples/simple/src/ent/generated/contact_email/actions/delete_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/delete_contact_email_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { ContactEmail } from "../../..";
 import {
   ContactEmailBuilder,
@@ -43,6 +50,36 @@ export class DeleteContactEmailActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<ContactEmail> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailInput,
+    ContactEmail
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailInput,
+    ContactEmail
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailInput,
+    ContactEmail
+  >[] {
+    return [];
   }
 
   getInput(): ContactEmailInput {

--- a/examples/simple/src/ent/generated/contact_email/actions/delete_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/delete_contact_email_action_base.ts
@@ -54,7 +54,7 @@ export class DeleteContactEmailActionBase
 
   getTriggers(): Trigger<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailInput, ContactEmail>,
     ExampleViewer,
     ContactEmailInput,
     ContactEmail
@@ -64,7 +64,7 @@ export class DeleteContactEmailActionBase
 
   getObservers(): Observer<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailInput, ContactEmail>,
     ExampleViewer,
     ContactEmailInput,
     ContactEmail
@@ -74,7 +74,7 @@ export class DeleteContactEmailActionBase
 
   getValidators(): Validator<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailInput, ContactEmail>,
     ExampleViewer,
     ContactEmailInput,
     ContactEmail

--- a/examples/simple/src/ent/generated/contact_email/actions/edit_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/edit_contact_email_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Contact, ContactEmail } from "../../..";
@@ -60,6 +63,36 @@ export class EditContactEmailActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<ContactEmail> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailEditInput,
+    ContactEmail
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailEditInput,
+    ContactEmail
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    ContactEmail,
+    ContactEmailBuilder,
+    ExampleViewer,
+    ContactEmailEditInput,
+    ContactEmail
+  >[] {
+    return [];
   }
 
   getInput(): ContactEmailEditInput {

--- a/examples/simple/src/ent/generated/contact_email/actions/edit_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/edit_contact_email_action_base.ts
@@ -67,7 +67,7 @@ export class EditContactEmailActionBase
 
   getTriggers(): Trigger<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailEditInput, ContactEmail>,
     ExampleViewer,
     ContactEmailEditInput,
     ContactEmail
@@ -77,7 +77,7 @@ export class EditContactEmailActionBase
 
   getObservers(): Observer<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailEditInput, ContactEmail>,
     ExampleViewer,
     ContactEmailEditInput,
     ContactEmail
@@ -87,7 +87,7 @@ export class EditContactEmailActionBase
 
   getValidators(): Validator<
     ContactEmail,
-    ContactEmailBuilder,
+    ContactEmailBuilder<ContactEmailEditInput, ContactEmail>,
     ExampleViewer,
     ContactEmailEditInput,
     ContactEmail

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/create_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/create_contact_phone_number_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Contact, ContactPhoneNumber } from "../../..";
@@ -57,6 +60,36 @@ export class CreateContactPhoneNumberActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<ContactPhoneNumber> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberCreateInput,
+    ContactPhoneNumber | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberCreateInput,
+    ContactPhoneNumber | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberCreateInput,
+    ContactPhoneNumber | null
+  >[] {
+    return [];
   }
 
   getInput(): ContactPhoneNumberCreateInput {

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/create_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/create_contact_phone_number_action_base.ts
@@ -64,7 +64,10 @@ export class CreateContactPhoneNumberActionBase
 
   getTriggers(): Trigger<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<
+      ContactPhoneNumberCreateInput,
+      ContactPhoneNumber | null
+    >,
     ExampleViewer,
     ContactPhoneNumberCreateInput,
     ContactPhoneNumber | null
@@ -74,7 +77,10 @@ export class CreateContactPhoneNumberActionBase
 
   getObservers(): Observer<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<
+      ContactPhoneNumberCreateInput,
+      ContactPhoneNumber | null
+    >,
     ExampleViewer,
     ContactPhoneNumberCreateInput,
     ContactPhoneNumber | null
@@ -84,7 +90,10 @@ export class CreateContactPhoneNumberActionBase
 
   getValidators(): Validator<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<
+      ContactPhoneNumberCreateInput,
+      ContactPhoneNumber | null
+    >,
     ExampleViewer,
     ContactPhoneNumberCreateInput,
     ContactPhoneNumber | null

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/delete_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/delete_contact_phone_number_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { ContactPhoneNumber } from "../../..";
 import {
   ContactPhoneNumberBuilder,
@@ -46,6 +53,36 @@ export class DeleteContactPhoneNumberActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<ContactPhoneNumber> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberInput,
+    ContactPhoneNumber
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberInput,
+    ContactPhoneNumber
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberInput,
+    ContactPhoneNumber
+  >[] {
+    return [];
   }
 
   getInput(): ContactPhoneNumberInput {

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/delete_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/delete_contact_phone_number_action_base.ts
@@ -57,7 +57,7 @@ export class DeleteContactPhoneNumberActionBase
 
   getTriggers(): Trigger<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<ContactPhoneNumberInput, ContactPhoneNumber>,
     ExampleViewer,
     ContactPhoneNumberInput,
     ContactPhoneNumber
@@ -67,7 +67,7 @@ export class DeleteContactPhoneNumberActionBase
 
   getObservers(): Observer<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<ContactPhoneNumberInput, ContactPhoneNumber>,
     ExampleViewer,
     ContactPhoneNumberInput,
     ContactPhoneNumber
@@ -77,7 +77,7 @@ export class DeleteContactPhoneNumberActionBase
 
   getValidators(): Validator<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<ContactPhoneNumberInput, ContactPhoneNumber>,
     ExampleViewer,
     ContactPhoneNumberInput,
     ContactPhoneNumber

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/edit_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/edit_contact_phone_number_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Contact, ContactPhoneNumber } from "../../..";
@@ -63,6 +66,36 @@ export class EditContactPhoneNumberActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<ContactPhoneNumber> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberEditInput,
+    ContactPhoneNumber
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberEditInput,
+    ContactPhoneNumber
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    ContactPhoneNumber,
+    ContactPhoneNumberBuilder,
+    ExampleViewer,
+    ContactPhoneNumberEditInput,
+    ContactPhoneNumber
+  >[] {
+    return [];
   }
 
   getInput(): ContactPhoneNumberEditInput {

--- a/examples/simple/src/ent/generated/contact_phone_number/actions/edit_contact_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number/actions/edit_contact_phone_number_action_base.ts
@@ -70,7 +70,7 @@ export class EditContactPhoneNumberActionBase
 
   getTriggers(): Trigger<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<ContactPhoneNumberEditInput, ContactPhoneNumber>,
     ExampleViewer,
     ContactPhoneNumberEditInput,
     ContactPhoneNumber
@@ -80,7 +80,7 @@ export class EditContactPhoneNumberActionBase
 
   getObservers(): Observer<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<ContactPhoneNumberEditInput, ContactPhoneNumber>,
     ExampleViewer,
     ContactPhoneNumberEditInput,
     ContactPhoneNumber
@@ -90,7 +90,7 @@ export class EditContactPhoneNumberActionBase
 
   getValidators(): Validator<
     ContactPhoneNumber,
-    ContactPhoneNumberBuilder,
+    ContactPhoneNumberBuilder<ContactPhoneNumberEditInput, ContactPhoneNumber>,
     ExampleViewer,
     ContactPhoneNumberEditInput,
     ContactPhoneNumber

--- a/examples/simple/src/ent/generated/event/actions/create_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/create_event_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Address, Event } from "../../..";
@@ -54,6 +57,36 @@ export class CreateEventActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventCreateInput,
+    Event | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventCreateInput,
+    Event | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventCreateInput,
+    Event | null
+  >[] {
+    return [];
   }
 
   getInput(): EventCreateInput {

--- a/examples/simple/src/ent/generated/event/actions/create_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/create_event_action_base.ts
@@ -61,7 +61,7 @@ export class CreateEventActionBase
 
   getTriggers(): Trigger<
     Event,
-    EventBuilder,
+    EventBuilder<EventCreateInput, Event | null>,
     ExampleViewer,
     EventCreateInput,
     Event | null
@@ -71,7 +71,7 @@ export class CreateEventActionBase
 
   getObservers(): Observer<
     Event,
-    EventBuilder,
+    EventBuilder<EventCreateInput, Event | null>,
     ExampleViewer,
     EventCreateInput,
     Event | null
@@ -81,7 +81,7 @@ export class CreateEventActionBase
 
   getValidators(): Validator<
     Event,
-    EventBuilder,
+    EventBuilder<EventCreateInput, Event | null>,
     ExampleViewer,
     EventCreateInput,
     Event | null

--- a/examples/simple/src/ent/generated/event/actions/delete_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/delete_event_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { Event } from "../../..";
 import { EventBuilder, EventInput } from "./event_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -40,6 +47,36 @@ export class DeleteEventActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
   }
 
   getInput(): EventInput {

--- a/examples/simple/src/ent/generated/event/actions/delete_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/delete_event_action_base.ts
@@ -51,7 +51,7 @@ export class DeleteEventActionBase
 
   getTriggers(): Trigger<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event
@@ -61,7 +61,7 @@ export class DeleteEventActionBase
 
   getObservers(): Observer<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event
@@ -71,7 +71,7 @@ export class DeleteEventActionBase
 
   getValidators(): Validator<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event

--- a/examples/simple/src/ent/generated/event/actions/edit_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/edit_event_action_base.ts
@@ -63,7 +63,7 @@ export class EditEventActionBase
 
   getTriggers(): Trigger<
     Event,
-    EventBuilder,
+    EventBuilder<EventEditInput, Event>,
     ExampleViewer,
     EventEditInput,
     Event
@@ -73,7 +73,7 @@ export class EditEventActionBase
 
   getObservers(): Observer<
     Event,
-    EventBuilder,
+    EventBuilder<EventEditInput, Event>,
     ExampleViewer,
     EventEditInput,
     Event
@@ -83,7 +83,7 @@ export class EditEventActionBase
 
   getValidators(): Validator<
     Event,
-    EventBuilder,
+    EventBuilder<EventEditInput, Event>,
     ExampleViewer,
     EventEditInput,
     Event

--- a/examples/simple/src/ent/generated/event/actions/edit_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/edit_event_action_base.ts
@@ -12,6 +12,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Address, Event } from "../../..";
@@ -56,6 +59,36 @@ export class EditEventActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventEditInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventEditInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventEditInput,
+    Event
+  >[] {
+    return [];
   }
 
   getInput(): EventEditInput {

--- a/examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts
@@ -11,6 +11,9 @@ import {
 import {
   Action,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
   setEdgeTypeInGroup,
 } from "@snowtop/ent/action";
@@ -62,6 +65,36 @@ export class EditEventRsvpStatusActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EditEventRsvpStatusInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EditEventRsvpStatusInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EditEventRsvpStatusInput,
+    Event
+  >[] {
+    return [];
   }
 
   getInput(): EditEventRsvpStatusInput {

--- a/examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts
@@ -69,7 +69,7 @@ export class EditEventRsvpStatusActionBase
 
   getTriggers(): Trigger<
     Event,
-    EventBuilder,
+    EventBuilder<EditEventRsvpStatusInput, Event>,
     ExampleViewer,
     EditEventRsvpStatusInput,
     Event
@@ -79,7 +79,7 @@ export class EditEventRsvpStatusActionBase
 
   getObservers(): Observer<
     Event,
-    EventBuilder,
+    EventBuilder<EditEventRsvpStatusInput, Event>,
     ExampleViewer,
     EditEventRsvpStatusInput,
     Event
@@ -89,7 +89,7 @@ export class EditEventRsvpStatusActionBase
 
   getValidators(): Validator<
     Event,
-    EventBuilder,
+    EventBuilder<EditEventRsvpStatusInput, Event>,
     ExampleViewer,
     EditEventRsvpStatusInput,
     Event

--- a/examples/simple/src/ent/generated/event/actions/event_add_host_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_add_host_action_base.ts
@@ -53,7 +53,7 @@ export class EventAddHostActionBase
 
   getTriggers(): Trigger<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event
@@ -63,7 +63,7 @@ export class EventAddHostActionBase
 
   getObservers(): Observer<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event
@@ -73,7 +73,7 @@ export class EventAddHostActionBase
 
   getValidators(): Validator<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event

--- a/examples/simple/src/ent/generated/event/actions/event_add_host_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_add_host_action_base.ts
@@ -13,6 +13,9 @@ import {
   Action,
   Builder,
   Changeset,
+  Observer,
+  Trigger,
+  Validator,
   WriteOperation,
 } from "@snowtop/ent/action";
 import { Event, User } from "../../..";
@@ -46,6 +49,36 @@ export class EventAddHostActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
   }
 
   getInput(): EventInput {

--- a/examples/simple/src/ent/generated/event/actions/event_remove_host_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_remove_host_action_base.ts
@@ -51,7 +51,7 @@ export class EventRemoveHostActionBase
 
   getTriggers(): Trigger<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event
@@ -61,7 +61,7 @@ export class EventRemoveHostActionBase
 
   getObservers(): Observer<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event
@@ -71,7 +71,7 @@ export class EventRemoveHostActionBase
 
   getValidators(): Validator<
     Event,
-    EventBuilder,
+    EventBuilder<EventInput, Event>,
     ExampleViewer,
     EventInput,
     Event

--- a/examples/simple/src/ent/generated/event/actions/event_remove_host_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_remove_host_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { Event, User } from "../../..";
 import { EventBuilder, EventInput } from "./event_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -40,6 +47,36 @@ export class EventRemoveHostActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Event> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Event,
+    EventBuilder,
+    ExampleViewer,
+    EventInput,
+    Event
+  >[] {
+    return [];
   }
 
   getInput(): EventInput {

--- a/examples/simple/src/ent/generated/holiday/actions/create_holiday_action_base.ts
+++ b/examples/simple/src/ent/generated/holiday/actions/create_holiday_action_base.ts
@@ -57,7 +57,7 @@ export class CreateHolidayActionBase
 
   getTriggers(): Trigger<
     Holiday,
-    HolidayBuilder,
+    HolidayBuilder<HolidayCreateInput, Holiday | null>,
     ExampleViewer,
     HolidayCreateInput,
     Holiday | null
@@ -67,7 +67,7 @@ export class CreateHolidayActionBase
 
   getObservers(): Observer<
     Holiday,
-    HolidayBuilder,
+    HolidayBuilder<HolidayCreateInput, Holiday | null>,
     ExampleViewer,
     HolidayCreateInput,
     Holiday | null
@@ -77,7 +77,7 @@ export class CreateHolidayActionBase
 
   getValidators(): Validator<
     Holiday,
-    HolidayBuilder,
+    HolidayBuilder<HolidayCreateInput, Holiday | null>,
     ExampleViewer,
     HolidayCreateInput,
     Holiday | null

--- a/examples/simple/src/ent/generated/holiday/actions/create_holiday_action_base.ts
+++ b/examples/simple/src/ent/generated/holiday/actions/create_holiday_action_base.ts
@@ -7,7 +7,14 @@ import {
   AllowIfViewerHasIdentityPrivacyPolicy,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { DayOfWeek, DayOfWeekAlt, Holiday } from "../../..";
 import { HolidayBuilder } from "./holiday_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -46,6 +53,36 @@ export class CreateHolidayActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<Holiday> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    Holiday,
+    HolidayBuilder,
+    ExampleViewer,
+    HolidayCreateInput,
+    Holiday | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    Holiday,
+    HolidayBuilder,
+    ExampleViewer,
+    HolidayCreateInput,
+    Holiday | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    Holiday,
+    HolidayBuilder,
+    ExampleViewer,
+    HolidayCreateInput,
+    Holiday | null
+  >[] {
+    return [];
   }
 
   getInput(): HolidayCreateInput {

--- a/examples/simple/src/ent/generated/hours_of_operation/actions/create_hours_of_operation_action_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation/actions/create_hours_of_operation_action_base.ts
@@ -63,7 +63,10 @@ export class CreateHoursOfOperationActionBase
 
   getTriggers(): Trigger<
     HoursOfOperation,
-    HoursOfOperationBuilder,
+    HoursOfOperationBuilder<
+      HoursOfOperationCreateInput,
+      HoursOfOperation | null
+    >,
     ExampleViewer,
     HoursOfOperationCreateInput,
     HoursOfOperation | null
@@ -73,7 +76,10 @@ export class CreateHoursOfOperationActionBase
 
   getObservers(): Observer<
     HoursOfOperation,
-    HoursOfOperationBuilder,
+    HoursOfOperationBuilder<
+      HoursOfOperationCreateInput,
+      HoursOfOperation | null
+    >,
     ExampleViewer,
     HoursOfOperationCreateInput,
     HoursOfOperation | null
@@ -83,7 +89,10 @@ export class CreateHoursOfOperationActionBase
 
   getValidators(): Validator<
     HoursOfOperation,
-    HoursOfOperationBuilder,
+    HoursOfOperationBuilder<
+      HoursOfOperationCreateInput,
+      HoursOfOperation | null
+    >,
     ExampleViewer,
     HoursOfOperationCreateInput,
     HoursOfOperation | null

--- a/examples/simple/src/ent/generated/hours_of_operation/actions/create_hours_of_operation_action_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation/actions/create_hours_of_operation_action_base.ts
@@ -7,7 +7,14 @@ import {
   AllowIfViewerHasIdentityPrivacyPolicy,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { DayOfWeek, DayOfWeekAlt, HoursOfOperation } from "../../..";
 import { HoursOfOperationBuilder } from "./hours_of_operation_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -52,6 +59,36 @@ export class CreateHoursOfOperationActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<HoursOfOperation> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    HoursOfOperation,
+    HoursOfOperationBuilder,
+    ExampleViewer,
+    HoursOfOperationCreateInput,
+    HoursOfOperation | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    HoursOfOperation,
+    HoursOfOperationBuilder,
+    ExampleViewer,
+    HoursOfOperationCreateInput,
+    HoursOfOperation | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    HoursOfOperation,
+    HoursOfOperationBuilder,
+    ExampleViewer,
+    HoursOfOperationCreateInput,
+    HoursOfOperation | null
+  >[] {
+    return [];
   }
 
   getInput(): HoursOfOperationCreateInput {

--- a/examples/simple/src/ent/generated/user/actions/confirm_edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/confirm_edit_email_address_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder } from "./user_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -51,6 +58,36 @@ export class ConfirmEditEmailAddressActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    ConfirmEditEmailAddressInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    ConfirmEditEmailAddressInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    ConfirmEditEmailAddressInput,
+    User
+  >[] {
+    return [];
   }
 
   getInput(): ConfirmEditEmailAddressInput {

--- a/examples/simple/src/ent/generated/user/actions/confirm_edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/confirm_edit_email_address_action_base.ts
@@ -62,7 +62,7 @@ export class ConfirmEditEmailAddressActionBase
 
   getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditEmailAddressInput, User>,
     ExampleViewer,
     ConfirmEditEmailAddressInput,
     User
@@ -72,7 +72,7 @@ export class ConfirmEditEmailAddressActionBase
 
   getObservers(): Observer<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditEmailAddressInput, User>,
     ExampleViewer,
     ConfirmEditEmailAddressInput,
     User
@@ -82,7 +82,7 @@ export class ConfirmEditEmailAddressActionBase
 
   getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditEmailAddressInput, User>,
     ExampleViewer,
     ConfirmEditEmailAddressInput,
     User

--- a/examples/simple/src/ent/generated/user/actions/confirm_edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/confirm_edit_phone_number_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder } from "./user_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -51,6 +58,36 @@ export class ConfirmEditPhoneNumberActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    ConfirmEditPhoneNumberInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    ConfirmEditPhoneNumberInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    ConfirmEditPhoneNumberInput,
+    User
+  >[] {
+    return [];
   }
 
   getInput(): ConfirmEditPhoneNumberInput {

--- a/examples/simple/src/ent/generated/user/actions/confirm_edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/confirm_edit_phone_number_action_base.ts
@@ -62,7 +62,7 @@ export class ConfirmEditPhoneNumberActionBase
 
   getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditPhoneNumberInput, User>,
     ExampleViewer,
     ConfirmEditPhoneNumberInput,
     User
@@ -72,7 +72,7 @@ export class ConfirmEditPhoneNumberActionBase
 
   getObservers(): Observer<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditPhoneNumberInput, User>,
     ExampleViewer,
     ConfirmEditPhoneNumberInput,
     User
@@ -82,7 +82,7 @@ export class ConfirmEditPhoneNumberActionBase
 
   getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditPhoneNumberInput, User>,
     ExampleViewer,
     ConfirmEditPhoneNumberInput,
     User

--- a/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
@@ -74,7 +74,7 @@ export class CreateUserActionBase
 
   getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<UserCreateInput, User | null>,
     ExampleViewer,
     UserCreateInput,
     User | null
@@ -84,7 +84,7 @@ export class CreateUserActionBase
 
   getObservers(): Observer<
     User,
-    UserBuilder,
+    UserBuilder<UserCreateInput, User | null>,
     ExampleViewer,
     UserCreateInput,
     User | null
@@ -94,7 +94,7 @@ export class CreateUserActionBase
 
   getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<UserCreateInput, User | null>,
     ExampleViewer,
     UserCreateInput,
     User | null

--- a/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { User, UserDaysOff, UserPreferredShift } from "../../..";
 import { UserBuilder } from "./user_builder";
 import { UserNestedObjectList } from "../../user_nested_object_list";
@@ -63,6 +70,36 @@ export class CreateUserActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    UserCreateInput,
+    User | null
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    UserCreateInput,
+    User | null
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    UserCreateInput,
+    User | null
+  >[] {
+    return [];
   }
 
   getInput(): UserCreateInput {

--- a/examples/simple/src/ent/generated/user/actions/delete_user_action_2_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/delete_user_action_2_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder } from "./user_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -46,6 +53,36 @@ export class DeleteUserAction2Base
 
   getPrivacyPolicy(): PrivacyPolicy<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    DeleteUserInput2,
+    User
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    DeleteUserInput2,
+    User
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    DeleteUserInput2,
+    User
+  >[] {
+    return [];
   }
 
   getInput(): DeleteUserInput2 {

--- a/examples/simple/src/ent/generated/user/actions/delete_user_action_2_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/delete_user_action_2_base.ts
@@ -57,7 +57,7 @@ export class DeleteUserAction2Base
 
   getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<DeleteUserInput2, User>,
     ExampleViewer,
     DeleteUserInput2,
     User
@@ -67,7 +67,7 @@ export class DeleteUserAction2Base
 
   getObservers(): Observer<
     User,
-    UserBuilder,
+    UserBuilder<DeleteUserInput2, User>,
     ExampleViewer,
     DeleteUserInput2,
     User
@@ -77,7 +77,7 @@ export class DeleteUserAction2Base
 
   getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<DeleteUserInput2, User>,
     ExampleViewer,
     DeleteUserInput2,
     User

--- a/examples/simple/src/ent/generated/user/actions/delete_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/delete_user_action_base.ts
@@ -43,13 +43,19 @@ export class DeleteUserActionBase
     return AllowIfViewerHasIdentityPrivacyPolicy;
   }
 
-  getTriggers(): Trigger<User, UserBuilder, ExampleViewer, UserInput, User>[] {
+  getTriggers(): Trigger<
+    User,
+    UserBuilder<UserInput, User>,
+    ExampleViewer,
+    UserInput,
+    User
+  >[] {
     return [];
   }
 
   getObservers(): Observer<
     User,
-    UserBuilder,
+    UserBuilder<UserInput, User>,
     ExampleViewer,
     UserInput,
     User
@@ -59,7 +65,7 @@ export class DeleteUserActionBase
 
   getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<UserInput, User>,
     ExampleViewer,
     UserInput,
     User

--- a/examples/simple/src/ent/generated/user/actions/delete_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/delete_user_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder, UserInput } from "./user_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -34,6 +41,30 @@ export class DeleteUserActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<User, UserBuilder, ExampleViewer, UserInput, User>[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    UserInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    UserInput,
+    User
+  >[] {
+    return [];
   }
 
   getInput(): UserInput {

--- a/examples/simple/src/ent/generated/user/actions/edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_email_address_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder } from "./user_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -46,6 +53,36 @@ export class EditEmailAddressActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    EditEmailAddressInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    EditEmailAddressInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    EditEmailAddressInput,
+    User
+  >[] {
+    return [];
   }
 
   getInput(): EditEmailAddressInput {

--- a/examples/simple/src/ent/generated/user/actions/edit_email_address_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_email_address_action_base.ts
@@ -57,7 +57,7 @@ export class EditEmailAddressActionBase
 
   getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<EditEmailAddressInput, User>,
     ExampleViewer,
     EditEmailAddressInput,
     User
@@ -67,7 +67,7 @@ export class EditEmailAddressActionBase
 
   getObservers(): Observer<
     User,
-    UserBuilder,
+    UserBuilder<EditEmailAddressInput, User>,
     ExampleViewer,
     EditEmailAddressInput,
     User
@@ -77,7 +77,7 @@ export class EditEmailAddressActionBase
 
   getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<EditEmailAddressInput, User>,
     ExampleViewer,
     EditEmailAddressInput,
     User

--- a/examples/simple/src/ent/generated/user/actions/edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_phone_number_action_base.ts
@@ -57,7 +57,7 @@ export class EditPhoneNumberActionBase
 
   getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<EditPhoneNumberInput, User>,
     ExampleViewer,
     EditPhoneNumberInput,
     User
@@ -67,7 +67,7 @@ export class EditPhoneNumberActionBase
 
   getObservers(): Observer<
     User,
-    UserBuilder,
+    UserBuilder<EditPhoneNumberInput, User>,
     ExampleViewer,
     EditPhoneNumberInput,
     User
@@ -77,7 +77,7 @@ export class EditPhoneNumberActionBase
 
   getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<EditPhoneNumberInput, User>,
     ExampleViewer,
     EditPhoneNumberInput,
     User

--- a/examples/simple/src/ent/generated/user/actions/edit_phone_number_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_phone_number_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder } from "./user_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -46,6 +53,36 @@ export class EditPhoneNumberActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    EditPhoneNumberInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    EditPhoneNumberInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    EditPhoneNumberInput,
+    User
+  >[] {
+    return [];
   }
 
   getInput(): EditPhoneNumberInput {

--- a/examples/simple/src/ent/generated/user/actions/edit_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_user_action_base.ts
@@ -8,7 +8,14 @@ import {
   ID,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Action, Changeset, WriteOperation } from "@snowtop/ent/action";
+import {
+  Action,
+  Changeset,
+  Observer,
+  Trigger,
+  Validator,
+  WriteOperation,
+} from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder } from "./user_builder";
 import { ExampleViewer } from "../../../../viewer/viewer";
@@ -47,6 +54,36 @@ export class EditUserActionBase
 
   getPrivacyPolicy(): PrivacyPolicy<User> {
     return AllowIfViewerHasIdentityPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    UserEditInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    UserEditInput,
+    User
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    User,
+    UserBuilder,
+    ExampleViewer,
+    UserEditInput,
+    User
+  >[] {
+    return [];
   }
 
   getInput(): UserEditInput {

--- a/examples/simple/src/ent/generated/user/actions/edit_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_user_action_base.ts
@@ -58,7 +58,7 @@ export class EditUserActionBase
 
   getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<UserEditInput, User>,
     ExampleViewer,
     UserEditInput,
     User
@@ -68,7 +68,7 @@ export class EditUserActionBase
 
   getObservers(): Observer<
     User,
-    UserBuilder,
+    UserBuilder<UserEditInput, User>,
     ExampleViewer,
     UserEditInput,
     User
@@ -78,7 +78,7 @@ export class EditUserActionBase
 
   getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<UserEditInput, User>,
     ExampleViewer,
     UserEditInput,
     User

--- a/examples/simple/src/ent/user/actions/confirm_edit_email_address_action.ts
+++ b/examples/simple/src/ent/user/actions/confirm_edit_email_address_action.ts
@@ -24,48 +24,58 @@ async function findAuthCode(
 }
 
 export default class ConfirmEditEmailAddressAction extends ConfirmEditEmailAddressActionBase {
-  validators: Validator<
+  getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditEmailAddressInput, User>,
     ExampleViewer,
-    ConfirmEditEmailAddressInput
-  >[] = [
-    {
-      async validate(builder, input) {
-        const authCode = await findAuthCode(
-          builder,
-          input.code,
-          input.emailAddress,
-        );
-        if (!authCode) {
-          throw new Error(`code ${input.code} not found associated with user`);
-        }
+    ConfirmEditEmailAddressInput,
+    User
+  >[] {
+    return [
+      {
+        async validate(builder, input) {
+          const authCode = await findAuthCode(
+            builder,
+            input.code,
+            input.emailAddress,
+          );
+          if (!authCode) {
+            throw new Error(
+              `code ${input.code} not found associated with user`,
+            );
+          }
+        },
       },
-    },
-  ];
+    ];
+  }
 
-  triggers: Trigger<
+  getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditEmailAddressInput, User>,
     ExampleViewer,
-    ConfirmEditEmailAddressInput
-  >[] = [
-    {
-      async changeset(builder, input) {
-        const authCode = await findAuthCode(
-          builder,
-          input.code,
-          input.emailAddress,
-        );
-        if (!authCode) {
-          throw new Error(`code ${input.code} not found associated with user`);
-        }
-        // delete the authCode
-        return await DeleteAuthCodeAction.create(
-          builder.viewer,
-          authCode,
-        ).changeset();
+    ConfirmEditEmailAddressInput,
+    User
+  >[] {
+    return [
+      {
+        async changeset(builder, input) {
+          const authCode = await findAuthCode(
+            builder,
+            input.code,
+            input.emailAddress,
+          );
+          if (!authCode) {
+            throw new Error(
+              `code ${input.code} not found associated with user`,
+            );
+          }
+          // delete the authCode
+          return await DeleteAuthCodeAction.create(
+            builder.viewer,
+            authCode,
+          ).changeset();
+        },
       },
-    },
-  ];
+    ];
+  }
 }

--- a/examples/simple/src/ent/user/actions/confirm_edit_phone_number_action.ts
+++ b/examples/simple/src/ent/user/actions/confirm_edit_phone_number_action.ts
@@ -23,48 +23,58 @@ async function findAuthCode(
 }
 // we're only writing this once except with --force and packageName provided
 export default class ConfirmEditPhoneNumberAction extends ConfirmEditPhoneNumberActionBase {
-  validators: Validator<
+  getValidators(): Validator<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditPhoneNumberInput, User>,
     ExampleViewer,
-    ConfirmEditPhoneNumberInput
-  >[] = [
-    {
-      async validate(builder, input) {
-        const authCode = await findAuthCode(
-          builder,
-          input.code,
-          input.phoneNumber,
-        );
-        if (!authCode) {
-          throw new Error(`code ${input.code} not found associated with user`);
-        }
+    ConfirmEditPhoneNumberInput,
+    User
+  >[] {
+    return [
+      {
+        async validate(builder, input) {
+          const authCode = await findAuthCode(
+            builder,
+            input.code,
+            input.phoneNumber,
+          );
+          if (!authCode) {
+            throw new Error(
+              `code ${input.code} not found associated with user`,
+            );
+          }
+        },
       },
-    },
-  ];
+    ];
+  }
 
-  triggers: Trigger<
+  getTriggers(): Trigger<
     User,
-    UserBuilder,
+    UserBuilder<ConfirmEditPhoneNumberInput, User>,
     ExampleViewer,
-    ConfirmEditPhoneNumberInput
-  >[] = [
-    {
-      async changeset(builder, input) {
-        const authCode = await findAuthCode(
-          builder,
-          input.code,
-          input.phoneNumber,
-        );
-        if (!authCode) {
-          throw new Error(`code ${input.code} not found associated with user`);
-        }
-        // delete the authCode
-        return await DeleteAuthCodeAction.create(
-          builder.viewer,
-          authCode,
-        ).changeset();
+    ConfirmEditPhoneNumberInput,
+    User
+  >[] {
+    return [
+      {
+        async changeset(builder, input) {
+          const authCode = await findAuthCode(
+            builder,
+            input.code,
+            input.phoneNumber,
+          );
+          if (!authCode) {
+            throw new Error(
+              `code ${input.code} not found associated with user`,
+            );
+          }
+          // delete the authCode
+          return await DeleteAuthCodeAction.create(
+            builder.viewer,
+            authCode,
+          ).changeset();
+        },
       },
-    },
-  ];
+    ];
+  }
 }

--- a/examples/simple/src/ent/user/actions/create_user_action.ts
+++ b/examples/simple/src/ent/user/actions/create_user_action.ts
@@ -4,7 +4,7 @@ import {
   IDViewer,
   PrivacyPolicy,
 } from "@snowtop/ent";
-import { Changeset } from "@snowtop/ent/action";
+import { Changeset, Trigger, Observer } from "@snowtop/ent/action";
 import { EntCreationObserver } from "@snowtop/ent/testutils/fake_log";
 import { FakeComms, Mode } from "@snowtop/ent/testutils/fake_comms";
 import {
@@ -16,6 +16,7 @@ import CreateContactAction from "../../contact/actions/create_contact_action";
 import { User } from "../../";
 
 export { UserCreateInput };
+import { ExampleViewer } from "../../../viewer/viewer";
 
 // we're only writing this once except with --force and packageName provided
 export default class CreateUserAction extends CreateUserActionBase {
@@ -27,45 +28,61 @@ export default class CreateUserAction extends CreateUserActionBase {
     return new IDViewer(data.id);
   }
 
-  triggers = [
-    {
-      // also create a contact for self when creating user
-      changeset: (
-        builder: UserBuilder,
-        input: UserCreateInput,
-      ): Promise<Changeset> => {
-        let action = CreateContactAction.create(this.builder.viewer, {
-          firstName: input.firstName,
-          lastName: input.lastName,
-          emails: [
-            {
-              emailAddress: input.emailAddress,
-              label: "self",
-            },
-          ],
-          userID: builder,
-        });
+  getTriggers(): Trigger<
+    User,
+    UserBuilder<UserCreateInput, User | null>,
+    ExampleViewer,
+    UserCreateInput,
+    User | null
+  >[] {
+    return [
+      {
+        // also create a contact for self when creating user
+        changeset: (
+          builder: UserBuilder,
+          input: UserCreateInput,
+        ): Promise<Changeset> => {
+          let action = CreateContactAction.create(this.builder.viewer, {
+            firstName: input.firstName,
+            lastName: input.lastName,
+            emails: [
+              {
+                emailAddress: input.emailAddress,
+                label: "self",
+              },
+            ],
+            userID: builder,
+          });
 
-        builder.addSelfContact(action.builder);
-        return action.changeset();
+          builder.addSelfContact(action.builder);
+          return action.changeset();
+        },
       },
-    },
-  ];
+    ];
+  }
 
-  observers = [
-    {
-      observe: (_builder: UserBuilder, input: UserCreateInput): void => {
-        let email = input.emailAddress;
-        let firstName = input.firstName;
-        FakeComms.send({
-          from: "noreply@foo.com",
-          to: email,
-          subject: `Welcome, ${firstName}!`,
-          body: `Hi ${firstName}, thanks for joining fun app!`,
-          mode: Mode.EMAIL,
-        });
+  getObservers(): Observer<
+    User,
+    UserBuilder<UserCreateInput, User | null>,
+    ExampleViewer,
+    UserCreateInput,
+    User | null
+  >[] {
+    return [
+      {
+        observe: (_builder: UserBuilder, input: UserCreateInput): void => {
+          let email = input.emailAddress;
+          let firstName = input.firstName;
+          FakeComms.send({
+            from: "noreply@foo.com",
+            to: email,
+            subject: `Welcome, ${firstName}!`,
+            body: `Hi ${firstName}, thanks for joining fun app!`,
+            mode: Mode.EMAIL,
+          });
+        },
       },
-    },
-    new EntCreationObserver<User>(),
-  ];
+      new EntCreationObserver<User>(),
+    ];
+  }
 }

--- a/examples/simple/src/ent/user/actions/create_user_action.ts
+++ b/examples/simple/src/ent/user/actions/create_user_action.ts
@@ -82,7 +82,7 @@ export default class CreateUserAction extends CreateUserActionBase {
           });
         },
       },
-      new EntCreationObserver<User>(),
+      new EntCreationObserver(),
     ];
   }
 }

--- a/examples/simple/src/ent/user/actions/edit_email_address_action.ts
+++ b/examples/simple/src/ent/user/actions/edit_email_address_action.ts
@@ -9,6 +9,8 @@ import { User } from "../..";
 import { EditUserPrivacy } from "./edit_user_privacy";
 
 export { EditEmailAddressInput };
+import { ExampleViewer } from "../../../viewer/viewer";
+import { Validator, Trigger, Observer } from "@snowtop/ent/action";
 
 class NewAuthCode {
   private code: string = "";
@@ -51,20 +53,44 @@ class NewAuthCode {
 export default class EditEmailAddressAction extends EditEmailAddressActionBase {
   private generateNewCode = new NewAuthCode();
 
-  validators = [
-    {
-      // confirm email not being used
-      async validate(builder: UserBuilder, input: EditEmailAddressInput) {
-        const id = await User.loadIDFromEmailAddress(input.newEmail);
-        if (id) {
-          throw new Error(`cannot change email to ${input.newEmail}`);
-        }
+  getValidators(): Validator<
+    User,
+    UserBuilder<EditEmailAddressInput, User>,
+    ExampleViewer,
+    EditEmailAddressInput,
+    User
+  >[] {
+    return [
+      {
+        // confirm email not being used
+        async validate(builder: UserBuilder, input: EditEmailAddressInput) {
+          const id = await User.loadIDFromEmailAddress(input.newEmail);
+          if (id) {
+            throw new Error(`cannot change email to ${input.newEmail}`);
+          }
+        },
       },
-    },
-  ];
-  triggers = [this.generateNewCode];
+    ];
+  }
+  getTriggers(): Trigger<
+    User,
+    UserBuilder<EditEmailAddressInput, User>,
+    ExampleViewer,
+    EditEmailAddressInput,
+    User
+  >[] {
+    return [this.generateNewCode];
+  }
 
-  observers = [this.generateNewCode];
+  getObservers(): Observer<
+    User,
+    UserBuilder<EditEmailAddressInput, User>,
+    ExampleViewer,
+    EditEmailAddressInput,
+    User
+  >[] {
+    return [this.generateNewCode];
+  }
 
   getPrivacyPolicy() {
     return EditUserPrivacy;

--- a/examples/simple/src/ent/user/actions/edit_phone_number_action.ts
+++ b/examples/simple/src/ent/user/actions/edit_phone_number_action.ts
@@ -9,6 +9,8 @@ import { User } from "../..";
 import { EditUserPrivacy } from "./edit_user_privacy";
 
 export { EditPhoneNumberInput };
+import { ExampleViewer } from "../../../viewer/viewer";
+import { Validator, Trigger, Observer } from "@snowtop/ent/action";
 
 class NewAuthCode {
   private code: string = "";
@@ -48,22 +50,46 @@ class NewAuthCode {
 export default class EditPhoneNumberAction extends EditPhoneNumberActionBase {
   private generateNewCode = new NewAuthCode();
 
-  validators = [
-    {
-      // confirm email not being used
-      async validate(builder: UserBuilder, input: EditPhoneNumberInput) {
-        const id = await User.loadIDFromPhoneNumber(input.newPhoneNumber);
-        if (id) {
-          throw new Error(
-            `cannot change phoneNumber to ${input.newPhoneNumber}`,
-          );
-        }
+  getValidators(): Validator<
+    User,
+    UserBuilder<EditPhoneNumberInput, User>,
+    ExampleViewer,
+    EditPhoneNumberInput,
+    User
+  >[] {
+    return [
+      {
+        // confirm email not being used
+        async validate(builder: UserBuilder, input: EditPhoneNumberInput) {
+          const id = await User.loadIDFromPhoneNumber(input.newPhoneNumber);
+          if (id) {
+            throw new Error(
+              `cannot change phoneNumber to ${input.newPhoneNumber}`,
+            );
+          }
+        },
       },
-    },
-  ];
-  triggers = [this.generateNewCode];
+    ];
+  }
+  getTriggers(): Trigger<
+    User,
+    UserBuilder<EditPhoneNumberInput, User>,
+    ExampleViewer,
+    EditPhoneNumberInput,
+    User
+  >[] {
+    return [this.generateNewCode];
+  }
 
-  observers = [this.generateNewCode];
+  getObservers(): Observer<
+    User,
+    UserBuilder<EditPhoneNumberInput, User>,
+    ExampleViewer,
+    EditPhoneNumberInput,
+    User
+  >[] {
+    return [this.generateNewCode];
+  }
 
   getPrivacyPolicy() {
     return EditUserPrivacy;

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -1,4 +1,4 @@
-{{ reserveImport .Package.ActionPackagePath "Action" "Builder" "WriteOperation" "Changeset" "Builder" "setEdgeTypeInGroup" }}
+{{ reserveImport .Package.ActionPackagePath "Action" "Builder" "WriteOperation" "Changeset" "Builder" "setEdgeTypeInGroup" "Trigger" "Observer" "Validator"}}
 {{ reserveImport .Package.PackagePath "Viewer" "ID" "Ent" "AssocEdgeInputOptions" "PrivacyPolicy"}}
 {{ reserveImport "src/ent/" "NodeType"}}
 {{ reserveImport .PrivacyConfig.Path .PrivacyConfig.PolicyName }}
@@ -139,6 +139,19 @@ export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}, {{useI
       return {{useImport .PrivacyConfig.PolicyName}};
     {{ end -}}
   };
+
+
+  getTriggers(): {{useImport "Trigger"}}<{{$node}}, {{$builderName}}, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
+    return [];
+  }
+
+  getObservers(): {{useImport "Observer"}}<{{$node}}, {{$builderName}}, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
+    return [];
+  }
+
+  getValidators(): {{useImport "Validator"}}<{{$node}}, {{$builderName}}, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
+    return [];
+  }
 
   getInput(): {{$inputData}} {
     {{ if $hasInput -}}

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -141,15 +141,15 @@ export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}, {{useI
   };
 
 
-  getTriggers(): {{useImport "Trigger"}}<{{$node}}, {{$builderName}}, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
+  getTriggers(): {{useImport "Trigger"}}<{{$node}}, {{$builderName}}<{{$inputData}}, {{$existingEnt}}>, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
     return [];
   }
 
-  getObservers(): {{useImport "Observer"}}<{{$node}}, {{$builderName}}, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
+  getObservers(): {{useImport "Observer"}}<{{$node}}, {{$builderName}}<{{$inputData}}, {{$existingEnt}}>, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
     return [];
   }
 
-  getValidators(): {{useImport "Validator"}}<{{$node}}, {{$builderName}}, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
+  getValidators(): {{useImport "Validator"}}<{{$node}}, {{$builderName}}<{{$inputData}}, {{$existingEnt}}>, {{$viewerType}}, {{$inputData}}, {{$existingEnt}}>[] {
     return [];
   }
 

--- a/internal/tsimport/path_test.go
+++ b/internal/tsimport/path_test.go
@@ -50,7 +50,6 @@ func TestImportPath(t *testing.T) {
 			filePath:   "src/ent/user/actions/generated/confirm_edit_email_address_action_base.ts",
 			importPath: "src/ent/",
 			expResult:  "../../..",
-			only:       true,
 		},
 		"action base from action": {
 			filePath:   "src/ent/user/actions/create_user_action.ts",
@@ -70,7 +69,7 @@ func TestImportPath(t *testing.T) {
 		"graphql internal from graphql": {
 			filePath:   "src/graphql/generated/resolvers/user_type.ts",
 			importPath: "src/graphql/resolvers/internal",
-			expResult:  "../internal",
+			expResult:  "../../resolvers/internal",
 		},
 		"directory root from nested path in dir": {
 			filePath:   "src/ent/user/actions/create_user_action.ts",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha15",
+  "version": "0.1.0-alpha16",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -130,12 +130,9 @@ export interface Action<
   // TODO template ent
   getPrivacyPolicy(): PrivacyPolicy<TEnt>;
 
-  // TODO consider making these methods. maybe they'll be easier to use then?
-  // performance implications of methods being called multiple times and new instances?
-  // even when declared in base class, if overriden in subclasses, still need to type it...
-  triggers?: Trigger<TEnt, TBuilder, TViewer, TInput, TExistingEnt>[];
-  observers?: Observer<TEnt, TBuilder, TViewer, TInput, TExistingEnt>[];
-  validators?: Validator<TEnt, TBuilder, TViewer, TInput, TExistingEnt>[];
+  getTriggers?(): Trigger<TEnt, TBuilder, TViewer, TInput, TExistingEnt>[];
+  getObservers?(): Observer<TEnt, TBuilder, TViewer, TInput, TExistingEnt>[];
+  getValidators?(): Validator<TEnt, TBuilder, TViewer, TInput, TExistingEnt>[];
   getInput(): TInput; // this input is passed to Triggers, Observers, Validators
   transformWrite?: (
     stmt: UpdateOperation<TEnt>,

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -54,12 +54,12 @@ export class ListBasedExecutor<T extends Ent> implements Executor {
 
   async executeObservers() {
     const action = this.options?.action;
-    if (!this.options || !action || !action.observers) {
+    if (!this.options || !action || !action.getObservers) {
       return;
     }
     const builder = this.options.builder;
     await Promise.all(
-      action.observers.map(async (observer) => {
+      action.getObservers().map(async (observer) => {
         await observer.observe(builder, action.getInput());
       }),
     );

--- a/ts/src/action/experimental_action.ts
+++ b/ts/src/action/experimental_action.ts
@@ -38,27 +38,36 @@ export class BaseAction<
 {
   builder: EntBuilder<TEnt, TViewer, TInput>;
   private input: TInput;
-  triggers: Trigger<
-    TEnt,
-    EntBuilder<TEnt, TViewer, TInput>,
-    TViewer,
-    TInput
-  >[] = [];
-  observers: Observer<
-    TEnt,
-    EntBuilder<TEnt, TViewer, TInput>,
-    TViewer,
-    TInput
-  >[] = [];
-  validators: Validator<
-    TEnt,
-    EntBuilder<TEnt, TViewer, TInput>,
-    TViewer,
-    TInput
-  >[] = [];
 
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
+  }
+
+  getTriggers(): Trigger<
+    TEnt,
+    EntBuilder<TEnt, TViewer, TInput>,
+    TViewer,
+    TInput
+  >[] {
+    return [];
+  }
+
+  getObservers(): Observer<
+    TEnt,
+    EntBuilder<TEnt, TViewer, TInput>,
+    TViewer,
+    TInput
+  >[] {
+    return [];
+  }
+
+  getValidators(): Validator<
+    TEnt,
+    EntBuilder<TEnt, TViewer, TInput>,
+    TViewer,
+    TInput
+  >[] {
+    return [];
   }
 
   constructor(
@@ -110,7 +119,7 @@ export class BaseAction<
     let action = new BaseAction(ent.viewer, builderCtr, {
       existingEnt: ent,
     });
-    action.triggers = [
+    action.getTriggers = () => [
       {
         changeset: (): Promise<Changeset>[] => {
           return actions.map((action) => action.changeset());

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -940,7 +940,7 @@ function commonTests() {
         ]),
       );
       action.builder.orchestrator.addInboundEdge(user.id, "edge", "User");
-      action.triggers = [
+      action.getTriggers = () => [
         {
           changeset: (builder: SimpleBuilder<User>) => {
             const derivedAction = getInsertUserAction(
@@ -1025,7 +1025,7 @@ function commonTests() {
         "symmetricEdge",
         "User",
       );
-      action.triggers = [
+      action.getTriggers = () => [
         {
           changeset: (builder: SimpleBuilder<User>) => {
             const derivedAction = getInsertUserAction(
@@ -1416,7 +1416,7 @@ function commonTests() {
         ]),
       );
       action.builder.orchestrator.addOutboundEdge(user.id, "edge", "User");
-      action.triggers = [
+      action.getTriggers = () => [
         {
           changeset: (builder: SimpleBuilder<User>) => {
             const derivedAction = getInsertUserAction(
@@ -1503,7 +1503,7 @@ function commonTests() {
       "symmetricEdge",
       "User",
     );
-    action.triggers = [
+    action.getTriggers = () => [
       {
         changeset: (builder: SimpleBuilder<User>) => {
           const derivedAction = getInsertUserAction(
@@ -1793,7 +1793,7 @@ function commonTests() {
         WriteOperation.Insert,
         null,
       );
-      action.validators = validators;
+      action.getValidators = () => validators;
 
       try {
         await action.validX();
@@ -1817,7 +1817,7 @@ function commonTests() {
         WriteOperation.Insert,
         null,
       );
-      action.validators = validators;
+      action.getValidators = () => validators;
 
       await action.validX();
 
@@ -2032,7 +2032,7 @@ function commonTests() {
         null,
       );
 
-      action.triggers = triggers;
+      action.getTriggers = () => triggers;
       const user = await action.saveX();
       if (!user) {
         throw new Error("couldn't save user");
@@ -2064,7 +2064,7 @@ function commonTests() {
         null,
       );
       // also create a contact when we create a user
-      action.triggers = [
+      action.getTriggers = () => [
         accountStatusTrigger,
         {
           changeset: (
@@ -2139,7 +2139,7 @@ function commonTests() {
         WriteOperation.Insert,
         null,
       );
-      action.observers = [sendEmailObserver];
+      action.getObservers = () => [sendEmailObserver];
 
       const user = await action.saveX();
       if (!user) {
@@ -2172,7 +2172,7 @@ function commonTests() {
         WriteOperation.Insert,
         null,
       );
-      action.observers = [sendEmailObserver];
+      action.getObservers = () => [sendEmailObserver];
 
       const user = await action.saveX();
       if (!user) {
@@ -2210,7 +2210,7 @@ function commonTests() {
         WriteOperation.Insert,
         null,
       );
-      action.observers = [sendEmailObserverAsync];
+      action.getObservers = () => [sendEmailObserverAsync];
 
       const user = await action.saveX();
       if (!user) {
@@ -2246,7 +2246,7 @@ function commonTests() {
         WriteOperation.Insert,
         null,
       );
-      action.triggers = [
+      action.getTriggers = () => [
         {
           changeset: (builder: SimpleBuilder<UserExtended>): void => {
             builder.fields.set("account_status", "VALID");
@@ -2258,7 +2258,7 @@ function commonTests() {
           rules: [DenyIfLoggedInRule, AlwaysAllowRule],
         };
       };
-      action.validators = [
+      action.getValidators = () => [
         {
           validate: async (
             builder: SimpleBuilder<UserExtended>,
@@ -2270,7 +2270,7 @@ function commonTests() {
           },
         },
       ];
-      action.observers = [sendEmailObserver];
+      action.getObservers = () => [sendEmailObserver];
       return action;
     };
 
@@ -2653,7 +2653,7 @@ function commonTests() {
       WriteOperation.Insert,
       null,
     );
-    action.triggers = [
+    action.getTriggers = () => [
       {
         changeset: async (builder: SimpleBuilder<Contact>) => {
           const emailIDs: string[] = [];
@@ -2742,7 +2742,7 @@ function commonTests() {
     );
 
     let idInTrigger: string | undefined;
-    action.triggers = [
+    action.getTriggers = () => [
       {
         changeset: async (builder: SimpleBuilder<Contact>) => {
           const edited = await builder.orchestrator.getEditedData();

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -547,12 +547,15 @@ export class Orchestrator<
 
     // have to run triggers which update fields first before field and other validators
     // so running this first to build things up
-    let triggers = action?.triggers;
-    if (triggers) {
-      await this.triggers(action!, builder, triggers);
+    if (action?.getTriggers) {
+      await this.triggers(action!, builder, action.getTriggers());
     }
 
-    let validators = action?.validators || [];
+    let validators: Validator<TEnt, Builder<TEnt, TViewer>, TViewer, TInput>[] =
+      [];
+    if (action?.getValidators) {
+      validators = action.getValidators();
+    }
 
     // not ideal we're calling this twice. fix...
     // needed for now. may need to rewrite some of this?

--- a/ts/src/core/config.ts
+++ b/ts/src/core/config.ts
@@ -105,6 +105,8 @@ interface CodegenConfig {
 
   // default is on_demand
   fieldPrivacyEvaluated?: fieldPrivacyEvaluated;
+
+  templatizedViewer?: templatizedViewer;
 }
 
 interface PrettierConfig {
@@ -119,6 +121,11 @@ interface PrivacyConfig {
   path: string; // e.g. "@snowtop/ent"
   policyName: string; // e.g. "AllowIfViewerHasIdentityPrivacyPolicy";
   class?: boolean;
+}
+
+interface templatizedViewer {
+  path: string;
+  name: string;
 }
 
 function setConfig(cfg: Config) {

--- a/ts/src/schema/uuid_field.test.ts
+++ b/ts/src/schema/uuid_field.test.ts
@@ -124,7 +124,7 @@ describe("fieldEdge no inverseEdge", () => {
       AccountSchema,
       new Map<string, any>([["userID", userAction.builder]]),
     );
-    action.triggers = [
+    action.getTriggers = () => [
       {
         changeset() {
           return userAction.changeset();
@@ -179,7 +179,7 @@ describe("fieldEdge no inverseEdge", () => {
       AccountSchema,
       new Map<string, any>([["userID", userAction.builder]]),
     );
-    action.triggers = [
+    action.getTriggers = () => [
       {
         changeset() {
           return userAction.changeset();

--- a/ts/src/scripts/move_generated.ts
+++ b/ts/src/scripts/move_generated.ts
@@ -6,7 +6,7 @@ import {
   getTargetFromCurrentDir,
 } from "../tsc/compilerOptions";
 import ts from "typescript";
-import { updateImportPath } from "../tsc/ast";
+import { isRelativeGeneratedImport, updateImportPath } from "../tsc/ast";
 import { execSync } from "child_process";
 
 // src/ent/generated and src/graphql/generated
@@ -132,17 +132,12 @@ function isGeneratedPath(
   sourceFile: ts.SourceFile,
   dirPath: string,
 ) {
-  const text = node.moduleSpecifier.getText(sourceFile).slice(1, -1);
-
   // it's relative and has generated in there, continue
-  if (
-    !(
-      (text.startsWith("..") || text.startsWith("./")) &&
-      text.indexOf("/generated") !== -1
-    )
-  ) {
+  if (!isRelativeGeneratedImport(node, sourceFile)) {
     return;
   }
+
+  const text = node.moduleSpecifier.getText(sourceFile).slice(1, -1);
   const oldPath = path.join(dirPath, text);
   const relFromRoot = path.relative(".", oldPath);
   const conv = transformPath(relFromRoot);

--- a/ts/src/scripts/transform_actions.ts
+++ b/ts/src/scripts/transform_actions.ts
@@ -123,9 +123,6 @@ async function main() {
   const viewerInfo = customInfo.viewerInfo;
 
   files.forEach((file) => {
-    if (!file.endsWith("create_contact_action.ts")) {
-      return;
-    }
     let { contents, sourceFile } = createSourceFile(target, file);
 
     let traversed = false;
@@ -241,14 +238,14 @@ async function main() {
                 sourceFile,
                 {
                   newImports: list,
-                  transformPath: impPath,
+                  // don't use normalized path here, we wanna use the path that's in code...
+                  transformPath: impInfo.importPath,
                 },
               );
               if (transformed) {
                 newContents += transformed;
                 seen.set(impPath, true);
                 continue;
-              } else {
               }
             }
           }

--- a/ts/src/scripts/transform_actions.ts
+++ b/ts/src/scripts/transform_actions.ts
@@ -216,10 +216,8 @@ async function main() {
       // we want to add new imports to end of imports and there's an assumption that imports are ordered
       // at top of file
       if (!afterProcessed) {
-        console.debug(seen);
         for (const [imp, list] of imports) {
           if (seen.has(imp)) {
-            console.debug("seen", imp);
             continue;
           }
           newContents += `\nimport { ${list.join(", ")} } from "${imp}"`;
@@ -227,18 +225,15 @@ async function main() {
         afterProcessed = true;
       }
     };
-    console.debug(imports);
 
     for (const node of nodes) {
       if (node.node) {
         if (ts.isImportDeclaration(node.node)) {
           const impInfo = getImportInfo(node.node, sourceFile);
-          //          console.debug(impInfo);
           if (impInfo) {
             const impPath = normalizePath(impInfo.importPath);
             // normalize paths...
             const list = imports.get(impPath);
-            console.debug(impPath, list);
             if (list) {
               let transformed = transformImport(
                 contents,
@@ -250,28 +245,20 @@ async function main() {
                 },
               );
               if (transformed) {
-                console.debug("transformed", impPath);
                 newContents += transformed;
                 seen.set(impPath, true);
-                console.debug("post seen", impPath);
                 continue;
               } else {
-                console.debug("not transformed", impPath);
               }
             }
           }
         } else {
-          //          console.debug("process after", node);
-          // sometimes we have exports early...
           if (!ts.isExportDeclaration(node.node)) {
             processAfterImport();
           }
-          //          continue;
         }
         newContents += node.node.getFullText(sourceFile);
       } else if (node.rawString) {
-        //        console.debug("process after raw ");
-
         processAfterImport();
         newContents += node.rawString;
       } else {

--- a/ts/src/scripts/transform_actions.ts
+++ b/ts/src/scripts/transform_actions.ts
@@ -172,7 +172,7 @@ async function main() {
 
           traversed = true;
 
-          const pp = property.initializer.getFullText(sourceFile);
+          const pp = property.initializer.getFullText(sourceFile).trim();
           const code = `${conv.method}(): ${conv.interface}<${nodeName}, ${builder}<${input}, ${existingEnt}>, ${viewer}, ${input}, ${existingEnt}>[] {
             return ${pp}
           }`;

--- a/ts/src/scripts/transform_actions.ts
+++ b/ts/src/scripts/transform_actions.ts
@@ -1,0 +1,321 @@
+import { glob } from "glob";
+import ts from "typescript";
+import {
+  getTargetFromCurrentDir,
+  createSourceFile,
+} from "../tsc/compilerOptions";
+import {
+  getClassInfo,
+  getImportInfo,
+  getPreText,
+  isRelativeGeneratedImport,
+  transformImport,
+} from "../tsc/ast";
+import { execSync } from "child_process";
+import * as fs from "fs";
+import { Action, WriteOperation } from "../action";
+import { LoggedOutViewer } from "../core/viewer";
+import * as path from "path";
+import { load } from "js-yaml";
+import { Config } from "../core/config";
+
+// inspired by transform_schema
+interface NodeInfo {
+  node?: ts.Node;
+  rawString?: string;
+}
+
+interface processImportInfo {
+  input?: string;
+  viewerImported?: boolean;
+}
+
+interface imports {
+  path: string;
+  import: string;
+}
+
+function processImports(
+  file: string,
+  sourceFile: ts.SourceFile,
+  viewerPath: string,
+  viewer: string,
+): processImportInfo {
+  // @ts-ignore
+  const importStatements: ts.ImportDeclaration[] = sourceFile.statements.filter(
+    (stmt) => ts.isImportDeclaration(stmt),
+  );
+  let input: string | undefined;
+  let viewerImported = false;
+
+  //  console.debug(importStatements);
+  for (const imp of importStatements) {
+    const text = imp.moduleSpecifier.getText(sourceFile).slice(1, -1);
+
+    if (isRelativeGeneratedImport(imp, sourceFile)) {
+      // base file and we're importing from it
+      // e.g. in create_user_action, we're importing from create_user_action_base
+      if (path.basename(file).slice(0, -3) + "_base" !== path.basename(text)) {
+        continue;
+      }
+
+      const impInfo = getImportInfo(imp, sourceFile);
+      if (!impInfo) {
+        continue;
+      }
+
+      const inputs = impInfo.imports
+        .filter((imp) => imp.trim() && imp.endsWith("Input"))
+        .map((v) => v.trim());
+      if (inputs.length === 1) {
+        input = inputs[0];
+      }
+    } else if (!viewerImported && text === viewerPath) {
+      // should work for both relative and absolute imports
+      const impInfo = getImportInfo(imp, sourceFile);
+      if (!impInfo) {
+        continue;
+      }
+      const inputs = impInfo.imports.filter((imp) => imp.trim() === viewer);
+      viewerImported = inputs.length === 1;
+    }
+  }
+
+  return {
+    viewerImported,
+    input,
+  };
+}
+
+interface customInfo {
+  viewerInfo: {
+    path: string;
+    name: string;
+  };
+  relativeImports?: boolean;
+}
+
+function getCustomInfo(): customInfo {
+  let yaml: Config | undefined = {};
+
+  let relativeImports = false;
+  try {
+    yaml = load(
+      fs.readFileSync(path.join(process.cwd(), "ent.yml"), {
+        encoding: "utf8",
+      }),
+    ) as Config;
+
+    relativeImports = yaml?.codegen?.relativeImports || false;
+
+    if (yaml?.codegen?.templatizedViewer) {
+      return {
+        viewerInfo: yaml.codegen.templatizedViewer,
+        relativeImports,
+      };
+    }
+  } catch (e) {}
+  return {
+    viewerInfo: {
+      path: "@snowtop/ent",
+      name: "Viewer",
+    },
+    relativeImports,
+  };
+}
+
+async function main() {
+  let files = glob.sync("src/ent/**/actions/**/*_action.ts");
+  const target = getTargetFromCurrentDir();
+  const customInfo = getCustomInfo();
+  const viewerInfo = customInfo.viewerInfo;
+
+  files.forEach((file) => {
+    if (!file.endsWith("create_auth_code_action.ts")) {
+      return;
+    }
+    //    console.debug(file);
+    let { contents, sourceFile } = createSourceFile(target, file);
+
+    let traversed = false;
+    let nodes: NodeInfo[] = [];
+
+    // require action
+    const p = require(path.join(process.cwd(), "./" + file.slice(0, -3)));
+    const action: Action<any, any> = new p.default(new LoggedOutViewer(), {});
+    // const options: OrchestratorOptions<any, any, any> =
+    //   action.builder.orchestrator.options;
+
+    const builder = action.builder.constructor.name;
+    const nodeName = action.builder.ent.name;
+    const existingEnt =
+      action.builder.operation === WriteOperation.Insert
+        ? `${nodeName} | null`
+        : nodeName;
+    const viewer = customInfo.viewerInfo.name;
+    // input is all that's left...
+    // need to read ent.yml for custom viewer
+
+    let viewerPath = viewerInfo.path;
+
+    // find relative path and convert to relative import if needed
+    if (customInfo.relativeImports && viewerInfo.path.startsWith("src")) {
+      const fileFullPath = path.join(process.cwd(), file);
+      const viewerFullPath = path.join(process.cwd(), viewerInfo.path);
+      // relative path is from directory
+      viewerPath = path.relative(path.dirname(fileFullPath), viewerFullPath);
+    }
+
+    const importsInfo = processImports(file, sourceFile, viewerPath, viewer);
+    if (!importsInfo?.input) {
+      return;
+    }
+    const input = importsInfo.input;
+    // TODO User, AuthCode etc
+
+    let missingImports: imports[] = [];
+    // add viewer to list of missing imports
+    if (!importsInfo.viewerImported) {
+      missingImports.push({
+        path: viewerPath,
+        import: viewer,
+      });
+    }
+
+    let newImports: string[] = [];
+    ts.forEachChild(sourceFile, function (node: ts.Node) {
+      if (!ts.isClassDeclaration(node) || !node.heritageClauses) {
+        nodes.push({ node });
+        return;
+      }
+
+      let classInfo = getClassInfo(contents, sourceFile, node);
+      // only do classes
+      if (!classInfo) {
+        return;
+      }
+
+      let klassContents = "";
+
+      for (const mm of node.members) {
+        const conv = getConversionInfo(mm);
+        if (conv !== null) {
+          const property = mm as ts.PropertyDeclaration;
+          // if invalid, bounce
+          if (!property.initializer) {
+            traversed = false;
+            return;
+          }
+
+          traversed = true;
+
+          const pp = property.initializer.getFullText(sourceFile);
+          const code = `${conv.method}(): ${conv.interface}<${nodeName}, ${builder}<${input}, ${existingEnt}>, ${viewer}, ${input}, ${existingEnt}>[] {
+            return ${pp}
+          }`;
+          newImports.push(conv.interface);
+          klassContents += getPreText(contents, mm, sourceFile) + code;
+        } else {
+          klassContents += mm.getFullText(sourceFile);
+        }
+      }
+
+      // wrap comments and transform to export class Foo extends Bar { ${inner} }
+      nodes.push({ rawString: classInfo.wrapClassContents(klassContents) });
+    });
+
+    // if traversed, overwrite.
+    if (!traversed) {
+      return;
+    }
+
+    let newContents = "";
+    let afterProcessed = false;
+
+    const processAfterImport = () => {
+      // do this for the first non-import node we see
+      // we want to add it last and there's an assumption that imports are ordered.
+      if (!afterProcessed && missingImports.length) {
+        for (const imp of missingImports) {
+          newContents += `\nimport { ${imp.import} } from "${imp.path}"`;
+        }
+        afterProcessed = true;
+      }
+    };
+
+    for (const node of nodes) {
+      if (node.node) {
+        if (ts.isImportDeclaration(node.node)) {
+          console.debug(newImports);
+          let transformed = transformImport(contents, node.node, sourceFile, {
+            newImports,
+            transformPath: "@snowtop/ent/action",
+          });
+          console.debug(transformed);
+          if (transformed) {
+            newContents += transformed;
+            continue;
+          }
+        } else {
+          processAfterImport();
+        }
+        newContents += node.node.getFullText(sourceFile);
+      } else if (node.rawString) {
+        processAfterImport();
+        newContents += node.rawString;
+      } else {
+        throw new Error(`malformed node with no node or rawString`);
+      }
+
+      fs.writeFileSync(file, newContents);
+    }
+  });
+
+  execSync("prettier src/ent/**/actions/**/*.ts --write");
+}
+
+let m = {
+  triggers: {
+    m: "getTriggers",
+    i: "Trigger",
+  },
+  observers: {
+    m: "getObservers",
+    i: "Observer",
+  },
+  validators: {
+    m: "getValidators",
+    i: "Validator",
+  },
+};
+
+interface convertReturnInfo {
+  text: string;
+  method: string;
+  interface: string;
+}
+
+function getConversionInfo(mm: ts.ClassElement): convertReturnInfo | null {
+  if (mm.kind !== ts.SyntaxKind.PropertyDeclaration) {
+    return null;
+  }
+  const text = (mm.name as ts.Identifier).escapedText as string;
+  const v = m[text];
+  if (v === undefined) {
+    return null;
+  }
+  return {
+    text,
+    method: v.m,
+    interface: v.i,
+  };
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/ts/src/scripts/transform_code.ts
+++ b/ts/src/scripts/transform_code.ts
@@ -4,7 +4,7 @@ import {
   getTargetFromCurrentDir,
   createSourceFile,
 } from "../tsc/compilerOptions";
-import { getClassInfo, transformImport } from "../tsc/ast";
+import { getClassInfo, getPreText, transformImport } from "../tsc/ast";
 import { execSync } from "child_process";
 import * as fs from "fs";
 
@@ -36,7 +36,6 @@ async function main() {
         return;
       }
 
-      // need to check for PrivacyPolicy import...
       traversed = true;
 
       let klassContents = "";
@@ -53,7 +52,7 @@ async function main() {
           const code = `getPrivacyPolicy(): PrivacyPolicy<this> {
             return ${pp}
           }`;
-          klassContents += code;
+          klassContents += getPreText(contents, mm, sourceFile) + code;
         } else {
           klassContents += mm.getFullText(sourceFile);
         }
@@ -61,7 +60,6 @@ async function main() {
 
       // wrap comments and transform to export class Foo extends Bar { ${inner} }
       nodes.push({ rawString: classInfo.wrapClassContents(klassContents) });
-      //      console.debug(classInfo.wrapClassContents(klassContents));
     });
 
     // if traversed, overwrite.

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -325,9 +325,6 @@ export class SimpleAction<
     Action<T, SimpleBuilder<T, TExistingEnt>, Viewer, Data, TExistingEnt>
 {
   builder: SimpleBuilder<T, TExistingEnt>;
-  validators: Validator<T, SimpleBuilder<T>>[] = [];
-  triggers: Trigger<T, SimpleBuilder<T>>[] = [];
-  observers: Observer<T, SimpleBuilder<T>>[] = [];
   viewerForEntLoad: viewerEntLoadFunc | undefined;
 
   constructor(
@@ -345,6 +342,18 @@ export class SimpleAction<
       existingEnt,
       this,
     );
+  }
+
+  getTriggers(): Trigger<T, SimpleBuilder<T>>[] {
+    return [];
+  }
+
+  getValidators(): Validator<T, SimpleBuilder<T>>[] {
+    return [];
+  }
+
+  getObservers(): Observer<T, SimpleBuilder<T>>[] {
+    return [];
   }
 
   getPrivacyPolicy() {

--- a/ts/src/tsc/ast.ts
+++ b/ts/src/tsc/ast.ts
@@ -232,6 +232,7 @@ interface importInfo {
   start: number;
   end: number;
   importText: string;
+  importPath: string;
 }
 
 export function getImportInfo(
@@ -241,10 +242,13 @@ export function getImportInfo(
   const importText = imp.importClause?.getText(sourceFile) || "";
   const start = importText.indexOf("{");
   const end = importText.lastIndexOf("}");
+  const text = imp.moduleSpecifier.getText(sourceFile).slice(1, -1);
+
   if (start === -1 || end === -1) {
     return;
   }
   return {
+    importPath: text,
     importText,
     start,
     end,


### PR DESCRIPTION
changes from properties `triggers`, `observers`, `validators` to methods `getTriggers`, `getObservers`, `getValidators`.

This seems to make it easier for vscode to autosuggest typings when used. important with the template soup going on now

also create a script to transform the code from old to new. script doesn't quite catch everything as seen by need for manual fixes when converting example e.g. https://github.com/lolopinto/ent/commit/c13f8992aa8213c80be0023b8a92ac1809a79f6a

doesn't currently seem that bad so not fixing it. the main thing it misses that's fixable is differentiating relative import paths e.g. `../..` vs `../../../ent` in actions.

