### PR TITLE
transform_schema updates

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha34",
+  "version": "0.1.0-alpha35",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
have transform_schema throw if it encounters files it can't change instead of failing silently

plus handle format that wasn't previously handled:

```ts
     FooType({
      name: 'name',
      maxLen: 150,
    }).formatter(formatter),
  ```

was previously failing. no longer failing