### PR TITLE
[auto_schema] add test for new uuid field with server_default when field is added

### DIFF
--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -990,6 +990,28 @@ class TestPostgresRunner(BaseTestRunner):
         diff = r3.compute_changes()
 
         assert len(diff) == 0
+        
+    
+    def test_field_with_server_default_uuid_to_start(self,new_test_runner):
+        metadata = conftest.metadata_with_uuid_col()
+
+        metadata = conftest.metadata_with_server_default_changed_uuid_type_in_practice(metadata)
+        
+        r = new_test_runner(metadata)
+
+        testingutils.run_and_validate_with_standard_metadata_tables(
+            r, metadata, ['accounts'])
+        
+        r2 = new_test_runner(metadata, r)
+        diff = r2.compute_changes()
+
+        # alter_op =diff[0].ops[0]
+        # print(alter_op.modify_server_default)
+        
+        assert len(diff) == 0
+        testingutils.validate_metadata_after_change(r2, metadata)
+        r2.run()
+
 
     # only in postgres because "No support for ALTER of constraints in SQLite dialect"
 

--- a/python/auto_schema/tests/testingutils.py
+++ b/python/auto_schema/tests/testingutils.py
@@ -259,6 +259,7 @@ def _validate_column_server_default(schema_column: sa.Column, db_column: sa.Colu
     if schema_clause_text is None and db_column.autoincrement == True:
         assert db_clause_text.startswith("nextval")
     else:
+        # print(str(schema_clause_text), str(db_clause_text))
         assert str(schema_clause_text) == str(db_clause_text)
 
 


### PR DESCRIPTION
ran into weird issue with a second change added for server_default field which was apparently fixed with changes done in https://github.com/lolopinto/ent/pull/1329 when i was adding test for that