### PR TITLE
fix issue which was leading to test that seemed flaky

### DIFF
--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -1050,7 +1050,7 @@ func verifyExpectedActions(t *testing.T, actionInfo *action.ActionInfo, expActio
 			// only do this for when we want to test this
 			// TODO we should change everywhere to test this
 			customInterfaces := a.GetCustomInterfaces()
-			require.Len(t, expAction.customInterfaces, len(customInterfaces))
+			require.Len(t, customInterfaces, len(expAction.customInterfaces))
 
 			for idx, customInt := range customInterfaces {
 				expCustomInt := expAction.customInterfaces[idx]

--- a/internal/action/interface.go
+++ b/internal/action/interface.go
@@ -222,6 +222,7 @@ func (action *commonActionInfo) getCustomInterface(typ enttype.TSTypeWithCustomT
 			GQLType: gqlType,
 		}
 	}
+
 	action.customInterfaces[tsTyp] = ci
 	return ci
 }


### PR DESCRIPTION
underlying issue was depending on order of how we processed these things, we'd end up with interfaces not having been processed and so no interface yet

in `internal/action`, run

```shell
DB_CONNECTION_STRING=sqlite:/// go test -run TestEmbeddedActionOnlyFields -count 10
```

to see the issue eventually pop up and work on fixing it until it doesn't

fixes https://github.com/lolopinto/ent/issues/295