### PR TITLE
Use rome instead of prettier for formatting files

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - run: npm install -g ts-node prettier typescript@4.8.3 @swc/core @swc/cli jest
+      - run: npm install -g ts-node prettier typescript@4.8.3 @swc/core @swc/cli jest rome@10.0.1
       - run: |
           cd ts 
           npm ci

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,8 @@
     "DB_CONNECTION_STRING": "postgres://ola:@localhost/ent_test?sslmode=disable"
   },
   "go.testTimeout": "90s",
-  "prettier.configPath": "ts/.prettierrc"
+  "prettier.configPath": "ts/.prettierrc",
+  "prettier.ignorePath": "ts/.prettierignore"
   // "jest.pathToConfig": "jest.config.js",
   // // TODO need to figure out how to get vscode intellisense to understand all these paths
   // "jest.rootPath": "ts",

--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.3.0",
         "@sentry/tracing": "^6.3.0",
-        "@snowtop/ent": "^0.1.0-alpha93",
+        "@snowtop/ent": "^0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha2",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -67,7 +67,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -294,7 +293,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
       "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -326,7 +324,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -340,7 +337,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -352,7 +348,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -366,7 +361,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -374,14 +368,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -390,7 +382,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -399,7 +390,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1171,12 +1161,13 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha93",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha93.tgz",
-      "integrity": "sha512-jHYpvFju6TjqA8FU3y/hnPKIveyOhLSHUXUFEZtmXVaxWHD01VYs1ZA0fBd1QWqIzm1f8jmBx6H13ItExxG+ww==",
+      "version": "0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624.tgz",
+      "integrity": "sha512-kpoEIH1UtXdQ3JWCsbGNeOKNALos2VzYE+d89DxrA3g5AerYgPSsXQsdYD3Ize9kRXelCd3drWhi3LKrT4PzQA==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
+        "cosmiconfig": "^7.0.1",
         "dataloader": "^2.0.0",
         "glob": "^7.1.6",
         "graph-data-structure": "^1.12.0",
@@ -1557,6 +1548,11 @@
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/passport": {
       "version": "1.0.7",
@@ -2008,7 +2004,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2235,6 +2230,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2443,7 +2453,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3152,6 +3161,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -3205,8 +3237,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-core-module": {
       "version": "2.10.0",
@@ -3932,8 +3963,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3961,8 +3991,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -4049,8 +4078,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -4483,11 +4511,21 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -4593,6 +4631,14 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pause": {
       "version": "0.0.1",
@@ -5813,6 +5859,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.5.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
@@ -5882,7 +5936,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -6052,8 +6105,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
-      "dev": true
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
@@ -6076,7 +6128,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -6087,7 +6138,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -6096,7 +6146,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -6107,7 +6156,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -6115,26 +6163,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -6738,12 +6782,13 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha93",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha93.tgz",
-      "integrity": "sha512-jHYpvFju6TjqA8FU3y/hnPKIveyOhLSHUXUFEZtmXVaxWHD01VYs1ZA0fBd1QWqIzm1f8jmBx6H13ItExxG+ww==",
+      "version": "0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624.tgz",
+      "integrity": "sha512-kpoEIH1UtXdQ3JWCsbGNeOKNALos2VzYE+d89DxrA3g5AerYgPSsXQsdYD3Ize9kRXelCd3drWhi3LKrT4PzQA==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
+        "cosmiconfig": "^7.0.1",
         "dataloader": "^2.0.0",
         "glob": "^7.1.6",
         "graph-data-structure": "^1.12.0",
@@ -7096,6 +7141,11 @@
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/passport": {
       "version": "1.0.7",
@@ -7453,8 +7503,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camel-case": {
       "version": "4.1.2",
@@ -7622,6 +7671,18 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
+      }
+    },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
       }
     },
     "create-require": {
@@ -7793,7 +7854,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -8325,6 +8385,22 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
+      }
+    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -8363,8 +8439,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-core-module": {
       "version": "2.10.0",
@@ -8918,8 +8993,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -8938,8 +9012,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json5": {
       "version": "2.2.1",
@@ -9009,8 +9082,7 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "locate-path": {
       "version": "5.0.0",
@@ -9359,11 +9431,18 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -9443,6 +9522,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "pause": {
       "version": "0.0.1",
@@ -10302,6 +10386,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "^6.3.0",
     "@sentry/tracing": "^6.3.0",
-    "@snowtop/ent": "^0.1.0-alpha93",
+    "@snowtop/ent": "^0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha2",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/ent-rsvp/backend/src/ent/address/actions/create_address_action.ts
+++ b/examples/ent-rsvp/backend/src/ent/address/actions/create_address_action.ts
@@ -27,7 +27,10 @@ export default class CreateAddressAction extends CreateAddressActionBase {
           return (
             (this.input.ownerID as Builder<Ent>).placeholderID === undefined
           );
-        }, new AllowIfEntIsVisibleRule(this.input.ownerID as ID, getLoaderOptions(this.input.ownerType as unknown as NodeType))),
+        }, new AllowIfEntIsVisibleRule(
+          this.input.ownerID as ID,
+          getLoaderOptions(this.input.ownerType as unknown as NodeType),
+        )),
         AlwaysDenyRule,
       ],
     };

