### PR TITLE
call valid in Orchestrator.getEntForPrivacyPolicyImpl

### DIFF
--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -491,6 +491,20 @@ export class Orchestrator<
       if (!val) {
         continue;
       }
+
+      if (field.valid) {
+        let valid = field.valid(val);
+        if (types.isPromise(valid)) {
+          valid = await valid;
+        }
+        // if not valid, don't format and don't pass to ent?
+        // or just early throw here
+        if (!valid) {
+          continue;
+          // throw new Error(`invalid field ${fieldName} with value ${val}`);
+        }
+      }
+
       // nested so it's not JSON stringified or anything like that
       val = field.format(formatted[dbKey], true);
       if (types.isPromise(val)) {


### PR DESCRIPTION
followup to https://github.com/lolopinto/ent/pull/1370

call `valid` if possible

`ent-phonenumber` is weird and doesn't format if it can't and previously, have assumed that `valid` is called before `format`