### PR TITLE
fix graphql type for struct type for snake_case defaultGraphQLFieldFormat

### DIFF
--- a/examples/todo-sqlite/src/graphql/generated/resolvers/account_prefs_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/resolvers/account_prefs_type.ts
@@ -15,12 +15,33 @@ export const AccountPrefsType = new GraphQLObjectType({
   fields: (): GraphQLFieldConfigMap<AccountPrefs, RequestContext> => ({
     finished_nux: {
       type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: (
+        accountPrefs: AccountPrefs,
+        args: {},
+        context: RequestContext,
+      ) => {
+        return accountPrefs.finishedNux;
+      },
     },
     enable_notifs: {
       type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: (
+        accountPrefs: AccountPrefs,
+        args: {},
+        context: RequestContext,
+      ) => {
+        return accountPrefs.enableNotifs;
+      },
     },
     preferred_language: {
       type: new GraphQLNonNull(GraphQLString),
+      resolve: (
+        accountPrefs: AccountPrefs,
+        args: {},
+        context: RequestContext,
+      ) => {
+        return accountPrefs.preferredLanguage;
+      },
     },
   }),
 });

--- a/examples/todo-sqlite/src/graphql/tests/account.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/account.test.ts
@@ -54,5 +54,13 @@ test("create with prefs", async () => {
       },
     ],
     ["account.name", "Jon Snow"],
+    [
+      "account.account_prefs",
+      {
+        finished_nux: true,
+        enable_notifs: false,
+        preferred_language: "en_US",
+      },
+    ],
   );
 });

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -2647,10 +2647,15 @@ func buildCustomInterfaceNode(processor *codegen.Processor, ci *customtype.Custo
 	}
 
 	for _, f := range ci.Fields {
-		result.Fields = append(result.Fields, &fieldType{
+		ft := &fieldType{
 			Name:         f.GetGraphQLName(),
 			FieldImports: getGQLFileImports(f.GetTSGraphQLTypeForFieldImports(ciInfo.input), ciInfo.input),
-		})
+		}
+		if !ciInfo.input && f.FieldName != f.GetGraphQLName() {
+			ft.HasResolveFunction = true
+			ft.FunctionContents = []string{fmt.Sprintf("return %s.%s", strcase.ToLowerCamel(node), f.FieldName)}
+		}
+		result.Fields = append(result.Fields, ft)
 	}
 
 	for _, f := range ci.NonEntFields {


### PR DESCRIPTION
when `defaultGraphQLFieldFormat` = `snake-case`, trying to get the data from graphql leads to issues since graphql format is different from format returned by code

followup to https://github.com/lolopinto/ent/pull/1158 and https://github.com/lolopinto/ent/pull/1159