--- a/examples/ent-rsvp/backend/src/ent/generated/address/actions/create_address_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address/actions/create_address_action_base.ts
@@ -130,7 +130,10 @@ export class CreateAddressActionBase
   }
 
   static create<T extends CreateAddressActionBase>(
-    this: new (viewer: Viewer, input: AddressCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: AddressCreateInput,
+    ) => T,
     viewer: Viewer,
     input: AddressCreateInput,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/address/actions/delete_address_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address/actions/delete_address_action_base.ts
@@ -119,7 +119,10 @@ export class DeleteAddressActionBase
   }
 
   static create<T extends DeleteAddressActionBase>(
-    this: new (viewer: Viewer, address: Address) => T,
+    this: new (
+      viewer: Viewer,
+      address: Address,
+    ) => T,
     viewer: Viewer,
     address: Address,
   ): T {
@@ -127,7 +130,10 @@ export class DeleteAddressActionBase
   }
 
   static async saveXFromID<T extends DeleteAddressActionBase>(
-    this: new (viewer: Viewer, address: Address) => T,
+    this: new (
+      viewer: Viewer,
+      address: Address,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/ent-rsvp/backend/src/ent/generated/address/actions/edit_address_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address/actions/edit_address_action_base.ts
@@ -132,7 +132,11 @@ export class EditAddressActionBase
   }
 
   static create<T extends EditAddressActionBase>(
-    this: new (viewer: Viewer, address: Address, input: AddressEditInput) => T,
+    this: new (
+      viewer: Viewer,
+      address: Address,
+      input: AddressEditInput,
+    ) => T,
     viewer: Viewer,
     address: Address,
     input: AddressEditInput,
@@ -141,7 +145,11 @@ export class EditAddressActionBase
   }
 
   static async saveXFromID<T extends EditAddressActionBase>(
-    this: new (viewer: Viewer, address: Address, input: AddressEditInput) => T,
+    this: new (
+      viewer: Viewer,
+      address: Address,
+      input: AddressEditInput,
+    ) => T,
     viewer: Viewer,
     id: ID,
     input: AddressEditInput,

--- a/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
@@ -73,7 +73,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async load<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -85,7 +88,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadX<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -97,7 +103,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadMany<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -109,7 +118,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadCustom<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -124,7 +136,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadCustomData<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<AddressDBData[]> {
@@ -139,7 +154,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadCustomCount<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -153,7 +171,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadRawData<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AddressDBData | null> {
@@ -165,7 +186,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadRawDataX<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AddressDBData> {
@@ -177,7 +201,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadFromOwnerID<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ownerID: ID,
   ): Promise<T | null> {
@@ -188,7 +215,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadFromOwnerIDX<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ownerID: ID,
   ): Promise<T> {
@@ -199,7 +229,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadIDFromOwnerID<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     ownerID: ID,
     context?: Context,
   ): Promise<ID | undefined> {
@@ -208,7 +241,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static async loadRawDataFromOwnerID<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     ownerID: ID,
     context?: Context,
   ): Promise<AddressDBData | null> {
@@ -220,7 +256,10 @@ export class AddressBase implements Ent<Viewer> {
   }
 
   static loaderOptions<T extends AddressBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: addressLoaderInfo.tableName,

--- a/examples/ent-rsvp/backend/src/ent/generated/address_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_query_base.ts
@@ -45,7 +45,10 @@ export abstract class AddressToLocatedAtQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends AddressToLocatedAtQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Address, Ent<Viewer>>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Address, Ent<Viewer>>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Address, Ent<Viewer>>,
   ): T {
@@ -77,7 +80,10 @@ export class OwnerToAddressesQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends OwnerToAddressesQueryBase>(
-    this: new (viewer: Viewer, src: Ent<Viewer>) => T,
+    this: new (
+      viewer: Viewer,
+      src: Ent<Viewer>,
+    ) => T,
     viewer: Viewer,
     src: Ent<Viewer>,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
@@ -129,7 +129,10 @@ export class CreateAuthCodeActionBase
   }
 
   static create<T extends CreateAuthCodeActionBase>(
-    this: new (viewer: Viewer, input: AuthCodeCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: AuthCodeCreateInput,
+    ) => T,
     viewer: Viewer,
     input: AuthCodeCreateInput,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
@@ -63,7 +63,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async load<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -75,7 +78,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadX<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -87,7 +93,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadMany<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -99,7 +108,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadCustom<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -114,7 +126,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadCustomData<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<AuthCodeDBData[]> {
@@ -129,7 +144,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadCustomCount<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -143,7 +161,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadRawData<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AuthCodeDBData | null> {
@@ -155,7 +176,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadRawDataX<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AuthCodeDBData> {
@@ -167,7 +191,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadFromGuestID<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     guestID: ID,
   ): Promise<T | null> {
@@ -178,7 +205,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadFromGuestIDX<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     guestID: ID,
   ): Promise<T> {
@@ -189,7 +219,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadIDFromGuestID<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     guestID: ID,
     context?: Context,
   ): Promise<ID | undefined> {
@@ -198,7 +231,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static async loadRawDataFromGuestID<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     guestID: ID,
     context?: Context,
   ): Promise<AuthCodeDBData | null> {
@@ -210,7 +246,10 @@ export class AuthCodeBase implements Ent<Viewer> {
   }
 
   static loaderOptions<T extends AuthCodeBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: authCodeLoaderInfo.tableName,

--- a/examples/ent-rsvp/backend/src/ent/generated/event/actions/create_event_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event/actions/create_event_action_base.ts
@@ -143,7 +143,10 @@ export class CreateEventActionBase
   }
 
   static create<T extends CreateEventActionBase>(
-    this: new (viewer: Viewer, input: EventCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: EventCreateInput,
+    ) => T,
     viewer: Viewer,
     input: EventCreateInput,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/event/actions/delete_event_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event/actions/delete_event_action_base.ts
@@ -101,7 +101,10 @@ export class DeleteEventActionBase
   }
 
   static create<T extends DeleteEventActionBase>(
-    this: new (viewer: Viewer, event: Event) => T,
+    this: new (
+      viewer: Viewer,
+      event: Event,
+    ) => T,
     viewer: Viewer,
     event: Event,
   ): T {
@@ -109,7 +112,10 @@ export class DeleteEventActionBase
   }
 
   static async saveXFromID<T extends DeleteEventActionBase>(
-    this: new (viewer: Viewer, event: Event) => T,
+    this: new (
+      viewer: Viewer,
+      event: Event,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/create_event_activity_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/create_event_activity_action_base.ts
@@ -141,7 +141,10 @@ export class CreateEventActivityActionBase
   }
 
   static create<T extends CreateEventActivityActionBase>(
-    this: new (viewer: Viewer, input: EventActivityCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: EventActivityCreateInput,
+    ) => T,
     viewer: Viewer,
     input: EventActivityCreateInput,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/delete_event_activity_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/delete_event_activity_action_base.ts
@@ -122,7 +122,10 @@ export class DeleteEventActivityActionBase
   }
 
   static create<T extends DeleteEventActivityActionBase>(
-    this: new (viewer: Viewer, eventActivity: EventActivity) => T,
+    this: new (
+      viewer: Viewer,
+      eventActivity: EventActivity,
+    ) => T,
     viewer: Viewer,
     eventActivity: EventActivity,
   ): T {
@@ -130,7 +133,10 @@ export class DeleteEventActivityActionBase
   }
 
   static async saveXFromID<T extends DeleteEventActivityActionBase>(
-    this: new (viewer: Viewer, eventActivity: EventActivity) => T,
+    this: new (
+      viewer: Viewer,
+      eventActivity: EventActivity,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/event_activity_add_invite_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/event_activity_add_invite_action_base.ts
@@ -138,7 +138,10 @@ export class EventActivityAddInviteActionBase
   }
 
   static create<T extends EventActivityAddInviteActionBase>(
-    this: new (viewer: Viewer, eventActivity: EventActivity) => T,
+    this: new (
+      viewer: Viewer,
+      eventActivity: EventActivity,
+    ) => T,
     viewer: Viewer,
     eventActivity: EventActivity,
   ): T {
@@ -146,7 +149,10 @@ export class EventActivityAddInviteActionBase
   }
 
   static async saveXFromID<T extends EventActivityAddInviteActionBase>(
-    this: new (viewer: Viewer, eventActivity: EventActivity) => T,
+    this: new (
+      viewer: Viewer,
+      eventActivity: EventActivity,
+    ) => T,
     viewer: Viewer,
     id: ID,
     inviteID: ID,

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/event_activity_remove_invite_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/event_activity_remove_invite_action_base.ts
@@ -128,7 +128,10 @@ export class EventActivityRemoveInviteActionBase
   }
 
   static create<T extends EventActivityRemoveInviteActionBase>(
-    this: new (viewer: Viewer, eventActivity: EventActivity) => T,
+    this: new (
+      viewer: Viewer,
+      eventActivity: EventActivity,
+    ) => T,
     viewer: Viewer,
     eventActivity: EventActivity,
   ): T {
@@ -136,7 +139,10 @@ export class EventActivityRemoveInviteActionBase
   }
 
   static async saveXFromID<T extends EventActivityRemoveInviteActionBase>(
-    this: new (viewer: Viewer, eventActivity: EventActivity) => T,
+    this: new (
+      viewer: Viewer,
+      eventActivity: EventActivity,
+    ) => T,
     viewer: Viewer,
     id: ID,
     inviteID: ID,

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
@@ -94,7 +94,10 @@ export class EventActivityBase
   }
 
   static async load<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -106,7 +109,10 @@ export class EventActivityBase
   }
 
   static async loadX<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -118,7 +124,10 @@ export class EventActivityBase
   }
 
   static async loadMany<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -130,7 +139,10 @@ export class EventActivityBase
   }
 
   static async loadCustom<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -145,7 +157,10 @@ export class EventActivityBase
   }
 
   static async loadCustomData<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<EventActivityDBData[]> {
@@ -160,7 +175,10 @@ export class EventActivityBase
   }
 
   static async loadCustomCount<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -174,7 +192,10 @@ export class EventActivityBase
   }
 
   static async loadRawData<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<EventActivityDBData | null> {
@@ -186,7 +207,10 @@ export class EventActivityBase
   }
 
   static async loadRawDataX<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<EventActivityDBData> {
@@ -198,7 +222,10 @@ export class EventActivityBase
   }
 
   static loaderOptions<T extends EventActivityBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: eventActivityLoaderInfo.tableName,

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity_query_base.ts
@@ -65,7 +65,10 @@ export abstract class EventActivityToAttendingQueryBase extends AssocEdgeQueryBa
   }
 
   static query<T extends EventActivityToAttendingQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<EventActivity, Guest>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<EventActivity, Guest>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<EventActivity, Guest>,
   ): T {
@@ -105,7 +108,10 @@ export abstract class EventActivityToDeclinedQueryBase extends AssocEdgeQueryBas
   }
 
   static query<T extends EventActivityToDeclinedQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<EventActivity, Guest>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<EventActivity, Guest>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<EventActivity, Guest>,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
@@ -67,7 +67,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async load<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -79,7 +82,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadX<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -91,7 +97,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadMany<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -103,7 +112,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadCustom<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -118,7 +130,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadCustomData<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<EventDBData[]> {
@@ -133,7 +148,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadCustomCount<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -147,7 +165,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadRawData<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<EventDBData | null> {
@@ -159,7 +180,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadRawDataX<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<EventDBData> {
@@ -171,7 +195,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadFromSlug<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     slug: string,
   ): Promise<T | null> {
@@ -182,7 +209,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadFromSlugX<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     slug: string,
   ): Promise<T> {
@@ -193,7 +223,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadIDFromSlug<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     slug: string,
     context?: Context,
   ): Promise<ID | undefined> {
@@ -202,7 +235,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static async loadRawDataFromSlug<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     slug: string,
     context?: Context,
   ): Promise<EventDBData | null> {
@@ -214,7 +250,10 @@ export class EventBase implements Ent<Viewer> {
   }
 
   static loaderOptions<T extends EventBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: eventLoaderInfo.tableName,

--- a/examples/ent-rsvp/backend/src/ent/generated/event_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_query_base.ts
@@ -25,7 +25,10 @@ export class EventToEventActivitiesQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends EventToEventActivitiesQueryBase>(
-    this: new (viewer: Viewer, src: Event | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: Event | ID,
+    ) => T,
     viewer: Viewer,
     src: Event | ID,
   ): T {
@@ -53,7 +56,10 @@ export class EventToGuestDataQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends EventToGuestDataQueryBase>(
-    this: new (viewer: Viewer, src: Event | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: Event | ID,
+    ) => T,
     viewer: Viewer,
     src: Event | ID,
   ): T {
@@ -81,7 +87,10 @@ export class EventToGuestGroupsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends EventToGuestGroupsQueryBase>(
-    this: new (viewer: Viewer, src: Event | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: Event | ID,
+    ) => T,
     viewer: Viewer,
     src: Event | ID,
   ): T {
@@ -109,7 +118,10 @@ export class EventToGuestsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends EventToGuestsQueryBase>(
-    this: new (viewer: Viewer, src: Event | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: Event | ID,
+    ) => T,
     viewer: Viewer,
     src: Event | ID,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/guest/actions/create_guest_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest/actions/create_guest_action_base.ts
@@ -128,7 +128,10 @@ export class CreateGuestActionBase
   }
 
   static create<T extends CreateGuestActionBase>(
-    this: new (viewer: Viewer, input: GuestCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: GuestCreateInput,
+    ) => T,
     viewer: Viewer,
     input: GuestCreateInput,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/guest/actions/delete_guest_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest/actions/delete_guest_action_base.ts
@@ -101,7 +101,10 @@ export class DeleteGuestActionBase
   }
 
   static create<T extends DeleteGuestActionBase>(
-    this: new (viewer: Viewer, guest: Guest) => T,
+    this: new (
+      viewer: Viewer,
+      guest: Guest,
+    ) => T,
     viewer: Viewer,
     guest: Guest,
   ): T {
@@ -109,7 +112,10 @@ export class DeleteGuestActionBase
   }
 
   static async saveXFromID<T extends DeleteGuestActionBase>(
-    this: new (viewer: Viewer, guest: Guest) => T,
+    this: new (
+      viewer: Viewer,
+      guest: Guest,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/ent-rsvp/backend/src/ent/generated/guest/actions/edit_guest_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest/actions/edit_guest_action_base.ts
@@ -125,7 +125,11 @@ export class EditGuestActionBase
   }
 
   static create<T extends EditGuestActionBase>(
-    this: new (viewer: Viewer, guest: Guest, input: GuestEditInput) => T,
+    this: new (
+      viewer: Viewer,
+      guest: Guest,
+      input: GuestEditInput,
+    ) => T,
     viewer: Viewer,
     guest: Guest,
     input: GuestEditInput,
@@ -134,7 +138,11 @@ export class EditGuestActionBase
   }
 
   static async saveXFromID<T extends EditGuestActionBase>(
-    this: new (viewer: Viewer, guest: Guest, input: GuestEditInput) => T,
+    this: new (
+      viewer: Viewer,
+      guest: Guest,
+      input: GuestEditInput,
+    ) => T,
     viewer: Viewer,
     id: ID,
     input: GuestEditInput,

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
@@ -77,7 +77,10 @@ export class GuestBase
   }
 
   static async load<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -89,7 +92,10 @@ export class GuestBase
   }
 
   static async loadX<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -101,7 +107,10 @@ export class GuestBase
   }
 
   static async loadMany<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -113,7 +122,10 @@ export class GuestBase
   }
 
   static async loadCustom<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -128,7 +140,10 @@ export class GuestBase
   }
 
   static async loadCustomData<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<GuestDBData[]> {
@@ -143,7 +158,10 @@ export class GuestBase
   }
 
   static async loadCustomCount<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -157,7 +175,10 @@ export class GuestBase
   }
 
   static async loadRawData<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<GuestDBData | null> {
@@ -169,7 +190,10 @@ export class GuestBase
   }
 
   static async loadRawDataX<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<GuestDBData> {
@@ -181,7 +205,10 @@ export class GuestBase
   }
 
   static loaderOptions<T extends GuestBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: guestLoaderInfo.tableName,

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_data/actions/create_guest_data_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_data/actions/create_guest_data_action_base.ts
@@ -129,7 +129,10 @@ export class CreateGuestDataActionBase
   }
 
   static create<T extends CreateGuestDataActionBase>(
-    this: new (viewer: Viewer, input: GuestDataCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: GuestDataCreateInput,
+    ) => T,
     viewer: Viewer,
     input: GuestDataCreateInput,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_data/actions/delete_guest_data_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_data/actions/delete_guest_data_action_base.ts
@@ -119,7 +119,10 @@ export class DeleteGuestDataActionBase
   }
 
   static create<T extends DeleteGuestDataActionBase>(
-    this: new (viewer: Viewer, guestData: GuestData) => T,
+    this: new (
+      viewer: Viewer,
+      guestData: GuestData,
+    ) => T,
     viewer: Viewer,
     guestData: GuestData,
   ): T {
@@ -127,7 +130,10 @@ export class DeleteGuestDataActionBase
   }
 
   static async saveXFromID<T extends DeleteGuestDataActionBase>(
-    this: new (viewer: Viewer, guestData: GuestData) => T,
+    this: new (
+      viewer: Viewer,
+      guestData: GuestData,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
@@ -65,7 +65,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static async load<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -77,7 +80,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static async loadX<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -89,7 +95,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static async loadMany<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -101,7 +110,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static async loadCustom<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -116,7 +128,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static async loadCustomData<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<GuestDataDBData[]> {
@@ -131,7 +146,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static async loadCustomCount<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -145,7 +163,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static async loadRawData<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<GuestDataDBData | null> {
@@ -157,7 +178,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static async loadRawDataX<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<GuestDataDBData> {
@@ -169,7 +193,10 @@ export class GuestDataBase implements Ent<Viewer> {
   }
 
   static loaderOptions<T extends GuestDataBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: guestDataLoaderInfo.tableName,

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group/actions/create_guest_group_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group/actions/create_guest_group_action_base.ts
@@ -134,7 +134,10 @@ export class CreateGuestGroupActionBase
   }
 
   static create<T extends CreateGuestGroupActionBase>(
-    this: new (viewer: Viewer, input: GuestGroupCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: GuestGroupCreateInput,
+    ) => T,
     viewer: Viewer,
     input: GuestGroupCreateInput,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group/actions/delete_guest_group_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group/actions/delete_guest_group_action_base.ts
@@ -119,7 +119,10 @@ export class DeleteGuestGroupActionBase
   }
 
   static create<T extends DeleteGuestGroupActionBase>(
-    this: new (viewer: Viewer, guestGroup: GuestGroup) => T,
+    this: new (
+      viewer: Viewer,
+      guestGroup: GuestGroup,
+    ) => T,
     viewer: Viewer,
     guestGroup: GuestGroup,
   ): T {
@@ -127,7 +130,10 @@ export class DeleteGuestGroupActionBase
   }
 
   static async saveXFromID<T extends DeleteGuestGroupActionBase>(
-    this: new (viewer: Viewer, guestGroup: GuestGroup) => T,
+    this: new (
+      viewer: Viewer,
+      guestGroup: GuestGroup,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
@@ -59,7 +59,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static async load<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -71,7 +74,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static async loadX<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -83,7 +89,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static async loadMany<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -95,7 +104,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static async loadCustom<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -110,7 +122,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static async loadCustomData<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<GuestGroupDBData[]> {
@@ -125,7 +140,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static async loadCustomCount<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -139,7 +157,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static async loadRawData<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<GuestGroupDBData | null> {
@@ -151,7 +172,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static async loadRawDataX<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<GuestGroupDBData> {
@@ -163,7 +187,10 @@ export class GuestGroupBase implements Ent<Viewer> {
   }
 
   static loaderOptions<T extends GuestGroupBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: guestGroupLoaderInfo.tableName,

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group_query_base.ts
@@ -91,7 +91,10 @@ export class GuestGroupToGuestsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends GuestGroupToGuestsQueryBase>(
-    this: new (viewer: Viewer, src: GuestGroup | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: GuestGroup | ID,
+    ) => T,
     viewer: Viewer,
     src: GuestGroup | ID,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_query_base.ts
@@ -58,7 +58,10 @@ export abstract class GuestToAttendingEventsQueryBase extends AssocEdgeQueryBase
   }
 
   static query<T extends GuestToAttendingEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Guest, EventActivity>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Guest, EventActivity>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Guest, EventActivity>,
   ): T {
@@ -102,7 +105,10 @@ export abstract class GuestToDeclinedEventsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends GuestToDeclinedEventsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Guest, EventActivity>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Guest, EventActivity>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Guest, EventActivity>,
   ): T {
@@ -142,7 +148,10 @@ export class GuestToAuthCodesQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends GuestToAuthCodesQueryBase>(
-    this: new (viewer: Viewer, src: Guest | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: Guest | ID,
+    ) => T,
     viewer: Viewer,
     src: Guest | ID,
   ): T {
@@ -170,7 +179,10 @@ export class GuestToGuestDataQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends GuestToGuestDataQueryBase>(
-    this: new (viewer: Viewer, src: Guest | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: Guest | ID,
+    ) => T,
     viewer: Viewer,
     src: Guest | ID,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/user/actions/create_user_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/user/actions/create_user_action_base.ts
@@ -124,7 +124,10 @@ export class CreateUserActionBase
   }
 
   static create<T extends CreateUserActionBase>(
-    this: new (viewer: Viewer, input: UserCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: UserCreateInput,
+    ) => T,
     viewer: Viewer,
     input: UserCreateInput,
   ): T {

--- a/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
@@ -63,7 +63,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async load<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -75,7 +78,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadX<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -87,7 +93,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadMany<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -99,7 +108,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadCustom<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -114,7 +126,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadCustomData<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<UserDBData[]> {
@@ -129,7 +144,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadCustomCount<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -143,7 +161,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadRawData<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<UserDBData | null> {
@@ -155,7 +176,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadRawDataX<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<UserDBData> {
@@ -167,7 +191,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadFromEmailAddress<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     emailAddress: string,
   ): Promise<T | null> {
@@ -178,7 +205,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadFromEmailAddressX<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     emailAddress: string,
   ): Promise<T> {
@@ -189,7 +219,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadIDFromEmailAddress<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     emailAddress: string,
     context?: Context,
   ): Promise<ID | undefined> {
@@ -200,7 +233,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static async loadRawDataFromEmailAddress<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     emailAddress: string,
     context?: Context,
   ): Promise<UserDBData | null> {
@@ -214,7 +250,10 @@ export class UserBase implements Ent<Viewer> {
   }
 
   static loaderOptions<T extends UserBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: userLoaderInfo.tableName,

--- a/examples/ent-rsvp/backend/src/ent/generated/user_query_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/user_query_base.ts
@@ -19,7 +19,10 @@ export class UserToEventsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends UserToEventsQueryBase>(
-    this: new (viewer: Viewer, src: User | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: User | ID,
+    ) => T,
     viewer: Viewer,
     src: User | ID,
   ): T {

--- a/examples/simple/.prettierignore
+++ b/examples/simple/.prettierignore
@@ -1,0 +1,2 @@
+src/ent/generated
+src/graphql/generated

--- a/examples/simple/src/ent/generated/address/actions/create_address_action_base.ts
+++ b/examples/simple/src/ent/generated/address/actions/create_address_action_base.ts
@@ -129,7 +129,10 @@ export class CreateAddressActionBase
   }
 
   static create<T extends CreateAddressActionBase>(
-    this: new (viewer: ExampleViewerAlias, input: AddressCreateInput) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      input: AddressCreateInput,
+    ) => T,
     viewer: ExampleViewerAlias,
     input: AddressCreateInput,
   ): T {

--- a/examples/simple/src/ent/generated/address_base.ts
+++ b/examples/simple/src/ent/generated/address_base.ts
@@ -66,7 +66,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static async load<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -78,7 +81,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadX<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -90,7 +96,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadMany<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -102,7 +111,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustom<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -117,7 +129,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustomData<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<AddressDBData[]> {
@@ -132,7 +147,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustomCount<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -146,7 +164,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadRawData<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AddressDBData | null> {
@@ -158,7 +179,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadRawDataX<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AddressDBData> {
@@ -170,7 +194,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
   }
 
   static loaderOptions<T extends AddressBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: addressLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/create_auth_code_action_base.ts
@@ -132,7 +132,10 @@ export class CreateAuthCodeActionBase
   }
 
   static create<T extends CreateAuthCodeActionBase>(
-    this: new (viewer: ExampleViewerAlias, input: AuthCodeCreateInput) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      input: AuthCodeCreateInput,
+    ) => T,
     viewer: ExampleViewerAlias,
     input: AuthCodeCreateInput,
   ): T {

--- a/examples/simple/src/ent/generated/auth_code/actions/delete_auth_code_action_base.ts
+++ b/examples/simple/src/ent/generated/auth_code/actions/delete_auth_code_action_base.ts
@@ -119,7 +119,10 @@ export class DeleteAuthCodeActionBase
   }
 
   static create<T extends DeleteAuthCodeActionBase>(
-    this: new (viewer: ExampleViewerAlias, authCode: AuthCode) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      authCode: AuthCode,
+    ) => T,
     viewer: ExampleViewerAlias,
     authCode: AuthCode,
   ): T {
@@ -127,7 +130,10 @@ export class DeleteAuthCodeActionBase
   }
 
   static async saveXFromID<T extends DeleteAuthCodeActionBase>(
-    this: new (viewer: ExampleViewerAlias, authCode: AuthCode) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      authCode: AuthCode,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<void> {

--- a/examples/simple/src/ent/generated/auth_code_base.ts
+++ b/examples/simple/src/ent/generated/auth_code_base.ts
@@ -60,7 +60,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static async load<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -72,7 +75,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadX<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -84,7 +90,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadMany<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -96,7 +105,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustom<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -111,7 +123,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustomData<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<AuthCodeDBData[]> {
@@ -126,7 +141,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustomCount<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -140,7 +158,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadRawData<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AuthCodeDBData | null> {
@@ -152,7 +173,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadRawDataX<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AuthCodeDBData> {
@@ -164,7 +188,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
   }
 
   static loaderOptions<T extends AuthCodeBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: authCodeLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/comment/actions/create_comment_action_base.ts
+++ b/examples/simple/src/ent/generated/comment/actions/create_comment_action_base.ts
@@ -132,7 +132,10 @@ export class CreateCommentActionBase
   }
 
   static create<T extends CreateCommentActionBase>(
-    this: new (viewer: ExampleViewerAlias, input: CommentCreateInput) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      input: CommentCreateInput,
+    ) => T,
     viewer: ExampleViewerAlias,
     input: CommentCreateInput,
   ): T {

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -72,7 +72,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static async load<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -84,7 +87,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadX<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -96,7 +102,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadMany<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -108,7 +117,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustom<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -123,7 +135,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustomData<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<CommentDBData[]> {
@@ -138,7 +153,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustomCount<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -152,7 +170,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadRawData<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<CommentDBData | null> {
@@ -164,7 +185,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadRawDataX<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<CommentDBData> {
@@ -176,7 +200,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static queryFromArticle<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ent: Ent<ExampleViewerAlias>,
   ): ArticleToCommentsQuery {
@@ -184,7 +211,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
   }
 
   static loaderOptions<T extends CommentBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: commentLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/comment_query_base.ts
+++ b/examples/simple/src/ent/generated/comment_query_base.ts
@@ -79,7 +79,10 @@ export class ArticleToCommentsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends ArticleToCommentsQueryBase>(
-    this: new (viewer: ExampleViewerAlias, src: Ent<ExampleViewerAlias>) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      src: Ent<ExampleViewerAlias>,
+    ) => T,
     viewer: ExampleViewerAlias,
     src: Ent<ExampleViewerAlias>,
   ): T {
@@ -111,7 +114,10 @@ export class StickerToCommentsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends StickerToCommentsQueryBase>(
-    this: new (viewer: ExampleViewerAlias, src: Ent<ExampleViewerAlias>) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      src: Ent<ExampleViewerAlias>,
+    ) => T,
     viewer: ExampleViewerAlias,
     src: Ent<ExampleViewerAlias>,
   ): T {

--- a/examples/simple/src/ent/generated/contact/actions/create_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/create_contact_action_base.ts
@@ -142,7 +142,10 @@ export class CreateContactActionBase
   }
 
   static create<T extends CreateContactActionBase>(
-    this: new (viewer: ExampleViewerAlias, input: ContactCreateInput) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      input: ContactCreateInput,
+    ) => T,
     viewer: ExampleViewerAlias,
     input: ContactCreateInput,
   ): T {

--- a/examples/simple/src/ent/generated/contact/actions/delete_contact_action_base.ts
+++ b/examples/simple/src/ent/generated/contact/actions/delete_contact_action_base.ts
@@ -119,7 +119,10 @@ export class DeleteContactActionBase
   }
 
   static create<T extends DeleteContactActionBase>(
-    this: new (viewer: ExampleViewerAlias, contact: Contact) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      contact: Contact,
+    ) => T,
     viewer: ExampleViewerAlias,
     contact: Contact,
   ): T {
@@ -127,7 +130,10 @@ export class DeleteContactActionBase
   }
 
   static async saveXFromID<T extends DeleteContactActionBase>(
-    this: new (viewer: ExampleViewerAlias, contact: Contact) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      contact: Contact,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<void> {

--- a/examples/simple/src/ent/generated/contact_base.ts
+++ b/examples/simple/src/ent/generated/contact_base.ts
@@ -77,7 +77,10 @@ export class ContactBase
   }
 
   static async load<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -89,7 +92,10 @@ export class ContactBase
   }
 
   static async loadX<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -101,7 +107,10 @@ export class ContactBase
   }
 
   static async loadMany<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -113,7 +122,10 @@ export class ContactBase
   }
 
   static async loadCustom<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -128,7 +140,10 @@ export class ContactBase
   }
 
   static async loadCustomData<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<ContactDBData[]> {
@@ -143,7 +158,10 @@ export class ContactBase
   }
 
   static async loadCustomCount<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -157,7 +175,10 @@ export class ContactBase
   }
 
   static async loadRawData<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<ContactDBData | null> {
@@ -169,7 +190,10 @@ export class ContactBase
   }
 
   static async loadRawDataX<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<ContactDBData> {
@@ -181,7 +205,10 @@ export class ContactBase
   }
 
   static loaderOptions<T extends ContactBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: contactLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/contact_email/actions/create_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/create_contact_email_action_base.ts
@@ -133,7 +133,10 @@ export class CreateContactEmailActionBase
   }
 
   static create<T extends CreateContactEmailActionBase>(
-    this: new (viewer: ExampleViewerAlias, input: ContactEmailCreateInput) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      input: ContactEmailCreateInput,
+    ) => T,
     viewer: ExampleViewerAlias,
     input: ContactEmailCreateInput,
   ): T {

--- a/examples/simple/src/ent/generated/contact_email/actions/delete_contact_email_action_base.ts
+++ b/examples/simple/src/ent/generated/contact_email/actions/delete_contact_email_action_base.ts
@@ -122,7 +122,10 @@ export class DeleteContactEmailActionBase
   }
 
   static create<T extends DeleteContactEmailActionBase>(
-    this: new (viewer: ExampleViewerAlias, contactEmail: ContactEmail) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      contactEmail: ContactEmail,
+    ) => T,
     viewer: ExampleViewerAlias,
     contactEmail: ContactEmail,
   ): T {
@@ -130,7 +133,10 @@ export class DeleteContactEmailActionBase
   }
 
   static async saveXFromID<T extends DeleteContactEmailActionBase>(
-    this: new (viewer: ExampleViewerAlias, contactEmail: ContactEmail) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      contactEmail: ContactEmail,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<void> {

--- a/examples/simple/src/ent/generated/contact_email_base.ts
+++ b/examples/simple/src/ent/generated/contact_email_base.ts
@@ -64,7 +64,10 @@ export class ContactEmailBase
   }
 
   static async load<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -76,7 +79,10 @@ export class ContactEmailBase
   }
 
   static async loadX<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -88,7 +94,10 @@ export class ContactEmailBase
   }
 
   static async loadMany<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -100,7 +109,10 @@ export class ContactEmailBase
   }
 
   static async loadCustom<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -115,7 +127,10 @@ export class ContactEmailBase
   }
 
   static async loadCustomData<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<ContactEmailDBData[]> {
@@ -130,7 +145,10 @@ export class ContactEmailBase
   }
 
   static async loadCustomCount<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -144,7 +162,10 @@ export class ContactEmailBase
   }
 
   static async loadRawData<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<ContactEmailDBData | null> {
@@ -156,7 +177,10 @@ export class ContactEmailBase
   }
 
   static async loadRawDataX<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<ContactEmailDBData> {
@@ -168,7 +192,10 @@ export class ContactEmailBase
   }
 
   static loaderOptions<T extends ContactEmailBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: contactEmailLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/contact_phone_number_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number_base.ts
@@ -67,7 +67,10 @@ export class ContactPhoneNumberBase
   }
 
   static async load<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -79,7 +82,10 @@ export class ContactPhoneNumberBase
   }
 
   static async loadX<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -91,7 +97,10 @@ export class ContactPhoneNumberBase
   }
 
   static async loadMany<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -103,7 +112,10 @@ export class ContactPhoneNumberBase
   }
 
   static async loadCustom<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -118,7 +130,10 @@ export class ContactPhoneNumberBase
   }
 
   static async loadCustomData<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<ContactPhoneNumberDBData[]> {
@@ -133,7 +148,10 @@ export class ContactPhoneNumberBase
   }
 
   static async loadCustomCount<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -147,7 +165,10 @@ export class ContactPhoneNumberBase
   }
 
   static async loadRawData<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<ContactPhoneNumberDBData | null> {
@@ -159,7 +180,10 @@ export class ContactPhoneNumberBase
   }
 
   static async loadRawDataX<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<ContactPhoneNumberDBData> {
@@ -171,7 +195,10 @@ export class ContactPhoneNumberBase
   }
 
   static loaderOptions<T extends ContactPhoneNumberBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: contactPhoneNumberLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/event/actions/create_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/create_event_action_base.ts
@@ -131,7 +131,10 @@ export class CreateEventActionBase
   }
 
   static create<T extends CreateEventActionBase>(
-    this: new (viewer: ExampleViewerAlias, input: EventCreateInput) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      input: EventCreateInput,
+    ) => T,
     viewer: ExampleViewerAlias,
     input: EventCreateInput,
   ): T {

--- a/examples/simple/src/ent/generated/event/actions/delete_event_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/delete_event_action_base.ts
@@ -119,7 +119,10 @@ export class DeleteEventActionBase
   }
 
   static create<T extends DeleteEventActionBase>(
-    this: new (viewer: ExampleViewerAlias, event: Event) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      event: Event,
+    ) => T,
     viewer: ExampleViewerAlias,
     event: Event,
   ): T {
@@ -127,7 +130,10 @@ export class DeleteEventActionBase
   }
 
   static async saveXFromID<T extends DeleteEventActionBase>(
-    this: new (viewer: ExampleViewerAlias, event: Event) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      event: Event,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<void> {

--- a/examples/simple/src/ent/generated/event/actions/event_add_host_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_add_host_action_base.ts
@@ -132,7 +132,10 @@ export class EventAddHostActionBase
   }
 
   static create<T extends EventAddHostActionBase>(
-    this: new (viewer: ExampleViewerAlias, event: Event) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      event: Event,
+    ) => T,
     viewer: ExampleViewerAlias,
     event: Event,
   ): T {
@@ -140,7 +143,10 @@ export class EventAddHostActionBase
   }
 
   static async saveXFromID<T extends EventAddHostActionBase>(
-    this: new (viewer: ExampleViewerAlias, event: Event) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      event: Event,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
     hostID: ID,

--- a/examples/simple/src/ent/generated/event/actions/event_remove_host_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/event_remove_host_action_base.ts
@@ -125,7 +125,10 @@ export class EventRemoveHostActionBase
   }
 
   static create<T extends EventRemoveHostActionBase>(
-    this: new (viewer: ExampleViewerAlias, event: Event) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      event: Event,
+    ) => T,
     viewer: ExampleViewerAlias,
     event: Event,
   ): T {
@@ -133,7 +136,10 @@ export class EventRemoveHostActionBase
   }
 
   static async saveXFromID<T extends EventRemoveHostActionBase>(
-    this: new (viewer: ExampleViewerAlias, event: Event) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      event: Event,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
     hostID: ID,

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -98,7 +98,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static async load<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -110,7 +113,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadX<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -122,7 +128,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadMany<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -134,7 +143,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustom<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -149,7 +161,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustomData<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<EventDBData[]> {
@@ -164,7 +179,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadCustomCount<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -178,7 +196,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadRawData<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<EventDBData | null> {
@@ -190,7 +211,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static async loadRawDataX<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<EventDBData> {
@@ -202,7 +226,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
   }
 
   static loaderOptions<T extends EventBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: eventLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/holiday/actions/create_holiday_action_base.ts
+++ b/examples/simple/src/ent/generated/holiday/actions/create_holiday_action_base.ts
@@ -127,7 +127,10 @@ export class CreateHolidayActionBase
   }
 
   static create<T extends CreateHolidayActionBase>(
-    this: new (viewer: ExampleViewerAlias, input: HolidayCreateInput) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      input: HolidayCreateInput,
+    ) => T,
     viewer: ExampleViewerAlias,
     input: HolidayCreateInput,
   ): T {

--- a/examples/simple/src/ent/generated/holiday_base.ts
+++ b/examples/simple/src/ent/generated/holiday_base.ts
@@ -67,7 +67,10 @@ export class HolidayBase
   }
 
   static async load<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -79,7 +82,10 @@ export class HolidayBase
   }
 
   static async loadX<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -91,7 +97,10 @@ export class HolidayBase
   }
 
   static async loadMany<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -103,7 +112,10 @@ export class HolidayBase
   }
 
   static async loadCustom<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -118,7 +130,10 @@ export class HolidayBase
   }
 
   static async loadCustomData<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<HolidayDBData[]> {
@@ -133,7 +148,10 @@ export class HolidayBase
   }
 
   static async loadCustomCount<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -147,7 +165,10 @@ export class HolidayBase
   }
 
   static async loadRawData<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<HolidayDBData | null> {
@@ -159,7 +180,10 @@ export class HolidayBase
   }
 
   static async loadRawDataX<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<HolidayDBData> {
@@ -171,7 +195,10 @@ export class HolidayBase
   }
 
   static loaderOptions<T extends HolidayBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: holidayLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/hours_of_operation_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation_base.ts
