### PR TITLE
Ent raw db data fix

### DIFF
--- a/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
@@ -30,7 +30,7 @@ import { NodeType } from "src/ent/generated/types";
 import { AddressToLocatedAtQuery } from "src/ent/internal";
 import schema from "src/schema/address_schema";
 
-interface AddressDBData {
+interface AddressData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -44,7 +44,7 @@ interface AddressDBData {
 }
 
 export class AddressBase implements Ent<Viewer> {
-  protected readonly data: AddressDBData;
+  protected readonly data: AddressData;
   readonly nodeType = NodeType.Address;
   readonly id: ID;
   readonly createdAt: Date;
@@ -72,8 +72,10 @@ export class AddressBase implements Ent<Viewer> {
     this.data = data;
   }
 
+  __setRawDBData<AddressData>(data: AddressData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): AddressDBData {
+  ___getRawDBData(): AddressData {
     return this.data;
   }
 
@@ -151,7 +153,7 @@ export class AddressBase implements Ent<Viewer> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<AddressDBData[]> {
+  ): Promise<AddressData[]> {
     return (await loadCustomData(
       {
         ...AddressBase.loaderOptions.apply(this),
@@ -159,7 +161,7 @@ export class AddressBase implements Ent<Viewer> {
       },
       query,
       context,
-    )) as AddressDBData[];
+    )) as AddressData[];
   }
 
   static async loadCustomCount<T extends AddressBase>(
@@ -186,12 +188,12 @@ export class AddressBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<AddressDBData | null> {
+  ): Promise<AddressData | null> {
     const row = await addressLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as AddressDBData;
+    return row as AddressData;
   }
 
   static async loadRawDataX<T extends AddressBase>(
@@ -201,12 +203,12 @@ export class AddressBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<AddressDBData> {
+  ): Promise<AddressData> {
     const row = await addressLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as AddressDBData;
+    return row as AddressData;
   }
 
   static async loadFromOwnerID<T extends AddressBase>(
@@ -256,12 +258,12 @@ export class AddressBase implements Ent<Viewer> {
     ) => T,
     ownerID: ID,
     context?: Context,
-  ): Promise<AddressDBData | null> {
+  ): Promise<AddressData | null> {
     const row = await addressOwnerIDLoader.createLoader(context).load(ownerID);
     if (!row) {
       return null;
     }
-    return row as AddressDBData;
+    return row as AddressData;
   }
 
   static loaderOptions<T extends AddressBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
@@ -29,7 +29,7 @@ import { NodeType } from "src/ent/generated/types";
 import { Guest } from "src/ent/internal";
 import schema from "src/schema/auth_code_schema";
 
-interface AuthCodeDBData {
+interface AuthCodeData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -40,7 +40,7 @@ interface AuthCodeDBData {
 }
 
 export class AuthCodeBase implements Ent<Viewer> {
-  protected readonly data: AuthCodeDBData;
+  protected readonly data: AuthCodeData;
   readonly nodeType = NodeType.AuthCode;
   readonly id: ID;
   readonly createdAt: Date;
@@ -62,8 +62,10 @@ export class AuthCodeBase implements Ent<Viewer> {
     this.data = data;
   }
 
+  __setRawDBData<AuthCodeData>(data: AuthCodeData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): AuthCodeDBData {
+  ___getRawDBData(): AuthCodeData {
     return this.data;
   }
 
@@ -141,7 +143,7 @@ export class AuthCodeBase implements Ent<Viewer> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<AuthCodeDBData[]> {
+  ): Promise<AuthCodeData[]> {
     return (await loadCustomData(
       {
         ...AuthCodeBase.loaderOptions.apply(this),
@@ -149,7 +151,7 @@ export class AuthCodeBase implements Ent<Viewer> {
       },
       query,
       context,
-    )) as AuthCodeDBData[];
+    )) as AuthCodeData[];
   }
 
   static async loadCustomCount<T extends AuthCodeBase>(
@@ -176,12 +178,12 @@ export class AuthCodeBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<AuthCodeDBData | null> {
+  ): Promise<AuthCodeData | null> {
     const row = await authCodeLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as AuthCodeDBData;
+    return row as AuthCodeData;
   }
 
   static async loadRawDataX<T extends AuthCodeBase>(
@@ -191,12 +193,12 @@ export class AuthCodeBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<AuthCodeDBData> {
+  ): Promise<AuthCodeData> {
     const row = await authCodeLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as AuthCodeDBData;
+    return row as AuthCodeData;
   }
 
   static async loadFromGuestID<T extends AuthCodeBase>(
@@ -246,12 +248,12 @@ export class AuthCodeBase implements Ent<Viewer> {
     ) => T,
     guestID: ID,
     context?: Context,
-  ): Promise<AuthCodeDBData | null> {
+  ): Promise<AuthCodeData | null> {
     const row = await authCodeGuestIDLoader.createLoader(context).load(guestID);
     if (!row) {
       return null;
     }
-    return row as AuthCodeDBData;
+    return row as AuthCodeData;
   }
 
   static loaderOptions<T extends AuthCodeBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
@@ -40,7 +40,7 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/event_activity_schema";
 
-interface EventActivityDBData {
+interface EventActivityData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -58,7 +58,7 @@ export class EventActivityBase
   extends WithAddressMixin(class {})
   implements Ent<Viewer>, IWithAddress
 {
-  protected readonly data: EventActivityDBData;
+  protected readonly data: EventActivityData;
   readonly nodeType = NodeType.EventActivity;
   readonly id: ID;
   readonly createdAt: Date;
@@ -88,8 +88,10 @@ export class EventActivityBase
     this.data = data;
   }
 
+  __setRawDBData<EventActivityData>(data: EventActivityData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): EventActivityDBData {
+  ___getRawDBData(): EventActivityData {
     return this.data;
   }
 
@@ -167,7 +169,7 @@ export class EventActivityBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<EventActivityDBData[]> {
+  ): Promise<EventActivityData[]> {
     return (await loadCustomData(
       {
         ...EventActivityBase.loaderOptions.apply(this),
@@ -175,7 +177,7 @@ export class EventActivityBase
       },
       query,
       context,
-    )) as EventActivityDBData[];
+    )) as EventActivityData[];
   }
 
   static async loadCustomCount<T extends EventActivityBase>(
@@ -202,12 +204,12 @@ export class EventActivityBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<EventActivityDBData | null> {
+  ): Promise<EventActivityData | null> {
     const row = await eventActivityLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as EventActivityDBData;
+    return row as EventActivityData;
   }
 
   static async loadRawDataX<T extends EventActivityBase>(
@@ -217,12 +219,12 @@ export class EventActivityBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<EventActivityDBData> {
+  ): Promise<EventActivityData> {
     const row = await eventActivityLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as EventActivityDBData;
+    return row as EventActivityData;
   }
 
   static loaderOptions<T extends EventActivityBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
@@ -35,7 +35,7 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/event_schema";
 
-interface EventDBData {
+interface EventData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -45,7 +45,7 @@ interface EventDBData {
 }
 
 export class EventBase implements Ent<Viewer> {
-  protected readonly data: EventDBData;
+  protected readonly data: EventData;
   readonly nodeType = NodeType.Event;
   readonly id: ID;
   readonly createdAt: Date;
@@ -65,8 +65,10 @@ export class EventBase implements Ent<Viewer> {
     this.data = data;
   }
 
+  __setRawDBData<EventData>(data: EventData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): EventDBData {
+  ___getRawDBData(): EventData {
     return this.data;
   }
 
@@ -144,7 +146,7 @@ export class EventBase implements Ent<Viewer> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<EventDBData[]> {
+  ): Promise<EventData[]> {
     return (await loadCustomData(
       {
         ...EventBase.loaderOptions.apply(this),
@@ -152,7 +154,7 @@ export class EventBase implements Ent<Viewer> {
       },
       query,
       context,
-    )) as EventDBData[];
+    )) as EventData[];
   }
 
   static async loadCustomCount<T extends EventBase>(
@@ -179,12 +181,12 @@ export class EventBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<EventDBData | null> {
+  ): Promise<EventData | null> {
     const row = await eventLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as EventDBData;
+    return row as EventData;
   }
 
   static async loadRawDataX<T extends EventBase>(
@@ -194,12 +196,12 @@ export class EventBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<EventDBData> {
+  ): Promise<EventData> {
     const row = await eventLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as EventDBData;
+    return row as EventData;
   }
 
   static async loadFromSlug<T extends EventBase>(
@@ -249,12 +251,12 @@ export class EventBase implements Ent<Viewer> {
     ) => T,
     slug: string,
     context?: Context,
-  ): Promise<EventDBData | null> {
+  ): Promise<EventData | null> {
     const row = await eventSlugLoader.createLoader(context).load(slug);
     if (!row) {
       return null;
     }
-    return row as EventDBData;
+    return row as EventData;
   }
 
   static loaderOptions<T extends EventBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
@@ -33,7 +33,7 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/guest_schema";
 
-interface GuestDBData {
+interface GuestData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -49,7 +49,7 @@ export class GuestBase
   extends WithAddressMixin(class {})
   implements Ent<Viewer>, IWithAddress
 {
-  protected readonly data: GuestDBData;
+  protected readonly data: GuestData;
   readonly nodeType = NodeType.Guest;
   readonly id: ID;
   readonly createdAt: Date;
@@ -75,8 +75,10 @@ export class GuestBase
     this.data = data;
   }
 
+  __setRawDBData<GuestData>(data: GuestData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): GuestDBData {
+  ___getRawDBData(): GuestData {
     return this.data;
   }
 
@@ -154,7 +156,7 @@ export class GuestBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<GuestDBData[]> {
+  ): Promise<GuestData[]> {
     return (await loadCustomData(
       {
         ...GuestBase.loaderOptions.apply(this),
@@ -162,7 +164,7 @@ export class GuestBase
       },
       query,
       context,
-    )) as GuestDBData[];
+    )) as GuestData[];
   }
 
   static async loadCustomCount<T extends GuestBase>(
@@ -189,12 +191,12 @@ export class GuestBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<GuestDBData | null> {
+  ): Promise<GuestData | null> {
     const row = await guestLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as GuestDBData;
+    return row as GuestData;
   }
 
   static async loadRawDataX<T extends GuestBase>(
@@ -204,12 +206,12 @@ export class GuestBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<GuestDBData> {
+  ): Promise<GuestData> {
     const row = await guestLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as GuestDBData;
+    return row as GuestData;
   }
 
   static loaderOptions<T extends GuestBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
@@ -30,7 +30,7 @@ import {
 import { Event, Guest } from "src/ent/internal";
 import schema from "src/schema/guest_data_schema";
 
-interface GuestDataDBData {
+interface GuestDataData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -41,7 +41,7 @@ interface GuestDataDBData {
 }
 
 export class GuestDataBase implements Ent<Viewer> {
-  protected readonly data: GuestDataDBData;
+  protected readonly data: GuestDataData;
   readonly nodeType = NodeType.GuestData;
   readonly id: ID;
   readonly createdAt: Date;
@@ -63,8 +63,10 @@ export class GuestDataBase implements Ent<Viewer> {
     this.data = data;
   }
 
+  __setRawDBData<GuestDataData>(data: GuestDataData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): GuestDataDBData {
+  ___getRawDBData(): GuestDataData {
     return this.data;
   }
 
@@ -142,7 +144,7 @@ export class GuestDataBase implements Ent<Viewer> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<GuestDataDBData[]> {
+  ): Promise<GuestDataData[]> {
     return (await loadCustomData(
       {
         ...GuestDataBase.loaderOptions.apply(this),
@@ -150,7 +152,7 @@ export class GuestDataBase implements Ent<Viewer> {
       },
       query,
       context,
-    )) as GuestDataDBData[];
+    )) as GuestDataData[];
   }
 
   static async loadCustomCount<T extends GuestDataBase>(
@@ -177,12 +179,12 @@ export class GuestDataBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<GuestDataDBData | null> {
+  ): Promise<GuestDataData | null> {
     const row = await guestDataLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as GuestDataDBData;
+    return row as GuestDataData;
   }
 
   static async loadRawDataX<T extends GuestDataBase>(
@@ -192,12 +194,12 @@ export class GuestDataBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<GuestDataDBData> {
+  ): Promise<GuestDataData> {
     const row = await guestDataLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as GuestDataDBData;
+    return row as GuestDataData;
   }
 
   static loaderOptions<T extends GuestDataBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
@@ -30,7 +30,7 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/guest_group_schema";
 
-interface GuestGroupDBData {
+interface GuestGroupData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -39,7 +39,7 @@ interface GuestGroupDBData {
 }
 
 export class GuestGroupBase implements Ent<Viewer> {
-  protected readonly data: GuestGroupDBData;
+  protected readonly data: GuestGroupData;
   readonly nodeType = NodeType.GuestGroup;
   readonly id: ID;
   readonly createdAt: Date;
@@ -57,8 +57,10 @@ export class GuestGroupBase implements Ent<Viewer> {
     this.data = data;
   }
 
+  __setRawDBData<GuestGroupData>(data: GuestGroupData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): GuestGroupDBData {
+  ___getRawDBData(): GuestGroupData {
     return this.data;
   }
 
@@ -136,7 +138,7 @@ export class GuestGroupBase implements Ent<Viewer> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<GuestGroupDBData[]> {
+  ): Promise<GuestGroupData[]> {
     return (await loadCustomData(
       {
         ...GuestGroupBase.loaderOptions.apply(this),
@@ -144,7 +146,7 @@ export class GuestGroupBase implements Ent<Viewer> {
       },
       query,
       context,
-    )) as GuestGroupDBData[];
+    )) as GuestGroupData[];
   }
 
   static async loadCustomCount<T extends GuestGroupBase>(
@@ -171,12 +173,12 @@ export class GuestGroupBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<GuestGroupDBData | null> {
+  ): Promise<GuestGroupData | null> {
     const row = await guestGroupLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as GuestGroupDBData;
+    return row as GuestGroupData;
   }
 
   static async loadRawDataX<T extends GuestGroupBase>(
@@ -186,12 +188,12 @@ export class GuestGroupBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<GuestGroupDBData> {
+  ): Promise<GuestGroupData> {
     const row = await guestGroupLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as GuestGroupDBData;
+    return row as GuestGroupData;
   }
 
   static loaderOptions<T extends GuestGroupBase>(

--- a/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
@@ -29,7 +29,7 @@ import { NodeType } from "src/ent/generated/types";
 import { UserToEventsQuery } from "src/ent/internal";
 import schema from "src/schema/user_schema";
 
-interface UserDBData {
+interface UserData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -40,7 +40,7 @@ interface UserDBData {
 }
 
 export class UserBase implements Ent<Viewer> {
-  protected readonly data: UserDBData;
+  protected readonly data: UserData;
   readonly nodeType = NodeType.User;
   readonly id: ID;
   readonly createdAt: Date;
@@ -62,8 +62,10 @@ export class UserBase implements Ent<Viewer> {
     this.data = data;
   }
 
+  __setRawDBData<UserData>(data: UserData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): UserDBData {
+  ___getRawDBData(): UserData {
     return this.data;
   }
 
@@ -141,7 +143,7 @@ export class UserBase implements Ent<Viewer> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<UserDBData[]> {
+  ): Promise<UserData[]> {
     return (await loadCustomData(
       {
         ...UserBase.loaderOptions.apply(this),
@@ -149,7 +151,7 @@ export class UserBase implements Ent<Viewer> {
       },
       query,
       context,
-    )) as UserDBData[];
+    )) as UserData[];
   }
 
   static async loadCustomCount<T extends UserBase>(
@@ -176,12 +178,12 @@ export class UserBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<UserDBData | null> {
+  ): Promise<UserData | null> {
     const row = await userLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as UserDBData;
+    return row as UserData;
   }
 
   static async loadRawDataX<T extends UserBase>(
@@ -191,12 +193,12 @@ export class UserBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<UserDBData> {
+  ): Promise<UserData> {
     const row = await userLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as UserDBData;
+    return row as UserData;
   }
 
   static async loadFromEmailAddress<T extends UserBase>(
@@ -248,14 +250,14 @@ export class UserBase implements Ent<Viewer> {
     ) => T,
     emailAddress: string,
     context?: Context,
-  ): Promise<UserDBData | null> {
+  ): Promise<UserData | null> {
     const row = await userEmailAddressLoader
       .createLoader(context)
       .load(emailAddress);
     if (!row) {
       return null;
     }
-    return row as UserDBData;
+    return row as UserData;
   }
 
   static loaderOptions<T extends UserBase>(

--- a/examples/ent-rsvp/backend/src/ent/internal.ts
+++ b/examples/ent-rsvp/backend/src/ent/internal.ts
@@ -41,3 +41,44 @@ export * from "src/ent/guest/query/guest_to_guest_data_query";
 export * from "src/ent/guest_group/query/guest_group_to_guests_query";
 export * from "src/ent/guest_group/query/guest_group_to_invited_events_query";
 export * from "src/ent/user/query/user_to_events_query";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha96-4c4de410-8d95-11ed-ae0d-dde452a51f5e",
+        "@snowtop/ent": "^0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1132,9 +1132,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha96-b0ce9100-8e0d-11ed-a5d9-015e8cfdc29c",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-b0ce9100-8e0d-11ed-a5d9-015e8cfdc29c.tgz",
-      "integrity": "sha512-ArrRKOqIU8UsATEww2uzcqGwIW+3eHj0v9a74oxgplsE2kOrYPXN4DElzuEAuY/XTK2TLk96ecLZuV4+RDahDw==",
+      "version": "0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e.tgz",
+      "integrity": "sha512-lgADR51b5aSLgfWWw3ps2MNzO13FsZtJPloWXVKIV9ZRpDZj+gpG9pKQk4Ua7Mabo4DAEyEKGiynvYUYahe4GQ==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",
@@ -6843,9 +6843,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha96-b0ce9100-8e0d-11ed-a5d9-015e8cfdc29c",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-b0ce9100-8e0d-11ed-a5d9-015e8cfdc29c.tgz",
-      "integrity": "sha512-ArrRKOqIU8UsATEww2uzcqGwIW+3eHj0v9a74oxgplsE2kOrYPXN4DElzuEAuY/XTK2TLk96ecLZuV4+RDahDw==",
+      "version": "0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e.tgz",
+      "integrity": "sha512-lgADR51b5aSLgfWWw3ps2MNzO13FsZtJPloWXVKIV9ZRpDZj+gpG9pKQk4Ua7Mabo4DAEyEKGiynvYUYahe4GQ==",
       "requires": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -33,7 +33,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha96-4c4de410-8d95-11ed-ae0d-dde452a51f5e",
+    "@snowtop/ent": "^0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/simple/src/ent/generated/address_base.ts
+++ b/examples/simple/src/ent/generated/address_base.ts
@@ -26,7 +26,7 @@ import { AddressToHostedEventsQuery } from "../internal";
 import schema from "../../schema/address";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface AddressDBData {
+interface AddressData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -39,7 +39,7 @@ interface AddressDBData {
 }
 
 export class AddressBase implements Ent<ExampleViewerAlias> {
-  protected readonly data: AddressDBData;
+  protected readonly data: AddressData;
   readonly nodeType = NodeType.Address;
   readonly id: ID;
   readonly createdAt: Date;
@@ -65,8 +65,10 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
     this.data = data;
   }
 
+  __setRawDBData<AddressData>(data: AddressData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): AddressDBData {
+  ___getRawDBData(): AddressData {
     return this.data;
   }
 
@@ -144,7 +146,7 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<AddressDBData[]> {
+  ): Promise<AddressData[]> {
     return (await loadCustomData(
       {
         ...AddressBase.loaderOptions.apply(this),
@@ -152,7 +154,7 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
       },
       query,
       context,
-    )) as AddressDBData[];
+    )) as AddressData[];
   }
 
   static async loadCustomCount<T extends AddressBase>(
@@ -179,12 +181,12 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<AddressDBData | null> {
+  ): Promise<AddressData | null> {
     const row = await addressLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as AddressDBData;
+    return row as AddressData;
   }
 
   static async loadRawDataX<T extends AddressBase>(
@@ -194,12 +196,12 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<AddressDBData> {
+  ): Promise<AddressData> {
     const row = await addressLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as AddressDBData;
+    return row as AddressData;
   }
 
   static loaderOptions<T extends AddressBase>(

--- a/examples/simple/src/ent/generated/auth_code_base.ts
+++ b/examples/simple/src/ent/generated/auth_code_base.ts
@@ -26,7 +26,7 @@ import { User } from "../internal";
 import schema from "../../schema/auth_code_schema";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface AuthCodeDBData {
+interface AuthCodeData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -37,7 +37,7 @@ interface AuthCodeDBData {
 }
 
 export class AuthCodeBase implements Ent<ExampleViewerAlias> {
-  protected readonly data: AuthCodeDBData;
+  protected readonly data: AuthCodeData;
   readonly nodeType = NodeType.AuthCode;
   readonly id: ID;
   readonly createdAt: Date;
@@ -59,8 +59,10 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
     this.data = data;
   }
 
+  __setRawDBData<AuthCodeData>(data: AuthCodeData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): AuthCodeDBData {
+  ___getRawDBData(): AuthCodeData {
     return this.data;
   }
 
@@ -138,7 +140,7 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<AuthCodeDBData[]> {
+  ): Promise<AuthCodeData[]> {
     return (await loadCustomData(
       {
         ...AuthCodeBase.loaderOptions.apply(this),
@@ -146,7 +148,7 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
       },
       query,
       context,
-    )) as AuthCodeDBData[];
+    )) as AuthCodeData[];
   }
 
   static async loadCustomCount<T extends AuthCodeBase>(
@@ -173,12 +175,12 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<AuthCodeDBData | null> {
+  ): Promise<AuthCodeData | null> {
     const row = await authCodeLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as AuthCodeDBData;
+    return row as AuthCodeData;
   }
 
   static async loadRawDataX<T extends AuthCodeBase>(
@@ -188,12 +190,12 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<AuthCodeDBData> {
+  ): Promise<AuthCodeData> {
     const row = await authCodeLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as AuthCodeDBData;
+    return row as AuthCodeData;
   }
 
   static loaderOptions<T extends AuthCodeBase>(

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -27,7 +27,7 @@ import { ArticleToCommentsQuery, CommentToPostQuery, User } from "../internal";
 import schema from "../../schema/comment_schema";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface CommentDBData {
+interface CommentData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -40,7 +40,7 @@ interface CommentDBData {
 }
 
 export class CommentBase implements Ent<ExampleViewerAlias> {
-  protected readonly data: CommentDBData;
+  protected readonly data: CommentData;
   readonly nodeType = NodeType.Comment;
   readonly id: ID;
   readonly createdAt: Date;
@@ -66,8 +66,10 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
     this.data = data;
   }
 
+  __setRawDBData<CommentData>(data: CommentData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): CommentDBData {
+  ___getRawDBData(): CommentData {
     return this.data;
   }
 
@@ -145,7 +147,7 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<CommentDBData[]> {
+  ): Promise<CommentData[]> {
     return (await loadCustomData(
       {
         ...CommentBase.loaderOptions.apply(this),
@@ -153,7 +155,7 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
       },
       query,
       context,
-    )) as CommentDBData[];
+    )) as CommentData[];
   }
 
   static async loadCustomCount<T extends CommentBase>(
@@ -180,12 +182,12 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<CommentDBData | null> {
+  ): Promise<CommentData | null> {
     const row = await commentLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as CommentDBData;
+    return row as CommentData;
   }
 
   static async loadRawDataX<T extends CommentBase>(
@@ -195,12 +197,12 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<CommentDBData> {
+  ): Promise<CommentData> {
     const row = await commentLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as CommentDBData;
+    return row as CommentData;
   }
 
   static queryFromArticle<T extends CommentBase>(

--- a/examples/simple/src/ent/generated/contact_base.ts
+++ b/examples/simple/src/ent/generated/contact_base.ts
@@ -34,7 +34,7 @@ import {
 import schema from "../../schema/contact_schema";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface ContactDBData {
+interface ContactData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -49,7 +49,7 @@ export class ContactBase
   extends FeedbackMixin(class {})
   implements Ent<ExampleViewerAlias>, IFeedback
 {
-  protected readonly data: ContactDBData;
+  protected readonly data: ContactData;
   readonly nodeType = NodeType.Contact;
   readonly id: ID;
   readonly createdAt: Date;
@@ -75,8 +75,10 @@ export class ContactBase
     this.data = data;
   }
 
+  __setRawDBData<ContactData>(data: ContactData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): ContactDBData {
+  ___getRawDBData(): ContactData {
     return this.data;
   }
 
@@ -154,7 +156,7 @@ export class ContactBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<ContactDBData[]> {
+  ): Promise<ContactData[]> {
     return (await loadCustomData(
       {
         ...ContactBase.loaderOptions.apply(this),
@@ -162,7 +164,7 @@ export class ContactBase
       },
       query,
       context,
-    )) as ContactDBData[];
+    )) as ContactData[];
   }
 
   static async loadCustomCount<T extends ContactBase>(
@@ -189,12 +191,12 @@ export class ContactBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactDBData | null> {
+  ): Promise<ContactData | null> {
     const row = await contactLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as ContactDBData;
+    return row as ContactData;
   }
 
   static async loadRawDataX<T extends ContactBase>(
@@ -204,12 +206,12 @@ export class ContactBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactDBData> {
+  ): Promise<ContactData> {
     const row = await contactLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as ContactDBData;
+    return row as ContactData;
   }
 
   static loaderOptions<T extends ContactBase>(

--- a/examples/simple/src/ent/generated/contact_email_base.ts
+++ b/examples/simple/src/ent/generated/contact_email_base.ts
@@ -31,7 +31,7 @@ import { Contact, ContactInfoMixin, IContactInfo } from "../internal";
 import schema from "../../schema/contact_email_schema";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface ContactEmailDBData {
+interface ContactEmailData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -45,7 +45,7 @@ export class ContactEmailBase
   extends ContactInfoMixin(class {})
   implements Ent<ExampleViewerAlias>, IContactInfo
 {
-  protected readonly data: ContactEmailDBData;
+  protected readonly data: ContactEmailData;
   readonly nodeType = NodeType.ContactEmail;
   readonly id: ID;
   readonly createdAt: Date;
@@ -67,8 +67,10 @@ export class ContactEmailBase
     this.data = data;
   }
 
+  __setRawDBData<ContactEmailData>(data: ContactEmailData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): ContactEmailDBData {
+  ___getRawDBData(): ContactEmailData {
     return this.data;
   }
 
@@ -146,7 +148,7 @@ export class ContactEmailBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<ContactEmailDBData[]> {
+  ): Promise<ContactEmailData[]> {
     return (await loadCustomData(
       {
         ...ContactEmailBase.loaderOptions.apply(this),
@@ -154,7 +156,7 @@ export class ContactEmailBase
       },
       query,
       context,
-    )) as ContactEmailDBData[];
+    )) as ContactEmailData[];
   }
 
   static async loadCustomCount<T extends ContactEmailBase>(
@@ -181,12 +183,12 @@ export class ContactEmailBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactEmailDBData | null> {
+  ): Promise<ContactEmailData | null> {
     const row = await contactEmailLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as ContactEmailDBData;
+    return row as ContactEmailData;
   }
 
   static async loadRawDataX<T extends ContactEmailBase>(
@@ -196,12 +198,12 @@ export class ContactEmailBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactEmailDBData> {
+  ): Promise<ContactEmailData> {
     const row = await contactEmailLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as ContactEmailDBData;
+    return row as ContactEmailData;
   }
 
   static loaderOptions<T extends ContactEmailBase>(

--- a/examples/simple/src/ent/generated/contact_phone_number_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number_base.ts
@@ -34,7 +34,7 @@ import { Contact, ContactInfoMixin, IContactInfo } from "../internal";
 import schema from "../../schema/contact_phone_number_schema";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface ContactPhoneNumberDBData {
+interface ContactPhoneNumberData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -48,7 +48,7 @@ export class ContactPhoneNumberBase
   extends ContactInfoMixin(class {})
   implements Ent<ExampleViewerAlias>, IContactInfo
 {
-  protected readonly data: ContactPhoneNumberDBData;
+  protected readonly data: ContactPhoneNumberData;
   readonly nodeType = NodeType.ContactPhoneNumber;
   readonly id: ID;
   readonly createdAt: Date;
@@ -70,8 +70,10 @@ export class ContactPhoneNumberBase
     this.data = data;
   }
 
+  __setRawDBData<ContactPhoneNumberData>(data: ContactPhoneNumberData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): ContactPhoneNumberDBData {
+  ___getRawDBData(): ContactPhoneNumberData {
     return this.data;
   }
 
@@ -149,7 +151,7 @@ export class ContactPhoneNumberBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<ContactPhoneNumberDBData[]> {
+  ): Promise<ContactPhoneNumberData[]> {
     return (await loadCustomData(
       {
         ...ContactPhoneNumberBase.loaderOptions.apply(this),
@@ -157,7 +159,7 @@ export class ContactPhoneNumberBase
       },
       query,
       context,
-    )) as ContactPhoneNumberDBData[];
+    )) as ContactPhoneNumberData[];
   }
 
   static async loadCustomCount<T extends ContactPhoneNumberBase>(
@@ -184,12 +186,12 @@ export class ContactPhoneNumberBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactPhoneNumberDBData | null> {
+  ): Promise<ContactPhoneNumberData | null> {
     const row = await contactPhoneNumberLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as ContactPhoneNumberDBData;
+    return row as ContactPhoneNumberData;
   }
 
   static async loadRawDataX<T extends ContactPhoneNumberBase>(
@@ -199,12 +201,12 @@ export class ContactPhoneNumberBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<ContactPhoneNumberDBData> {
+  ): Promise<ContactPhoneNumberData> {
     const row = await contactPhoneNumberLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as ContactPhoneNumberDBData;
+    return row as ContactPhoneNumberData;
   }
 
   static loaderOptions<T extends ContactPhoneNumberBase>(

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -36,7 +36,7 @@ import {
 import schema from "../../schema/event_schema";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface EventDBData {
+interface EventData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -49,7 +49,7 @@ interface EventDBData {
 }
 
 export class EventBase implements Ent<ExampleViewerAlias> {
-  protected readonly data: EventDBData;
+  protected readonly data: EventData;
   readonly nodeType = NodeType.Event;
   readonly id: ID;
   readonly createdAt: Date;
@@ -75,8 +75,10 @@ export class EventBase implements Ent<ExampleViewerAlias> {
     this.data = data;
   }
 
+  __setRawDBData<EventData>(data: EventData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): EventDBData {
+  ___getRawDBData(): EventData {
     return this.data;
   }
 
@@ -167,7 +169,7 @@ export class EventBase implements Ent<ExampleViewerAlias> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<EventDBData[]> {
+  ): Promise<EventData[]> {
     return (await loadCustomData(
       {
         ...EventBase.loaderOptions.apply(this),
@@ -175,7 +177,7 @@ export class EventBase implements Ent<ExampleViewerAlias> {
       },
       query,
       context,
-    )) as EventDBData[];
+    )) as EventData[];
   }
 
   static async loadCustomCount<T extends EventBase>(
@@ -202,12 +204,12 @@ export class EventBase implements Ent<ExampleViewerAlias> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<EventDBData | null> {
+  ): Promise<EventData | null> {
     const row = await eventLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as EventDBData;
+    return row as EventData;
   }
 
   static async loadRawDataX<T extends EventBase>(
@@ -217,12 +219,12 @@ export class EventBase implements Ent<ExampleViewerAlias> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<EventDBData> {
+  ): Promise<EventData> {
     const row = await eventLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as EventDBData;
+    return row as EventData;
   }
 
   static loaderOptions<T extends EventBase>(

--- a/examples/simple/src/ent/generated/holiday_base.ts
+++ b/examples/simple/src/ent/generated/holiday_base.ts
@@ -26,7 +26,7 @@ import { DayOfWeekMixin, IDayOfWeek } from "../internal";
 import schema from "../../schema/holiday_schema";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface HolidayDBData {
+interface HolidayData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -40,7 +40,7 @@ export class HolidayBase
   extends DayOfWeekMixin(class {})
   implements Ent<ExampleViewerAlias>, IDayOfWeek
 {
-  protected readonly data: HolidayDBData;
+  protected readonly data: HolidayData;
   readonly nodeType = NodeType.Holiday;
   readonly id: ID;
   readonly createdAt: Date;
@@ -60,8 +60,10 @@ export class HolidayBase
     this.data = data;
   }
 
+  __setRawDBData<HolidayData>(data: HolidayData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): HolidayDBData {
+  ___getRawDBData(): HolidayData {
     return this.data;
   }
 
@@ -139,7 +141,7 @@ export class HolidayBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<HolidayDBData[]> {
+  ): Promise<HolidayData[]> {
     return (await loadCustomData(
       {
         ...HolidayBase.loaderOptions.apply(this),
@@ -147,7 +149,7 @@ export class HolidayBase
       },
       query,
       context,
-    )) as HolidayDBData[];
+    )) as HolidayData[];
   }
 
   static async loadCustomCount<T extends HolidayBase>(
@@ -174,12 +176,12 @@ export class HolidayBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<HolidayDBData | null> {
+  ): Promise<HolidayData | null> {
     const row = await holidayLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as HolidayDBData;
+    return row as HolidayData;
   }
 
   static async loadRawDataX<T extends HolidayBase>(
@@ -189,12 +191,12 @@ export class HolidayBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<HolidayDBData> {
+  ): Promise<HolidayData> {
     const row = await holidayLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as HolidayDBData;
+    return row as HolidayData;
   }
 
   static loaderOptions<T extends HolidayBase>(

--- a/examples/simple/src/ent/generated/hours_of_operation_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation_base.ts
@@ -26,7 +26,7 @@ import { DayOfWeekMixin, IDayOfWeek } from "../internal";
 import schema from "../../schema/hours_of_operation_schema";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface HoursOfOperationDBData {
+interface HoursOfOperationData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -40,7 +40,7 @@ export class HoursOfOperationBase
   extends DayOfWeekMixin(class {})
   implements Ent<ExampleViewerAlias>, IDayOfWeek
 {
-  protected readonly data: HoursOfOperationDBData;
+  protected readonly data: HoursOfOperationData;
   readonly nodeType = NodeType.HoursOfOperation;
   readonly id: ID;
   readonly createdAt: Date;
@@ -60,8 +60,10 @@ export class HoursOfOperationBase
     this.data = data;
   }
 
+  __setRawDBData<HoursOfOperationData>(data: HoursOfOperationData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): HoursOfOperationDBData {
+  ___getRawDBData(): HoursOfOperationData {
     return this.data;
   }
 
@@ -139,7 +141,7 @@ export class HoursOfOperationBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<HoursOfOperationDBData[]> {
+  ): Promise<HoursOfOperationData[]> {
     return (await loadCustomData(
       {
         ...HoursOfOperationBase.loaderOptions.apply(this),
@@ -147,7 +149,7 @@ export class HoursOfOperationBase
       },
       query,
       context,
-    )) as HoursOfOperationDBData[];
+    )) as HoursOfOperationData[];
   }
 
   static async loadCustomCount<T extends HoursOfOperationBase>(
@@ -174,12 +176,12 @@ export class HoursOfOperationBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<HoursOfOperationDBData | null> {
+  ): Promise<HoursOfOperationData | null> {
     const row = await hoursOfOperationLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as HoursOfOperationDBData;
+    return row as HoursOfOperationData;
   }
 
   static async loadRawDataX<T extends HoursOfOperationBase>(
@@ -189,12 +191,12 @@ export class HoursOfOperationBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<HoursOfOperationDBData> {
+  ): Promise<HoursOfOperationData> {
     const row = await hoursOfOperationLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as HoursOfOperationDBData;
+    return row as HoursOfOperationData;
   }
 
   static loaderOptions<T extends HoursOfOperationBase>(

--- a/examples/simple/src/ent/generated/user/actions/edit_user_all_fields_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/edit_user_all_fields_action_base.ts
@@ -114,7 +114,7 @@ export class EditUserAllFieldsActionBase
   ) {
     this.viewer = viewer;
     let expressions = new Map<string, Clause>();
-    const data = user.___getData();
+    const data = user.___getRawDBData();
     this.input = {
       ...input,
       timeInMs: maybeConvertRelativeInputPlusExpressions(

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -77,7 +77,7 @@ import {
 } from "../../util/convert_user_fields";
 import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
 
-interface UserDBData {
+interface UserData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -113,7 +113,7 @@ export class UserBase
   extends FeedbackMixin(class {})
   implements Ent<ExampleViewerAlias>, IFeedback
 {
-  protected readonly data: UserDBData;
+  protected readonly data: UserData;
   readonly nodeType = NodeType.User;
   readonly id: ID;
   readonly createdAt: Date;
@@ -170,8 +170,10 @@ export class UserBase
     this.data = data;
   }
 
+  __setRawDBData<UserData>(data: UserData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): UserDBData {
+  ___getRawDBData(): UserData {
     return this.data;
   }
 
@@ -323,7 +325,7 @@ export class UserBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<UserDBData[]> {
+  ): Promise<UserData[]> {
     return (await loadCustomData(
       {
         ...UserBase.loaderOptions.apply(this),
@@ -331,7 +333,7 @@ export class UserBase
       },
       query,
       context,
-    )) as UserDBData[];
+    )) as UserData[];
   }
 
   static async loadCustomCount<T extends UserBase>(
@@ -358,12 +360,12 @@ export class UserBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<UserDBData | null> {
+  ): Promise<UserData | null> {
     const row = await userLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as UserDBData;
+    return row as UserData;
   }
 
   static async loadRawDataX<T extends UserBase>(
@@ -373,12 +375,12 @@ export class UserBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<UserDBData> {
+  ): Promise<UserData> {
     const row = await userLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as UserDBData;
+    return row as UserData;
   }
 
   static async loadFromEmailAddress<T extends UserBase>(
@@ -430,14 +432,14 @@ export class UserBase
     ) => T,
     emailAddress: string,
     context?: Context,
-  ): Promise<UserDBData | null> {
+  ): Promise<UserData | null> {
     const row = await userEmailAddressLoader
       .createLoader(context)
       .load(emailAddress);
     if (!row) {
       return null;
     }
-    return row as UserDBData;
+    return row as UserData;
   }
 
   static async loadFromPhoneNumber<T extends UserBase>(
@@ -489,14 +491,14 @@ export class UserBase
     ) => T,
     phoneNumber: string,
     context?: Context,
-  ): Promise<UserDBData | null> {
+  ): Promise<UserData | null> {
     const row = await userPhoneNumberLoader
       .createLoader(context)
       .load(phoneNumber);
     if (!row) {
       return null;
     }
-    return row as UserDBData;
+    return row as UserData;
   }
 
   static loaderOptions<T extends UserBase>(

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha96-74b1d9c0-8d31-11ed-8745-35ccc81d5579",
+        "@snowtop/ent": "^0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
         "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
         "@snowtop/ent-soft-delete": "^0.1.0-alpha4",
         "@types/node": "^15.0.3",
@@ -1100,9 +1100,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha96-74b1d9c0-8d31-11ed-8745-35ccc81d5579",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-74b1d9c0-8d31-11ed-8745-35ccc81d5579.tgz",
-      "integrity": "sha512-12U+FTFR+PVWaYTVWTrmi2cNPFZNMLWX/IHkxqK9OxbWdHieSCbAtKP/lG78F2JSEaIs32mrOj0OeP8v26eoOQ==",
+      "version": "0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e.tgz",
+      "integrity": "sha512-lgADR51b5aSLgfWWw3ps2MNzO13FsZtJPloWXVKIV9ZRpDZj+gpG9pKQk4Ua7Mabo4DAEyEKGiynvYUYahe4GQ==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",
@@ -6744,9 +6744,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha96-74b1d9c0-8d31-11ed-8745-35ccc81d5579",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-74b1d9c0-8d31-11ed-8745-35ccc81d5579.tgz",
-      "integrity": "sha512-12U+FTFR+PVWaYTVWTrmi2cNPFZNMLWX/IHkxqK9OxbWdHieSCbAtKP/lG78F2JSEaIs32mrOj0OeP8v26eoOQ==",
+      "version": "0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e.tgz",
+      "integrity": "sha512-lgADR51b5aSLgfWWw3ps2MNzO13FsZtJPloWXVKIV9ZRpDZj+gpG9pKQk4Ua7Mabo4DAEyEKGiynvYUYahe4GQ==",
       "requires": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -36,7 +36,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha96-74b1d9c0-8d31-11ed-8745-35ccc81d5579",
+    "@snowtop/ent": "^0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
     "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
     "@snowtop/ent-soft-delete": "^0.1.0-alpha4",
     "@types/node": "^15.0.3",

--- a/examples/todo-sqlite/src/ent/generated/account/actions/account_builder.ts
+++ b/examples/todo-sqlite/src/ent/generated/account/actions/account_builder.ts
@@ -441,7 +441,7 @@ export class AccountBuilder<
   }
 
   // get value of credits. Retrieves it from the input if specified or takes it from existingEnt
-  getNewCreditsValue(): number {
+  getNewCreditsValue(): number | null {
     if (this.input.credits !== undefined) {
       return this.input.credits;
     }

--- a/examples/todo-sqlite/src/ent/generated/account/actions/account_update_balance_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account/actions/account_update_balance_action_base.ts
@@ -84,7 +84,7 @@ export class AccountUpdateBalanceActionBase
   ) {
     this.viewer = viewer;
     let expressions = new Map<string, Clause>();
-    const data = account.___getData();
+    const data = account.___getRawDBData();
     this.input = {
       ...input,
       credits: maybeConvertRelativeInputPlusExpressions(

--- a/examples/todo-sqlite/src/ent/generated/account_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_base.ts
@@ -56,10 +56,6 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/account_schema";
 
-// there's 2 data types here
-// there's raw db data and there's ent data
-// they are different if we have on ent load field privacy and an ent with this...
-
 interface AccountData {
   id: ID;
   created_at: Date;

--- a/examples/todo-sqlite/src/ent/generated/tag_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_base.ts
@@ -30,10 +30,6 @@ import { NodeType } from "src/ent/generated/types";
 import { Account, Tag, TagToTodosQuery } from "src/ent/internal";
 import schema from "src/schema/tag_schema";
 
-// there's 2 data types here
-// there's raw db data and there's ent data
-// they are different if we have on ent load field privacy and an ent with this...
-
 interface TagData {
   id: ID;
   created_at: Date;

--- a/examples/todo-sqlite/src/ent/generated/tag_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_base.ts
@@ -30,7 +30,11 @@ import { NodeType } from "src/ent/generated/types";
 import { Account, Tag, TagToTodosQuery } from "src/ent/internal";
 import schema from "src/schema/tag_schema";
 
-interface TagDBData {
+// there's 2 data types here
+// there's raw db data and there's ent data
+// they are different if we have on ent load field privacy and an ent with this...
+
+interface TagData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -42,7 +46,7 @@ interface TagDBData {
 }
 
 export class TagBase implements Ent<Viewer> {
-  protected readonly data: TagDBData;
+  protected readonly data: TagData;
   readonly nodeType = NodeType.Tag;
   readonly id: ID;
   readonly createdAt: Date;
@@ -66,8 +70,10 @@ export class TagBase implements Ent<Viewer> {
     this.data = data;
   }
 
+  __setRawDBData<TagData>(data: TagData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): TagDBData {
+  ___getRawDBData(): TagData {
     return this.data;
   }
 
@@ -176,7 +182,7 @@ export class TagBase implements Ent<Viewer> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<TagDBData[]> {
+  ): Promise<TagData[]> {
     return (await loadCustomData(
       {
         ...TagBase.loaderOptions.apply(this),
@@ -184,7 +190,7 @@ export class TagBase implements Ent<Viewer> {
       },
       query,
       context,
-    )) as TagDBData[];
+    )) as TagData[];
   }
 
   static async loadCustomCount<T extends TagBase>(
@@ -211,12 +217,12 @@ export class TagBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<TagDBData | null> {
+  ): Promise<TagData | null> {
     const row = await tagLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as TagDBData;
+    return row as TagData;
   }
 
   static async loadRawDataX<T extends TagBase>(
@@ -226,12 +232,12 @@ export class TagBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<TagDBData> {
+  ): Promise<TagData> {
     const row = await tagLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as TagDBData;
+    return row as TagData;
   }
 
   static loaderOptions<T extends TagBase>(

--- a/examples/todo-sqlite/src/ent/generated/todo/actions/change_todo_bounty_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo/actions/change_todo_bounty_action_base.ts
@@ -83,7 +83,7 @@ export class ChangeTodoBountyActionBase
   ) {
     this.viewer = viewer;
     let expressions = new Map<string, Clause>();
-    const data = todo.___getData();
+    const data = todo.___getRawDBData();
     this.input = {
       ...input,
       bounty: maybeConvertRelativeInputPlusExpressions(

--- a/examples/todo-sqlite/src/ent/generated/todo_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_base.ts
@@ -35,10 +35,6 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/todo_schema";
 
-// there's 2 data types here
-// there's raw db data and there's ent data
-// they are different if we have on ent load field privacy and an ent with this...
-
 interface TodoData {
   id: ID;
   created_at: Date;

--- a/examples/todo-sqlite/src/ent/generated/todo_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_base.ts
@@ -35,7 +35,11 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/todo_schema";
 
-interface TodoDBData {
+// there's 2 data types here
+// there's raw db data and there's ent data
+// they are different if we have on ent load field privacy and an ent with this...
+
+interface TodoData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -51,7 +55,7 @@ interface TodoDBData {
 }
 
 export class TodoBase implements Ent<Viewer> {
-  protected readonly data: TodoDBData;
+  protected readonly data: TodoData;
   readonly nodeType = NodeType.Todo;
   readonly id: ID;
   readonly createdAt: Date;
@@ -83,8 +87,10 @@ export class TodoBase implements Ent<Viewer> {
     this.data = data;
   }
 
+  __setRawDBData<TodoData>(data: TodoData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): TodoDBData {
+  ___getRawDBData(): TodoData {
     return this.data;
   }
 
@@ -197,7 +203,7 @@ export class TodoBase implements Ent<Viewer> {
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<TodoDBData[]> {
+  ): Promise<TodoData[]> {
     return (await loadCustomData(
       {
         ...TodoBase.loaderOptions.apply(this),
@@ -205,7 +211,7 @@ export class TodoBase implements Ent<Viewer> {
       },
       query,
       context,
-    )) as TodoDBData[];
+    )) as TodoData[];
   }
 
   static async loadCustomCount<T extends TodoBase>(
@@ -232,12 +238,12 @@ export class TodoBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<TodoDBData | null> {
+  ): Promise<TodoData | null> {
     const row = await todoLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as TodoDBData;
+    return row as TodoData;
   }
 
   static async loadRawDataX<T extends TodoBase>(
@@ -247,12 +253,12 @@ export class TodoBase implements Ent<Viewer> {
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<TodoDBData> {
+  ): Promise<TodoData> {
     const row = await todoLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as TodoDBData;
+    return row as TodoData;
   }
 
   static loaderOptions<T extends TodoBase>(

--- a/examples/todo-sqlite/src/ent/generated/workspace_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace_base.ts
@@ -38,7 +38,11 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/workspace_schema";
 
-interface WorkspaceDBData {
+// there's 2 data types here
+// there's raw db data and there's ent data
+// they are different if we have on ent load field privacy and an ent with this...
+
+interface WorkspaceData {
   id: ID;
   created_at: Date;
   updated_at: Date;
@@ -53,7 +57,7 @@ export class WorkspaceBase
   extends TodoContainerMixin(class {})
   implements Ent<Viewer>, ITodoContainer
 {
-  protected readonly data: WorkspaceDBData;
+  protected readonly data: WorkspaceData;
   readonly nodeType = NodeType.Workspace;
   readonly id: ID;
   readonly createdAt: Date;
@@ -79,8 +83,10 @@ export class WorkspaceBase
     this.data = data;
   }
 
+  __setRawDBData<WorkspaceData>(data: WorkspaceData) {}
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): WorkspaceDBData {
+  ___getRawDBData(): WorkspaceData {
     return this.data;
   }
 
@@ -193,7 +199,7 @@ export class WorkspaceBase
     ) => T,
     query: CustomQuery,
     context?: Context,
-  ): Promise<WorkspaceDBData[]> {
+  ): Promise<WorkspaceData[]> {
     return (await loadCustomData(
       {
         ...WorkspaceBase.loaderOptions.apply(this),
@@ -201,7 +207,7 @@ export class WorkspaceBase
       },
       query,
       context,
-    )) as WorkspaceDBData[];
+    )) as WorkspaceData[];
   }
 
   static async loadCustomCount<T extends WorkspaceBase>(
@@ -228,12 +234,12 @@ export class WorkspaceBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<WorkspaceDBData | null> {
+  ): Promise<WorkspaceData | null> {
     const row = await workspaceLoader.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as WorkspaceDBData;
+    return row as WorkspaceData;
   }
 
   static async loadRawDataX<T extends WorkspaceBase>(
@@ -243,12 +249,12 @@ export class WorkspaceBase
     ) => T,
     id: ID,
     context?: Context,
-  ): Promise<WorkspaceDBData> {
+  ): Promise<WorkspaceData> {
     const row = await workspaceLoader.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as WorkspaceDBData;
+    return row as WorkspaceData;
   }
 
   static async loadFromSlug<T extends WorkspaceBase>(
@@ -298,12 +304,12 @@ export class WorkspaceBase
     ) => T,
     slug: string,
     context?: Context,
-  ): Promise<WorkspaceDBData | null> {
+  ): Promise<WorkspaceData | null> {
     const row = await workspaceSlugLoader.createLoader(context).load(slug);
     if (!row) {
       return null;
     }
-    return row as WorkspaceDBData;
+    return row as WorkspaceData;
   }
 
   static loaderOptions<T extends WorkspaceBase>(

--- a/examples/todo-sqlite/src/ent/generated/workspace_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace_base.ts
@@ -38,10 +38,6 @@ import {
 } from "src/ent/internal";
 import schema from "src/schema/workspace_schema";
 
-// there's 2 data types here
-// there's raw db data and there's ent data
-// they are different if we have on ent load field privacy and an ent with this...
-
 interface WorkspaceData {
   id: ID;
   created_at: Date;

--- a/examples/todo-sqlite/src/ent/tests/todo.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/todo.test.ts
@@ -1,7 +1,7 @@
 import ChangeTodoStatusAction from "src/ent/todo/actions/change_todo_status_action";
 import RenameTodoStatusAction from "src/ent/todo/actions/rename_todo_status_action";
 import DeleteTodoAction from "src/ent/todo/actions/delete_todo_action";
-import { Todo } from "src/ent/";
+import { Account, Todo } from "src/ent/";
 import { AccountTodoStatus, EdgeType, NodeType } from "src/ent/generated/types";
 import {
   createAccount,
@@ -10,7 +10,7 @@ import {
   createTodoSelfInWorkspace,
   createWorkspace,
 } from "../testutils/util";
-import { query } from "@snowtop/ent";
+import { IDViewer, query } from "@snowtop/ent";
 import { advanceTo } from "jest-date-mock";
 import TodoAddTagAction from "../todo/actions/todo_add_tag_action";
 import TodoRemoveTagAction from "../todo/actions/todo_remove_tag_action";
@@ -226,7 +226,10 @@ test("complete with bounty", async () => {
 
   await changeCompleted(todo, true);
 
-  const assignee = await todo.loadAssigneeX();
+  const assignee = await Account.loadX(
+    new IDViewer(todo.assigneeID),
+    todo.assigneeID,
+  );
   const creator = await todo.loadCreatorX();
   // completing successfully transfered credits
   expect(assignee.credits).toBe(1100);
@@ -252,9 +255,15 @@ test("complete with bounty, multiple in transaction", async () => {
   ]);
   await tx.run();
 
-  const assignee1 = await todo.loadAssigneeX();
+  const assignee1 = await Account.loadX(
+    new IDViewer(todo.assigneeID),
+    todo.assigneeID,
+  );
+  const assignee2 = await Account.loadX(
+    new IDViewer(todo2.assigneeID),
+    todo2.assigneeID,
+  );
   const creator = await todo.loadCreatorX();
-  const assignee2 = await todo2.loadAssigneeX();
   // completing successfully transfered credits
   expect(assignee1.credits).toBe(1100);
   expect(assignee2.credits).toBe(1100);

--- a/examples/todo-sqlite/src/ent/todo/actions/change_todo_bounty_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/change_todo_bounty_action.ts
@@ -11,7 +11,7 @@ import {
   ChangeTodoBountyInput,
 } from "src/ent/generated/todo/actions/change_todo_bounty_action_base";
 import { NodeType } from "src/ent/generated/types";
-import { Todo } from "src/ent/todo";
+import { Account } from "src/ent/internal";
 
 export { ChangeTodoBountyInput };
 
@@ -26,10 +26,13 @@ export default class ChangeTodoBountyAction extends ChangeTodoBountyActionBase {
           if (!input.bounty) {
             return;
           }
-          const creator = await builder.existingEnt.loadCreatorX();
+          const creatorData = await Account.loadRawDataX(
+            builder.existingEnt.creatorID,
+            builder.viewer.context,
+          );
           const bounty = input.bounty;
 
-          if (bounty > creator.credits) {
+          if (bounty > creatorData.credits) {
             throw new Error(
               `cannot create bounty when account doesn't have enough credits for it`,
             );

--- a/examples/todo-sqlite/src/graphql/generated/resolvers/account_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/resolvers/account_type.ts
@@ -80,7 +80,7 @@ export const AccountType = new GraphQLObjectType({
       },
     },
     credits: {
-      type: new GraphQLNonNull(GraphQLInt),
+      type: GraphQLInt,
     },
     closed_todos_dup: {
       type: new GraphQLNonNull(AccountToClosedTodosDupConnectionType()),

--- a/examples/todo-sqlite/src/graphql/generated/schema.gql
+++ b/examples/todo-sqlite/src/graphql/generated/schema.gql
@@ -49,7 +49,7 @@ type Account implements Node {
   phone_number: String
   account_prefs: AccountPrefs
   account_prefs_list: [AccountPrefs2!]
-  credits: Int!
+  credits: Int
   closed_todos_dup(first: Int, after: String, last: Int, before: String): AccountToClosedTodosDupConnection!
   created_workspaces(first: Int, after: String, last: Int, before: String): AccountToCreatedWorkspacesConnection!
   open_todos_dup(first: Int, after: String, last: Int, before: String): AccountToOpenTodosDupConnection!

--- a/examples/todo-sqlite/src/schema/account_schema.ts
+++ b/examples/todo-sqlite/src/schema/account_schema.ts
@@ -62,6 +62,8 @@ const AccountSchema = new TodoBaseEntSchema({
     // with a bounty
     credits: IntegerType({
       serverDefault: 1000,
+      // only viewer can see their credits balance
+      privacyPolicy: AllowIfViewerPrivacyPolicy,
     }),
   },
 

--- a/internal/field/field.go
+++ b/internal/field/field.go
@@ -607,6 +607,12 @@ func (f *Field) TsBuilderType(cfg codegenapi.Config) string {
 	return fmt.Sprintf("%s | Builder<%s, %s>", typ, f.transformBuilderEnt(typeName, cfg), cfg.GetTemplatizedViewer().GetImport())
 }
 
+// return type with no shenanigans
+// TODO test in fields_type_test.go
+func (f *Field) TsActualType() string {
+	return f.tsRawUnderlyingType()
+}
+
 // this assumes it's ok to do relative. up to caller to confirm that it is before calling
 func (f *Field) TSBuilderWithRelativeType(cfg codegenapi.Config) string {
 	typ := f.TsBuilderType(cfg)

--- a/internal/field/field.go
+++ b/internal/field/field.go
@@ -608,7 +608,6 @@ func (f *Field) TsBuilderType(cfg codegenapi.Config) string {
 }
 
 // return type with no shenanigans
-// TODO test in fields_type_test.go
 func (f *Field) TsActualType() string {
 	return f.tsRawUnderlyingType()
 }

--- a/internal/field/fields_type_test.go
+++ b/internal/field/fields_type_test.go
@@ -20,6 +20,7 @@ type expected struct {
 	tsBuilderFieldName string
 	tsPublicAPIName    string
 	tsType             string
+	tsActualType       string
 	tsFieldType        string
 	tsBuilderType      string
 	// undefined added in builder.tmpl
@@ -57,6 +58,7 @@ func TestNonNullableField(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string",
+		tsActualType:       "string",
 		tsFieldType:        "string",
 		tsBuilderType:      "string",
 		tsBuilderUnionType: "string",
@@ -93,6 +95,7 @@ func TestNullableField(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string | null",
 		tsFieldType:        "string | null",
 		tsBuilderType:      "string | null",
 		tsBuilderUnionType: "string | null",
@@ -107,6 +110,121 @@ func TestNullableField(t *testing.T) {
 		},
 		fieldTypeType:   &enttype.NullableStringType{},
 		tsFieldTypeType: &enttype.NullableStringType{},
+	})
+}
+
+func TestNonNullableIDField(t *testing.T) {
+	cfg := &codegenapi.DummyConfig{}
+	f, err := newFieldFromInputTest(cfg, &input.Field{
+		Name: "name",
+		Type: &input.FieldType{
+			DBType: input.UUID,
+		},
+		ForeignKey: &input.ForeignKey{
+			Schema: "User",
+			Column: "ID",
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "ID",
+		tsActualType:       "ID",
+		tsFieldType:        "ID",
+		tsBuilderType:      "ID | Builder<User, Viewer>",
+		tsBuilderUnionType: "ID | Builder<User, Viewer>",
+		graphqlImports: []*tsimport.ImportPath{
+			tsimport.NewGQLClassImportPath("GraphQLNonNull"),
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		graphqlMutationImports: []*tsimport.ImportPath{
+			tsimport.NewGQLClassImportPath("GraphQLNonNull"),
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		graphqlMutationImportsForceOptional: []*tsimport.ImportPath{
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		fieldTypeType:   &enttype.IDType{},
+		tsFieldTypeType: &enttype.IDType{},
+	})
+}
+
+func TestNonNullableIDFieldNoType(t *testing.T) {
+	cfg := &codegenapi.DummyConfig{}
+	f, err := newFieldFromInputTest(cfg, &input.Field{
+		Name: "name",
+		Type: &input.FieldType{
+			DBType: input.UUID,
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "ID",
+		tsActualType:       "ID",
+		tsFieldType:        "ID",
+		tsBuilderType:      "ID",
+		tsBuilderUnionType: "ID",
+		graphqlImports: []*tsimport.ImportPath{
+			tsimport.NewGQLClassImportPath("GraphQLNonNull"),
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		graphqlMutationImports: []*tsimport.ImportPath{
+			tsimport.NewGQLClassImportPath("GraphQLNonNull"),
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		graphqlMutationImportsForceOptional: []*tsimport.ImportPath{
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		fieldTypeType:   &enttype.IDType{},
+		tsFieldTypeType: &enttype.IDType{},
+	})
+}
+
+func TestNullableIDField(t *testing.T) {
+	cfg := &codegenapi.DummyConfig{}
+	f, err := newFieldFromInputTest(cfg, &input.Field{
+		Name: "name",
+		Type: &input.FieldType{
+			DBType: input.UUID,
+		},
+		Nullable: true,
+		ForeignKey: &input.ForeignKey{
+			Schema: "User",
+			Column: "ID",
+		},
+	})
+	require.Nil(t, err)
+	doTestField(t, cfg, f, &expected{
+		private:            false,
+		asyncAccessor:      false,
+		tsFieldName:        "name",
+		tsBuilderFieldName: "name",
+		tsPublicAPIName:    "name",
+		tsType:             "ID | null",
+		tsActualType:       "ID | null",
+		tsFieldType:        "ID | null",
+		tsBuilderType:      "ID | null | Builder<User, Viewer>",
+		tsBuilderUnionType: "ID | null | Builder<User, Viewer>",
+		graphqlImports: []*tsimport.ImportPath{
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		graphqlMutationImports: []*tsimport.ImportPath{
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		graphqlMutationImportsForceOptional: []*tsimport.ImportPath{
+			tsimport.NewGQLImportPath("GraphQLID"),
+		},
+		fieldTypeType:   &enttype.NullableIDType{},
+		tsFieldTypeType: &enttype.NullableIDType{},
 	})
 }
 
@@ -126,6 +244,7 @@ func TestOptionalFieldInAction(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string",
+		tsActualType:       "string",
 		tsFieldType:        "string",
 		tsBuilderType:      "string",
 		tsBuilderUnionType: "string",
@@ -162,6 +281,7 @@ func TestRequiredFieldInAction(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string | null",
 		tsFieldType:        "string | null",
 		tsBuilderType:      "string | null",
 		tsBuilderUnionType: "string | null",
@@ -200,6 +320,7 @@ func TestNonNullableListField(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string[]",
+		tsActualType:       "string[]",
 		tsFieldType:        "string[]",
 		tsBuilderType:      "string[]",
 		tsBuilderUnionType: "string[]",
@@ -262,6 +383,7 @@ func TestNonNullableFieldOnDemand(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string",
 		tsFieldType:        "string",
 		tsBuilderType:      "string",
 		tsBuilderUnionType: "string | null",
@@ -297,6 +419,7 @@ func TestNonNullableFieldOnDemandNoFieldPrivacy(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string",
+		tsActualType:       "string",
 		tsFieldType:        "string",
 		tsBuilderType:      "string",
 		tsBuilderUnionType: "string",
@@ -334,6 +457,7 @@ func TestNullableFieldOnDemand(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string | null",
 		tsFieldType:        "string | null",
 		tsBuilderType:      "string | null",
 		tsBuilderUnionType: "string | null",
@@ -368,6 +492,7 @@ func TestNullableFieldOnDemandNoFieldPrivacy(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string | null",
 		tsFieldType:        "string | null",
 		tsBuilderType:      "string | null",
 		tsBuilderUnionType: "string | null",
@@ -402,6 +527,7 @@ func TestNonNullableFieldOnEntLoad(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string",
 		tsFieldType:        "string | null",
 		tsBuilderType:      "string",
 		tsBuilderUnionType: "string | null",
@@ -437,6 +563,7 @@ func TestNonNullableFieldOnEntLoadNoFieldPrivacy(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string",
+		tsActualType:       "string",
 		tsFieldType:        "string",
 		tsBuilderType:      "string",
 		tsBuilderUnionType: "string",
@@ -474,6 +601,7 @@ func TestNullableFieldOnEntLoad(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string | null",
 		tsFieldType:        "string | null",
 		tsBuilderType:      "string | null",
 		tsBuilderUnionType: "string | null",
@@ -509,6 +637,7 @@ func TestNullableFieldOnEntLoadNoFieldPrivacy(t *testing.T) {
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
 		tsFieldType:        "string | null",
+		tsActualType:       "string | null",
 		tsBuilderType:      "string | null",
 		tsBuilderUnionType: "string | null",
 		graphqlImports: []*tsimport.ImportPath{
@@ -562,6 +691,7 @@ func TestNullableJSONBAsListFieldOnDemand(t *testing.T) {
 		tsBuilderFieldName: "foo",
 		tsPublicAPIName:    "foo",
 		tsType:             "Foo[] | null",
+		tsActualType:       "Foo[] | null",
 		tsFieldType:        "Foo[] | null",
 		tsBuilderType:      "Foo[] | null",
 		tsBuilderUnionType: "Foo[] | null",
@@ -652,6 +782,7 @@ func TestNonNullableFieldDelayedFetch(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string",
 		tsFieldType:        "string | null | undefined",
 		tsBuilderType:      "string",
 		tsBuilderUnionType: "string | null",
@@ -688,6 +819,7 @@ func TestNullableFieldDelayedFetch(t *testing.T) {
 		tsBuilderFieldName: "name",
 		tsPublicAPIName:    "name",
 		tsType:             "string | null",
+		tsActualType:       "string | null",
 		tsFieldType:        "string | null | undefined",
 		tsBuilderType:      "string | null",
 		tsBuilderUnionType: "string | null",
@@ -725,6 +857,7 @@ func TestNonNullableListFieldDelayedFetch(t *testing.T) {
 		tsBuilderFieldName: "list",
 		tsPublicAPIName:    "list",
 		tsType:             "string[] | null",
+		tsActualType:       "string[]",
 		tsFieldType:        "string[] | null | undefined",
 		tsBuilderType:      "string[]",
 		tsBuilderUnionType: "string[] | null",
@@ -774,6 +907,7 @@ func TestNullableListFieldDelayedFetch(t *testing.T) {
 		tsBuilderFieldName: "list",
 		tsPublicAPIName:    "list",
 		tsType:             "string[] | null",
+		tsActualType:       "string[] | null",
 		tsFieldType:        "string[] | null | undefined",
 		tsBuilderType:      "string[] | null",
 		tsBuilderUnionType: "string[] | null",
@@ -808,6 +942,7 @@ func doTestField(t *testing.T, cfg codegenapi.Config, f *Field, exp *expected) {
 	assert.Equal(t, exp.tsBuilderFieldName, f.TsBuilderFieldName())
 	assert.Equal(t, exp.tsPublicAPIName, f.TSPublicAPIName())
 	assert.Equal(t, exp.tsType, f.TsType())
+	assert.Equal(t, exp.tsActualType, f.TsActualType())
 	assert.Equal(t, exp.tsFieldType, f.TsFieldType(cfg))
 	assert.Equal(t, exp.tsBuilderType, f.TsBuilderType(cfg))
 	assert.Equal(t, exp.tsBuilderUnionType, f.TsBuilderUnionType(cfg))

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -164,7 +164,7 @@ export class {{$actionName}} implements {{useImport "Action"}}<{{$node}}, {{useI
     {{ if $hasInput -}}
       {{if $inputWithRelative -}}
           let expressions = new Map<string, {{useImport "Clause"}}>();
-          const data = {{$instance}}.___getData();
+          const data = {{$instance}}.___getRawDBData();
           this.input = {
             ...input,
         {{ range $field := $inputWithRelative.FieldsWithRelative -}}

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -35,7 +35,12 @@
 
 {{$nodeData := .}}
 
-{{$dataType := printf "%sDBData" .Node -}}
+// there's 2 data types here
+// there's raw db data and there's ent data 
+// they are different if we have on ent load field privacy and an ent with this...
+
+{{$dataType := printf "%sData" .Node -}}
+{{$rawDBDataType := $dataType -}}
 
 interface {{$dataType}} {
   {{range $field := .FieldInfo.EntFields -}}
@@ -49,6 +54,18 @@ interface {{$dataType}} {
     {{$field.GetDbColName}}: {{$field.TsType}};
   {{ end -}}
 }
+
+{{if .OnEntLoadFieldPrivacy $cfg -}}
+  {{$rawDBDataType = printf "%sDBData" .Node -}}
+  interface {{$rawDBDataType}} extends {{$dataType}} {
+    {{range $field := .FieldInfo.EntFields -}}
+      {{ if ne $field.TsType $field.TsActualType -}}
+        {{$field.GetDbColName}}: {{$field.TsActualType}};
+      {{ end -}}
+    {{ end -}}
+  }
+{{ end -}}
+
 
 {{range $field := .FieldInfo.EntFields -}}
   {{ if $field.FetchOnDemand -}}
@@ -81,6 +98,9 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
 {
 
   protected readonly data: {{$dataType}};
+  {{if .OnEntLoadFieldPrivacy $cfg -}}
+    private rawDBData: {{$rawDBDataType}} | undefined;
+  {{ end -}}
   readonly nodeType = {{useImport "NodeType"}}.{{.Node}};
   {{range $field := .FieldInfo.EntFields -}}
     {{ range $field.GetTsTypeImports -}}
@@ -117,9 +137,23 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
     this.data = data
   }
 
+  __setRawDBData<{{$rawDBDataType}}>(data: {{$rawDBDataType}}) {
+  {{if .OnEntLoadFieldPrivacy $cfg -}}
+    // @ts-expect-error
+    this.rawDBData = data;
+  {{end }}
+  }
+
   /** used by some ent internals to get access to raw db data. should not be depended on. may not always be on the ent **/
-  ___getData(): {{$dataType}} {
+  ___getRawDBData(): {{$rawDBDataType}} {
+  {{if .OnEntLoadFieldPrivacy $cfg -}}
+    if (this.rawDBData === undefined) {
+      throw new Error(`trying to get raw db data when it was never set`);
+    }
+    return this.rawDBData;
+  {{ else -}}
     return this.data;
+  {{ end -}}
   }
   
   getPrivacyPolicy(): {{useImport "PrivacyPolicy"}}<this, {{$viewerType}}> {
@@ -260,7 +294,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
     this: {{$thisType}},
     query: {{useImport "CustomQuery"}},
     context?: {{useImport "Context"}}
-  ): Promise<{{$dataType}}[]> {
+  ): Promise<{{$rawDBDataType}}[]> {
     return  await {{useImport "loadCustomData"}}(
       {
         ...{{$baseClass}}.loaderOptions.apply(this),
@@ -268,7 +302,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
       },
       query,
       context,
-    ) as {{$dataType}}[];
+    ) as {{$rawDBDataType}}[];
   }
 
   static async loadCustomCount<T extends {{$baseClass}}>(
@@ -289,24 +323,24 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
     this: {{$thisType}},
     id: ID,
     context?: {{useImport "Context"}},
-  ): Promise<{{$dataType}} | null> {
+  ): Promise<{{$rawDBDataType}} | null> {
     const row = await {{useImport $loaderName}}.createLoader(context).load(id);
     if (!row) {
       return null;
     }
-    return row as {{$dataType}};
+    return row as {{$rawDBDataType}};
   }
 
   static async loadRawDataX<T extends {{$baseClass}}>(
     this: {{$thisType}},
     id: ID,
     context?: {{useImport "Context"}},
-  ): Promise<{{$dataType}}> {
+  ): Promise<{{$rawDBDataType}}> {
     const row = await {{useImport $loaderName}}.createLoader(context).load(id);
     if (!row) {
       throw new Error(`couldn't load row for ${id}`);
     }
-    return row as {{$dataType}};
+    return row as {{$rawDBDataType}};
   }
 
 
@@ -356,12 +390,12 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
         this: {{$thisType}},
         {{$field.TsFieldName $cfg}}: {{$field.GetNotNullableTsType}},
         context?: {{useImport "Context"}},
-      ): Promise<{{$dataType}} | null> {
+      ): Promise<{{$rawDBDataType}} | null> {
         const row = await {{$fieldLoader}}.createLoader(context).load({{$field.TsFieldName $cfg}});
         if (!row) {
           return null;
         }
-        return row as {{$dataType}};
+        return row as {{$rawDBDataType}};
       }
     {{ else if $field.QueryFromEnt -}}
       {{$queryName := useImport ($this.GetFieldQueryName $field) -}}

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -35,10 +35,10 @@
 
 {{$nodeData := .}}
 
-// there's 2 data types here
+{{/* there's 2 data types here
 // there's raw db data and there's ent data 
 // they are different if we have on ent load field privacy and an ent with this...
-
+*/}}
 {{$dataType := printf "%sData" .Node -}}
 {{$rawDBDataType := $dataType -}}
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha96-4c4de410-8d95-11ed-ae0d-dde452a51f5e",
+  "version": "0.1.0-alpha96-71395a80-8e52-11ed-8650-8330e581e72e",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -41,6 +41,7 @@ import {
   SimpleBuilder,
   SimpleAction,
   getBuilderSchemaFromFields,
+  BaseEnt,
 } from "../testutils/builder";
 import { FakeComms, Mode } from "../testutils/fake_comms";
 import {
@@ -289,17 +290,13 @@ const ContactEmailSchema = getBuilderSchemaFromFields(
   ContactEmail,
 );
 
-class CustomUser implements Ent {
-  id: ID;
+class CustomUser extends BaseEnt {
   accountID: string = "";
   nodeType = "User";
   getPrivacyPolicy() {
     return {
       rules: [AllowIfViewerRule, AlwaysDenyRule],
     };
-  }
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
   }
 }
 

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -112,6 +112,9 @@ export interface Ent<TViewer extends Viewer = Viewer> {
   viewer: TViewer;
   getPrivacyPolicy(): PrivacyPolicy<this, TViewer>;
   nodeType: string;
+  // used to set raw data that's then used by ent internals
+  // shouldn't be used...
+  __setRawDBData(data: Data);
 }
 
 export declare type Data = {

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -114,7 +114,7 @@ export interface Ent<TViewer extends Viewer = Viewer> {
   nodeType: string;
   // used to set raw data that's then used by ent internals
   // shouldn't be used...
-  __setRawDBData(data: Data);
+  __setRawDBData<T extends Data = Data>(data: T);
 }
 
 export declare type Data = {

--- a/ts/src/core/ent.test.ts
+++ b/ts/src/core/ent.test.ts
@@ -4,6 +4,7 @@ import {
   BuilderSchema,
   SimpleBuilder,
   SimpleAction,
+  BaseEnt,
 } from "../testutils/builder";
 import { IDViewer, LoggedOutViewer } from "./viewer";
 import { FieldMap, StringType, UUIDType } from "../schema";
@@ -98,17 +99,13 @@ async function createEdgeRows(edges: string[], table?: string) {
 
 const loggedOutViewer = new LoggedOutViewer();
 
-class DerivedUser implements Ent {
-  id: ID;
+class DerivedUser extends BaseEnt {
   accountID: string;
   nodeType = "User";
   getPrivacyPolicy(): PrivacyPolicy<this> {
     return {
       rules: [AllowIfViewerRule, AlwaysDenyRule],
     };
-  }
-  constructor(public viewer: Viewer, data: Data) {
-    this.id = data["id"];
   }
 
   static async load(v: Viewer, data: Data): Promise<DerivedUser | null> {
@@ -401,18 +398,13 @@ function commonTests() {
       expect(ent).toBeInstanceOf(User);
     });
 
-    class User2 implements Ent {
-      id: ID;
+    class User2 extends BaseEnt {
       accountID: string;
       nodeType = "User2";
       getPrivacyPolicy() {
         return {
           rules: [AllowIfViewerRule, AlwaysDenyRule],
         };
-      }
-
-      constructor(public viewer: Viewer, public data: Data) {
-        this.id = data.id;
       }
     }
 

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -779,6 +779,9 @@ async function doFieldPrivacy<
   }
   const promises: Promise<void>[] = [];
   let somethingChanged = false;
+  const origData = {
+    ...data,
+  };
   for (const [k, policy] of options.fieldPrivacy) {
     const curr = data[k];
     if (curr === null || curr === undefined) {
@@ -799,8 +802,11 @@ async function doFieldPrivacy<
   await Promise.all(promises);
   if (somethingChanged) {
     // have to create new instance
-    return new options.ent(viewer, data);
+    const ent = new options.ent(viewer, data);
+    ent.__setRawDBData(origData);
+    return ent;
   }
+  ent.__setRawDBData(origData);
   return ent;
 }
 

--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -37,12 +37,12 @@ import { clearLogLevels, setLogLevels } from "./logger";
 import DB, { Dialect } from "./db";
 import { ObjectLoaderFactory } from "./loaders";
 import { CustomEdgeQueryBase } from "./query";
+import { BaseEnt } from "../testutils/builder";
 
 let ctx: Context;
 const ml = new MockLogs();
 
-class User implements Ent {
-  id: ID;
+class User extends BaseEnt {
   accountID: string;
   nodeType = "User";
   getPrivacyPolicy(): PrivacyPolicy<this> {
@@ -64,9 +64,6 @@ class User implements Ent {
         AlwaysDenyRule,
       ],
     };
-  }
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data["id"];
   }
 }
 

--- a/ts/src/core/ent_data.test.ts
+++ b/ts/src/core/ent_data.test.ts
@@ -36,6 +36,7 @@ import {
 } from "../testutils/db/temp_db";
 import { MockLogs } from "../testutils/mock_log";
 import { clearLogLevels, setLogLevels } from "./logger";
+import { BaseEnt } from "../testutils/builder";
 
 const loggedOutViewer = new LoggedOutViewer();
 
@@ -52,8 +53,7 @@ const selectOptionsContacts: SelectDataOptions = {
 const loaderFactory = new ObjectLoaderFactory(selectOptions);
 const loaderFactoryContacts = new ObjectLoaderFactory(selectOptionsContacts);
 
-class User implements Ent {
-  id: ID;
+class User extends BaseEnt {
   baz: string | null;
   foo: string | null;
   accountID: string;
@@ -64,9 +64,13 @@ class User implements Ent {
     };
   }
   constructor(public viewer: Viewer, public data: Data) {
-    this.id = data["bar"];
+    super(viewer, data);
     this.baz = data["baz"];
     this.foo = data["foo"];
+  }
+
+  getKey(): string {
+    return "bar";
   }
 
   static async load(v: Viewer, id: ID): Promise<User | null> {
@@ -87,8 +91,7 @@ class User implements Ent {
 }
 
 // Contact has field privacy
-class Contact implements Ent {
-  id: ID;
+class Contact extends BaseEnt {
   baz: string | null;
   foo: string | null;
   accountID: string;
@@ -99,9 +102,13 @@ class Contact implements Ent {
     };
   }
   constructor(public viewer: Viewer, public data: Data) {
-    this.id = data["bar"];
+    super(viewer, data);
     this.baz = data["baz"];
     this.foo = data["foo"];
+  }
+
+  getKey(): string {
+    return "bar";
   }
 
   static async load(v: Viewer, id: ID): Promise<Contact | null> {

--- a/ts/src/core/ent_errors.test.ts
+++ b/ts/src/core/ent_errors.test.ts
@@ -29,9 +29,9 @@ import {
 import DB, { Dialect } from "./db";
 import { ObjectLoaderFactory } from "./loaders";
 import { TestContext } from "../testutils/context/test_context";
+import { BaseEnt } from "../testutils/builder";
 
-class User implements Ent {
-  id: ID;
+class User extends BaseEnt {
   accountID: string;
   nodeType = "User";
   getPrivacyPolicy(): PrivacyPolicy<this> {
@@ -53,9 +53,6 @@ class User implements Ent {
         AlwaysDenyRule,
       ],
     };
-  }
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data["id"];
   }
 }
 

--- a/ts/src/core/loaders/query_loader.test.ts
+++ b/ts/src/core/loaders/query_loader.test.ts
@@ -398,6 +398,7 @@ function commonTests() {
       const edge = edges[i];
       const expEdge = events[i].data;
       // both raw from db so no conversion needed
+
       expect(edge, `${i}th index`).toMatchObject(expEdge);
     }
   }

--- a/ts/src/core/privacy.test.ts
+++ b/ts/src/core/privacy.test.ts
@@ -25,6 +25,7 @@ import { LoggedOutViewer, IDViewer } from "./viewer";
 import { createRowForTest } from "../testutils/write";
 import { ObjectLoaderFactory } from "./loaders";
 import { setupPostgres, table, text } from "../testutils/db/temp_db";
+import { BaseEnt } from "../testutils/builder";
 
 const loggedOutViewer = new LoggedOutViewer();
 
@@ -32,17 +33,14 @@ setupPostgres(() => [
   table("users", text("id", { primaryKey: true }), text("name")),
 ]);
 
-class User implements Ent {
-  id: ID;
+class User extends BaseEnt {
   accountID: string;
+
+  // TODO add policy here
   getPrivacyPolicy(): PrivacyPolicy<this> {
     return { rules: [] };
   }
   nodeType = "User";
-  // TODO add policy here
-  constructor(public viewer: Viewer, data: Data) {
-    this.id = data.id;
-  }
 }
 
 const getUser = function (

--- a/ts/src/schema/postgres_schema_live.test.ts
+++ b/ts/src/schema/postgres_schema_live.test.ts
@@ -20,6 +20,7 @@ import {
   getBuilderSchemaFromFields,
   getBuilderSchemaTZFromFields,
   BuilderSchema,
+  BaseEnt,
 } from "../testutils/builder";
 import {
   table,
@@ -286,17 +287,9 @@ test("timestamptz", async () => {
   expect(date.getTimezoneOffset()).toBe(updatedAt.getTimezoneOffset());
 });
 
-class Hours implements Ent {
-  id: ID;
+class Hours extends BaseEnt {
   accountID: string;
   nodeType = "Hours";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
 const HoursSchema = getBuilderSchemaFromFields(
@@ -428,16 +421,9 @@ describe("timetz", () => {
   });
 });
 
-class Holiday implements Ent {
-  id: ID;
+class Holiday extends BaseEnt {
   accountID: string;
   nodeType = "Holiday";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
 const HolidaySchema = getBuilderSchemaFromFields(
@@ -576,17 +562,9 @@ each([
     ),
   );
 
-  class Table implements Ent {
-    id: ID;
+  class Table extends BaseEnt {
     accountID: string;
     nodeType = "Table";
-    getPrivacyPolicy(): PrivacyPolicy<this> {
-      return AlwaysAllowPrivacyPolicy;
-    }
-
-    constructor(public viewer: Viewer, public data: Data) {
-      this.id = data.id;
-    }
   }
 
   const TableSchema = getBuilderSchemaFromFields(

--- a/ts/src/testutils/action/complex_schemas.ts
+++ b/ts/src/testutils/action/complex_schemas.ts
@@ -23,6 +23,7 @@ import {
   SimpleAction,
   getTableName,
   getBuilderSchemaFromFields,
+  BaseEnt,
 } from "../../testutils/builder";
 import { LoggedOutViewer, IDViewer } from "../../core/viewer";
 import {
@@ -155,17 +156,9 @@ export const UserBalanceWithCheckSchema = getBuilderSchemaFromFields(
   },
 );
 
-export class Account implements Ent {
-  id: ID;
+export class Account extends BaseEnt {
   accountID: string = "";
   nodeType = "Account";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
 export const AccountSchema = getBuilderSchemaFromFields({}, Account);
@@ -187,16 +180,8 @@ export const GroupSchema = getBuilderSchemaFromFields(
   Group,
 );
 
-export class GroupMembership implements Ent {
-  id: ID;
+export class GroupMembership extends BaseEnt {
   nodeType = "GroupMembership";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
 export const GroupMembershipSchema = getBuilderSchemaFromFields(
@@ -208,16 +193,8 @@ export const GroupMembershipSchema = getBuilderSchemaFromFields(
   GroupMembership,
 );
 
-export class Changelog implements Ent {
-  id: ID;
+export class Changelog extends BaseEnt {
   nodeType = "Changelog";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
 export const ChangelogSchema = getBuilderSchemaFromFields(
@@ -499,16 +476,8 @@ export async function verifyChangelogFromMeberships(
   );
 }
 
-export class GroupMemberOf implements Ent {
-  id: ID;
+export class GroupMemberOf extends BaseEnt {
   nodeType = "GroupMemberOf";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
 export const GroupMemberOfSchema = getBuilderSchemaFromFields(

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -34,88 +34,67 @@ import {
 import { FieldInfoMap, getStorageKey } from "../schema/schema";
 import { Clause } from "src/core/clause";
 
-export class User implements Ent {
-  id: ID;
-  accountID: string = "";
-  nodeType = "User";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
+export class BaseEnt {
+  readonly id: ID;
+
+  constructor(public viewer: Viewer, public readonly data: Data) {
+    this.data.created_at = convertDate(data.created_at);
+    this.data.updated_at = convertDate(data.updated_at);
+    this.id = data[this.getKey()];
+  }
+
+  getKey() {
+    return "id";
+  }
+
+  getPrivacyPolicy(): PrivacyPolicy {
     return AlwaysAllowPrivacyPolicy;
   }
+  __setRawDBData(data: Data) {
+    // doesn't apply here so ignore...
+  }
+}
+
+export class User extends BaseEnt implements Ent {
+  accountID: string = "";
+  nodeType = "User";
   firstName: string;
 
   constructor(public viewer: Viewer, public data: Data) {
-    this.data.created_at = convertDate(data.created_at);
-    this.data.updated_at = convertDate(data.updated_at);
-    this.id = data.id;
+    super(viewer, data);
     this.firstName = data.first_name;
   }
 }
 
-export class Event implements Ent {
-  id: ID;
+export class Event extends BaseEnt implements Ent {
   accountID: string = "";
   nodeType = "Event";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
-export class Contact implements Ent {
-  id: ID;
+export class Contact extends BaseEnt implements Ent {
   accountID: string = "";
   nodeType = "Contact";
   getPrivacyPolicy(): PrivacyPolicy<this> {
     return AlwaysAllowPrivacyPolicy;
   }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.data.created_at = convertDate(data.created_at);
-    this.data.updated_at = convertDate(data.updated_at);
-    this.id = data.id;
-  }
 }
 
-export class Group implements Ent {
-  id: ID;
+export class Group extends BaseEnt implements Ent {
   accountID: string = "";
   nodeType = "Group";
   getPrivacyPolicy(): PrivacyPolicy<this> {
     return AlwaysAllowPrivacyPolicy;
   }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
-export class Message implements Ent {
-  id: ID;
+export class Message extends BaseEnt implements Ent {
   accountID: string = "";
   nodeType = "Message";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
-export class Address implements Ent {
-  id: ID;
+export class Address extends BaseEnt implements Ent {
   accountID: string = "";
   nodeType = "Address";
-  getPrivacyPolicy(): PrivacyPolicy<this> {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
 export interface BuilderSchema<T extends Ent> extends Schema {

--- a/ts/src/testutils/db/test_db_helpers.test.ts
+++ b/ts/src/testutils/db/test_db_helpers.test.ts
@@ -1,6 +1,5 @@
-import { ID, Ent, Data, Viewer } from "../../core/base";
-import { AlwaysAllowPrivacyPolicy } from "../../core/privacy";
 import {
+  BaseEnt,
   getBuilderSchemaFromFields,
   getSchemaName,
   getTableName,
@@ -8,17 +7,9 @@ import {
 import { getSchemaTable } from "./temp_db";
 import { Dialect } from "../../core/db";
 
-class Account implements Ent {
-  id: ID;
+class Account extends BaseEnt {
   accountID: string;
   nodeType = "Account";
-  getPrivacyPolicy() {
-    return AlwaysAllowPrivacyPolicy;
-  }
-
-  constructor(public viewer: Viewer, public data: Data) {
-    this.id = data.id;
-  }
 }
 
 const AccountSchema = getBuilderSchemaFromFields({}, Account);

--- a/ts/src/testutils/fake_data/fake_contact.ts
+++ b/ts/src/testutils/fake_data/fake_contact.ts
@@ -45,6 +45,8 @@ export class FakeContact implements Ent {
     this.userID = data.user_id;
   }
 
+  __setRawDBData(data: Data) {}
+
   static getFields(): string[] {
     return [
       "id",

--- a/ts/src/testutils/fake_data/fake_event.ts
+++ b/ts/src/testutils/fake_data/fake_event.ts
@@ -46,6 +46,8 @@ export class FakeEvent implements Ent {
     this.userID = data.user_id;
   }
 
+  __setRawDBData(data: Data) {}
+
   private static getFields(): string[] {
     return [
       "id",

--- a/ts/src/testutils/fake_data/fake_tag.ts
+++ b/ts/src/testutils/fake_data/fake_tag.ts
@@ -45,6 +45,8 @@ export class FakeTag implements Ent {
     this.ownerID = data.owner_id;
   }
 
+  __setRawDBData(data: Data) {}
+
   static getFields(): string[] {
     return [
       "id",

--- a/ts/src/testutils/fake_data/fake_user.ts
+++ b/ts/src/testutils/fake_data/fake_user.ts
@@ -89,6 +89,8 @@ export class FakeUser implements Ent {
     this.password = data.password;
   }
 
+  __setRawDBData(data: Data) {}
+
   static getFields(): string[] {
     return [
       "id",


### PR DESCRIPTION
basically a followup to https://github.com/lolopinto/ent/pull/867, https://github.com/lolopinto/ent/pull/1298, and https://github.com/lolopinto/ent/pull/1300

the logic in https://github.com/lolopinto/ent/pull/1300 didn't quite work for fields which have privacy evaluated at ent load because the value would be null if it somehow wasn't visible but was editable (doesn't make sense but could be possible...)

so we store the raw data (before privacy was evaluated) on the ent and use that for these checks 

right long term solution is probably to pass this in constructor somehow but using a setter method to make the change simpler