### PR TITLE
cleanup testhelper files 

### DIFF
--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/lolopinto/ent/internal/action"
 	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/field"
-	"github.com/lolopinto/ent/internal/schema/base"
 	"github.com/lolopinto/ent/internal/schema/testhelper"
 	"github.com/lolopinto/ent/internal/testingutils/testmodel"
 
@@ -169,7 +168,6 @@ func TestActionFields(t *testing.T) {
 			export default ContactSchema;
 			`),
 		},
-		base.TypeScript,
 		"ContactConfig",
 	)
 
@@ -263,7 +261,6 @@ func TestActionFieldsWithPrivateFields(t *testing.T) {
 			export default UserSchema;
 			`),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -332,7 +329,6 @@ func TestDefaultActionFieldsWithPrivateFields(t *testing.T) {
 			export default UserSchema;
 			`),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -398,7 +394,6 @@ func TestDefaultNoFields(t *testing.T) {
 				`,
 			),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -449,7 +444,6 @@ func TestExplicitNoFields(t *testing.T) {
 				`,
 			),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -492,7 +486,6 @@ func TestNullableFieldInAction(t *testing.T) {
 				`,
 			),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -541,7 +534,6 @@ func TestOverriddenRequiredActionField(t *testing.T) {
 				`,
 			),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -593,7 +585,6 @@ func TestPrivateFieldExposedToActions(t *testing.T) {
 				`,
 			),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -657,7 +648,6 @@ func TestPrivateField(t *testing.T) {
 				`,
 			),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -716,7 +706,6 @@ func TestOverriddenOptionalActionField(t *testing.T) {
 				`,
 			),
 		},
-		base.TypeScript,
 		"UserConfig",
 	)
 
@@ -774,7 +763,6 @@ func TestActionOnlyFields(t *testing.T) {
 				});
 				export default Event;`),
 		},
-		base.TypeScript,
 		"EventConfig",
 	)
 
@@ -863,7 +851,6 @@ func TestActionOnlyFieldsInvalidAction(t *testing.T) {
 				export default ContactEmail;`,
 			),
 		},
-		base.TypeScript,
 	)
 
 	require.Nil(t, schema)
@@ -938,7 +925,6 @@ func TestEmbeddedActionOnlyFields(t *testing.T) {
 				});
 				export default Event;`),
 		},
-		base.TypeScript,
 	)
 
 	activityActionInfo := schema.Nodes["EventActivityConfig"].NodeData.ActionInfo
@@ -1097,7 +1083,6 @@ func TestFieldEdgeFields(t *testing.T) {
 				});
 				export default Profile`),
 		},
-		base.TypeScript,
 	)
 
 	addressInfo := schema.Nodes["AddressConfig"].NodeData.ActionInfo

--- a/internal/field/fields_test.go
+++ b/internal/field/fields_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/lolopinto/ent/internal/codegen/codegenapi"
-	"github.com/lolopinto/ent/internal/schema/base"
 	"github.com/lolopinto/ent/internal/schema/testhelper"
 	"github.com/lolopinto/ent/internal/tsimport"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +30,6 @@ func TestDerivedFields(t *testing.T) {
 		});
 		export default Address`),
 		},
-		base.TypeScript,
 	)
 	info := schema.Nodes["AddressConfig"]
 	require.NotNil(t, info)
@@ -75,7 +73,6 @@ func TestDuplicateFields(t *testing.T) {
 		});
 		export default Address`),
 		},
-		base.TypeScript,
 	)
 
 	require.Error(t, err)
@@ -105,7 +102,6 @@ func TestDisableBuilderIDField(t *testing.T) {
 		});
 		export default Address`),
 		},
-		base.TypeScript,
 	)
 	info := schema.Nodes["AddressConfig"]
 	require.NotNil(t, info)
@@ -153,7 +149,6 @@ func TestUUIDFieldList(t *testing.T) {
 		});
 		export default ContactEmail`),
 		},
-		base.TypeScript,
 	)
 	info := schema.Nodes["ContactConfig"]
 	require.NotNil(t, info)