@@ -67,7 +67,10 @@ export class HoursOfOperationBase
   }
 
   static async load<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -79,7 +82,10 @@ export class HoursOfOperationBase
   }
 
   static async loadX<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -91,7 +97,10 @@ export class HoursOfOperationBase
   }
 
   static async loadMany<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -103,7 +112,10 @@ export class HoursOfOperationBase
   }
 
   static async loadCustom<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -118,7 +130,10 @@ export class HoursOfOperationBase
   }
 
   static async loadCustomData<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<HoursOfOperationDBData[]> {
@@ -133,7 +148,10 @@ export class HoursOfOperationBase
   }
 
   static async loadCustomCount<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -147,7 +165,10 @@ export class HoursOfOperationBase
   }
 
   static async loadRawData<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<HoursOfOperationDBData | null> {
@@ -159,7 +180,10 @@ export class HoursOfOperationBase
   }
 
   static async loadRawDataX<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<HoursOfOperationDBData> {
@@ -171,7 +195,10 @@ export class HoursOfOperationBase
   }
 
   static loaderOptions<T extends HoursOfOperationBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: hoursOfOperationLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/mixins/feedback/actions/feedback_builder.ts
+++ b/examples/simple/src/ent/generated/mixins/feedback/actions/feedback_builder.ts
@@ -7,7 +7,9 @@ import { AssocEdgeInputOptions, Ent, ID } from "@snowtop/ent";
 import { Builder, Orchestrator } from "@snowtop/ent/action";
 import { EdgeType, NodeType } from "../../../const";
 import { Comment, IFeedback, User } from "../../../../internal";
