### PR TITLE
if we somehow only have graphql-only changes, flag as no db changes

### DIFF
--- a/internal/codegen/prompts.go
+++ b/internal/codegen/prompts.go
@@ -170,9 +170,13 @@ func getPromptsFromChanges(p *Processor) ([]prompt.Prompt, error) {
 		return nil, nil
 	}
 
+	allGraphQLOnly := true
 	var prompts []prompt.Prompt
 	for k, changes := range p.ChangeMap {
 		for _, c := range changes {
+			if !c.GraphQLOnly {
+				allGraphQLOnly = false
+			}
 			var pt prompt.Prompt
 			var err error
 
@@ -198,6 +202,12 @@ func getPromptsFromChanges(p *Processor) ([]prompt.Prompt, error) {
 				prompts = append(prompts, pt)
 			}
 		}
+	}
+
+	// somehow there were changes and they were all graphql only.
+	// flag as no db changes
+	if allGraphQLOnly {
+		p.noDBChanges = true
 	}
 
 	return prompts, nil


### PR DESCRIPTION
kinda followup to https://github.com/lolopinto/ent/pull/1232

even if we have a random bug like https://github.com/lolopinto/ent/pull/1232, should be smart about what happens