@@ -232,7 +227,6 @@ func TestNullableUUIDFieldList(t *testing.T) {
 		});
 		export default ContactEmail`),
 		},
-		base.TypeScript,
 	)
 	info := schema.Nodes["ContactConfig"]
 	require.NotNil(t, info)

--- a/internal/graphql/custom_ts_test.go
+++ b/internal/graphql/custom_ts_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/lolopinto/ent/internal/codegen"
 	"github.com/lolopinto/ent/internal/codepath"
-	"github.com/lolopinto/ent/internal/schema/base"
 	"github.com/lolopinto/ent/internal/schema/testhelper"
 	"github.com/lolopinto/ent/internal/tsimport"
 	"github.com/stretchr/testify/assert"
@@ -62,7 +61,7 @@ func TestCustomMutation(t *testing.T) {
 	defer os.RemoveAll(dirPath)
 	require.NoError(t, err)
 
-	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
+	schema := testhelper.ParseSchemaForTest(t, m, testhelper.TempDir(dirPath))
 	data := &codegen.Processor{
 		Schema: schema,
 		Config: getCodePath(t, dirPath),
@@ -194,7 +193,7 @@ func TestCustomQuery(t *testing.T) {
 	defer os.RemoveAll(dirPath)
 	require.NoError(t, err)
 
-	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
+	schema := testhelper.ParseSchemaForTest(t, m, testhelper.TempDir(dirPath))
 	data := &codegen.Processor{
 		Schema: schema,
 		Config: getCodePath(t, dirPath),
@@ -314,7 +313,7 @@ func TestCustomListQuery(t *testing.T) {
 	defer os.RemoveAll(dirPath)
 	require.NoError(t, err)
 
-	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
+	schema := testhelper.ParseSchemaForTest(t, m, testhelper.TempDir(dirPath))
 	data := &codegen.Processor{
 		Schema: schema,
 		Config: getCodePath(t, dirPath),
@@ -466,7 +465,7 @@ func TestCustomQueryReferencesExistingObject(t *testing.T) {
 	defer os.RemoveAll(dirPath)
 	require.NoError(t, err)
 
-	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
+	schema := testhelper.ParseSchemaForTest(t, m, testhelper.TempDir(dirPath))
 	data := &codegen.Processor{
 		Schema: schema,
 		Config: getCodePath(t, dirPath),
@@ -589,7 +588,7 @@ func TestCustomUploadType(t *testing.T) {
 	defer os.RemoveAll(dirPath)
 	require.NoError(t, err)
 
-	schema := testhelper.ParseSchemaForTest(t, m, base.TypeScript, testhelper.TempDir(dirPath))
+	schema := testhelper.ParseSchemaForTest(t, m, testhelper.TempDir(dirPath))
 	data := &codegen.Processor{
 		Schema: schema,
 		Config: getCodePath(t, dirPath),

--- a/internal/graphql/graphql_fields_test.go
+++ b/internal/graphql/graphql_fields_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/lolopinto/ent/internal/action"
 	"github.com/lolopinto/ent/internal/codegen"
-	"github.com/lolopinto/ent/internal/schema/base"
 	"github.com/lolopinto/ent/internal/schema/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,7 +47,6 @@ func TestActionWithFieldEdgeFieldConfig(t *testing.T) {
 				});
 				export default Profile`),
 		},