-import { ExampleViewer as ExampleViewerAlias } from "../../../../../viewer/viewer";
+import {
+  ExampleViewer as ExampleViewerAlias,
+} from "../../../../../viewer/viewer";
 
 interface IEntWithFeedback extends Ent<ExampleViewerAlias>, IFeedback {}
 

--- a/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
@@ -145,7 +145,10 @@ export class CreateUserActionBase
   }
 
   static create<T extends CreateUserActionBase>(
-    this: new (viewer: ExampleViewerAlias, input: UserCreateInput) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      input: UserCreateInput,
+    ) => T,
     viewer: ExampleViewerAlias,
     input: UserCreateInput,
   ): T {

--- a/examples/simple/src/ent/generated/user/actions/delete_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/delete_user_action_base.ts
@@ -119,7 +119,10 @@ export class DeleteUserActionBase
   }
 
   static create<T extends DeleteUserActionBase>(
-    this: new (viewer: ExampleViewerAlias, user: User) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      user: User,
+    ) => T,
     viewer: ExampleViewerAlias,
     user: User,
   ): T {
@@ -127,7 +130,10 @@ export class DeleteUserActionBase
   }
 
   static async saveXFromID<T extends DeleteUserActionBase>(
-    this: new (viewer: ExampleViewerAlias, user: User) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      user: User,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<void> {

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -272,7 +272,10 @@ export class UserBase
   }
 
   static async load<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T | null> {
@@ -284,7 +287,10 @@ export class UserBase
   }
 
   static async loadX<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     id: ID,
   ): Promise<T> {
@@ -296,7 +302,10 @@ export class UserBase
   }
 
   static async loadMany<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -308,7 +317,10 @@ export class UserBase
   }
 
   static async loadCustom<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -323,7 +335,10 @@ export class UserBase
   }
 
   static async loadCustomData<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<UserDBData[]> {
@@ -338,7 +353,10 @@ export class UserBase
   }
 
   static async loadCustomCount<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -352,7 +370,10 @@ export class UserBase
   }
 
   static async loadRawData<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<UserDBData | null> {
@@ -364,7 +385,10 @@ export class UserBase
   }
 
   static async loadRawDataX<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<UserDBData> {
@@ -376,7 +400,10 @@ export class UserBase
   }
 
   static async loadFromEmailAddress<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     emailAddress: string,
   ): Promise<T | null> {
@@ -387,7 +414,10 @@ export class UserBase
   }
 
   static async loadFromEmailAddressX<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     emailAddress: string,
   ): Promise<T> {
@@ -398,7 +428,10 @@ export class UserBase
   }
 
   static async loadIDFromEmailAddress<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     emailAddress: string,
     context?: Context,
   ): Promise<ID | undefined> {
@@ -409,7 +442,10 @@ export class UserBase
   }
 
   static async loadRawDataFromEmailAddress<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     emailAddress: string,
     context?: Context,
   ): Promise<UserDBData | null> {
@@ -423,7 +459,10 @@ export class UserBase
   }
 
   static async loadFromPhoneNumber<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     phoneNumber: string,
   ): Promise<T | null> {
@@ -434,7 +473,10 @@ export class UserBase
   }
 
   static async loadFromPhoneNumberX<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     viewer: ExampleViewerAlias,
     phoneNumber: string,
   ): Promise<T> {
@@ -445,7 +487,10 @@ export class UserBase
   }
 
   static async loadIDFromPhoneNumber<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     phoneNumber: string,
     context?: Context,
   ): Promise<ID | undefined> {
@@ -456,7 +501,10 @@ export class UserBase
   }
 
   static async loadRawDataFromPhoneNumber<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
     phoneNumber: string,
     context?: Context,
   ): Promise<UserDBData | null> {
@@ -470,7 +518,10 @@ export class UserBase
   }
 
   static loaderOptions<T extends UserBase>(
-    this: new (viewer: ExampleViewerAlias, data: Data) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, ExampleViewerAlias> {
     return {
       tableName: userLoaderInfo.tableName,

--- a/examples/simple/src/ent/generated/user_query_base.ts
+++ b/examples/simple/src/ent/generated/user_query_base.ts
@@ -619,7 +619,10 @@ export class UserToAuthCodesQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends UserToAuthCodesQueryBase>(
-    this: new (viewer: ExampleViewerAlias, src: User | ID) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      src: User | ID,
+    ) => T,
     viewer: ExampleViewerAlias,
     src: User | ID,
   ): T {
@@ -647,7 +650,10 @@ export class UserToContactsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends UserToContactsQueryBase>(
-    this: new (viewer: ExampleViewerAlias, src: User | ID) => T,
+    this: new (
+      viewer: ExampleViewerAlias,
+      src: User | ID,
+    ) => T,
     viewer: ExampleViewerAlias,
     src: User | ID,
   ): T {

--- a/examples/simple/src/graphql/generated/resolvers/user_super_nested_object_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/user_super_nested_object_type.ts
@@ -161,7 +161,13 @@ const RabbitTypeType = new GraphQLObjectType({
 
 const PetUnionTypeType = new GraphQLUnionType({
   name: "PetUnionType",
-  types: [CatTypeType, DogTypeType, RabbitTypeType],
+  types: [
+    CatTypeType,
+
+    DogTypeType,
+
+    RabbitTypeType,
+  ],
 });
 
 export const UserSuperNestedObjectType = new GraphQLObjectType({

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha93",
+        "@snowtop/ent": "^0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
         "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
         "@snowtop/ent-soft-delete": "^0.1.0-alpha4",
         "@types/node": "^15.0.3",
@@ -48,7 +48,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
       "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.14.5"
       },
@@ -313,7 +312,6 @@
       "version": "7.14.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
       "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -345,7 +343,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
       "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
@@ -359,7 +356,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -371,7 +367,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -385,7 +380,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -393,14 +387,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -409,7 +401,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -418,7 +409,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1321,12 +1311,13 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha93",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha93.tgz",
-      "integrity": "sha512-jHYpvFju6TjqA8FU3y/hnPKIveyOhLSHUXUFEZtmXVaxWHD01VYs1ZA0fBd1QWqIzm1f8jmBx6H13ItExxG+ww==",
+      "version": "0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624.tgz",
+      "integrity": "sha512-kpoEIH1UtXdQ3JWCsbGNeOKNALos2VzYE+d89DxrA3g5AerYgPSsXQsdYD3Ize9kRXelCd3drWhi3LKrT4PzQA==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
+        "cosmiconfig": "^7.0.1",
         "dataloader": "^2.0.0",
         "glob": "^7.1.6",
         "graph-data-structure": "^1.12.0",
@@ -1587,6 +1578,11 @@
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
@@ -2031,7 +2027,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2290,6 +2285,21 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2478,7 +2488,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3118,6 +3127,29 @@
         }
       ]
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -3176,8 +3208,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-core-module": {
       "version": "2.9.0",
@@ -4526,8 +4557,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4555,8 +4585,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -4595,8 +4624,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5039,11 +5067,21 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -5110,6 +5148,14 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pg": {
       "version": "8.8.0",
@@ -6442,6 +6488,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.5.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
@@ -6524,7 +6578,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
       "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.14.5"
       }
@@ -6723,8 +6776,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.14.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
-      "dev": true
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
@@ -6747,7 +6799,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
       "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
@@ -6758,7 +6809,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -6767,7 +6817,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -6778,7 +6827,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -6786,26 +6834,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7512,12 +7556,13 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha93",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha93.tgz",
-      "integrity": "sha512-jHYpvFju6TjqA8FU3y/hnPKIveyOhLSHUXUFEZtmXVaxWHD01VYs1ZA0fBd1QWqIzm1f8jmBx6H13ItExxG+ww==",
+      "version": "0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624.tgz",
+      "integrity": "sha512-kpoEIH1UtXdQ3JWCsbGNeOKNALos2VzYE+d89DxrA3g5AerYgPSsXQsdYD3Ize9kRXelCd3drWhi3LKrT4PzQA==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
+        "cosmiconfig": "^7.0.1",
         "dataloader": "^2.0.0",
         "glob": "^7.1.6",
         "graph-data-structure": "^1.12.0",
@@ -7750,6 +7795,11 @@
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/pg": {
       "version": "8.6.1",
@@ -8102,8 +8152,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camel-case": {
       "version": "4.1.2",
@@ -8302,6 +8351,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -8451,7 +8512,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -8939,6 +8999,22 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
+      }
+    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -8982,8 +9058,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-core-module": {
       "version": "2.9.0",
@@ -10020,8 +10095,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -10040,8 +10114,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json5": {
       "version": "2.2.1",
@@ -10068,8 +10141,7 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "locate-path": {
       "version": "5.0.0",
@@ -10412,11 +10484,18 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -10465,6 +10544,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "pg": {
       "version": "8.8.0",
@@ -11435,6 +11519,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -36,7 +36,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha93",
+    "@snowtop/ent": "^0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
     "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
     "@snowtop/ent-soft-delete": "^0.1.0-alpha4",
     "@types/node": "^15.0.3",

--- a/examples/todo-sqlite/src/ent/generated/account/actions/create_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account/actions/create_account_action_base.ts
@@ -127,7 +127,10 @@ export class CreateAccountActionBase
   }
 
   static create<T extends CreateAccountActionBase>(
-    this: new (viewer: Viewer, input: AccountCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: AccountCreateInput,
+    ) => T,
     viewer: Viewer,
     input: AccountCreateInput,
   ): T {

--- a/examples/todo-sqlite/src/ent/generated/account/actions/delete_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account/actions/delete_account_action_base.ts
@@ -129,7 +129,10 @@ export class DeleteAccountActionBase
   }
 
   static create<T extends DeleteAccountActionBase>(
-    this: new (viewer: Viewer, account: Account) => T,
+    this: new (
+      viewer: Viewer,
+      account: Account,
+    ) => T,
     viewer: Viewer,
     account: Account,
   ): T {
@@ -137,7 +140,10 @@ export class DeleteAccountActionBase
   }
 
   static async saveXFromID<T extends DeleteAccountActionBase>(
-    this: new (viewer: Viewer, account: Account) => T,
+    this: new (
+      viewer: Viewer,
+      account: Account,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/todo-sqlite/src/ent/generated/account/actions/edit_account_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account/actions/edit_account_action_base.ts
@@ -130,7 +130,11 @@ export class EditAccountActionBase
   }
 
   static create<T extends EditAccountActionBase>(
-    this: new (viewer: Viewer, account: Account, input: AccountEditInput) => T,
+    this: new (
+      viewer: Viewer,
+      account: Account,
+      input: AccountEditInput,
+    ) => T,
     viewer: Viewer,
     account: Account,
     input: AccountEditInput,
@@ -139,7 +143,11 @@ export class EditAccountActionBase
   }
 
   static async saveXFromID<T extends EditAccountActionBase>(
-    this: new (viewer: Viewer, account: Account, input: AccountEditInput) => T,
+    this: new (
+      viewer: Viewer,
+      account: Account,
+      input: AccountEditInput,
+    ) => T,
     viewer: Viewer,
     id: ID,
     input: AccountEditInput,

--- a/examples/todo-sqlite/src/ent/generated/account_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_base.ts
@@ -117,7 +117,10 @@ export class AccountBase
   }
 
   static async load<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -129,7 +132,10 @@ export class AccountBase
   }
 
   static async loadX<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -145,7 +151,10 @@ export class AccountBase
   // we don't generate the full complement of read-APIs
   // but can easily query the raw data with accountNoTransformLoader
   static async loadNoTransform<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -158,7 +167,10 @@ export class AccountBase
   }
 
   static async loadNoTransformX<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -170,7 +182,10 @@ export class AccountBase
   }
 
   static async loadMany<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -182,7 +197,10 @@ export class AccountBase
   }
 
   static async loadCustom<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -197,7 +215,10 @@ export class AccountBase
   }
 
   static async loadCustomData<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<AccountDBData[]> {
@@ -212,7 +233,10 @@ export class AccountBase
   }
 
   static async loadCustomCount<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -226,7 +250,10 @@ export class AccountBase
   }
 
   static async loadRawData<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AccountDBData | null> {
@@ -238,7 +265,10 @@ export class AccountBase
   }
 
   static async loadRawDataX<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<AccountDBData> {
@@ -250,7 +280,10 @@ export class AccountBase
   }
 
   static async loadFromPhoneNumber<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     phoneNumber: string,
   ): Promise<T | null> {
@@ -261,7 +294,10 @@ export class AccountBase
   }
 
   static async loadFromPhoneNumberX<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     phoneNumber: string,
   ): Promise<T> {
@@ -272,7 +308,10 @@ export class AccountBase
   }
 
   static async loadIDFromPhoneNumber<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     phoneNumber: string,
     context?: Context,
   ): Promise<ID | undefined> {
@@ -283,7 +322,10 @@ export class AccountBase
   }
 
   static async loadRawDataFromPhoneNumber<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     phoneNumber: string,
     context?: Context,
   ): Promise<AccountDBData | null> {
@@ -297,7 +339,10 @@ export class AccountBase
   }
 
   static loaderOptions<T extends AccountBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: accountLoaderInfo.tableName,

