### PR TITLE
[cleanup] fix most things noUnusedLocals complains about

### DIFF
--- a/ts/packages/ent-graphql-tests/src/index.ts
+++ b/ts/packages/ent-graphql-tests/src/index.ts
@@ -130,7 +130,7 @@ function makeGraphQLRequest(
 
     let m = {};
     let idx = 0;
-    for (const [key, val] of files) {
+    for (const [key] of files) {
       m[idx] = [`variables.${key}`];
       idx++;
     }

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -126,7 +126,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
 
       graph.addNode(c.placeholderID.toString());
       if (c.dependencies) {
-        for (let [key, builder] of c.dependencies) {
+        for (let [_, builder] of c.dependencies) {
           // dependency should go first...
           graph.addEdge(
             builder.placeholderID.toString(),

--- a/ts/src/core/context.ts
+++ b/ts/src/core/context.ts
@@ -1,4 +1,4 @@
-import { Viewer, Data, Loader, Ent, LoaderWithLoadMany } from "./base";
+import { Viewer, Data, Loader, LoaderWithLoadMany } from "./base";
 import { IncomingMessage, ServerResponse } from "http";
 
 import * as clause from "./clause";

--- a/ts/src/core/db.test.ts
+++ b/ts/src/core/db.test.ts
@@ -228,8 +228,6 @@ describe("sqlite", () => {
   });
 
   test("rollback transaction", async () => {
-    const client = DB.getInstance().getSQLiteClient();
-
     try {
       await createUsers([1, 2], { rollback: true });
       throw new Error("should have thrown");

--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -37,7 +37,6 @@ import { clearLogLevels, setLogLevels } from "./logger";
 import DB, { Dialect } from "./db";
 import { ObjectLoaderFactory } from "./loaders";
 import { CustomEdgeQueryBase } from "./query";
-import { CustomEdgeQueryOptions } from "./query/custom_query";
 
 let ctx: Context;
 const ml = new MockLogs();

--- a/ts/src/core/ent_data.test.ts
+++ b/ts/src/core/ent_data.test.ts
@@ -1330,8 +1330,6 @@ function commonTests() {
       expect(ents.size).toBe(1);
       expect(ents.has(1)).toBe(true);
 
-      const expQueries = [qOption];
-
       validateQueries([qOption]);
 
       const ents2 = await ent.loadEntsFromClause(vc, cls, User.loaderOptions());
@@ -1423,8 +1421,6 @@ function commonTests() {
       // only loading self worked because of privacy
       expect(ents.size).toBe(1);
       expect(ents.has(1)).toBe(true);
-
-      const expQueries = [qOption];
 
       validateQueries([qOption]);
 

--- a/ts/src/core/loaders/object_loader.test.ts
+++ b/ts/src/core/loaders/object_loader.test.ts
@@ -1,12 +1,7 @@
 import { ObjectLoader, ObjectLoaderFactory } from "./object_loader";
 import { Pool } from "pg";
 import { QueryRecorder } from "../../testutils/db_mock";
-
-import {
-  createRowForTest,
-  deleteRowsForTest,
-  editRowForTest,
-} from "../../testutils/write";
+import { createRowForTest, editRowForTest } from "../../testutils/write";
 import { TestContext } from "../../testutils/context/test_context";
 import { setLogLevels } from "../logger";
 import { MockLogs } from "../../testutils/mock_log";
@@ -31,7 +26,6 @@ import {
   text,
   timestamp,
 } from "../../testutils/db/temp_db";
-import DB, { Dialect } from "../db";
 import { advanceTo } from "jest-date-mock";
 import { convertDate } from "../convert";
 
@@ -450,7 +444,7 @@ function commonTests() {
     });
 
     // same data loaded  but not same row
-    const row2 = await loader.load(1);
+    await loader.load(1);
 
     expect(row).toBe(null);
 

--- a/ts/src/core/loaders/raw_count_loader.test.ts
+++ b/ts/src/core/loaders/raw_count_loader.test.ts
@@ -259,7 +259,7 @@ function commonTests() {
 
     test("single id. with context", async () => {
       clear();
-      const [user, events] = await createAllEvents({
+      const [user] = await createAllEvents({
         howMany: HOW_MANY,
         interval: INTERVAL,
       });

--- a/ts/src/core/loaders/raw_count_loader.ts
+++ b/ts/src/core/loaders/raw_count_loader.ts
@@ -2,7 +2,6 @@ import DataLoader from "dataloader";
 import {
   LoadRowOptions,
   ID,
-  DataOptions,
   Context,
   Loader,
   LoaderFactory,

--- a/ts/src/core/query/assoc_query_global.test.ts
+++ b/ts/src/core/query/assoc_query_global.test.ts
@@ -1,12 +1,10 @@
-import { Pool } from "pg";
-import { QueryRecorder } from "../../testutils/db_mock";
 import { Viewer } from "../base";
 import {
   EdgeType,
   FakeUser,
   UserToContactsQuery,
 } from "../../testutils/fake_data/index";
-import { createEdges, inputs } from "../../testutils/fake_data/test_helpers";
+import { inputs } from "../../testutils/fake_data/test_helpers";
 import { commonTests } from "./shared_test";
 import { assocTests } from "./shared_assoc_test";
 import { loadCustomEdges } from "../ent";

--- a/ts/src/core/query/shared_assoc_test.ts
+++ b/ts/src/core/query/shared_assoc_test.ts
@@ -896,10 +896,9 @@ export function assocTests(ml: MockLogs, global = false) {
     let user: FakeUser;
     let friendRequests: FakeUser[];
     let user2: FakeUser;
-    let friendRequests2: FakeUser[];
     beforeEach(async () => {
       [user, friendRequests] = await createUserPlusFriendRequests();
-      [user2, friendRequests2] = await createUserPlusFriendRequests();
+      [user2] = await createUserPlusFriendRequests();
     });
 
     function getQuery(viewer?: Viewer) {

--- a/ts/src/core/query/shared_test.ts
+++ b/ts/src/core/query/shared_test.ts
@@ -153,8 +153,6 @@ export const commonTests = <TData extends Data>(opts: options<TData>) => {
     }
 
     private verifyEdges(edges: Data[]) {
-      const q = this.getQuery();
-
       // TODO sad not generic enough
       if (this.customQuery) {
         verifyUserToContactRawData(this.user, edges, this.filteredContacts);

--- a/ts/src/graphql/graphql.test.ts
+++ b/ts/src/graphql/graphql.test.ts
@@ -5,7 +5,6 @@ import {
   gqlArgType,
   CustomFieldType,
   gqlConnection,
-  GraphQLConnection,
 } from "./graphql";
 import {
   GraphQLInt,

--- a/ts/src/graphql/query/shared_assoc_test.ts
+++ b/ts/src/graphql/query/shared_assoc_test.ts
@@ -207,7 +207,7 @@ export function sharedAssocTests() {
 
     const length = (m: GraphQLFieldMap<any, any>) => {
       let count = 0;
-      for (let k in m) {
+      for (let _ in m) {
         count++;
       }
       return count;

--- a/ts/src/imports/dataz/example1/_viewer.ts
+++ b/ts/src/imports/dataz/example1/_viewer.ts
@@ -1,5 +1,4 @@
 import {
-  gqlInputObjectType,
   gqlField,
   gqlObjectType,
   gqlContextType,

--- a/ts/src/schema/field.ts
+++ b/ts/src/schema/field.ts
@@ -11,7 +11,6 @@ import {
   FieldMap,
   FieldOptions,
   ForeignKey,
-  getStorageKey,
   PolymorphicOptions,
   Type,
 } from "./schema";
@@ -653,7 +652,7 @@ export class EnumField extends BaseField implements Field {
       }
       if (options.map) {
         let count = 0;
-        for (const k in options.map) {
+        for (const _ in options.map) {
           count++;
           break;
         }
@@ -752,7 +751,7 @@ export class IntegerEnumField extends BaseField implements Field {
     };
 
     let count = 0;
-    for (const k in options.map) {
+    for (const _ in options.map) {
       count++;
       break;
     }

--- a/ts/src/schema/schema_json.test.ts
+++ b/ts/src/schema/schema_json.test.ts
@@ -76,7 +76,7 @@ function commonTests() {
     const requiredKeys = {
       context: true,
     };
-    for (const k in val) {
+    for (const _ in val) {
       if (val === undefined) {
         return false;
       }

--- a/ts/src/schema/struct_field.test.ts
+++ b/ts/src/schema/struct_field.test.ts
@@ -352,7 +352,6 @@ describe("struct as list", () => {
 
   test("invalid item in list", async () => {
     const d = new Date();
-    const d2 = new Date();
     const val = {
       uuid: v1(),
       int: 2,

--- a/ts/src/schema/struct_field.ts
+++ b/ts/src/schema/struct_field.ts
@@ -1,5 +1,4 @@
 import { camelCase } from "camel-case";
-import { snakeCase } from "snake-case";
 import { BaseField, ListField } from "./field";
 import {
   FieldOptions,

--- a/ts/src/testutils/db/value.test.ts
+++ b/ts/src/testutils/db/value.test.ts
@@ -15,7 +15,6 @@ import {
   DateType,
   EnumType,
   Schema,
-  Field,
   StringListType,
   IntListType,
   JSONBType,

--- a/ts/src/testutils/db/value.ts
+++ b/ts/src/testutils/db/value.ts
@@ -182,7 +182,6 @@ const emailType = {
   regex: /^email(_address)|_email$/,
 };
 
-const pdt = StringType();
 const phoneType = {
   dbType: DBType.String,
   newValue: () => {

--- a/ts/src/testutils/ent-graphql-tests/index.ts
+++ b/ts/src/testutils/ent-graphql-tests/index.ts
@@ -131,7 +131,7 @@ function makeGraphQLRequest(
 
     let m = {};
     let idx = 0;
-    for (const [key, val] of files) {
+    for (const [key] of files) {
       m[idx] = [`variables.${key}`];
       idx++;
     }

--- a/ts/src/testutils/fake_data/events_query.ts
+++ b/ts/src/testutils/fake_data/events_query.ts
@@ -9,14 +9,6 @@ import { EdgeType, FakeEvent } from "./internal";
 import { AssocEdgeCountLoaderFactory } from "../../core/loaders/assoc_count_loader";
 import { AssocEdgeLoaderFactory } from "../../core/loaders/assoc_edge_loader";
 
-interface EventsDestQuery {
-  queryHosts(): EventToHostsQuery;
-  queryAttendees(): EventToAttendeesQuery;
-  queryInvited(): EventToInvitedQuery;
-  queryDeclined(): EventToDeclinedQuery;
-  queryMaybe(): EventToMaybeQuery;
-}
-
 export class EventToAttendeesQuery extends AssocEdgeQueryBase<
   FakeEvent,
   FakeUser,

--- a/ts/src/testutils/fake_data/fake_tag.ts
+++ b/ts/src/testutils/fake_data/fake_tag.ts
@@ -8,17 +8,12 @@ import {
 } from "../../core/base";
 import { loadEnt, loadEntX } from "../../core/ent";
 import {
-  AllowIfViewerRule,
   AlwaysDenyRule,
-  AllowIfViewerInboundEdgeExistsRule,
-  AllowIfConditionAppliesRule,
   AllowIfViewerIsEntPropertyRule,
 } from "../../core/privacy";
 import { getBuilderSchemaFromFields, SimpleAction } from "../builder";
 import { StringType, UUIDType } from "../../schema";
-import { EdgeType } from "./internal";
 import { NodeType } from "./const";
-import { IDViewer, IDViewerOptions } from "../../core/viewer";
 import { table, uuid, text, timestamptz, index } from "../db/temp_db";
 import { ObjectLoaderFactory } from "../../core/loaders";
 import { convertDate } from "../../core/convert";

--- a/ts/src/testutils/write.ts
+++ b/ts/src/testutils/write.ts
@@ -1,7 +1,6 @@
 import {
   EditRowOptions,
   Data,
-  ID,
   DataOptions,
   CreateRowOptions,
 } from "../core/base";


### PR DESCRIPTION
left places that are using decorators and not explicitly referenced (used in tests)