### PR TITLE
Db only fields

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha95",
+        "@snowtop/ent": "^0.1.0-alpha96-2a5ea200-82e5-11ed-8c55-4da1cd949242",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha2",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1140,9 +1140,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha95",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha95.tgz",
-      "integrity": "sha512-micTPwc0dmqN1jWR3dY5vHhklGg/dwlzC/nMMHyno0clzyt1DayxhAJiwHQ6vu96XJjKlkJF35Bey0u1lCzDhg==",
+      "version": "0.1.0-alpha96-2a5ea200-82e5-11ed-8c55-4da1cd949242",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-2a5ea200-82e5-11ed-8c55-4da1cd949242.tgz",
+      "integrity": "sha512-Zq+DHkAMLTRcAR6Kvwsq8nsf1wyOv+2yWI1fWUiXf30odXArvTg49EyHk/ON0UGVdKfUSocjYsqYTphdB66Jow==",
       "dependencies": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",
@@ -6847,9 +6847,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha95",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha95.tgz",
-      "integrity": "sha512-micTPwc0dmqN1jWR3dY5vHhklGg/dwlzC/nMMHyno0clzyt1DayxhAJiwHQ6vu96XJjKlkJF35Bey0u1lCzDhg==",
+      "version": "0.1.0-alpha96-2a5ea200-82e5-11ed-8c55-4da1cd949242",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-2a5ea200-82e5-11ed-8c55-4da1cd949242.tgz",
+      "integrity": "sha512-Zq+DHkAMLTRcAR6Kvwsq8nsf1wyOv+2yWI1fWUiXf30odXArvTg49EyHk/ON0UGVdKfUSocjYsqYTphdB66Jow==",
       "requires": {
         "@types/node": "^15.0.2",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -34,7 +34,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha95",
+    "@snowtop/ent": "^0.1.0-alpha96-2a5ea200-82e5-11ed-8c55-4da1cd949242",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha2",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/simple/src/ent/generated/loaders.ts
+++ b/examples/simple/src/ent/generated/loaders.ts
@@ -548,8 +548,6 @@ const userFields = [
   "preferred_shift",
   "time_in_ms",
   "fun_uuids",
-  "new_col",
-  "new_col_2",
   "nested_list",
   "int_enum",
 ];
@@ -653,14 +651,6 @@ export const userLoaderInfo = {
     fun_uuids: {
       dbCol: "fun_uuids",
       inputKey: "funUuids",
-    },
-    new_col: {
-      dbCol: "new_col",
-      inputKey: "newCol",
-    },
-    new_col2: {
-      dbCol: "new_col_2",
-      inputKey: "newCol2",
     },
     superNestedObject: {
       dbCol: "super_nested_object",

--- a/examples/simple/src/ent/generated/user/actions/edit_user_all_fields_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_user_all_fields_action_base.ts
@@ -47,8 +47,6 @@ export interface EditUserAllFieldsInput {
   preferredShift?: UserPreferredShift[] | null;
   timeInMs?: BigInt | null;
   funUuids?: ID[] | null;
-  newCol?: string | null;
-  newCol2?: string | null;
   superNestedObject?: UserSuperNestedObject | null;
   nestedList?: UserNestedObjectList[] | null;
   intEnum?: UserIntEnum | null;

--- a/examples/simple/src/ent/generated/user/actions/user_builder.ts
+++ b/examples/simple/src/ent/generated/user/actions/user_builder.ts
@@ -49,8 +49,6 @@ export interface UserInput {
   preferredShift?: UserPreferredShift[] | null;
   timeInMs?: BigInt | null;
   funUuids?: ID[] | null;
-  newCol?: string | null;
-  newCol2?: string | null;
   superNestedObject?: UserSuperNestedObject | null;
   nestedList?: UserNestedObjectList[] | null;
   intEnum?: UserIntEnum | null;
@@ -601,8 +599,6 @@ export class UserBuilder<
     addField("preferredShift", input.preferredShift);
     addField("timeInMs", input.timeInMs);
     addField("fun_uuids", input.funUuids);
-    addField("new_col", input.newCol);
-    addField("new_col2", input.newCol2);
     addField("superNestedObject", input.superNestedObject);
     addField("nestedList", input.nestedList);
     addField("int_enum", input.intEnum);
@@ -748,24 +744,6 @@ export class UserBuilder<
     }
 
     return this.existingEnt?.funUuids ?? null;
-  }
-
-  // get value of new_col. Retrieves it from the input if specified or takes it from existingEnt
-  getNewNewColValue(): string | null {
-    if (this.input.newCol !== undefined) {
-      return this.input.newCol;
-    }
-
-    return this.existingEnt?.newCol ?? null;
-  }
-
-  // get value of new_col2. Retrieves it from the input if specified or takes it from existingEnt
-  getNewNewCol2Value(): string | null {
-    if (this.input.newCol2 !== undefined) {
-      return this.input.newCol2;
-    }
-
-    return this.existingEnt?.newCol2 ?? null;
   }
 
   // get value of superNestedObject. Retrieves it from the input if specified or takes it from existingEnt

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -97,8 +97,6 @@ interface UserDBData {
   preferred_shift: UserPreferredShift[] | null;
   time_in_ms: BigInt | null;
   fun_uuids: ID[] | null;
-  new_col: string | null;
-  new_col_2: string | null;
   super_nested_object: UserSuperNestedObject | null;
   nested_list: UserNestedObjectList[] | null;
   int_enum: UserIntEnum | null;
@@ -135,8 +133,6 @@ export class UserBase
   readonly preferredShift: UserPreferredShift[] | null;
   readonly timeInMs: BigInt | null;
   readonly funUuids: ID[] | null;
-  readonly newCol: string | null;
-  readonly newCol2: string | null;
   protected _superNestedObject: UserSuperNestedObject | null | undefined;
   readonly nestedList: UserNestedObjectList[] | null;
   readonly intEnum: UserIntEnum | null;
@@ -167,8 +163,6 @@ export class UserBase
     );
     this.timeInMs = BigInt(data.time_in_ms);
     this.funUuids = data.fun_uuids;
-    this.newCol = data.new_col;
-    this.newCol2 = data.new_col_2;
     this.nestedList = convertNullableUserNestedObjectListList(data.nested_list);
     this.intEnum = convertNullableUserIntEnum(data.int_enum);
   }

--- a/examples/simple/src/graphql/generated/resolvers/user_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/user_type.ts
@@ -138,12 +138,6 @@ export const UserType = new GraphQLObjectType({
     funUuids: {
       type: new GraphQLList(new GraphQLNonNull(GraphQLID)),
     },
-    newCol: {
-      type: GraphQLString,
-    },
-    newCol2: {
-      type: GraphQLString,
-    },
     superNestedObject: {
       type: UserSuperNestedObjectType,
       resolve: async (

--- a/examples/simple/src/graphql/generated/schema.gql
+++ b/examples/simple/src/graphql/generated/schema.gql
@@ -393,8 +393,6 @@ type User implements Node {
   preferredShift: [UserPreferredShift!]
   timeInMs: String
   funUuids: [ID!]
-  newCol: String
-  newCol2: String
   superNestedObject: UserSuperNestedObject
   nestedList: [UserNestedObjectList!]
   intEnum: UserIntEnum

--- a/examples/simple/src/schema/user_schema.ts
+++ b/examples/simple/src/schema/user_schema.ts
@@ -130,8 +130,9 @@ const UserSchema = new EntSchema({
       defaultValueOnCreate: () => BigInt(Date.now()),
     }),
     fun_uuids: UUIDListType({ nullable: true }),
-    new_col: StringType({ nullable: true }),
-    new_col2: StringType({ nullable: true }),
+    // drop from ent but keep in db
+    new_col: StringType({ nullable: true, dbOnly: true }),
+    new_col2: StringType({ nullable: true, dbOnly: true }),
     superNestedObject: StructType({
       fetchOnDemand: true,
       nullable: true,

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -227,7 +227,7 @@ func getFieldsForAction(nodeName string, action *input.Action, fieldInfo *field.
 
 	// no override of fields so we should get default fields
 	if len(fieldNames) == 0 {
-		for _, f := range fieldInfo.Fields {
+		for _, f := range fieldInfo.EntFields() {
 			if f.ExposeToActionsByDefault() && f.EditableField() && !excludedFields[f.FieldName] {
 				f2, err := getField(f, f.FieldName)
 				if err != nil {

--- a/internal/db/db_schema.go
+++ b/internal/db/db_schema.go
@@ -414,7 +414,7 @@ func (s *dbSchema) createTableForNode(nodeData *schema.NodeData) *dbTable {
 	colMap := make(map[string]*dbColumn)
 	var constraints []dbConstraint
 
-	for _, f := range nodeData.FieldInfo.Fields {
+	for _, f := range nodeData.FieldInfo.AllFields() {
 		if !f.CreateDBColumn() {
 			continue
 		}
@@ -440,7 +440,7 @@ func (s *dbSchema) createTableForNode(nodeData *schema.NodeData) *dbTable {
 }
 
 func (s *dbSchema) findFieldForCol(nodeData *schema.NodeData, col string) *field.Field {
-	for _, f := range nodeData.FieldInfo.Fields {
+	for _, f := range nodeData.FieldInfo.AllFields() {
 		if f.GetDbColName() == col {
 			return f
 		}
@@ -680,7 +680,7 @@ func (s *dbSchema) getSchemaForTemplate() (*dbSchemaTemplate, error) {
 
 	addData := func(nodeData *schema.NodeData) error {
 		pkeys := []string{}
-		for _, field := range nodeData.FieldInfo.Fields {
+		for _, field := range nodeData.FieldInfo.AllFields() {
 			// we only support single field primary keys here so this is the solution
 			// eventually, this needs to change...
 			if field.SingleFieldPrimaryKey() {

--- a/internal/field/field.go
+++ b/internal/field/field.go
@@ -66,6 +66,7 @@ type Field struct {
 	defaultToViewerOnCreate    bool
 	hasFieldPrivacy            bool
 	fetchOnDemand              bool
+	dbOnly                     bool
 
 	forceRequiredInAction bool
 	forceOptionalInAction bool
@@ -108,6 +109,7 @@ func newFieldFromInput(cfg codegenapi.Config, nodeName string, f *input.Field) (
 		defaultToViewerOnCreate:    f.DefaultToViewerOnCreate,
 		hasFieldPrivacy:            f.HasFieldPrivacy,
 		fetchOnDemand:              f.FetchOnDemand,
+		dbOnly:                     f.DBOnly,
 		derivedWhenEmbedded:        f.DerivedWhenEmbedded,
 		patternName:                f.PatternName,
 		userConvert:                f.UserConvert,
@@ -876,6 +878,8 @@ func (f *Field) Clone(opts ...Option) (*Field, error) {
 		hasDefaultValueOnEdit:      f.hasDefaultValueOnEdit,
 		defaultToViewerOnCreate:    f.defaultToViewerOnCreate,
 		hasFieldPrivacy:            f.hasFieldPrivacy,
+		fetchOnDemand:              f.fetchOnDemand,
+		dbOnly:                     f.dbOnly,
 		forceRequiredInAction:      f.forceRequiredInAction,
 		forceOptionalInAction:      f.forceOptionalInAction,
 		derivedWhenEmbedded:        f.derivedWhenEmbedded,

--- a/internal/field/field.go
+++ b/internal/field/field.go
@@ -194,6 +194,10 @@ func newFieldFromInput(cfg codegenapi.Config, nodeName string, f *input.Field) (
 		}
 	}
 
+	if f.DBOnly && !(f.Nullable || f.ServerDefault != nil) {
+		return nil, fmt.Errorf("for field %s to be db only, it needs to be nullable or have a server default", f.Name)
+	}
+
 	return ret, nil
 }
 

--- a/internal/field/field_test.go
+++ b/internal/field/field_test.go
@@ -238,6 +238,44 @@ func TestForeignKey(t *testing.T) {
 	)
 }
 
+func TestDBOnlyNullableField(t *testing.T) {
+	_, err := newFieldFromInputTest(&codegenapi.DummyConfig{}, &input.Field{
+		Name: "foo",
+		Type: &input.FieldType{
+			DBType: input.Int,
+		},
+		DBOnly:   true,
+		Nullable: true,
+	})
+	require.Nil(t, err)
+}
+
+func TestDBOnlyServerDefaultField(t *testing.T) {
+	dv := "2"
+
+	_, err := newFieldFromInputTest(&codegenapi.DummyConfig{}, &input.Field{
+		Name: "foo",
+		Type: &input.FieldType{
+			DBType: input.Int,
+		},
+		DBOnly:        true,
+		Nullable:      true,
+		ServerDefault: &dv,
+	})
+	require.Nil(t, err)
+}
+
+func TestDBOnlyNoNullableNoServerDefault(t *testing.T) {
+	_, err := newFieldFromInputTest(&codegenapi.DummyConfig{}, &input.Field{
+		Name: "foo",
+		Type: &input.FieldType{
+			DBType: input.Int,
+		},
+		DBOnly: true,
+	})
+	require.NotNil(t, err)
+}
+
 func getFieldFromInput(t *testing.T, f *input.Field) *Field {
 	cfg := &codegenapi.DummyConfig{}
 

--- a/internal/field/fields_test.go
+++ b/internal/field/fields_test.go
@@ -37,7 +37,7 @@ func TestDerivedFields(t *testing.T) {
 	fieldInfo := info.NodeData.FieldInfo
 
 	// 5 fields above + OwnerType field + id,createdat,updatedat
-	require.Len(t, fieldInfo.Fields, 9)
+	require.Len(t, fieldInfo.AllFields(), 9)
 
 	// field exists
 	f := fieldInfo.GetFieldByName("OwnerType")

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -2330,7 +2330,7 @@ func checkUnionType(cfg codegenapi.Config, nodeName string, f *field.Field, curr
 			if err != nil {
 				return nil, false, err
 			}
-			for _, v := range fi.Fields {
+			for _, v := range fi.EntFields() {
 				ret, done, err := checkUnionType(cfg, nodeName, v, newCurr)
 				if err != nil {
 					return nil, false, err

--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -206,6 +206,7 @@ type Field struct {
 	DerivedFields       []*Field            `json:"derivedFields,omitempty"`
 	UserConvert         *UserConvertType    `json:"convert,omitempty"`
 	FetchOnDemand       bool                `json:"fetchOnDemand,omitempty"`
+	DBOnly              bool                `json:"dbOnly,omitempty"`
 
 	// set when parsed via tsent generate schema
 	Import enttype.Import `json:"-"`

--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -152,7 +152,7 @@ func (nodeData *NodeData) GetActionByGraphQLName(graphQLName string) action.Acti
 }
 
 func (nodeData *NodeData) HasPrivateField(cfg codegenapi.Config) bool {
-	for _, field := range nodeData.FieldInfo.Fields {
+	for _, field := range nodeData.FieldInfo.EntFields() {
 		if field.Private(cfg) {
 			return true
 		}
@@ -173,7 +173,7 @@ func (nodeData *NodeData) HasAssocGroups() bool {
 }
 
 func (nodeData *NodeData) FieldsWithFieldPrivacy() bool {
-	for _, f := range nodeData.FieldInfo.Fields {
+	for _, f := range nodeData.FieldInfo.EntFields() {
 		if f.HasFieldPrivacy() {
 			return true
 		}
@@ -250,7 +250,7 @@ func (nodeData *NodeData) GetImportsForBaseFile(s *Schema, cfg codegenapi.Config
 		})
 	}
 
-	for _, f := range nodeData.FieldInfo.Fields {
+	for _, f := range nodeData.FieldInfo.EntFields() {
 		if f.Index() && f.EvolvedIDField() {
 			imp, err := nodeData.GetFieldQueryName(f)
 			if err != nil {
@@ -304,7 +304,7 @@ func (nodeData *NodeData) GetImportPathsForDependencies(s *Schema) []*tsimport.I
 		})
 	}
 
-	for _, f := range nodeData.FieldInfo.Fields {
+	for _, f := range nodeData.FieldInfo.EntFields() {
 		t := f.GetFieldType()
 		if enttype.IsImportDepsType(t) {
 			t2 := t.(enttype.ImportDepsType)
@@ -493,7 +493,7 @@ func (nodeData *NodeData) GetNodeLoaders() [][]*loader {
 		}
 	}
 
-	for _, field := range nodeData.FieldInfo.Fields {
+	for _, field := range nodeData.FieldInfo.EntFields() {
 		if field.Unique() {
 			group1 = append(group1, &loader{
 				Name:                 nodeData.GetFieldLoaderName(field),

--- a/internal/schema/pattern_info.go
+++ b/internal/schema/pattern_info.go
@@ -113,7 +113,7 @@ func (p *PatternInfo) ForeignImport(imp string) bool {
 }
 
 func (p *PatternInfo) HasFields() bool {
-	return len(p.FieldInfo.Fields) > 0
+	return len(p.FieldInfo.EntFields()) > 0
 }
 
 func (p *PatternInfo) GetImportsForMixin(s *Schema, cfg codegenapi.Config) []*tsimport.ImportPath {
@@ -126,7 +126,7 @@ func (p *PatternInfo) GetImportsForMixin(s *Schema, cfg codegenapi.Config) []*ts
 		})
 	}
 
-	for _, f := range p.FieldInfo.Fields {
+	for _, f := range p.FieldInfo.EntFields() {
 		ret = append(ret, f.GetImportsForTypes(cfg, s)...)
 	}
 	return ret

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -574,7 +574,7 @@ func (s *Schema) parseGlobalSchema(cfg codegenapi.Config, gs *input.GlobalSchema
 		if err != nil {
 			errs = append(errs, err)
 		}
-		s.extraEdgeFields = fi.Fields
+		s.extraEdgeFields = fi.AllFields()
 	}
 
 	s.initForEdges = gs.InitForEdges
@@ -682,7 +682,7 @@ func (s *Schema) processFields(cfg codegenapi.Config, nodeName string, fields []
 		return nil, err
 	}
 
-	for _, f := range fieldInfo.Fields {
+	for _, f := range fieldInfo.EntFields() {
 		entType := f.GetFieldType()
 		enumType, ok := enttype.GetEnumType(entType)
 		// don't add enums which are defined in patterns
@@ -744,7 +744,7 @@ func (s *Schema) checkForEnum(cfg codegenapi.Config, f *field.Field, ci *customt
 	if err != nil {
 		return err
 	}
-	for _, f2 := range fi.Fields {
+	for _, f2 := range fi.EntFields() {
 		if err := s.checkForEnum(cfg, f2, ci); err != nil {
 			return err
 		}
@@ -797,7 +797,7 @@ func (s *Schema) checkCustomInterface(cfg codegenapi.Config, f *field.Field, roo
 	if err != nil {
 		return err
 	}
-	for _, f2 := range fi.Fields {
+	for _, f2 := range fi.EntFields() {
 		ci.Fields = append(ci.Fields, f2)
 		// add custom interface maybe
 		if err := s.checkCustomInterface(cfg, f2, root); err != nil {
@@ -845,7 +845,7 @@ func (s *Schema) getCustomUnion(cfg codegenapi.Config, f *field.Field) (*customt
 	if err != nil {
 		return nil, err
 	}
-	for _, f2 := range fi.Fields {
+	for _, f2 := range fi.EntFields() {
 		ci, subFields := s.getCustomInterfaceFromField(f2)
 		if ci == nil || subFields == nil {
 			return nil, fmt.Errorf("couldn't get custom interface from field %s", f.FieldName)
@@ -857,7 +857,7 @@ func (s *Schema) getCustomUnion(cfg codegenapi.Config, f *field.Field) (*customt
 		if err != nil {
 			return nil, err
 		}
-		ci.Fields = fi2.Fields
+		ci.Fields = fi2.EntFields()
 		// TODO getCustomInterfaceFromField needs to handle this all
 		// instead of this mess
 		for _, f3 := range ci.Fields {
@@ -1213,7 +1213,7 @@ func (s *Schema) addEdgesFromFields(
 	fieldInfo := nodeData.FieldInfo
 	edgeInfo := nodeData.EdgeInfo
 
-	for _, f := range fieldInfo.Fields {
+	for _, f := range fieldInfo.EntFields() {
 		fkeyInfo := f.ForeignKeyInfo()
 		if fkeyInfo != nil {
 			if err := s.addForeignKeyEdges(cfg, nodeData, fieldInfo, edgeInfo, f, fkeyInfo); err != nil {
@@ -1522,7 +1522,7 @@ func (s *Schema) processConstraints(nodeData *NodeData) error {
 	tableName := nodeData.TableName
 
 	var constraints []*input.Constraint
-	for _, f := range nodeData.FieldInfo.Fields {
+	for _, f := range nodeData.FieldInfo.EntFields() {
 		// always use db col name here
 		cols := []string{f.GetDbColName()}
 

--- a/internal/schema/schema_overrides_test.go
+++ b/internal/schema/schema_overrides_test.go
@@ -812,7 +812,7 @@ func testOverrides(
 		require.NotNil(t, expNodeData)
 		require.NotNil(t, nodeData)
 
-		for _, exp := range expNodeData.FieldInfo.Fields {
+		for _, exp := range expNodeData.FieldInfo.AllFields() {
 			f := nodeData.FieldInfo.GetFieldByName(exp.FieldName)
 
 			require.NotNil(t, f)

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -38,7 +38,7 @@
 {{$dataType := printf "%sDBData" .Node -}}
 
 interface {{$dataType}} {
-  {{range $field := .FieldInfo.Fields -}}
+  {{range $field := .FieldInfo.EntFields -}}
     {{ range $field.GetTsTypeImports -}}
       {{ if ($nodeData.ForeignImport .Import) -}}
         {{ reserveImportPath . false -}}
@@ -50,7 +50,7 @@ interface {{$dataType}} {
   {{ end -}}
 }
 
-{{range $field := .FieldInfo.Fields -}}
+{{range $field := .FieldInfo.EntFields -}}
   {{ if $field.FetchOnDemand -}}
     const {{$field.TSPublicAPIName}}Loader = new {{useImport "ObjectLoaderFactory"}}({
       tableName: {{useImport $loaderInfo}}.tableName,
@@ -81,7 +81,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
 {
 
   readonly nodeType = {{useImport "NodeType"}}.{{.Node}};
-  {{range $field := .FieldInfo.Fields -}}
+  {{range $field := .FieldInfo.EntFields -}}
     {{ range $field.GetTsTypeImports -}}
       {{ if ($nodeData.ForeignImport .Import) -}}
         {{ reserveImportPath . false -}}
@@ -106,7 +106,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
       // @ts-ignore pass to mixin
       super(viewer, data);
     {{ end -}}
-    {{range $field := .FieldInfo.Fields -}}
+    {{range $field := .FieldInfo.EntFields -}}
       {{ if fieldLoadedInBaseClass $schema $field -}}
         {{$val := printf "data.%s" $field.GetDbColName -}}
         this.{{$field.TsFieldName $cfg}} = {{callAndConvertFunc $field $cfg $val }}
@@ -123,7 +123,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
   }
 
   {{$node := .Node}}
-  {{range $field := .FieldInfo.Fields -}}
+  {{range $field := .FieldInfo.EntFields -}}
     {{ if $field.HasAsyncAccessor $cfg -}}
       async {{$field.TSPublicAPIName}}(): Promise<{{$field.TsType}}> {
         {{ $fieldName := $field.TsFieldName $cfg -}}
@@ -302,7 +302,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
   }
 
 
-  {{ range $field := .FieldInfo.Fields -}}
+  {{ range $field := .FieldInfo.EntFields -}}
     {{ if $field.Unique  -}}
       {{$fieldLoader := useImport ($this.GetFieldLoaderName $field) -}}
       static async loadFrom{{$field.CamelCaseName}}<T extends {{$baseClass}}>(

--- a/internal/tscode/loaders.tmpl
+++ b/internal/tscode/loaders.tmpl
@@ -11,7 +11,7 @@
 
   const {{$table}} = '{{.TableName}}';
   const {{$fields}} = [
-    {{range $field := .FieldInfo.Fields -}}
+    {{range $field := .FieldInfo.EntFields -}}
       {{if $field.FetchOnLoad -}}
         '{{$field.GetDbColName}}',
       {{end -}}
@@ -39,7 +39,7 @@
     nodeType: {{useImport "NodeType"}}.{{.Node}},
     loaderFactory: {{printf "%sLoader" .NodeInstance }},
     fieldInfo: {
-      {{range $field := .FieldInfo.Fields -}}
+      {{range $field := .FieldInfo.EntFields -}}
       {{$field.FieldName}}: {
         dbCol: '{{$field.GetDbColName}}',
         inputKey: '{{$field.TsBuilderFieldName}}',

--- a/internal/tscode/mixin.tmpl
+++ b/internal/tscode/mixin.tmpl
@@ -13,7 +13,7 @@ type Constructor<T = {}> = new (...args: any[]) => T;
 
 export interface {{$p.GetMixinInterfaceName}} {
   {{$p.GetPatternMethod}}(): boolean;
-  {{ range $field := $p.FieldInfo.Fields -}}
+  {{ range $field := $p.FieldInfo.EntFields -}}
     {{ range $field.GetTsTypeImports -}}
       {{ if ($p.ForeignImport .Import) -}}
         {{ reserveImportPath . false -}}
@@ -48,7 +48,7 @@ export interface {{$p.GetMixinInterfaceName}} {
 export function {{$p.GetMixinName}}<T extends Constructor>(BaseClass: T) {
   return class {{$p.GetMixinName}} extends BaseClass {
 
-    {{ range $field := $p.FieldInfo.Fields -}}
+    {{ range $field := $p.FieldInfo.EntFields -}}
       readonly {{$field.TsFieldName $cfg}}: {{$field.TsFieldType $cfg}};
     {{end -}}
   
@@ -58,7 +58,7 @@ export function {{$p.GetMixinName}}<T extends Constructor>(BaseClass: T) {
         const { data } = extractFromArgs(args);
       {{ end -}}
 
-      {{ range $field := $p.FieldInfo.Fields -}}
+      {{ range $field := $p.FieldInfo.EntFields -}}
         {{$val := printf "data.%s" $field.GetDbColName -}}
         this.{{$field.TsFieldName $cfg}} = {{callAndConvertFunc $field $cfg  $val }}
       {{end -}}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha95",
+  "version": "0.1.0-alpha96-2a5ea200-82e5-11ed-8c55-4da1cd949242",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -487,6 +487,13 @@ export interface FieldOptions {
 
   fetchOnDemand?: boolean;
 
+  // if dbOnly, field isn't exposed in ent and graphql
+  // will still exit in the db and not be removed
+  // allows keeping the field in the db and avoid data loss if we still want the field for some reason
+  // won't be queryable automatically though
+  // can't use deprecated because intEnum uses it
+  dbOnly?: boolean;
+
   // allow name for now
   [x: string]: any;
 }
@@ -559,6 +566,9 @@ export function getFields(value: SchemaInputType): Map<string, Field> {
   function addFields(fields: FieldMap | Field[]) {
     if (Array.isArray(fields)) {
       for (const field of fields) {
+        if (field.dbOnly) {
+          continue;
+        }
         const name = field.name;
         if (!name) {
           throw new Error(`name required`);
@@ -572,6 +582,9 @@ export function getFields(value: SchemaInputType): Map<string, Field> {
     }
     for (const name in fields) {
       const field = fields[name];
+      if (field.dbOnly) {
+        continue;
+      }
       if (field.getDerivedFields !== undefined) {
         addFields(field.getDerivedFields(name));
       }


### PR DESCRIPTION
add dbOnly fields for fields that we want to still keep in the db but don't want in ent and graphql

allows fields to be dropped from the API but still keep in the db (hopefully for a little while before being dropped)