### PR TITLE
loadEdgeForID2 cleanup

### DIFF
--- a/ts/src/action/action.test.ts
+++ b/ts/src/action/action.test.ts
@@ -1,7 +1,5 @@
 import { User, BuilderSchema, SimpleBuilder } from "../testutils/builder";
 import { IDViewer, LoggedOutViewer } from "../core/viewer";
-import { Pool } from "pg";
-import { QueryRecorder } from "../testutils/db_mock";
 import { StringType, UUIDType, FieldMap } from "../schema";
 import { createRowForTest } from "../testutils/write";
 import {
@@ -28,55 +26,87 @@ import {
   assoc_edge_table,
   setupSqlite,
   table,
+  TempDB,
   text,
 } from "../testutils/db/temp_db";
 import DB, { Dialect } from "../core/db";
 import * as clause from "../core/clause";
 import { testEdgeGlobalSchema } from "../testutils/test_edge_global_schema";
+import { snakeCase } from "snake-case";
+import { v1 } from "uuid";
 
-jest.mock("pg");
-QueryRecorder.mockPool(Pool);
 const ml = new MockLogs();
-
-beforeEach(async () => {
-  // does assoc_edge_config loader need to be cleared?
-  await createEdgeRows(["edge"]);
-  QueryRecorder.clearQueries();
-  ml.clear();
-});
 
 afterEach(() => {
   assocEdgeLoader.clearAll();
 });
 
+function getTables(global = false) {
+  return [
+    table(
+      "users",
+      // uuid field goes here
+      text("id", { primaryKey: true }),
+      text("foo"),
+    ),
+    assoc_edge_config_table(),
+    assoc_edge_table("edge_table", global),
+    assoc_edge_table("edge1_table", global),
+    assoc_edge_table("edge2_table", global),
+    assoc_edge_table("edge3_table", global),
+  ];
+}
+
+function setupPostgresTables(tdb: TempDB, global = false) {
+  beforeAll(async () => {
+    for (const tbl of getTables(global)) {
+      await tdb.create(tbl);
+    }
+    await createEdgeRows(["edge1", "edge2", "edge3", "edge"]);
+    ml.clear();
+  });
+
+  afterAll(async () => {
+    await tdb.dropAll();
+  });
+
+  if (global) {
+    beforeAll(() => {
+      setGlobalSchema(testEdgeGlobalSchema);
+    });
+    afterAll(() => {
+      clearGlobalSchema();
+    });
+  }
+}
+
 describe("postgres", () => {
-  beforeAll(() => {
+  const tdb = new TempDB(Dialect.Postgres);
+
+  beforeAll(async () => {
+    await tdb.beforeAll();
     ml.mock();
     setLogLevels(["query", "error", "cache"]);
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    await tdb.afterAll();
     ml.restore();
   });
 
   afterEach(() => {
     ml.clear();
-    QueryRecorder.clear();
   });
 
   describe("with global schema", () => {
-    beforeAll(() => {
-      setGlobalSchema(testEdgeGlobalSchema);
-    });
-
-    afterAll(() => {
-      clearGlobalSchema();
-    });
+    setupPostgresTables(tdb, true);
 
     commonTests();
   });
 
   describe("without global schema", () => {
+    setupPostgresTables(tdb);
+
     commonTests();
   });
 });
@@ -87,29 +117,18 @@ describe("sqlite", () => {
     setLogLevels(["query", "error", "cache"]);
   });
 
-  afterAll(() => {
-    ml.restore();
-  });
-  afterEach(() => {
-    QueryRecorder.clear();
+  beforeEach(async () => {
+    await createEdgeRows(["edge", "edge1", "edge2", "edge3"]);
     ml.clear();
   });
 
-  function getTables(global = false) {
-    return [
-      table(
-        "users",
-        // uuid field goes here
-        text("id", { primaryKey: true }),
-        text("foo"),
-      ),
-      assoc_edge_config_table(),
-      assoc_edge_table("edge_table", global),
-      assoc_edge_table("edge1_table", global),
-      assoc_edge_table("edge2_table", global),
-      assoc_edge_table("edge3_table", global),
-    ];
-  }
+  afterAll(() => {
+    ml.restore();
+  });
+
+  afterEach(() => {
+    ml.clear();
+  });
 
   describe("with global schema", () => {
     beforeAll(() => {
@@ -212,7 +231,7 @@ async function createEdgeRows(edges: string[]) {
     await createRowForTest({
       tableName: "assoc_edge_config",
       fields: {
-        edge_table: `${edge}_table`,
+        edge_table: `${snakeCase(edge)}_table`,
         symmetric_edge: false,
         inverse_edge_type: null,
         edge_type: edge,
@@ -272,7 +291,7 @@ function commonTests() {
   test("new ent with edge", async () => {
     const date = new Date();
     const builder = getUserCreateBuilder();
-    const id2 = QueryRecorder.newID();
+    const id2 = v1();
     builder.orchestrator.addOutboundEdge(id2, "edge", "User", { time: date });
     await builder.saveX();
     let ent = await builder.editedEntX();
@@ -326,7 +345,7 @@ function commonTests() {
     ml.clear();
 
     const builder = getUserEditBuilder(user, new Map([["foo", "bar"]]));
-    const id2 = QueryRecorder.newID();
+    const id2 = v1();
 
     builder.orchestrator.addOutboundEdge(id2, "edge", "User", {
       time: date,
@@ -390,7 +409,9 @@ function commonTests() {
       expect(error.message).toMatch(/could not resolve placeholder value/);
     }
 
-    const id = QueryRecorder.getCurrentIDs()[0];
+    const data = await builder.orchestrator.getEditedData();
+    const id = data.id;
+
     expect(ml.logs[0].query).toMatch(/SELECT (.+) FROM assoc_edge_config/);
     expect(ml.logs[1]).toEqual(getInsertQuery(id));
     const selectQuery = getSelectQuery(id);
@@ -400,8 +421,6 @@ function commonTests() {
       expLength = 3;
     }
     expect(ml.logs.length).toEqual(expLength);
-
-    // TODO we don't log BEGIN, ROLLBACK, COMMIT... with the refactors
   });
 
   describe("setEdgeTypeInGroup", () => {
@@ -409,19 +428,18 @@ function commonTests() {
     let user1: User, user2: User;
     let m = new Map<string, string>();
 
-    beforeEach(async () => {
-      for (const edgeType of edgeTypes) {
-        m.set(edgeType + "Enum", edgeType);
-      }
+    for (const edgeType of edgeTypes) {
+      m.set(edgeType + "Enum", edgeType);
+    }
 
-      await createEdgeRows(edgeTypes);
+    beforeAll(async () => {
       [user1, user2] = await Promise.all([createUser(), createUser()]);
     });
 
     async function verifyEdges(edgeTypes: string[], edgeSet: string) {
       const edges = await Promise.all(
         edgeTypes.map(async (edgeType) => {
-          return await loadEdgeForID2({
+          return loadEdgeForID2({
             id1: user1.id,
             id2: user2.id,
             edgeType,

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -409,7 +409,7 @@ export class Orchestrator<
           ops.push(edgeOp);
           const edgeData = edgeDatas.get(edgeType);
           if (!edgeData) {
-            throw new Error(`could not load edge data for ${edgeType}`);
+            throw new Error(`could not load edge data for '${edgeType}'`);
           }
 
           if (edgeData.symmetricEdge) {

--- a/ts/src/core/ent.test.ts
+++ b/ts/src/core/ent.test.ts
@@ -153,7 +153,6 @@ function commonTests() {
   });
 
   test("getEdgeTypeInGroup different table", async () => {
-    // setLogLevels("query");
     const edgeTypes = ["edge1", "edge2", "edge3"];
     let m = new Map<string, string>();
     for (const edgeType of edgeTypes) {
@@ -175,7 +174,7 @@ function commonTests() {
     // TODO should be able to do empty map here
     const builder = getUserEditBuilder(user1, new Map([["foo", "bar2"]]));
 
-    // let's manually do edge1 and then we'll set separate edges...
+    // let's manually do edge1Group and then we'll set separate edges...
     builder.orchestrator.addOutboundEdge(user2.id, "edge1", user2.nodeType);
     await builder.saveX();
 
@@ -654,6 +653,7 @@ function getTempDB() {
 
   return sqliteTDB;
 }
+
 describe("postgres", () => {
   postgresTDB = new TempDB(Dialect.Postgres, getTables);
   commonTests();

--- a/ts/src/core/loaders/assoc_count_loader.ts
+++ b/ts/src/core/loaders/assoc_count_loader.ts
@@ -27,11 +27,7 @@ export class AssocEdgeCountLoader implements Loader<ID, number> {
     }
     const { cls } = getEdgeClauseAndFields(
       clause.Eq("edge_type", this.edgeType),
-      {
-        // don't need this..
-        id1: "1",
-        edgeType: this.edgeType,
-      },
+      {},
     );
 
     this.loader = createCountDataLoader({

--- a/ts/src/testutils/db/temp_db.ts
+++ b/ts/src/testutils/db/temp_db.ts
@@ -9,6 +9,8 @@ import { snakeCase } from "snake-case";
 import { BuilderSchema, getTableName } from "../builder";
 import { Ent } from "../../core/base";
 import { testEdgeGlobalSchema } from "../test_edge_global_schema";
+import { clearGlobalSchema, setGlobalSchema } from "../../core/ent";
+import { createRowForTest } from "../write";
 
 interface SchemaItem {
   name: string;
@@ -401,12 +403,6 @@ function randomDB(): string {
 
   // always ensure it starts with an alpha character
   return "abcdefghijklmnopqrstuvwxyz"[Math.floor(Math.random() * 26)] + str;
-}
-
-function isDialect(
-  dialect: Dialect | Table[] | CoreConcept[],
-): dialect is Dialect {
-  return !Array.isArray(dialect);
 }
 
 export class TempDB {

--- a/ts/src/testutils/db/temp_db.ts
+++ b/ts/src/testutils/db/temp_db.ts
@@ -9,8 +9,6 @@ import { snakeCase } from "snake-case";
 import { BuilderSchema, getTableName } from "../builder";
 import { Ent } from "../../core/base";
 import { testEdgeGlobalSchema } from "../test_edge_global_schema";
-import { clearGlobalSchema, setGlobalSchema } from "../../core/ent";
-import { createRowForTest } from "../write";
 
 interface SchemaItem {
   name: string;


### PR DESCRIPTION
noticed it was still fetching all edges (limit to 1000) instead of just fetching row for `id1-edge_type-id2`

eventually, we could have some smart logic to use the most recent edges if we have caching, caching is cheap and edge count below a number but we're not there yet so better to aim for accuracy here

also did some optimization to do only one query for `getEdgeTypeInGroup` when the edges are stored in the same table (default case)