### PR TITLE
break query in log-levels into query and cache

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha40",
+  "version": "0.1.0-alpha42",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/action.test.ts
+++ b/ts/src/action/action.test.ts
@@ -44,7 +44,7 @@ afterEach(() => {
 describe("postgres", () => {
   beforeAll(() => {
     ml.mock();
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
   });
 
   afterAll(() => {
@@ -61,7 +61,7 @@ describe("postgres", () => {
 describe("sqlite", () => {
   beforeAll(() => {
     ml.mock();
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
   });
 
   afterAll(() => {

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -92,7 +92,7 @@ beforeEach(async () => {
 });
 
 beforeAll(() => {
-  setLogLevels(["query", "error"]);
+  setLogLevels(["query", "error", "cache"]);
   ml.mock();
 });
 

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -2486,7 +2486,7 @@ function commonTests() {
 
     beforeAll(() => {
       mockLog.mock();
-      setLogLevels("query");
+      setLogLevels(["query", "cache"]);
     });
 
     afterAll(() => {

--- a/ts/src/core/config.test.ts
+++ b/ts/src/core/config.test.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from "./config";
 import DB, { Dialect } from "./db";
-import { logEnabled, logIf, setLogLevels } from "./logger";
+import { logEnabled, logIf } from "./logger";
 import { MockLogs } from "../testutils/mock_log";
 
 afterEach(() => {

--- a/ts/src/core/context.ts
+++ b/ts/src/core/context.ts
@@ -54,7 +54,7 @@ export class ContextCache {
     const key = this.getkey(options);
     let rows = m.get(key);
     if (rows) {
-      log("query", {
+      log("cache", {
         "cache-hit": key,
         "tableName": options.tableName,
       });
@@ -70,7 +70,7 @@ export class ContextCache {
     const key = this.getkey(options);
     let row = m.get(key);
     if (row) {
-      log("query", {
+      log("cache", {
         "cache-hit": key,
         "tableName": options.tableName,
       });

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -43,7 +43,7 @@ class cacheMap {
   get(key: string) {
     const ret = this.m.get(key);
     if (ret) {
-      log("query", {
+      log("cache", {
         "dataloader-cache-hit": key,
         "tableName": this.options.tableName,
       });

--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -126,7 +126,7 @@ afterAll(() => {
 
 beforeEach(() => {
   ctx = getCtx();
-  setLogLevels(["query", "error"]);
+  setLogLevels(["query", "error", "cache"]);
   ml.clear();
 });
 

--- a/ts/src/core/ent_data.test.ts
+++ b/ts/src/core/ent_data.test.ts
@@ -135,7 +135,7 @@ afterAll(() => {
 
 beforeEach(() => {
   ctx = getCtx();
-  setLogLevels(["query", "error"]);
+  setLogLevels(["query", "error", "cache"]);
   ml.clear();
 });
 

--- a/ts/src/core/ent_logs.test.ts
+++ b/ts/src/core/ent_logs.test.ts
@@ -46,7 +46,7 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  setLogLevels(["query", "error"]);
+  setLogLevels(["query", "error", "cache"]);
   ml.clear();
 });
 

--- a/ts/src/core/loaders/assoc_count_loader.test.ts
+++ b/ts/src/core/loaders/assoc_count_loader.test.ts
@@ -29,7 +29,7 @@ const getNewLoader = (context: boolean = true) => {
 describe("postgres", () => {
   let tdb: TempDB;
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
 
     tdb = await setupTempDB();
@@ -50,7 +50,7 @@ describe("sqlite", () => {
   setupSqlite(`sqlite:///assoc_count_loader.db`, tempDBTables);
 
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
   });
 

--- a/ts/src/core/loaders/assoc_edge_loader.test.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.test.ts
@@ -48,7 +48,7 @@ describe("postgres", () => {
   let tdb: TempDB;
 
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
 
     tdb = await setupTempDB();
@@ -74,7 +74,7 @@ describe("sqlite", () => {
   setupSqlite(`sqlite:///assoc_edge_loader.db`, tempDBTables);
 
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
   });
 

--- a/ts/src/core/loaders/index_loader.test.ts
+++ b/ts/src/core/loaders/index_loader.test.ts
@@ -48,7 +48,7 @@ const getConfigurableLoader = (
 
 describe("postgres", () => {
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
 
     tdb = await setupTempDB();
@@ -74,7 +74,7 @@ describe("sqlite", () => {
   setupSqlite(`sqlite:///index_loader.db`, tempDBTables);
 
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
   });
 

--- a/ts/src/core/loaders/loader.ts
+++ b/ts/src/core/loaders/loader.ts
@@ -44,12 +44,12 @@ export class cacheMap {
       // might be a lot?
       // TODO this is not the best log format
       // was designed for ObjectLoader time. Now we have different needs e.g. count, assoc etc
-      log("query", {
+      log("cache", {
         "dataloader-cache-hit": key,
         "tableName": this.options.tableName,
       });
       // } else {
-      //   log("query", {
+      //   log("cache", {
       //     "dataloader-cache-miss": key,
       //     "tableName": options.tableName,
       //   });
@@ -58,7 +58,7 @@ export class cacheMap {
   }
 
   set(key, value) {
-    // log("query", {
+    // log("cache", {
     //   "dataloader-cache-set": key,
     //   "tableName": options.tableName,
     // });
@@ -66,7 +66,7 @@ export class cacheMap {
   }
 
   delete(key) {
-    // log("query", {
+    // log("cache", {
     //   "dataloader-cache-delete": key,
     //   "tableName": options.tableName,
     // });
@@ -74,7 +74,7 @@ export class cacheMap {
   }
 
   clear() {
-    // log("query", {
+    // log("cache", {
     //   "dataloader-cache-clear": true,
     //   "tableName": options.tableName,
     // });

--- a/ts/src/core/loaders/object_loader.test.ts
+++ b/ts/src/core/loaders/object_loader.test.ts
@@ -127,7 +127,7 @@ async function createWithDeletedAt(id?: ID) {
 
 describe("postgres", () => {
   beforeAll(async () => {
-    setLogLevels("query");
+    setLogLevels(["query", "cache"]);
     ml.mock();
 
     await createEdges();
@@ -160,7 +160,7 @@ describe("sqlite", () => {
   setupSqlite(`sqlite:///object_loader.db`, tables);
 
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
   });
 

--- a/ts/src/core/loaders/query_loader.test.ts
+++ b/ts/src/core/loaders/query_loader.test.ts
@@ -65,7 +65,7 @@ const getNonGroupableLoader = (id: ID, context: boolean = true) => {
 
 describe("postgres", () => {
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
 
     tdb = await setupTempDB();
@@ -91,7 +91,7 @@ describe("sqlite", () => {
   setupSqlite(`sqlite:///query_loader.db`, tempDBTables);
 
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
   });
 

--- a/ts/src/core/loaders/raw_count_loader.test.ts
+++ b/ts/src/core/loaders/raw_count_loader.test.ts
@@ -36,7 +36,7 @@ describe("postgres", () => {
   let tdb: TempDB;
 
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
 
     tdb = await setupTempDB();
@@ -57,7 +57,7 @@ describe("sqlite", () => {
   setupSqlite(`sqlite:///raw_count_loader.db`, tempDBTables);
 
   beforeAll(async () => {
-    setLogLevels(["query", "error"]);
+    setLogLevels(["query", "error", "cache"]);
     ml.mock();
   });
 

--- a/ts/src/core/logger.ts
+++ b/ts/src/core/logger.ts
@@ -1,10 +1,12 @@
-type logType = "query" | "warn" | "info" | "error" | "debug";
-var m = {
+// query are things that go in database
+type logType = "query" | "warn" | "info" | "error" | "debug" | "cache";
+var m: { [key in logType]: string } = {
   query: "log",
   warn: "warn",
   info: "log",
   error: "error",
   debug: "debug",
+  cache: "log",
 };
 var logLevels = new Map<logType, boolean>();
 

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -28,7 +28,7 @@ let ml = new MockLogs();
 let tdb: TempDB;
 
 beforeAll(async () => {
-  setLogLevels(["query", "error"]);
+  setLogLevels(["query", "error", "cache"]);
   ml.mock();
 
   tdb = await setupTempDB();


### PR DESCRIPTION
'query' is too noisy and makes it difficult to figure out what's happening.