--- a/examples/todo-sqlite/src/ent/generated/account_query_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_query_base.ts
@@ -73,7 +73,10 @@ export abstract class AccountToClosedTodosDupQueryBase extends AssocEdgeQueryBas
   }
 
   static query<T extends AccountToClosedTodosDupQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Account, Todo>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Account, Todo>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Account, Todo>,
   ): T {
@@ -113,7 +116,10 @@ export abstract class AccountToCreatedWorkspacesQueryBase extends AssocEdgeQuery
   }
 
   static query<T extends AccountToCreatedWorkspacesQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Account, Workspace>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Account, Workspace>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Account, Workspace>,
   ): T {
@@ -150,7 +156,10 @@ export abstract class AccountToOpenTodosDupQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends AccountToOpenTodosDupQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Account, Todo>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Account, Todo>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Account, Todo>,
   ): T {
@@ -190,7 +199,10 @@ export abstract class AccountToWorkspacesQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends AccountToWorkspacesQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Account, Workspace>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Account, Workspace>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Account, Workspace>,
   ): T {
@@ -226,7 +238,10 @@ export class AccountToTagsQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends AccountToTagsQueryBase>(
-    this: new (viewer: Viewer, src: Account | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: Account | ID,
+    ) => T,
     viewer: Viewer,
     src: Account | ID,
   ): T {
@@ -254,7 +269,10 @@ export class AccountToTodosQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends AccountToTodosQueryBase>(
-    this: new (viewer: Viewer, src: Account | ID) => T,
+    this: new (
+      viewer: Viewer,
+      src: Account | ID,
+    ) => T,
     viewer: Viewer,
     src: Account | ID,
   ): T {

--- a/examples/todo-sqlite/src/ent/generated/patterns/todo_container_query_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/patterns/todo_container_query_base.ts
@@ -43,7 +43,10 @@ export abstract class ObjectToScopedTodosQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends ObjectToScopedTodosQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Ent<Viewer>, Todo>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Ent<Viewer>, Todo>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Ent<Viewer>, Todo>,
   ): T {

--- a/examples/todo-sqlite/src/ent/generated/tag/actions/create_tag_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag/actions/create_tag_action_base.ts
@@ -126,7 +126,10 @@ export class CreateTagActionBase
   }
 
   static create<T extends CreateTagActionBase>(
-    this: new (viewer: Viewer, input: TagCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: TagCreateInput,
+    ) => T,
     viewer: Viewer,
     input: TagCreateInput,
   ): T {

--- a/examples/todo-sqlite/src/ent/generated/tag_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_base.ts
@@ -67,7 +67,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async load<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -79,7 +82,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async loadX<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -91,7 +97,10 @@ export class TagBase implements Ent<Viewer> {
   // we don't generate the full complement of read-APIs
   // but can easily query the raw data with tagNoTransformLoader
   static async loadNoTransform<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -104,7 +113,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async loadNoTransformX<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -116,7 +128,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async loadMany<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -128,7 +143,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async loadCustom<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -143,7 +161,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async loadCustomData<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<TagDBData[]> {
@@ -158,7 +179,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async loadCustomCount<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -172,7 +196,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async loadRawData<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<TagDBData | null> {
@@ -184,7 +211,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static async loadRawDataX<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<TagDBData> {
@@ -196,7 +226,10 @@ export class TagBase implements Ent<Viewer> {
   }
 
   static loaderOptions<T extends TagBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: tagLoaderInfo.tableName,

--- a/examples/todo-sqlite/src/ent/generated/tag_query_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_query_base.ts
@@ -42,7 +42,10 @@ export abstract class TagToTodosQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends TagToTodosQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Tag, Todo>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Tag, Todo>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Tag, Todo>,
   ): T {

--- a/examples/todo-sqlite/src/ent/generated/todo/actions/change_todo_status_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo/actions/change_todo_status_action_base.ts
@@ -124,7 +124,11 @@ export class ChangeTodoStatusActionBase
   }
 
   static create<T extends ChangeTodoStatusActionBase>(
-    this: new (viewer: Viewer, todo: Todo, input: ChangeTodoStatusInput) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+      input: ChangeTodoStatusInput,
+    ) => T,
     viewer: Viewer,
     todo: Todo,
     input: ChangeTodoStatusInput,
@@ -133,7 +137,11 @@ export class ChangeTodoStatusActionBase
   }
 
   static async saveXFromID<T extends ChangeTodoStatusActionBase>(
-    this: new (viewer: Viewer, todo: Todo, input: ChangeTodoStatusInput) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+      input: ChangeTodoStatusInput,
+    ) => T,
     viewer: Viewer,
     id: ID,
     input: ChangeTodoStatusInput,

--- a/examples/todo-sqlite/src/ent/generated/todo/actions/create_todo_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo/actions/create_todo_action_base.ts
@@ -127,7 +127,10 @@ export class CreateTodoActionBase
   }
 
   static create<T extends CreateTodoActionBase>(
-    this: new (viewer: Viewer, input: TodoCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: TodoCreateInput,
+    ) => T,
     viewer: Viewer,
     input: TodoCreateInput,
   ): T {

--- a/examples/todo-sqlite/src/ent/generated/todo/actions/delete_todo_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo/actions/delete_todo_action_base.ts
@@ -42,8 +42,7 @@ export type DeleteTodoActionValidators = Validator<
 >[];
 
 export class DeleteTodoActionBase
-  implements
-    Action<Todo, TodoBuilder<TodoInput, Todo>, Viewer, TodoInput, Todo>
+  implements Action<Todo, TodoBuilder<TodoInput, Todo>, Viewer, TodoInput, Todo>
 {
   public readonly builder: TodoBuilder<TodoInput, Todo>;
   public readonly viewer: Viewer;
@@ -111,7 +110,10 @@ export class DeleteTodoActionBase
   }
 
   static create<T extends DeleteTodoActionBase>(
-    this: new (viewer: Viewer, todo: Todo) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+    ) => T,
     viewer: Viewer,
     todo: Todo,
   ): T {
@@ -119,7 +121,10 @@ export class DeleteTodoActionBase
   }
 
   static async saveXFromID<T extends DeleteTodoActionBase>(
-    this: new (viewer: Viewer, todo: Todo) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/todo-sqlite/src/ent/generated/todo/actions/rename_todo_status_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo/actions/rename_todo_status_action_base.ts
@@ -125,7 +125,11 @@ export class RenameTodoStatusActionBase
   }
 
   static create<T extends RenameTodoStatusActionBase>(
-    this: new (viewer: Viewer, todo: Todo, input: RenameTodoInput) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+      input: RenameTodoInput,
+    ) => T,
     viewer: Viewer,
     todo: Todo,
     input: RenameTodoInput,
@@ -134,7 +138,11 @@ export class RenameTodoStatusActionBase
   }
 
   static async saveXFromID<T extends RenameTodoStatusActionBase>(
-    this: new (viewer: Viewer, todo: Todo, input: RenameTodoInput) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+      input: RenameTodoInput,
+    ) => T,
     viewer: Viewer,
     id: ID,
     input: RenameTodoInput,

--- a/examples/todo-sqlite/src/ent/generated/todo/actions/todo_add_tag_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo/actions/todo_add_tag_action_base.ts
@@ -44,8 +44,7 @@ export type TodoAddTagActionValidators = Validator<
 >[];
 
 export class TodoAddTagActionBase
-  implements
-    Action<Todo, TodoBuilder<TodoInput, Todo>, Viewer, TodoInput, Todo>
+  implements Action<Todo, TodoBuilder<TodoInput, Todo>, Viewer, TodoInput, Todo>
 {
   public readonly builder: TodoBuilder<TodoInput, Todo>;
   public readonly viewer: Viewer;
@@ -114,7 +113,10 @@ export class TodoAddTagActionBase
   }
 
   static create<T extends TodoAddTagActionBase>(
-    this: new (viewer: Viewer, todo: Todo) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+    ) => T,
     viewer: Viewer,
     todo: Todo,
   ): T {
@@ -122,7 +124,10 @@ export class TodoAddTagActionBase
   }
 
   static async saveXFromID<T extends TodoAddTagActionBase>(
-    this: new (viewer: Viewer, todo: Todo) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+    ) => T,
     viewer: Viewer,
     id: ID,
     tagID: ID,

--- a/examples/todo-sqlite/src/ent/generated/todo/actions/todo_remove_tag_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo/actions/todo_remove_tag_action_base.ts
@@ -42,8 +42,7 @@ export type TodoRemoveTagActionValidators = Validator<
 >[];
 
 export class TodoRemoveTagActionBase
-  implements
-    Action<Todo, TodoBuilder<TodoInput, Todo>, Viewer, TodoInput, Todo>
+  implements Action<Todo, TodoBuilder<TodoInput, Todo>, Viewer, TodoInput, Todo>
 {
   public readonly builder: TodoBuilder<TodoInput, Todo>;
   public readonly viewer: Viewer;
@@ -107,7 +106,10 @@ export class TodoRemoveTagActionBase
   }
 
   static create<T extends TodoRemoveTagActionBase>(
-    this: new (viewer: Viewer, todo: Todo) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+    ) => T,
     viewer: Viewer,
     todo: Todo,
   ): T {
@@ -115,7 +117,10 @@ export class TodoRemoveTagActionBase
   }
 
   static async saveXFromID<T extends TodoRemoveTagActionBase>(
-    this: new (viewer: Viewer, todo: Todo) => T,
+    this: new (
+      viewer: Viewer,
+      todo: Todo,
+    ) => T,
     viewer: Viewer,
     id: ID,
     tagID: ID,

--- a/examples/todo-sqlite/src/ent/generated/todo_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_base.ts
@@ -82,7 +82,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async load<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -94,7 +97,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async loadX<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -110,7 +116,10 @@ export class TodoBase implements Ent<Viewer> {
   // we don't generate the full complement of read-APIs
   // but can easily query the raw data with todoNoTransformLoader
   static async loadNoTransform<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -123,7 +132,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async loadNoTransformX<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -135,7 +147,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async loadMany<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -147,7 +162,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async loadCustom<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -162,7 +180,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async loadCustomData<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<TodoDBData[]> {
@@ -177,7 +198,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async loadCustomCount<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -191,7 +215,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async loadRawData<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<TodoDBData | null> {
@@ -203,7 +230,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static async loadRawDataX<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<TodoDBData> {
@@ -215,7 +245,10 @@ export class TodoBase implements Ent<Viewer> {
   }
 
   static loaderOptions<T extends TodoBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: todoLoaderInfo.tableName,

--- a/examples/todo-sqlite/src/ent/generated/todo_query_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_query_base.ts
@@ -53,7 +53,10 @@ export abstract class TodoToTagsQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends TodoToTagsQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Todo, Tag>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Todo, Tag>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Todo, Tag>,
   ): T {
@@ -86,7 +89,10 @@ export abstract class TodoToTodoScopeQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends TodoToTodoScopeQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Todo, Ent<Viewer>>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Todo, Ent<Viewer>>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Todo, Ent<Viewer>>,
   ): T {
@@ -118,7 +124,10 @@ export class ScopeToTodosQueryBase extends CustomEdgeQueryBase<
   }
 
   static query<T extends ScopeToTodosQueryBase>(
-    this: new (viewer: Viewer, src: Ent<Viewer>) => T,
+    this: new (
+      viewer: Viewer,
+      src: Ent<Viewer>,
+    ) => T,
     viewer: Viewer,
     src: Ent<Viewer>,
   ): T {

--- a/examples/todo-sqlite/src/ent/generated/workspace/actions/create_workspace_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace/actions/create_workspace_action_base.ts
@@ -125,7 +125,10 @@ export class CreateWorkspaceActionBase
   }
 
   static create<T extends CreateWorkspaceActionBase>(
-    this: new (viewer: Viewer, input: WorkspaceCreateInput) => T,
+    this: new (
+      viewer: Viewer,
+      input: WorkspaceCreateInput,
+    ) => T,
     viewer: Viewer,
     input: WorkspaceCreateInput,
   ): T {

--- a/examples/todo-sqlite/src/ent/generated/workspace/actions/delete_workspace_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace/actions/delete_workspace_action_base.ts
@@ -129,7 +129,10 @@ export class DeleteWorkspaceActionBase
   }
 
   static create<T extends DeleteWorkspaceActionBase>(
-    this: new (viewer: Viewer, workspace: Workspace) => T,
+    this: new (
+      viewer: Viewer,
+      workspace: Workspace,
+    ) => T,
     viewer: Viewer,
     workspace: Workspace,
   ): T {
@@ -137,7 +140,10 @@ export class DeleteWorkspaceActionBase
   }
 
   static async saveXFromID<T extends DeleteWorkspaceActionBase>(
-    this: new (viewer: Viewer, workspace: Workspace) => T,
+    this: new (
+      viewer: Viewer,
+      workspace: Workspace,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<void> {

--- a/examples/todo-sqlite/src/ent/generated/workspace_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace_base.ts
@@ -81,7 +81,10 @@ export class WorkspaceBase
   }
 
   static async load<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -93,7 +96,10 @@ export class WorkspaceBase
   }
 
   static async loadX<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -109,7 +115,10 @@ export class WorkspaceBase
   // we don't generate the full complement of read-APIs
   // but can easily query the raw data with workspaceNoTransformLoader
   static async loadNoTransform<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T | null> {
@@ -122,7 +131,10 @@ export class WorkspaceBase
   }
 
   static async loadNoTransformX<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     id: ID,
   ): Promise<T> {
@@ -134,7 +146,10 @@ export class WorkspaceBase
   }
 
   static async loadMany<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     ...ids: ID[]
   ): Promise<Map<ID, T>> {
@@ -146,7 +161,10 @@ export class WorkspaceBase
   }
 
   static async loadCustom<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     query: CustomQuery,
   ): Promise<T[]> {
@@ -161,7 +179,10 @@ export class WorkspaceBase
   }
 
   static async loadCustomData<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<WorkspaceDBData[]> {
@@ -176,7 +197,10 @@ export class WorkspaceBase
   }
 
   static async loadCustomCount<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     query: CustomQuery,
     context?: Context,
   ): Promise<number> {
@@ -190,7 +214,10 @@ export class WorkspaceBase
   }
 
   static async loadRawData<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<WorkspaceDBData | null> {
@@ -202,7 +229,10 @@ export class WorkspaceBase
   }
 
   static async loadRawDataX<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     id: ID,
     context?: Context,
   ): Promise<WorkspaceDBData> {
@@ -214,7 +244,10 @@ export class WorkspaceBase
   }
 
   static async loadFromSlug<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     slug: string,
   ): Promise<T | null> {
@@ -225,7 +258,10 @@ export class WorkspaceBase
   }
 
   static async loadFromSlugX<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     viewer: Viewer,
     slug: string,
   ): Promise<T> {
@@ -236,7 +272,10 @@ export class WorkspaceBase
   }
 
   static async loadIDFromSlug<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     slug: string,
     context?: Context,
   ): Promise<ID | undefined> {
@@ -245,7 +284,10 @@ export class WorkspaceBase
   }
 
   static async loadRawDataFromSlug<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
     slug: string,
     context?: Context,
   ): Promise<WorkspaceDBData | null> {
@@ -257,7 +299,10 @@ export class WorkspaceBase
   }
 
   static loaderOptions<T extends WorkspaceBase>(
-    this: new (viewer: Viewer, data: Data) => T,
+    this: new (
+      viewer: Viewer,
+      data: Data,
+    ) => T,
   ): LoadEntOptions<T, Viewer> {
     return {
       tableName: workspaceLoaderInfo.tableName,

--- a/examples/todo-sqlite/src/ent/generated/workspace_query_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace_query_base.ts
@@ -47,7 +47,10 @@ export abstract class WorkspaceToMembersQueryBase extends AssocEdgeQueryBase<
   }
 
   static query<T extends WorkspaceToMembersQueryBase>(
-    this: new (viewer: Viewer, src: EdgeQuerySource<Workspace, Account>) => T,
+    this: new (
+      viewer: Viewer,
+      src: EdgeQuerySource<Workspace, Account>,
+    ) => T,
     viewer: Viewer,
     src: EdgeQuerySource<Workspace, Account>,
   ): T {

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lolopinto/ent/internal/build_info"
 	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/file"
@@ -451,7 +450,6 @@ func NewCodegenProcessor(currentSchema *schema.Schema, configPath string, option
 	}
 	// if changes == nil, don't use changes
 	useChanges := changes != nil
-	spew.Dump("changes", changes)
 	writeAll := !useChanges
 	// this is different
 	if opt.writeAll {

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -207,9 +207,6 @@ func (p *Processor) FormatTS() error {
 }
 
 func (p *Processor) formatWithRome() error {
-	// TODO need to deal with write-all logic
-	// TODO in tsent/cmd/codegen.go is related.
-
 	rome := p.Config.GetRomeConfig()
 	// get files without "generated" in the path and pass them manually to rome
 	// for the generated paths, we'll pass src/ent/generated and src/graphql/generated to handle that

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lolopinto/ent/internal/build_info"
 	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/file"
@@ -201,7 +200,6 @@ func (p *Processor) FormatTS() error {
 	if p.Config.forcePrettier {
 		return p.formatWithPrettier()
 	}
-	spew.Dump("rome...")
 
 	return p.formatWithRome()
 }
@@ -239,7 +237,6 @@ func (p *Processor) formatWithRome() error {
 	cmd := exec.Command("rome", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {
 		str := stderr.String()
 		err = errors.Wrap(err, str)

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -207,6 +207,9 @@ func (p *Processor) FormatTS() error {
 }
 
 func (p *Processor) formatWithRome() error {
+	// TODO need to deal with write-all logic
+	// TODO in tsent/cmd/codegen.go is related.
+
 	rome := p.Config.GetRomeConfig()
 	// get files without "generated" in the path and pass them manually to rome
 	// for the generated paths, we'll pass src/ent/generated and src/graphql/generated to handle that

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -434,7 +434,7 @@ var defaultArgs = []string{
 // options: https://docs.rome.tools/formatter/#use-the-formatter-with-the-cli
 // everything else is sticking with default...
 var defaultRomeArgs = []string{
-	"--indent-style", "tabs",
+	"--indent-style", "space",
 }
 
 func (cfg *Config) getPrettierArgs() [][]string {

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/codepath"
 	"github.com/lolopinto/ent/internal/schema/change"
@@ -120,6 +121,7 @@ func (cfg *Config) SetWriteAll(writeAll bool) {
 }
 
 func (cfg *Config) SetUseChanges(useChanges bool) {
+	spew.Dump("setUseChanges", useChanges)
 	cfg.useChanges = useChanges
 }
 

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/codepath"
 	"github.com/lolopinto/ent/internal/schema/change"
+	"github.com/lolopinto/ent/internal/schema/input"
 	"github.com/lolopinto/ent/internal/tsimport"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -31,11 +32,13 @@ type Config struct {
 	// writeAll, even if changes are valid, still write all the files
 	writeAll bool
 	// changes are valid
-	useChanges bool
-	dummyWrite bool
-	changes    change.ChangeMap
+	useChanges    bool
+	dummyWrite    bool
+	changes       change.ChangeMap
+	forcePrettier bool
 	// keep track of changed ts files to pass to prettier
 	changedTSFiles []string
+	inputConfig    *input.Config
 }
 
 // Clone doesn't clone changes and changedTSFiles
@@ -51,6 +54,7 @@ func (cfg *Config) Clone() *Config {
 		debugMode:             cfg.debugMode,
 		writeAll:              cfg.writeAll,
 		useChanges:            cfg.useChanges,
+		inputConfig:           cfg.inputConfig,
 	}
 }
 
@@ -64,6 +68,10 @@ func (cfg *Config) OverrideGraphQLMutationName(mutationName codegenapi.GraphQLMu
 			DefaultGraphQLMutationName: mutationName,
 		},
 	}
+}
+
+func (cfg *Config) SetInputConfig(inputCfg *input.Config) {
+	cfg.inputConfig = inputCfg
 }
 
 func NewConfig(configPath, modulePath string) (*Config, error) {
@@ -264,6 +272,13 @@ func (cfg *Config) DummyWrite() bool {
 	return cfg.dummyWrite
 }
 
+func (cfg *Config) GetRomeConfig() *input.RomeConfig {
+	if cfg.inputConfig == nil {
+		return nil
+	}
+	return cfg.inputConfig.RomeConfig
+}
+
 func (cfg *Config) SetDummyWrite(val bool) {
 	cfg.dummyWrite = val
 }
@@ -404,6 +419,7 @@ func (cfg *Config) GetGlobalImportPath() *tsimport.ImportPath {
 	return nil
 }
 
+// use rome instead of prettier to speed up
 const DEFAULT_GLOB = "src/**/*.ts"
 const PRETTIER_FILE_CHUNKS = 20
 
@@ -413,6 +429,12 @@ var defaultArgs = []string{
 	"--quote-props", "consistent",
 	"--parser", "typescript",
 	"--end-of-line", "lf",
+}
+
+// options: https://docs.rome.tools/formatter/#use-the-formatter-with-the-cli
+// everything else is sticking with default...
+var defaultRomeArgs = []string{
+	"--indent-style", "tabs",
 }
 
 func (cfg *Config) getPrettierArgs() [][]string {
@@ -435,6 +457,7 @@ func (cfg *Config) getPrettierArgs() [][]string {
 		}
 	}
 
+	// writeAll
 	// if writeAll, break into src/ent/**/*.ts and src/graphql/**/*.ts
 	if cfg.writeAll {
 		return [][]string{

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/codepath"
 	"github.com/lolopinto/ent/internal/schema/change"
@@ -121,7 +120,6 @@ func (cfg *Config) SetWriteAll(writeAll bool) {
 }
 
 func (cfg *Config) SetUseChanges(useChanges bool) {
-	spew.Dump("setUseChanges", useChanges)
 	cfg.useChanges = useChanges
 }
 

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -428,10 +428,10 @@ func (cfg *Config) GetGlobalImportPath() *tsimport.ImportPath {
 	return nil
 }
 
-// use rome instead of prettier to speed up
-const DEFAULT_GLOB = "src/**/*.ts"
+const DEFAULT_PRETTIER_GLOB = "src/**/*.ts"
 const PRETTIER_FILE_CHUNKS = 20
 
+// use rome instead of prettier to speed up
 // options: https://prettier.io/docs/en/options.html
 var defaultArgs = []string{
 	"--trailing-comma", "all",
@@ -452,7 +452,7 @@ func (cfg *Config) getPrettierArgs() [][]string {
 		return nil
 	}
 
-	glob := DEFAULT_GLOB
+	glob := DEFAULT_PRETTIER_GLOB
 	args := defaultArgs
 
 	if cfg.config != nil && cfg.config.Codegen != nil && cfg.config.Codegen.Prettier != nil {
@@ -466,7 +466,6 @@ func (cfg *Config) getPrettierArgs() [][]string {
 		}
 	}
 
-	// writeAll
 	// if writeAll, break into src/ent/**/*.ts and src/graphql/**/*.ts
 	if cfg.writeAll {
 		return [][]string{

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 
 	"github.com/lolopinto/ent/ent"
@@ -46,8 +47,10 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 	if s.db == nil {
 		return errors.New("weirdness. dbSchema is nil when it shouldn't be")
 	}
-	// if write all, process db changes also
-	if processor.NoDBChanges() && !processor.Config.WriteAllFiles() {
+	// no changes and we should use changes, nothing to do
+	spew.Dump(processor.NoDBChanges(), processor.Config.UseChanges())
+	if processor.NoDBChanges() && processor.Config.UseChanges() {
+		spew.Dump("no changes bye")
 		return nil
 	}
 	return s.db.makeDBChanges(processor.Config)

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 
 	"github.com/lolopinto/ent/ent"
@@ -48,9 +47,7 @@ func (s *Step) ProcessData(processor *codegen.Processor) error {
 		return errors.New("weirdness. dbSchema is nil when it shouldn't be")
 	}
 	// no changes and we should use changes, nothing to do
-	spew.Dump(processor.NoDBChanges(), processor.Config.UseChanges())
 	if processor.NoDBChanges() && processor.Config.UseChanges() {
-		spew.Dump("no changes bye")
 		return nil
 	}
 	return s.db.makeDBChanges(processor.Config)

--- a/internal/field/compare_field.go
+++ b/internal/field/compare_field.go
@@ -52,6 +52,15 @@ func compareType(t1, t2 enttype.TSType) bool {
 		t1.GetTSType() == t2.GetTSType()
 }
 
+func compareDefaultValue(existing, field *Field) bool {
+	ret := change.CompareNilVals(existing.defaultValue == nil, field.defaultValue == nil)
+	if ret != nil {
+		return *ret
+	}
+
+	return *existing.defaultValue == *field.defaultValue
+}
+
 func FieldEqual(existing, field *Field) bool {
 	return existing.FieldName == field.FieldName &&
 		compareType(existing.fieldType, field.fieldType) &&
@@ -62,7 +71,7 @@ func FieldEqual(existing, field *Field) bool {
 		input.PolymorphicOptionsEqual(existing.polymorphic, field.polymorphic) &&
 		existing.nullable == field.nullable &&
 		existing.graphqlNullable == field.graphqlNullable &&
-		existing.defaultValue == field.defaultValue &&
+		compareDefaultValue(existing, field) &&
 		existing.unique == field.unique &&
 		foreignKeyInfoEqual(existing.fkey, field.fkey) &&
 		base.FieldEdgeInfoEqual(existing.fieldEdge, field.fieldEdge) &&

--- a/internal/field/compare_field_test.go
+++ b/internal/field/compare_field_test.go
@@ -302,3 +302,77 @@ func TestFieldWithUnequalInverseEdge(t *testing.T) {
 	}
 	require.False(t, FieldEqual(f, f2))
 }
+
+func TestFieldWithEqualServerDefault(t *testing.T) {
+	def := "true"
+	f := &Field{
+		FieldName:    "name",
+		fieldType:    &enttype.TimeType{},
+		defaultValue: &def,
+	}
+	f2 := &Field{
+		FieldName:    "name",
+		fieldType:    &enttype.TimeType{},
+		defaultValue: &def,
+	}
+	require.True(t, FieldEqual(f, f2))
+}
+
+func TestFieldWithEqualServerDefaultDate(t *testing.T) {
+	def := "2020-01-01"
+	f := &Field{
+		FieldName:    "date",
+		fieldType:    &enttype.TimeType{},
+		defaultValue: &def,
+	}
+	f2 := &Field{
+		FieldName:    "date",
+		fieldType:    &enttype.TimeType{},
+		defaultValue: &def,
+	}
+	require.True(t, FieldEqual(f, f2))
+}
+
+func TestFieldWithUnEqualServerDefaultDate(t *testing.T) {
+	def1 := "2020-01-01"
+	def2 := "2020-01-02"
+	f := &Field{
+		FieldName:    "date",
+		fieldType:    &enttype.TimeType{},
+		defaultValue: &def1,
+	}
+	f2 := &Field{
+		FieldName:    "date",
+		fieldType:    &enttype.TimeType{},
+		defaultValue: &def2,
+	}
+	require.False(t, FieldEqual(f, f2))
+}
+
+func TestFieldWithNoServerDefault2(t *testing.T) {
+	def1 := "2020-01-01"
+	f := &Field{
+		FieldName:    "date",
+		fieldType:    &enttype.TimeType{},
+		defaultValue: &def1,
+	}
+	f2 := &Field{
+		FieldName: "date",
+		fieldType: &enttype.TimeType{},
+	}
+	require.False(t, FieldEqual(f, f2))
+}
+
+func TestFieldWithNoServerDefault1(t *testing.T) {
+	def2 := "2020-01-01"
+	f := &Field{
+		FieldName: "date",
+		fieldType: &enttype.TimeType{},
+	}
+	f2 := &Field{
+		FieldName:    "date",
+		fieldType:    &enttype.TimeType{},
+		defaultValue: &def2,
+	}
+	require.False(t, FieldEqual(f, f2))
+}

--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -15,6 +15,57 @@ type Schema struct {
 	Nodes        map[string]*Node    `json:"schemas,omitempty"`
 	Patterns     map[string]*Pattern `json:"patterns,omitempty"`
 	GlobalSchema *GlobalSchema       `json:"globalSchema"`
+	Config       *Config             `json:"config"`
+}
+
+type Config struct {
+	// the prettier config that's being used is parsed and sent up to format the files as needed
+	// since we're trying to use rome...
+	RomeConfig *RomeConfig `json:"rome"`
+}
+
+// indicates the rome onfig that should be used here
+// taken from the prettier config
+// https://prettier.io/docs/en/options.html#quotes
+// https://docs.rome.tools/formatter/#use-the-formatter-with-the-cli
+type RomeConfig struct {
+	// we always do --indent-style=space
+	IndentStyle     *string `json:"indentStyle"`
+	LineWidth       *int    `json:"lineWidth"`
+	IndentSize      *int    `json:"indentSize"`
+	QuoteStyle      *string `json:"quoteStyle"`
+	QuoteProperties *string `json:"quoteProperties"`
+	TrailingComma   *string `json:"trailingComma"`
+}
+
+func (cfg *RomeConfig) GetArgs() []string {
+	var ret []string
+
+	if cfg.IndentStyle != nil {
+		ret = append(ret, "--indent-style", *cfg.IndentStyle)
+	}
+
+	if cfg.IndentSize != nil {
+		// int to string
+		ret = append(ret, "--indent-size", fmt.Sprintf("%v", *cfg.IndentSize))
+	}
+
+	if cfg.LineWidth != nil {
+		ret = append(ret, "--line-width", fmt.Sprintf("%v", *cfg.LineWidth))
+	}
+
+	if cfg.QuoteStyle != nil {
+		ret = append(ret, "--quote-style", *cfg.QuoteStyle)
+	}
+
+	if cfg.QuoteProperties != nil {
+		ret = append(ret, "--quote-properties", *cfg.QuoteProperties)
+	}
+
+	if cfg.TrailingComma != nil {
+		ret = append(ret, "--trailing-comma", *cfg.TrailingComma)
+	}
+	return ret
 }
 
 type Pattern struct {

--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -46,7 +46,6 @@ func (cfg *RomeConfig) GetArgs() []string {
 	}
 
 	if cfg.IndentSize != nil {
-		// int to string
 		ret = append(ret, "--indent-size", fmt.Sprintf("%v", *cfg.IndentSize))
 	}
 

--- a/ts/.prettierignore
+++ b/ts/.prettierignore
@@ -1,0 +1,3 @@
+# for vscode
+**/src/ent/generated
+**/src/graphql/generated

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha92-dfacbae0-4413-11ed-aaab-4b58b33faa4c",
+  "version": "0.1.0-alpha92",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@snowtop/ent",
-      "version": "0.1.0-alpha92-dfacbae0-4413-11ed-aaab-4b58b33faa4c",
+      "version": "0.1.0-alpha92",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
+        "cosmiconfig": "^7.0.1",
         "dataloader": "^2.0.0",
         "glob": "^7.1.6",
         "graph-data-structure": "^1.12.0",
@@ -107,7 +108,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -334,7 +334,6 @@
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
       "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -366,7 +365,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -380,7 +378,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -392,7 +389,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -406,7 +402,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -414,14 +409,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -430,7 +423,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -439,7 +431,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1453,6 +1444,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "node_modules/@types/passport": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.6.tgz",
@@ -2048,7 +2044,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2290,6 +2285,21 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2519,7 +2529,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3291,6 +3300,29 @@
         }
       ]
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -3351,8 +3383,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-core-module": {
       "version": "2.10.0",
@@ -4108,8 +4139,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4137,8 +4167,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -4172,8 +4201,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -4672,11 +4700,21 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -4745,6 +4783,14 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pg": {
       "version": "8.8.0",
@@ -6184,6 +6230,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.5.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
@@ -6253,7 +6307,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -6423,8 +6476,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
@@ -6447,7 +6499,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -6458,7 +6509,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -6467,7 +6517,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -6478,7 +6527,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -6486,26 +6534,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7372,6 +7416,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "@types/passport": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.6.tgz",
@@ -7849,8 +7898,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camel-case": {
       "version": "4.1.2",
@@ -8033,6 +8081,18 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -8213,7 +8273,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -8809,6 +8868,22 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
+      }
+    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -8854,8 +8929,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-core-module": {
       "version": "2.10.0",
@@ -9435,8 +9509,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -9455,8 +9528,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json5": {
       "version": "2.2.1",
@@ -9478,8 +9550,7 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "locate-path": {
       "version": "5.0.0",
@@ -9868,11 +9939,18 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -9923,6 +10001,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "pg": {
       "version": "8.8.0",
@@ -10963,6 +11046,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha93",
+  "version": "0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/package.json
+++ b/ts/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@types/node": "^15.0.2",
     "camel-case": "^4.1.2",
+    "cosmiconfig": "^7.0.1",
     "dataloader": "^2.0.0",
     "glob": "^7.1.6",
     "graph-data-structure": "^1.12.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha93-fdb6e620-6130-11ed-98a5-23a6c2772624",
+  "version": "0.1.0-alpha93-9117d260-61f6-11ed-8b12-01f8b91c91d4",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tsent/cmd/codegen.go
+++ b/tsent/cmd/codegen.go
@@ -18,6 +18,7 @@ type codegenArgs struct {
 	disableCustomGraphQL bool
 	disablePrompts       bool
 	disableUpgrade       bool
+	forcePrettier        bool
 }
 
 var codegenInfo codegenArgs
@@ -77,6 +78,13 @@ var codegenCmd = &cobra.Command{
 		// flag that next time we do this, we force write all
 		if codegenInfo.step != "" {
 			bi.ForceWriteAllNextTime = true
+		}
+		if codegenInfo.forcePrettier {
+			opts = append(opts, codegen.ForcePrettier())
+		} else {
+			// automatically --write-all with rome
+			// TODO would be nice to eventually differentiate this vs not
+			opts = append(opts, codegen.WriteAll())
 		}
 		// same as ParseSchemaFromTSDir. default to schema. we want a flag here eventually
 		processor, err := codegen.NewCodegenProcessor(currentSchema, "src/schema", opts...)

--- a/tsent/cmd/codegen.go
+++ b/tsent/cmd/codegen.go
@@ -85,10 +85,7 @@ var codegenCmd = &cobra.Command{
 		if codegenInfo.forcePrettier {
 			opts = append(opts, codegen.ForcePrettier())
 		} else {
-			// automatically --write-all with rome
-			// TODO would be nice to eventually differentiate this vs not
-			// TODO this flag use changes
-			// and use bi.Changes() or something
+			// automatically force write-all with rome
 			opts = append(opts, codegen.ForceWriteAll())
 		}
 		// same as ParseSchemaFromTSDir. default to schema. we want a flag here eventually

--- a/tsent/cmd/codegen.go
+++ b/tsent/cmd/codegen.go
@@ -84,7 +84,9 @@ var codegenCmd = &cobra.Command{
 		} else {
 			// automatically --write-all with rome
 			// TODO would be nice to eventually differentiate this vs not
-			opts = append(opts, codegen.WriteAll())
+			// TODO this flag use changes
+			// and use bi.Changes() or something
+			opts = append(opts, codegen.ForceWriteAll())
 		}
 		// same as ParseSchemaFromTSDir. default to schema. we want a flag here eventually
 		processor, err := codegen.NewCodegenProcessor(currentSchema, "src/schema", opts...)

--- a/tsent/cmd/root.go
+++ b/tsent/cmd/root.go
@@ -98,6 +98,7 @@ func init() {
 	codegenCmd.Flags().BoolVar(&codegenInfo.disableCustomGraphQL, "disable-custom-graphql", false, "to disable custom graphql during codegen. used when we need to rebuild everything and minimize parsing code")
 	codegenCmd.Flags().BoolVar(&codegenInfo.disablePrompts, "disable_prompts", false, "disable prompts")
 	codegenCmd.Flags().BoolVar(&codegenInfo.disableUpgrade, "disable_upgrade", false, "disable upgrade when running codegen. codegen automatically checks that the db is upgraded before making any changes. if you want to disable that for any reason, use this flag")
+	codegenCmd.Flags().BoolVar(&codegenInfo.forcePrettier, "force_prettier", false, "force prettier instead of rome when running codegen.")
 
 	generateSchemasCmd.Flags().StringVar(&schemasInfo.file, "file", "", "file to get data from. also supports piping it through")
 	generateSchemasCmd.Flags().BoolVar(&schemasInfo.force, "force", false, "if force is true, it overwrites existing schema, otherwise throws error")


### PR DESCRIPTION
[`rome`](https://rome.tools/) is much faster and speeds up codegen. will also eventually lead to `--write-all` not being needed.

uses [`cosmicconfig`](https://github.com/davidtheclark/cosmiconfig) to read the `prettier` config and translate it to the supported rome ones.

i've already seen at least one change in rome's formatting vs prettier's, so now a `.prettierignore` is recommended to include `src/ent/generated` and `src/graphql/generated` so that vscode or other editors don't change the formatting back to prettier's if prettier is used in an org.

will update docs to reflect this

fixes https://github.com/lolopinto/ent/issues/1201 and should also fix all `--write-all` class of bugs like https://github.com/lolopinto/ent/issues/984