### PR TITLE
fix generated graphql type for nullable edge

### DIFF
--- a/examples/todo-sqlite/src/ent/generated/tag_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_base.ts
@@ -29,6 +29,7 @@ import {
   DeletedAtMixin,
   IDeletedAt,
   NodeType,
+  Tag,
   TagToTodosQuery,
 } from "src/ent/internal";
 import schema from "src/schema/tag_schema";
@@ -218,5 +219,17 @@ export class TagBase
 
   loadOwnerX(): Promise<Account> {
     return loadEntX(this.viewer, this.ownerID, Account.loaderOptions());
+  }
+
+  async loadRelatedTags(): Promise<Tag[] | null> {
+    if (!this.relatedTagIds) {
+      return null;
+    }
+    const ents = await loadEnts(
+      this.viewer,
+      Tag.loaderOptions(),
+      ...this.relatedTagIds,
+    );
+    return Array.from(ents.values());
   }
 }

--- a/examples/todo-sqlite/src/graphql/generated/resolvers/tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/resolvers/tag_type.ts
@@ -29,6 +29,12 @@ export const TagType = new GraphQLObjectType({
         return tag.loadOwner();
       },
     },
+    related_tags: {
+      type: new GraphQLList(new GraphQLNonNull(TagType)),
+      resolve: (tag: Tag, args: {}, context: RequestContext) => {
+        return tag.loadRelatedTags();
+      },
+    },
     id: {
       type: new GraphQLNonNull(GraphQLID),
     },
@@ -42,12 +48,6 @@ export const TagType = new GraphQLObjectType({
       type: new GraphQLNonNull(GraphQLString),
       resolve: (tag: Tag, args: {}, context: RequestContext) => {
         return tag.canonicalName;
-      },
-    },
-    related_tag_ids: {
-      type: new GraphQLList(new GraphQLNonNull(GraphQLID)),
-      resolve: (tag: Tag, args: {}, context: RequestContext) => {
-        return tag.relatedTagIds;
       },
     },
     todos: {

--- a/examples/todo-sqlite/src/graphql/generated/schema.gql
+++ b/examples/todo-sqlite/src/graphql/generated/schema.gql
@@ -45,10 +45,10 @@ type Account implements Node {
 
 type Tag implements Node {
   owner: Account
+  related_tags: [Tag!]
   id: ID!
   display_name: String!
   canonical_name: String!
-  related_tag_ids: [ID!]
   todos(first: Int, after: String, last: Int, before: String): TagToTodosConnection!
 }
 

--- a/examples/todo-sqlite/src/graphql/tests/tag.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/tag.test.ts
@@ -26,6 +26,32 @@ test("create", async () => {
     ["tag.display_name", "SPORTS"],
     ["tag.canonical_name", "sports"],
     ["tag.owner.id", account.id],
-    ["tag.related_tag_ids[0]", tag.id],
+    ["tag.related_tags[0].id", tag.id],
+  );
+});
+
+test("create no tags", async () => {
+  const account = await createAccount();
+  await expectMutation(
+    {
+      viewer: account.viewer,
+      schema,
+      mutation: "createTag",
+      args: {
+        owner_id: account.id,
+        display_name: "SPORTS",
+      },
+      nullQueryPaths: ["tag.related_tags"],
+    },
+    [
+      "tag.id",
+      async (id: string) => {
+        await Tag.loadX(account.viewer, id);
+      },
+    ],
+    ["tag.display_name", "SPORTS"],
+    ["tag.canonical_name", "sports"],
+    ["tag.owner.id", account.id],
+    ["tag.related_tags[0].id", null],
   );
 });

--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/iancoleman/strcase"
 	"github.com/jinzhu/inflection"
 	"github.com/lolopinto/ent/ent"
@@ -247,6 +246,7 @@ func getFieldEdge(cfg codegenapi.Config,
 		"ID":  "ID",
 		"IDs": "IDs",
 		"ids": "_ids",
+		"Ids": "Ids",
 	}
 	// well this is dumb
 	// not an id field, do nothing
@@ -490,6 +490,13 @@ func (edge *FieldEdge) PolymorphicEdge() bool {
 
 func (edge *FieldEdge) GetTSGraphQLTypeImports() []*tsimport.ImportPath {
 	if edge.IsList() {
+		if edge.Nullable {
+			return []*tsimport.ImportPath{
+				tsimport.NewGQLClassImportPath("GraphQLList"),
+				tsimport.NewGQLClassImportPath("GraphQLNonNull"),
+				tsimport.NewLocalGraphQLEntImportPath(edge.NodeInfo.Node),
+			}
+		}
 		return []*tsimport.ImportPath{
 			tsimport.NewGQLClassImportPath("GraphQLNonNull"),
 			tsimport.NewGQLClassImportPath("GraphQLList"),
@@ -1364,9 +1371,6 @@ func getCommonEdgeInfo(
 	entConfig *schemaparser.EntConfigInfo,
 ) commonEdgeInfo {
 
-	if edgeName == "" {
-		spew.Dump("null edgeName")
-	}
 	ret := commonEdgeInfo{
 		EdgeName:        edgeName,
 		entConfig:       entConfig,

--- a/internal/edge/edge_test.go
+++ b/internal/edge/edge_test.go
@@ -669,6 +669,8 @@ func testFieldEdge(t *testing.T, edge, expectedEdge *FieldEdge) {
 		assert.Equal(t, expectedEdge.Polymorphic.Unique, edge.Polymorphic.Unique)
 	}
 
+	assert.Equal(t, expectedEdge.GetTSGraphQLTypeImports(), edge.GetTSGraphQLTypeImports())
+
 	testEntConfig(t, edge.entConfig, expectedEdge.entConfig)
 
 	testNodeInfo(t, edge.NodeInfo, expectedEdge.NodeInfo.Node)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1019,7 +1019,6 @@ func (s *Schema) addLinkedEdges(cfg codegenapi.Config, info *NodeDataInfo) error
 					// only add polymorphic accessors on foreign if index or unique
 					if f.Index() || f.Unique() {
 						fEdgeInfo := foreign.NodeData.EdgeInfo
-						//						spew.Dump(nodeData.Node, foreign.NodeData.Node)
 						if err := fEdgeInfo.AddDestinationEdgeFromPolymorphicOptions(
 							cfg,
 							f.TsFieldName(cfg),


### PR DESCRIPTION
saw a scenario where I was getting an error

```
Cannot return null for non-nullable field Foo.bar
```

looked at the type and saw it was wrong.

also fixed an issue with Tag field `relatedTagIds` not having an edge generated for it 
more of https://github.com/lolopinto/ent/issues/644
https://github.com/lolopinto/ent/issues/674