### PR TITLE
 In clause changes

### DIFF
--- a/ts/src/core/clause.test.ts
+++ b/ts/src/core/clause.test.ts
@@ -304,6 +304,7 @@ describe("postgres", () => {
       expect(cls.logValues()).toStrictEqual([1]);
       expect(cls.instanceKey()).toEqual("in:id:1");
     });
+
     test("spread args", () => {
       const cls = clause.In("id", 1, 2, 3);
       expect(cls.clause(1)).toBe("id IN ($1, $2, $3)");
@@ -353,16 +354,11 @@ describe("postgres", () => {
         const ids = [1, 2, 3, 4, 5].map((_) => v1());
 
         const cls = clause.In("id", ids);
-        expect(cls.clause(1)).toBe("id IN (VALUES($1, $2, $3, $4, $5))");
-        expect(cls.columns()).toStrictEqual(["id"]);
-        expect(cls.values()).toStrictEqual(
-          ids.map((id, idx) => {
-            if (idx === 0) {
-              return `${id}::uuid`;
-            }
-            return id;
-          }),
+        expect(cls.clause(1)).toBe(
+          "id IN (VALUES($1::uuid), ($2), ($3), ($4), ($5))",
         );
+        expect(cls.columns()).toStrictEqual(["id"]);
+        expect(cls.values()).toStrictEqual(ids);
         expect(cls.logValues()).toStrictEqual(ids);
         expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
       });
@@ -371,16 +367,11 @@ describe("postgres", () => {
         const ids = [1, 2, 3, 4, 5];
 
         const cls = clause.In("id", ids, "int");
-        expect(cls.clause(1)).toBe("id IN (VALUES($1, $2, $3, $4, $5))");
-        expect(cls.columns()).toStrictEqual(["id"]);
-        expect(cls.values()).toStrictEqual(
-          ids.map((id, idx) => {
-            if (idx === 0) {
-              return `${id}::int`;
-            }
-            return id;
-          }),
+        expect(cls.clause(1)).toBe(
+          "id IN (VALUES($1::int), ($2), ($3), ($4), ($5))",
         );
+        expect(cls.columns()).toStrictEqual(["id"]);
+        expect(cls.values()).toStrictEqual(ids);
         expect(cls.logValues()).toStrictEqual(ids);
         expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
       });
@@ -389,16 +380,11 @@ describe("postgres", () => {
         const ids = [1, 2, 3, 4, 5];
 
         const cls = clause.In("id", ids, "integer");
-        expect(cls.clause(1)).toBe("id IN (VALUES($1, $2, $3, $4, $5))");
-        expect(cls.columns()).toStrictEqual(["id"]);
-        expect(cls.values()).toStrictEqual(
-          ids.map((id, idx) => {
-            if (idx === 0) {
-              return `${id}::integer`;
-            }
-            return id;
-          }),
+        expect(cls.clause(1)).toBe(
+          "id IN (VALUES($1::integer), ($2), ($3), ($4), ($5))",
         );
+        expect(cls.columns()).toStrictEqual(["id"]);
+        expect(cls.values()).toStrictEqual(ids);
         expect(cls.logValues()).toStrictEqual(ids);
         expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
       });
@@ -407,16 +393,11 @@ describe("postgres", () => {
         const ids = [1, 2, 3, 4, 5].map((_) => v1());
 
         const cls = clause.In("id", ids, "uuid");
-        expect(cls.clause(1)).toBe("id IN (VALUES($1, $2, $3, $4, $5))");
-        expect(cls.columns()).toStrictEqual(["id"]);
-        expect(cls.values()).toStrictEqual(
-          ids.map((id, idx) => {
-            if (idx === 0) {
-              return `${id}::uuid`;
-            }
-            return id;
-          }),
+        expect(cls.clause(1)).toBe(
+          "id IN (VALUES($1::uuid), ($2), ($3), ($4), ($5))",
         );
+        expect(cls.columns()).toStrictEqual(["id"]);
+        expect(cls.values()).toStrictEqual(ids);
         expect(cls.logValues()).toStrictEqual(ids);
         expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
       });

--- a/ts/src/core/clause.test.ts
+++ b/ts/src/core/clause.test.ts
@@ -1,3 +1,4 @@
+import { v1 } from "uuid";
 import * as clause from "./clause";
 import { loadConfig } from "./config";
 
@@ -295,6 +296,14 @@ describe("postgres", () => {
   // TODO: AND OR mixed together?
 
   describe("In", () => {
+    test("1 arg", () => {
+      const cls = clause.In("id", 1);
+      expect(cls.clause(1)).toBe("id = $1");
+      expect(cls.columns()).toStrictEqual(["id"]);
+      expect(cls.values()).toStrictEqual([1]);
+      expect(cls.logValues()).toStrictEqual([1]);
+      expect(cls.instanceKey()).toEqual("in:id:1");
+    });
     test("spread args", () => {
       const cls = clause.In("id", 1, 2, 3);
       expect(cls.clause(1)).toBe("id IN ($1, $2, $3)");
@@ -329,6 +338,88 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([1, 2, 3]);
       expect(cls.logValues()).toStrictEqual([1, "*", 3]);
       expect(cls.instanceKey()).toEqual("in:id:1,2,3");
+    });
+
+    describe("valuesList threshold", () => {
+      const spy = jest
+        .spyOn(clause.inClause, "getPostgresInClauseValuesThreshold")
+        .mockImplementation(() => 5);
+
+      afterAll(() => {
+        spy.mockRestore();
+      });
+
+      test("uuid implicit", () => {
+        const ids = [1, 2, 3, 4, 5].map((_) => v1());
+
+        const cls = clause.In("id", ids);
+        expect(cls.clause(1)).toBe("id IN (VALUES($1, $2, $3, $4, $5))");
+        expect(cls.columns()).toStrictEqual(["id"]);
+        expect(cls.values()).toStrictEqual(
+          ids.map((id, idx) => {
+            if (idx === 0) {
+              return `${id}::uuid`;
+            }
+            return id;
+          }),
+        );
+        expect(cls.logValues()).toStrictEqual(ids);
+        expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
+      });
+
+      test("int", () => {
+        const ids = [1, 2, 3, 4, 5];
+
+        const cls = clause.In("id", ids, "int");
+        expect(cls.clause(1)).toBe("id IN (VALUES($1, $2, $3, $4, $5))");
+        expect(cls.columns()).toStrictEqual(["id"]);
+        expect(cls.values()).toStrictEqual(
+          ids.map((id, idx) => {
+            if (idx === 0) {
+              return `${id}::int`;
+            }
+            return id;
+          }),
+        );
+        expect(cls.logValues()).toStrictEqual(ids);
+        expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
+      });
+
+      test("integer", () => {
+        const ids = [1, 2, 3, 4, 5];
+
+        const cls = clause.In("id", ids, "integer");
+        expect(cls.clause(1)).toBe("id IN (VALUES($1, $2, $3, $4, $5))");
+        expect(cls.columns()).toStrictEqual(["id"]);
+        expect(cls.values()).toStrictEqual(
+          ids.map((id, idx) => {
+            if (idx === 0) {
+              return `${id}::integer`;
+            }
+            return id;
+          }),
+        );
+        expect(cls.logValues()).toStrictEqual(ids);
+        expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
+      });
+
+      test("uuid explicit", () => {
+        const ids = [1, 2, 3, 4, 5].map((_) => v1());
+
+        const cls = clause.In("id", ids, "uuid");
+        expect(cls.clause(1)).toBe("id IN (VALUES($1, $2, $3, $4, $5))");
+        expect(cls.columns()).toStrictEqual(["id"]);
+        expect(cls.values()).toStrictEqual(
+          ids.map((id, idx) => {
+            if (idx === 0) {
+              return `${id}::uuid`;
+            }
+            return id;
+          }),
+        );
+        expect(cls.logValues()).toStrictEqual(ids);
+        expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
+      });
     });
   });
 
@@ -971,6 +1062,15 @@ describe("sqlite", () => {
   // TODO: AND OR mixed together?
 
   describe("In", () => {
+    test("1 arg", () => {
+      const cls = clause.In("id", 1);
+      expect(cls.clause(1)).toBe("id = ?");
+      expect(cls.columns()).toStrictEqual(["id"]);
+      expect(cls.values()).toStrictEqual([1]);
+      expect(cls.logValues()).toStrictEqual([1]);
+      expect(cls.instanceKey()).toEqual("in:id:1");
+    });
+
     test("spread args", () => {
       const cls = clause.In("id", 1, 2, 3);
       expect(cls.clause(1)).toBe("id IN (?, ?, ?)");

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -299,24 +299,16 @@ export class inClause implements Clause {
 
   values(): any[] {
     const result: any[] = [];
-    for (let i = 0; i < this.value.length; i++) {
-      let value = this.value[i];
-      if (isSensitive(value)) {
-        value = value.value();
-      }
-      result.push(value);
+    for (let value of this.value) {
+      result.push(rawValue(value));
     }
     return result;
   }
 
   logValues(): any[] {
     const result: any[] = [];
-    for (const value of this.value) {
-      if (isSensitive(value)) {
-        result.push(value.logValue());
-      } else {
-        result.push(value);
-      }
+    for (let value of this.value) {
+      result.push(isSensitive(value) ? value.logValue() : value);
     }
     return result;
   }

--- a/ts/src/core/db_clause.test.ts
+++ b/ts/src/core/db_clause.test.ts
@@ -159,8 +159,6 @@ test("create + array query", async () => {
     clause: clause.PostgresArrayNotContains("emails", row.emails),
   });
   expect(notFromAllEmails.length).toBe(19);
-
-  //  const
 });
 
 test("jsonb", async () => {
@@ -253,14 +251,10 @@ test("jsonb", async () => {
   // TODO check to make sure we tested it all...
 });
 
-test.only("in clause", async () => {
+test("in clause", async () => {
   const ids: string[] = [];
-  for (
-    let i = 0;
-    // i < 70;
-    i < clause.inClause.getPostgresInClauseValuesThreshold() * 1.5;
-    i++
-  ) {
+  const count = clause.inClause.getPostgresInClauseValuesThreshold();
+  for (let i = 0; i < count; i++) {
     const data: Data = {
       id: v1(),
       first_name: "Jon",
@@ -283,8 +277,9 @@ test.only("in clause", async () => {
   const allIds = await loadRows({
     tableName,
     fields,
-    clause: clause.In("id", ids),
+    clause: clause.In("id", ids, "uuid"),
   });
-  console.debug(ml.logs, ml.errors);
-  console.debug(allIds.length);
+  expect(ml.logs.length).toBe(1);
+  expect(ml.errors.length).toBe(0);
+  expect(allIds.length).toBe(count);
 });


### PR DESCRIPTION
there seems to be a performance benefit of using a values list instead of in() for large queries 

https://postgres.cz/wiki/PostgreSQL_SQL_Tricks_I#Predicate_IN_optimalization

i tried with a few queries when querying 100+ ids and timed the performance and there was a noticeable difference in some of them especially with large ids

variants i tried
* big in
```sql
select {cols} from {tbl} where id in ($1...$100) and foo = $101
```

* inner join
```sql
select {cols} from {tbl} inner join (values($1)...($100) ) v(hello) on (tbl::uuid = hello::uuid) and foo = $101
```

* values with cast on col
```sql
select {cols} from tbl where id::text  in (values($1)...($100)) and foo = $101
```

* values with cast on values 1st item
```sql
select {cols} from tbl where id in (values($1::uuid)...($100)) and foo = $101
```

the last 2 seemed to consistently perform the best in the sample size i tried so changing the query for large enough ids.

the current value 70 is chosen arbitrarily based on that comment and can be changed in the future or maybe even configured