-		base.TypeScript,
 	)
 	processor, err := codegen.NewTestCodegenProcessor("src/schema", schema, &codegen.CodegenConfig{
 		DisableGraphQLRoot: true,

--- a/internal/schema/schema_constraints_test.go
+++ b/internal/schema/schema_constraints_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/lolopinto/ent/internal/schema"
-	"github.com/lolopinto/ent/internal/schema/base"
 	"github.com/lolopinto/ent/internal/schema/input"
 	"github.com/lolopinto/ent/internal/schema/testhelper"
 	"github.com/stretchr/testify/assert"
@@ -1330,11 +1329,7 @@ func testConstraints(
 	expectedMap map[string]*schema.NodeData,
 	expectedErr error,
 ) {
-	s, err := testhelper.ParseSchemaForTestFull(
-		t,
-		code,
-		base.TypeScript,
-	)
+	s, err := testhelper.ParseSchemaForTestFull(t, code)
 	if expectedErr != nil {
 		require.Error(t, err)
 		assert.Equal(t, err.Error(), expectedErr.Error())

--- a/internal/schema/schema_edge_test.go
+++ b/internal/schema/schema_edge_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/lolopinto/ent/ent"
 	"github.com/lolopinto/ent/internal/schema"
-	"github.com/lolopinto/ent/internal/schema/base"
 	"github.com/lolopinto/ent/internal/schema/testhelper"
 	"github.com/lolopinto/ent/internal/testingutils"
 	"github.com/lolopinto/ent/internal/testingutils/test_db"
@@ -111,7 +110,7 @@ func (suite *edgeTestSuite) TestInverseAssocEdgeAddedAfter() {
 	code := make(map[string]string)
 	code["account_schema.ts"] = getSourceForEdgeWithoutInverse(suite.T())
 
-	s := testhelper.ParseSchemaForTest(suite.T(), code, base.TypeScript)
+	s := testhelper.ParseSchemaForTest(suite.T(), code)
 	friendRequests := getEdgeFromSchema(suite.T(), s, "AccountConfig", "FriendRequests")
 
 	require.NotNil(
@@ -167,7 +166,7 @@ func (suite *edgeTestSuite) TestInverseAssocEdgeAddedAfter() {
 
 	code2 := make(map[string]string)
 	code2["account_schema.ts"] = getSourceForInverseAssocEdgeSameEnt(suite.T())
-	s2 := testhelper.ParseSchemaForTest(suite.T(), code2, base.TypeScript)
+	s2 := testhelper.ParseSchemaForTest(suite.T(), code2)
 	verifyInverseAssocEdgeSameEnt(suite.T(), s2)
 
 	// 1 new edge added. 2 edge total
@@ -178,7 +177,7 @@ func (suite *edgeTestSuite) TestInverseAssocEdgeSameEnt() {
 	code := make(map[string]string)
 	code["account_schema.ts"] = getSourceForInverseAssocEdgeSameEnt(suite.T())
 
-	s := testhelper.ParseSchemaForTest(suite.T(), code, base.TypeScript)
+	s := testhelper.ParseSchemaForTest(suite.T(), code)
 	verifyInverseAssocEdgeSameEnt(suite.T(), s)
 }
 
@@ -271,7 +270,7 @@ func getCodeForNewConstsAndEdges2(t *testing.T) map[string]string {
 
 func getSchemaForNewConstsAndEdges2(t *testing.T) *schema.Schema {
 	code := getCodeForNewConstsAndEdges2(t)
-	return testhelper.ParseSchemaForTest(t, code, base.TypeScript)
+	return testhelper.ParseSchemaForTest(t, code)
 }
 
 func verifyInverseAssocEdgeSameEnt(t *testing.T, s *schema.Schema) {
@@ -367,11 +366,7 @@ func getCodeForNewConstsAndEdges() map[string]string {
 
 func getSchemaForNewConstsAndEdges(t *testing.T) *schema.Schema {
 	code := getCodeForNewConstsAndEdges()
-	s, err := testhelper.ParseSchemaForTestFull(
-		t,
-		code,
-		base.TypeScript,
-	)
+	s, err := testhelper.ParseSchemaForTestFull(t, code)
 	require.Nil(t, err)
 	return s
 }

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestInverseFieldEdge(t *testing.T) {
-	s := testhelper.ParseSchemaForTestFixed(t,
+	s := testhelper.ParseSchemaForTest(t,
 		map[string]string{
 			"account_schema.ts": testhelper.GetCodeWithSchema(`
 			import {EntSchema, StringType} from "{schema}";
@@ -109,7 +109,7 @@ func TestInverseFieldEdge(t *testing.T) {
 }
 
 func TestForeignKey(t *testing.T) {
-	s := testhelper.ParseSchemaForTestFixed(t,
+	s := testhelper.ParseSchemaForTest(t,
 		map[string]string{
 			"account_schema.ts": testhelper.GetCodeWithSchema(`
 			import {EntSchema, StringType} from "{schema}";
@@ -158,7 +158,7 @@ func TestForeignKey(t *testing.T) {
 }
 
 func TestForeignKeyInvalidKeys(t *testing.T) {
-	_, err := testhelper.ParseSchemaForTestFullFixed(t,
+	_, err := testhelper.ParseSchemaForTestFull(t,
 		map[string]string{
 			"todo_schema.ts": testhelper.GetCodeWithSchema(`
 			import {EntSchema, StringType, UUIDType} from "{schema}";
@@ -182,7 +182,7 @@ func TestForeignKeyInvalidKeys(t *testing.T) {
 }
 
 func TestInverseAssocEdge(t *testing.T) {
-	s := testhelper.ParseSchemaForTestFixed(t,
+	s := testhelper.ParseSchemaForTest(t,
 		map[string]string{
 			"account_schema.ts": testhelper.GetCodeWithSchema(`
 			import {EntSchema, StringType} from "{schema}";
@@ -290,7 +290,7 @@ func TestInverseAssocEdge(t *testing.T) {
 }
 
 func TestEdgeGroup(t *testing.T) {
-	s := testhelper.ParseSchemaForTestFixed(t,
+	s := testhelper.ParseSchemaForTest(t,
 		map[string]string{
 			"account_schema.ts": testhelper.GetCodeWithSchema(`
 			import {EntSchema, StringType} from "{schema}";

--- a/internal/schema/testhelper/test_helper.go
+++ b/internal/schema/testhelper/test_helper.go
@@ -72,34 +72,21 @@ func ParseInputSchemaForTest(t *testing.T, code map[string]string, opts ...func(
 	return inputSchema
 }
 
-func ParseSchemaForTest(t *testing.T, code map[string]string, lang base.Language, opts ...func(*Options)) *schema.Schema {
-	s, err := ParseSchemaForTestFull(t, code, lang, opts...)
+func ParseSchemaForTest(t *testing.T, code map[string]string, opts ...func(*Options)) *schema.Schema {
+	s, err := ParseSchemaForTestFull(t, code, opts...)
 	require.NoError(t, err)
 
 	require.NotNil(t, s)
 	return s
 }
 
-func ParseSchemaForTestFixed(t *testing.T, code map[string]string, opts ...func(*Options)) *schema.Schema {
-	s, err := ParseSchemaForTestFull(t, code, base.TypeScript, opts...)
-	require.NoError(t, err)
-
-	require.NotNil(t, s)
-	return s
-}
-
-func ParseSchemaForTestFull(t *testing.T, code map[string]string, lang base.Language, opts ...func(*Options)) (*schema.Schema, error) {
-	inputSchema := ParseInputSchemaForTest(t, code, opts...)
-	return schema.ParseFromInputSchema(&codegenapi.DummyConfig{}, inputSchema, lang)
-}
-
-func ParseSchemaForTestFullFixed(t *testing.T, code map[string]string, opts ...func(*Options)) (*schema.Schema, error) {
+func ParseSchemaForTestFull(t *testing.T, code map[string]string, opts ...func(*Options)) (*schema.Schema, error) {
 	inputSchema := ParseInputSchemaForTest(t, code, opts...)
 	return schema.ParseFromInputSchema(&codegenapi.DummyConfig{}, inputSchema, base.TypeScript)
 }
 
-func ParseActionInfoForTest(t *testing.T, code map[string]string, lang base.Language, nodeName string) *action.ActionInfo {
-	schema := ParseSchemaForTest(t, code, lang)
+func ParseActionInfoForTest(t *testing.T, code map[string]string, nodeName string) *action.ActionInfo {
+	schema := ParseSchemaForTest(t, code)
 
 	info := schema.Nodes[nodeName]
 	require.NotNil(t, info)


### PR DESCRIPTION
not to include base.TypeScript. only current supported lang and this code is always TS anyways

so if we eventually add separate language, it should be different API