### PR TITLE
change this test to use live postgres db instead of QueryRecorder

### DIFF
--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -770,7 +770,7 @@ function softDeleteTests(opts: LoadCustomEntOptions<User>) {
       // soft deleted items not included...
       expect(ents2.length).toBe(3);
       // order not actually guaranteed so this may eventually break
-      expect(ents2.map((ent) => ent.id)).toEqual([2, 4, 6]);
+      expect(ents2.map((ent) => ent.id).sort()).toEqual([2, 4, 6]);
     });
 
     test("options", async () => {


### PR DESCRIPTION
want to kill QueryRecorder and this is too important not to be hitting postgres