### PR TITLE
Type custom data query

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - run: npm install -g ts-node prettier typescript @swc/core @swc/cli
+    - run: npm install -g ts-node prettier typescript @swc/core@1.2.155 @swc/cli@0.1.55
     - run: |
         cd ts 
         npm ci

--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.3.0",
         "@sentry/tracing": "^6.3.0",
-        "@snowtop/ent": "^0.1.0-alpha116",
+        "@snowtop/ent": "^0.1.0-alpha117",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1217,9 +1217,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha116",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha116.tgz",
-      "integrity": "sha512-x5bOlVZro7yTnDQ6Uq94EqKOuKB9OhkCNgsltM31yGPTksd7YJjyEsYc/e1Q7cDbOzCxkC0sFqhElvhsKHuBow==",
+      "version": "0.1.0-alpha117",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha117.tgz",
+      "integrity": "sha512-Khr+C4RPHNt28VcAIvGGSNbJsKSe037NlRlG7CL+70fOAxLh4LnIv6dkQWMAwAE2y85/6/E0hO+sFmEyeoWOsg==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",
@@ -6969,9 +6969,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha116",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha116.tgz",
-      "integrity": "sha512-x5bOlVZro7yTnDQ6Uq94EqKOuKB9OhkCNgsltM31yGPTksd7YJjyEsYc/e1Q7cDbOzCxkC0sFqhElvhsKHuBow==",
+      "version": "0.1.0-alpha117",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha117.tgz",
+      "integrity": "sha512-Khr+C4RPHNt28VcAIvGGSNbJsKSe037NlRlG7CL+70fOAxLh4LnIv6dkQWMAwAE2y85/6/E0hO+sFmEyeoWOsg==",
       "requires": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "^6.3.0",
     "@sentry/tracing": "^6.3.0",
-    "@snowtop/ent": "^0.1.0-alpha116",
+    "@snowtop/ent": "^0.1.0-alpha117",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
@@ -122,7 +122,7 @@ export class AddressBase implements Ent<Viewer> {
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<AddressDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -139,17 +139,17 @@ export class AddressBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AddressDBData>,
     context?: Context,
   ): Promise<AddressDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<AddressDBData, AddressDBData>(
       {
         ...AddressBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as AddressDBData[];
+    );
   }
 
   static async loadCustomCount<T extends AddressBase>(
@@ -157,7 +157,7 @@ export class AddressBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AddressDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
@@ -115,7 +115,7 @@ export class AuthCodeBase implements Ent<Viewer> {
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<AuthCodeDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -132,17 +132,17 @@ export class AuthCodeBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AuthCodeDBData>,
     context?: Context,
   ): Promise<AuthCodeDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<AuthCodeDBData, AuthCodeDBData>(
       {
         ...AuthCodeBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as AuthCodeDBData[];
+    );
   }
 
   static async loadCustomCount<T extends AuthCodeBase>(
@@ -150,7 +150,7 @@ export class AuthCodeBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AuthCodeDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
@@ -137,7 +137,7 @@ export class EventActivityBase
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<EventActivityDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -154,17 +154,17 @@ export class EventActivityBase
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<EventActivityDBData>,
     context?: Context,
   ): Promise<EventActivityDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<EventActivityDBData, EventActivityDBData>(
       {
         ...EventActivityBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as EventActivityDBData[];
+    );
   }
 
   static async loadCustomCount<T extends EventActivityBase>(
@@ -172,7 +172,7 @@ export class EventActivityBase
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<EventActivityDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
@@ -119,7 +119,7 @@ export class EventBase implements Ent<Viewer> {
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<EventDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -136,17 +136,17 @@ export class EventBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<EventDBData>,
     context?: Context,
   ): Promise<EventDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<EventDBData, EventDBData>(
       {
         ...EventBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as EventDBData[];
+    );
   }
 
   static async loadCustomCount<T extends EventBase>(
@@ -154,7 +154,7 @@ export class EventBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<EventDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
@@ -129,7 +129,7 @@ export class GuestBase
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<GuestDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -146,17 +146,17 @@ export class GuestBase
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<GuestDBData>,
     context?: Context,
   ): Promise<GuestDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<GuestDBData, GuestDBData>(
       {
         ...GuestBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as GuestDBData[];
+    );
   }
 
   static async loadCustomCount<T extends GuestBase>(
@@ -164,7 +164,7 @@ export class GuestBase
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<GuestDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
@@ -116,7 +116,7 @@ export class GuestDataBase implements Ent<Viewer> {
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<GuestDataDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -133,17 +133,17 @@ export class GuestDataBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<GuestDataDBData>,
     context?: Context,
   ): Promise<GuestDataDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<GuestDataDBData, GuestDataDBData>(
       {
         ...GuestDataBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as GuestDataDBData[];
+    );
   }
 
   static async loadCustomCount<T extends GuestDataBase>(
@@ -151,7 +151,7 @@ export class GuestDataBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<GuestDataDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
@@ -112,7 +112,7 @@ export class GuestGroupBase implements Ent<Viewer> {
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<GuestGroupDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -129,17 +129,17 @@ export class GuestGroupBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<GuestGroupDBData>,
     context?: Context,
   ): Promise<GuestGroupDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<GuestGroupDBData, GuestGroupDBData>(
       {
         ...GuestGroupBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as GuestGroupDBData[];
+    );
   }
 
   static async loadCustomCount<T extends GuestGroupBase>(
@@ -147,7 +147,7 @@ export class GuestGroupBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<GuestGroupDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
@@ -115,7 +115,7 @@ export class UserBase implements Ent<Viewer> {
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<UserDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -132,17 +132,17 @@ export class UserBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<UserDBData>,
     context?: Context,
   ): Promise<UserDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<UserDBData, UserDBData>(
       {
         ...UserBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as UserDBData[];
+    );
   }
 
   static async loadCustomCount<T extends UserBase>(
@@ -150,7 +150,7 @@ export class UserBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<UserDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha116",
+        "@snowtop/ent": "^0.1.0-alpha117",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1194,9 +1194,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha116",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha116.tgz",
-      "integrity": "sha512-x5bOlVZro7yTnDQ6Uq94EqKOuKB9OhkCNgsltM31yGPTksd7YJjyEsYc/e1Q7cDbOzCxkC0sFqhElvhsKHuBow==",
+      "version": "0.1.0-alpha117",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha117.tgz",
+      "integrity": "sha512-Khr+C4RPHNt28VcAIvGGSNbJsKSe037NlRlG7CL+70fOAxLh4LnIv6dkQWMAwAE2y85/6/E0hO+sFmEyeoWOsg==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",
@@ -8007,9 +8007,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha116",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha116.tgz",
-      "integrity": "sha512-x5bOlVZro7yTnDQ6Uq94EqKOuKB9OhkCNgsltM31yGPTksd7YJjyEsYc/e1Q7cDbOzCxkC0sFqhElvhsKHuBow==",
+      "version": "0.1.0-alpha117",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha117.tgz",
+      "integrity": "sha512-Khr+C4RPHNt28VcAIvGGSNbJsKSe037NlRlG7CL+70fOAxLh4LnIv6dkQWMAwAE2y85/6/E0hO+sFmEyeoWOsg==",
       "requires": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -33,7 +33,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha116",
+    "@snowtop/ent": "^0.1.0-alpha117",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/simple/src/ent/generated/address_base.ts
+++ b/examples/simple/src/ent/generated/address_base.ts
@@ -135,7 +135,7 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
     query: CustomQuery<AddressDBData>,
     context?: Context,
   ): Promise<AddressDBData[]> {
-    return loadCustomData(
+    return loadCustomData<AddressDBData, AddressDBData>(
       {
         ...AddressBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/address_base.ts
+++ b/examples/simple/src/ent/generated/address_base.ts
@@ -115,7 +115,7 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<AddressDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -132,17 +132,17 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AddressDBData>,
     context?: Context,
   ): Promise<AddressDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...AddressBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as AddressDBData[];
+    );
   }
 
   static async loadCustomCount<T extends AddressBase>(
@@ -150,7 +150,7 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AddressDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/auth_code_base.ts
+++ b/examples/simple/src/ent/generated/auth_code_base.ts
@@ -111,7 +111,7 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<AuthCodeDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -128,17 +128,17 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AuthCodeDBData>,
     context?: Context,
   ): Promise<AuthCodeDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...AuthCodeBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as AuthCodeDBData[];
+    );
   }
 
   static async loadCustomCount<T extends AuthCodeBase>(
@@ -146,7 +146,7 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AuthCodeDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/auth_code_base.ts
+++ b/examples/simple/src/ent/generated/auth_code_base.ts
@@ -131,7 +131,7 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
     query: CustomQuery<AuthCodeDBData>,
     context?: Context,
   ): Promise<AuthCodeDBData[]> {
-    return loadCustomData(
+    return loadCustomData<AuthCodeDBData, AuthCodeDBData>(
       {
         ...AuthCodeBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -116,7 +116,7 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<CommentDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -133,17 +133,17 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<CommentDBData>,
     context?: Context,
   ): Promise<CommentDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...CommentBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as CommentDBData[];
+    );
   }
 
   static async loadCustomCount<T extends CommentBase>(
@@ -151,7 +151,7 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<CommentDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -136,7 +136,7 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
     query: CustomQuery<CommentDBData>,
     context?: Context,
   ): Promise<CommentDBData[]> {
-    return loadCustomData(
+    return loadCustomData<CommentDBData, CommentDBData>(
       {
         ...CommentBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/contact_base.ts
+++ b/examples/simple/src/ent/generated/contact_base.ts
@@ -146,7 +146,7 @@ export class ContactBase
     query: CustomQuery<ContactDBData>,
     context?: Context,
   ): Promise<ContactDBData[]> {
-    return loadCustomData(
+    return loadCustomData<ContactDBData, ContactDBData>(
       {
         ...ContactBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/contact_base.ts
+++ b/examples/simple/src/ent/generated/contact_base.ts
@@ -126,7 +126,7 @@ export class ContactBase
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<ContactDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -143,17 +143,17 @@ export class ContactBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<ContactDBData>,
     context?: Context,
   ): Promise<ContactDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...ContactBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as ContactDBData[];
+    );
   }
 
   static async loadCustomCount<T extends ContactBase>(
@@ -161,7 +161,7 @@ export class ContactBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<ContactDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/contact_email_base.ts
+++ b/examples/simple/src/ent/generated/contact_email_base.ts
@@ -138,7 +138,7 @@ export class ContactEmailBase
     query: CustomQuery<ContactEmailDBData>,
     context?: Context,
   ): Promise<ContactEmailDBData[]> {
-    return loadCustomData(
+    return loadCustomData<ContactEmailDBData, ContactEmailDBData>(
       {
         ...ContactEmailBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/contact_email_base.ts
+++ b/examples/simple/src/ent/generated/contact_email_base.ts
@@ -118,7 +118,7 @@ export class ContactEmailBase
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<ContactEmailDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -135,17 +135,17 @@ export class ContactEmailBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<ContactEmailDBData>,
     context?: Context,
   ): Promise<ContactEmailDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...ContactEmailBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as ContactEmailDBData[];
+    );
   }
 
   static async loadCustomCount<T extends ContactEmailBase>(
@@ -153,7 +153,7 @@ export class ContactEmailBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<ContactEmailDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/contact_phone_number_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number_base.ts
@@ -122,7 +122,7 @@ export class ContactPhoneNumberBase
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<ContactPhoneNumberDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -139,17 +139,17 @@ export class ContactPhoneNumberBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<ContactPhoneNumberDBData>,
     context?: Context,
   ): Promise<ContactPhoneNumberDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...ContactPhoneNumberBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as ContactPhoneNumberDBData[];
+    );
   }
 
   static async loadCustomCount<T extends ContactPhoneNumberBase>(
@@ -157,7 +157,7 @@ export class ContactPhoneNumberBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<ContactPhoneNumberDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/contact_phone_number_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number_base.ts
@@ -142,7 +142,7 @@ export class ContactPhoneNumberBase
     query: CustomQuery<ContactPhoneNumberDBData>,
     context?: Context,
   ): Promise<ContactPhoneNumberDBData[]> {
-    return loadCustomData(
+    return loadCustomData<ContactPhoneNumberDBData, ContactPhoneNumberDBData>(
       {
         ...ContactPhoneNumberBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -138,7 +138,7 @@ export class EventBase implements Ent<ExampleViewerAlias> {
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<EventDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -155,17 +155,17 @@ export class EventBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<EventDBData>,
     context?: Context,
   ): Promise<EventDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...EventBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as EventDBData[];
+    );
   }
 
   static async loadCustomCount<T extends EventBase>(
@@ -173,7 +173,7 @@ export class EventBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<EventDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -158,7 +158,7 @@ export class EventBase implements Ent<ExampleViewerAlias> {
     query: CustomQuery<EventDBData>,
     context?: Context,
   ): Promise<EventDBData[]> {
-    return loadCustomData(
+    return loadCustomData<EventDBData, EventDBData>(
       {
         ...EventBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/holiday_base.ts
+++ b/examples/simple/src/ent/generated/holiday_base.ts
@@ -114,7 +114,7 @@ export class HolidayBase
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<HolidayDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -131,17 +131,17 @@ export class HolidayBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<HolidayDBData>,
     context?: Context,
   ): Promise<HolidayDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...HolidayBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as HolidayDBData[];
+    );
   }
 
   static async loadCustomCount<T extends HolidayBase>(
@@ -149,7 +149,7 @@ export class HolidayBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<HolidayDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/holiday_base.ts
+++ b/examples/simple/src/ent/generated/holiday_base.ts
@@ -134,7 +134,7 @@ export class HolidayBase
     query: CustomQuery<HolidayDBData>,
     context?: Context,
   ): Promise<HolidayDBData[]> {
-    return loadCustomData(
+    return loadCustomData<HolidayDBData, HolidayDBData>(
       {
         ...HolidayBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/hours_of_operation_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation_base.ts
@@ -136,7 +136,7 @@ export class HoursOfOperationBase
     query: CustomQuery<HoursOfOperationDBData>,
     context?: Context,
   ): Promise<HoursOfOperationDBData[]> {
-    return loadCustomData(
+    return loadCustomData<HoursOfOperationDBData, HoursOfOperationDBData>(
       {
         ...HoursOfOperationBase.loaderOptions.apply(this),
         prime: true,

--- a/examples/simple/src/ent/generated/hours_of_operation_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation_base.ts
@@ -116,7 +116,7 @@ export class HoursOfOperationBase
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<HoursOfOperationDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -133,17 +133,17 @@ export class HoursOfOperationBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<HoursOfOperationDBData>,
     context?: Context,
   ): Promise<HoursOfOperationDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData(
       {
         ...HoursOfOperationBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as HoursOfOperationDBData[];
+    );
   }
 
   static async loadCustomCount<T extends HoursOfOperationBase>(
@@ -151,7 +151,7 @@ export class HoursOfOperationBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<HoursOfOperationDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -75,7 +75,11 @@ import {
   convertSuperNestedObject,
   userConvertAccountStatus,
 } from "../../util/convert_user_fields";
-import { ExampleViewer as ExampleViewerAlias,  } from "../../viewer/viewer";
+import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
+
+interface UserCustomQueryData extends UserDBData {
+  name_idx: string;
+}
 
 const superNestedObjectLoader = new ObjectLoaderFactory({
   tableName: userLoaderInfo.tableName,
@@ -281,7 +285,7 @@ export class UserBase
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery<UserDBData>,
+    query: CustomQuery<UserCustomQueryData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -298,17 +302,17 @@ export class UserBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery<UserDBData>,
+    query: CustomQuery<UserCustomQueryData>,
     context?: Context,
   ): Promise<UserDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<UserCustomQueryData, UserDBData>(
       {
         ...UserBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as UserDBData[];
+    );
   }
 
   static async loadCustomCount<T extends UserBase>(
@@ -316,7 +320,7 @@ export class UserBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery<UserDBData>,
+    query: CustomQuery<UserCustomQueryData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -75,7 +75,7 @@ import {
   convertSuperNestedObject,
   userConvertAccountStatus,
 } from "../../util/convert_user_fields";
-import { ExampleViewer as ExampleViewerAlias } from "../../viewer/viewer";
+import { ExampleViewer as ExampleViewerAlias,  } from "../../viewer/viewer";
 
 const superNestedObjectLoader = new ObjectLoaderFactory({
   tableName: userLoaderInfo.tableName,
@@ -281,7 +281,7 @@ export class UserBase
       data: Data,
     ) => T,
     viewer: ExampleViewerAlias,
-    query: CustomQuery,
+    query: CustomQuery<UserDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -298,7 +298,7 @@ export class UserBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<UserDBData>,
     context?: Context,
   ): Promise<UserDBData[]> {
     return (await loadCustomData(
@@ -316,7 +316,7 @@ export class UserBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<UserDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/simple/src/graphql/generated/resolvers/comment_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/comment_list_deprecated_query_type.ts
@@ -68,6 +68,7 @@ export const CommentListDeprecatedQueryType: GraphQLFieldConfig<
 
     return Comment.loadCustom(
       context.getViewer(),
+      // @ts-expect-error Clause shenanigans
       query.AndOptional(...whereQueries),
     );
   },

--- a/examples/simple/src/graphql/generated/resolvers/contact_email_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_email_list_deprecated_query_type.ts
@@ -68,6 +68,7 @@ export const ContactEmailListDeprecatedQueryType: GraphQLFieldConfig<
 
     return ContactEmail.loadCustom(
       context.getViewer(),
+      // @ts-expect-error Clause shenanigans
       query.AndOptional(...whereQueries),
     );
   },

--- a/examples/simple/src/graphql/generated/resolvers/contact_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_list_deprecated_query_type.ts
@@ -68,6 +68,7 @@ export const ContactListDeprecatedQueryType: GraphQLFieldConfig<
 
     return Contact.loadCustom(
       context.getViewer(),
+      // @ts-expect-error Clause shenanigans
       query.AndOptional(...whereQueries),
     );
   },

--- a/examples/simple/src/graphql/generated/resolvers/contact_phone_number_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_phone_number_list_deprecated_query_type.ts
@@ -68,6 +68,7 @@ export const ContactPhoneNumberListDeprecatedQueryType: GraphQLFieldConfig<
 
     return ContactPhoneNumber.loadCustom(
       context.getViewer(),
+      // @ts-expect-error Clause shenanigans
       query.AndOptional(...whereQueries),
     );
   },

--- a/examples/simple/src/graphql/generated/resolvers/event_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/event_list_deprecated_query_type.ts
@@ -68,6 +68,7 @@ export const EventListDeprecatedQueryType: GraphQLFieldConfig<
 
     return Event.loadCustom(
       context.getViewer(),
+      // @ts-expect-error Clause shenanigans
       query.AndOptional(...whereQueries),
     );
   },

--- a/examples/simple/src/graphql/generated/resolvers/holiday_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/holiday_list_deprecated_query_type.ts
@@ -68,6 +68,7 @@ export const HolidayListDeprecatedQueryType: GraphQLFieldConfig<
 
     return Holiday.loadCustom(
       context.getViewer(),
+      // @ts-expect-error Clause shenanigans
       query.AndOptional(...whereQueries),
     );
   },

--- a/examples/simple/src/graphql/generated/resolvers/hours_of_operation_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/hours_of_operation_list_deprecated_query_type.ts
@@ -68,6 +68,7 @@ export const HoursOfOperationListDeprecatedQueryType: GraphQLFieldConfig<
 
     return HoursOfOperation.loadCustom(
       context.getViewer(),
+      // @ts-expect-error Clause shenanigans
       query.AndOptional(...whereQueries),
     );
   },

--- a/examples/simple/src/graphql/generated/resolvers/user_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/user_list_deprecated_query_type.ts
@@ -68,6 +68,7 @@ export const UserListDeprecatedQueryType: GraphQLFieldConfig<
 
     return User.loadCustom(
       context.getViewer(),
+      // @ts-expect-error Clause shenanigans
       query.AndOptional(...whereQueries),
     );
   },

--- a/examples/simple/src/scripts/custom_queries.ts
+++ b/examples/simple/src/scripts/custom_queries.ts
@@ -118,7 +118,11 @@ async function main() {
       throw new Error('invalid query. must provid id or ids');
     }
 
-    return ${node}.loadCustom(context.getViewer(), query.AndOptional(...whereQueries));
+    return ${node}.loadCustom(
+      context.getViewer(), 
+      // @ts-expect-error Clause shenanigans
+      query.AndOptional(...whereQueries),
+    );
     `;
 
     const connectionContent = `

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha116",
+        "@snowtop/ent": "^0.1.0-alpha117",
         "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
         "@snowtop/ent-soft-delete": "^0.1.0-alpha5",
         "@types/node": "^15.0.3",
@@ -1094,9 +1094,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha116",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha116.tgz",
-      "integrity": "sha512-x5bOlVZro7yTnDQ6Uq94EqKOuKB9OhkCNgsltM31yGPTksd7YJjyEsYc/e1Q7cDbOzCxkC0sFqhElvhsKHuBow==",
+      "version": "0.1.0-alpha117",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha117.tgz",
+      "integrity": "sha512-Khr+C4RPHNt28VcAIvGGSNbJsKSe037NlRlG7CL+70fOAxLh4LnIv6dkQWMAwAE2y85/6/E0hO+sFmEyeoWOsg==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",
@@ -6732,9 +6732,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha116",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha116.tgz",
-      "integrity": "sha512-x5bOlVZro7yTnDQ6Uq94EqKOuKB9OhkCNgsltM31yGPTksd7YJjyEsYc/e1Q7cDbOzCxkC0sFqhElvhsKHuBow==",
+      "version": "0.1.0-alpha117",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha117.tgz",
+      "integrity": "sha512-Khr+C4RPHNt28VcAIvGGSNbJsKSe037NlRlG7CL+70fOAxLh4LnIv6dkQWMAwAE2y85/6/E0hO+sFmEyeoWOsg==",
       "requires": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -36,7 +36,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha116",
+    "@snowtop/ent": "^0.1.0-alpha117",
     "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
     "@snowtop/ent-soft-delete": "^0.1.0-alpha5",
     "@types/node": "^15.0.3",

--- a/examples/todo-sqlite/src/ent/generated/account_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_base.ts
@@ -212,7 +212,7 @@ export class AccountBase
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<AccountDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -229,17 +229,17 @@ export class AccountBase
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AccountDBData>,
     context?: Context,
   ): Promise<AccountDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<AccountDBData, AccountDBData>(
       {
         ...AccountBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as AccountDBData[];
+    );
   }
 
   static async loadCustomCount<T extends AccountBase>(
@@ -247,7 +247,7 @@ export class AccountBase
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<AccountDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/todo-sqlite/src/ent/generated/tag_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_base.ts
@@ -149,7 +149,7 @@ export class TagBase implements Ent<Viewer> {
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<TagDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -166,17 +166,17 @@ export class TagBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<TagDBData>,
     context?: Context,
   ): Promise<TagDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<TagDBData, TagDBData>(
       {
         ...TagBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as TagDBData[];
+    );
   }
 
   static async loadCustomCount<T extends TagBase>(
@@ -184,7 +184,7 @@ export class TagBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<TagDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/todo-sqlite/src/ent/generated/todo_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_base.ts
@@ -166,7 +166,7 @@ export class TodoBase implements Ent<Viewer> {
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<TodoDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -183,17 +183,17 @@ export class TodoBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<TodoDBData>,
     context?: Context,
   ): Promise<TodoDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<TodoDBData, TodoDBData>(
       {
         ...TodoBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as TodoDBData[];
+    );
   }
 
   static async loadCustomCount<T extends TodoBase>(
@@ -201,7 +201,7 @@ export class TodoBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<TodoDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/examples/todo-sqlite/src/ent/generated/workspace_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace_base.ts
@@ -166,7 +166,7 @@ export class WorkspaceBase
       data: Data,
     ) => T,
     viewer: Viewer,
-    query: CustomQuery,
+    query: CustomQuery<WorkspaceDBData>,
   ): Promise<T[]> {
     return (await loadCustomEnts(
       viewer,
@@ -183,17 +183,17 @@ export class WorkspaceBase
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<WorkspaceDBData>,
     context?: Context,
   ): Promise<WorkspaceDBData[]> {
-    return (await loadCustomData(
+    return loadCustomData<WorkspaceDBData, WorkspaceDBData>(
       {
         ...WorkspaceBase.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    )) as WorkspaceDBData[];
+    );
   }
 
   static async loadCustomCount<T extends WorkspaceBase>(
@@ -201,7 +201,7 @@ export class WorkspaceBase
       viewer: Viewer,
       data: Data,
     ) => T,
-    query: CustomQuery,
+    query: CustomQuery<WorkspaceDBData>,
     context?: Context,
   ): Promise<number> {
     return loadCustomCount(

--- a/internal/schema/input/parse_ts.go
+++ b/internal/schema/input/parse_ts.go
@@ -48,7 +48,7 @@ func GetRawSchema(dirPath string, fromTest bool) ([]byte, error) {
 	}
 
 	if !util.EnvIsTrue("DISABLE_SWC") {
-		cmdArgs = append(cmdArgs, "--swc")
+		// cmdArgs = append(cmdArgs, "--swc")
 	}
 
 	cmdArgs = append(

--- a/internal/schema/input/parse_ts.go
+++ b/internal/schema/input/parse_ts.go
@@ -48,7 +48,7 @@ func GetRawSchema(dirPath string, fromTest bool) ([]byte, error) {
 	}
 
 	if !util.EnvIsTrue("DISABLE_SWC") {
-		// cmdArgs = append(cmdArgs, "--swc")
+		cmdArgs = append(cmdArgs, "--swc")
 	}
 
 	cmdArgs = append(

--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -555,6 +555,38 @@ func (nodeData *NodeData) GetOnEntLoadPrivacyInfo(cfg codegenapi.Config) (*entLo
 	return ret, nil
 }
 
+type extraCustomQueryInfo struct {
+	Interface string
+	Extends   string
+	Columns   []struct {
+		Name string
+		Type string
+	}
+}
+
+func (nodeData *NodeData) GetExtraCustomQueryInfo() *extraCustomQueryInfo {
+	ret := &extraCustomQueryInfo{}
+	for _, idx := range nodeData.Indices {
+		if idx.FullText.GeneratedColumnName != "" {
+			ret.Columns = append(ret.Columns, struct {
+				Name string
+				Type string
+			}{
+				Name: idx.FullText.GeneratedColumnName,
+				// always string for now. doesn't actually matter at the moment
+				Type: "string",
+			})
+		}
+	}
+
+	if len(ret.Columns) != 0 {
+		ret.Interface = fmt.Sprintf("%sCustomQueryData", nodeData.Node)
+		ret.Extends = nodeData.GetRawDBDataName()
+		return ret
+	}
+	return nil
+}
+
 func (nodeData *NodeData) GetFieldLoaderName(field *field.Field) string {
 	return fmt.Sprintf("%s%sLoader", nodeData.NodeInstance, field.CamelCaseName())
 }

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -35,13 +35,17 @@
 
 {{$nodeData := .}}
 
-{{/* there's 2 data types here
-// there's raw db data and there's ent data 
+{{/* there's 3 data types here
+// 1/ there's raw db data 
+// 2/ there's ent data 
 // they are different if we have on ent load field privacy and an ent with this...
+// 3/ there's potentially extra columns in the db that can be queried which aren't returned in the 
+// query e.g. generated column indices. we can have a third type for that
 */}}
 {{ reserveImport "src/ent/generated/loaders" .GetRawDBDataName -}}
 {{$rawDBDataType := useImport .GetRawDBDataName -}}
 {{$dataType := $rawDBDataType -}}
+{{$customQueryDataType := $rawDBDataType -}}
 
 {{if .OnEntLoadFieldPrivacy $cfg -}}
   {{$info := .GetOnEntLoadPrivacyInfo $cfg -}}
@@ -53,6 +57,15 @@
   }
 {{ end -}}
 
+{{ $customQuery := .GetExtraCustomQueryInfo -}} 
+{{ if $customQuery -}}
+  {{$customQueryDataType = $customQuery.Interface -}}
+  interface {{$customQueryDataType}} extends {{$customQuery.Extends}} {
+    {{range $col := $customQuery.Columns -}}
+      {{$col.Name}}: {{$col.Type}};
+    {{ end -}}
+  }
+{{ end}}
 
 {{range $field := .FieldInfo.EntFields -}}
   {{ if $field.FetchOnDemand -}}
@@ -265,9 +278,9 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
   static async loadCustom<T extends {{$baseClass}}>(
     this: {{$thisType}},
     viewer: {{$viewerType}},
-    query: {{useImport "CustomQuery"}}<{{useImport $rawDBDataType}}>,
+    query: {{useImport "CustomQuery"}}<{{$customQueryDataType}}>,
   ): Promise<T[]> {
-    return await {{useImport "loadCustomEnts"}}(
+    return await {{useImport "loadCustomEnts"}}<{{$customQueryDataType}}, {{$rawDBDataType}}>(
       viewer,
       {
       ...{{$baseClass}}.loaderOptions.apply(this),
@@ -279,10 +292,10 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
 
   static async loadCustomData<T extends {{$baseClass}}>(
     this: {{$thisType}},
-    query: {{useImport "CustomQuery"}}<{{useImport $rawDBDataType}}>,
+    query: {{useImport "CustomQuery"}}<{{$customQueryDataType}}>,
     context?: {{useImport "Context"}}
   ): Promise<{{$rawDBDataType}}[]> {
-    return {{useImport "loadCustomData"}}(
+    return {{useImport "loadCustomData"}}<{{$customQueryDataType}}, {{$rawDBDataType}}>(
       {
         ...{{$baseClass}}.loaderOptions.apply(this),
         prime: true,
@@ -294,7 +307,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
 
   static async loadCustomCount<T extends {{$baseClass}}>(
     this: {{$thisType}},
-    query: {{useImport "CustomQuery"}}<{{useImport $rawDBDataType}}>,
+    query: {{useImport "CustomQuery"}}<{{$customQueryDataType}}>,
     context?: {{useImport "Context"}}
   ): Promise<number> {
     return {{useImport "loadCustomCount"}}(

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -265,7 +265,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
   static async loadCustom<T extends {{$baseClass}}>(
     this: {{$thisType}},
     viewer: {{$viewerType}},
-    query: {{useImport "CustomQuery"}},
+    query: {{useImport "CustomQuery"}}<{{useImport $rawDBDataType}}>,
   ): Promise<T[]> {
     return await {{useImport "loadCustomEnts"}}(
       viewer,
@@ -279,22 +279,22 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
 
   static async loadCustomData<T extends {{$baseClass}}>(
     this: {{$thisType}},
-    query: {{useImport "CustomQuery"}},
+    query: {{useImport "CustomQuery"}}<{{useImport $rawDBDataType}}>,
     context?: {{useImport "Context"}}
   ): Promise<{{$rawDBDataType}}[]> {
-    return  await {{useImport "loadCustomData"}}(
+    return {{useImport "loadCustomData"}}(
       {
         ...{{$baseClass}}.loaderOptions.apply(this),
         prime: true,
       },
       query,
       context,
-    ) as {{$rawDBDataType}}[];
+    );
   }
 
   static async loadCustomCount<T extends {{$baseClass}}>(
     this: {{$thisType}},
-    query: {{useImport "CustomQuery"}},
+    query: {{useImport "CustomQuery"}}<{{useImport $rawDBDataType}}>,
     context?: {{useImport "Context"}}
   ): Promise<number> {
     return {{useImport "loadCustomCount"}}(

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -280,7 +280,8 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
     viewer: {{$viewerType}},
     query: {{useImport "CustomQuery"}}<{{$customQueryDataType}}>,
   ): Promise<T[]> {
-    return await {{useImport "loadCustomEnts"}}<{{$customQueryDataType}}, {{$rawDBDataType}}>(
+    {{/* there's technically some mismatch in the raw db types passed/returned here but doesn't matter */}}
+    return await {{useImport "loadCustomEnts"}}(
       viewer,
       {
       ...{{$baseClass}}.loaderOptions.apply(this),

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha116",
+  "version": "0.1.0-alpha117",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -156,11 +156,11 @@ export interface QueryableDataOptions
   extends SelectBaseDataOptions,
     QueryDataOptions {}
 
-export interface QueryDataOptions {
+export interface QueryDataOptions<T extends Data = Data, K = keyof T> {
   distinct?: boolean;
-  clause: clause.Clause;
+  clause: clause.Clause<T, K>;
   orderby?: string; // this technically doesn't make sense when querying just one row but whatevs
-  groupby?: string;
+  groupby?: K;
   limit?: number;
   disableTransformations?: boolean;
 }

--- a/ts/src/core/clause.test.ts
+++ b/ts/src/core/clause.test.ts
@@ -2,6 +2,40 @@ import { v1 } from "uuid";
 import * as clause from "./clause";
 import { loadConfig } from "./config";
 
+interface ExampleData {
+  id: string;
+  bar: string;
+  ids: string;
+}
+
+interface EdgeData {
+  id1: string;
+  id2: string;
+  id3: string;
+  id4: string;
+  id5: string;
+  id6: string;
+  id7: string;
+  id8: string;
+}
+
+interface JSONData {
+  jsonb: string[];
+}
+
+interface FullTextData {
+  name_idx: string;
+}
+
+interface EventData {
+  id: string;
+  start_time: Date;
+}
+
+interface BalanceData {
+  balance: number;
+}
+
 describe("postgres", () => {
   beforeAll(() => {
     // specify dialect as postgres
@@ -11,7 +45,7 @@ describe("postgres", () => {
 
   describe("Eq", () => {
     test("normal", () => {
-      const cls = clause.Eq("id", 4);
+      const cls = clause.Eq<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id = $1");
       expect(cls.clause(2)).toBe("id = $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -21,7 +55,7 @@ describe("postgres", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.Eq("id", clause.sensitiveValue(4));
+      const cls = clause.Eq<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id = $1");
       expect(cls.clause(2)).toBe("id = $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -33,7 +67,7 @@ describe("postgres", () => {
 
   describe("NotEq", () => {
     test("normal", () => {
-      const cls = clause.NotEq("id", 4);
+      const cls = clause.NotEq<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id != $1");
       expect(cls.clause(2)).toBe("id != $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -43,7 +77,7 @@ describe("postgres", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.NotEq("id", clause.sensitiveValue(4));
+      const cls = clause.NotEq<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id != $1");
       expect(cls.clause(2)).toBe("id != $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -55,7 +89,7 @@ describe("postgres", () => {
 
   describe("Greater", () => {
     test("normal", () => {
-      const cls = clause.Greater("id", 4);
+      const cls = clause.Greater<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id > $1");
       expect(cls.clause(2)).toBe("id > $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -65,7 +99,7 @@ describe("postgres", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.Greater("id", clause.sensitiveValue(4));
+      const cls = clause.Greater<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id > $1");
       expect(cls.clause(2)).toBe("id > $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -77,7 +111,7 @@ describe("postgres", () => {
 
   describe("Less", () => {
     test("normal", () => {
-      const cls = clause.Less("id", 4);
+      const cls = clause.Less<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id < $1");
       expect(cls.clause(2)).toBe("id < $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -87,7 +121,7 @@ describe("postgres", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.Less("id", clause.sensitiveValue(4));
+      const cls = clause.Less<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id < $1");
       expect(cls.clause(2)).toBe("id < $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -99,7 +133,7 @@ describe("postgres", () => {
 
   describe("GreaterEq", () => {
     test("normal", () => {
-      const cls = clause.GreaterEq("id", 4);
+      const cls = clause.GreaterEq<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id >= $1");
       expect(cls.clause(2)).toBe("id >= $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -109,7 +143,7 @@ describe("postgres", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.GreaterEq("id", clause.sensitiveValue(4));
+      const cls = clause.GreaterEq<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id >= $1");
       expect(cls.clause(2)).toBe("id >= $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -121,7 +155,7 @@ describe("postgres", () => {
 
   describe("LessEq", () => {
     test("normal", () => {
-      const cls = clause.LessEq("id", 4);
+      const cls = clause.LessEq<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id <= $1");
       expect(cls.clause(2)).toBe("id <= $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -131,7 +165,7 @@ describe("postgres", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.LessEq("id", clause.sensitiveValue(4));
+      const cls = clause.LessEq<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id <= $1");
       expect(cls.clause(2)).toBe("id <= $2");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -143,7 +177,10 @@ describe("postgres", () => {
 
   describe("And", () => {
     test("2 items", () => {
-      const cls = clause.And(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo"));
+      const cls = clause.And<EdgeData>(
+        clause.Eq("id1", "iddd"),
+        clause.Eq("id2", "foo"),
+      );
       expect(cls.clause(1)).toBe("id1 = $1 AND id2 = $2");
       expect(cls.columns()).toStrictEqual(["id1", "id2"]);
       expect(cls.values()).toStrictEqual(["iddd", "foo"]);
@@ -152,7 +189,7 @@ describe("postgres", () => {
     });
 
     test("3 items", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Eq("id2", "foo"),
         clause.Eq("id3", "baz"),
@@ -165,7 +202,7 @@ describe("postgres", () => {
     });
 
     test("3 items. one sensitive value", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Eq("id2", clause.sensitiveValue("foo")),
         clause.Eq("id3", "baz"),
@@ -178,7 +215,7 @@ describe("postgres", () => {
     });
 
     test("composite And with And first", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.And(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo")),
         clause.Eq("id3", "baz"),
       );
@@ -190,7 +227,7 @@ describe("postgres", () => {
     });
 
     test("composite And with And after", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.And(clause.Eq("id2", "foo"), clause.Eq("id3", "baz")),
       );
@@ -202,7 +239,7 @@ describe("postgres", () => {
     });
 
     test("composite And with sensitive value in there", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.And(
           clause.Eq("id2", "foo"),
@@ -219,7 +256,10 @@ describe("postgres", () => {
 
   describe("Or", () => {
     test("2 items", () => {
-      const cls = clause.Or(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo"));
+      const cls = clause.Or<EdgeData>(
+        clause.Eq("id1", "iddd"),
+        clause.Eq("id2", "foo"),
+      );
       expect(cls.clause(1)).toBe("id1 = $1 OR id2 = $2");
       expect(cls.columns()).toStrictEqual(["id1", "id2"]);
       expect(cls.values()).toStrictEqual(["iddd", "foo"]);
@@ -228,7 +268,7 @@ describe("postgres", () => {
     });
 
     test("3 items", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Eq("id2", "foo"),
         clause.Eq("id3", "baz"),
@@ -241,7 +281,7 @@ describe("postgres", () => {
     });
 
     test("3 items. one sensitive value", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Eq("id2", clause.sensitiveValue("foo")),
         clause.Eq("id3", "baz"),
@@ -254,7 +294,7 @@ describe("postgres", () => {
     });
 
     test("composite Or with Or first", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Or(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo")),
         clause.Eq("id3", "baz"),
       );
@@ -266,7 +306,7 @@ describe("postgres", () => {
     });
 
     test("composite Or with Or after", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Or(clause.Eq("id2", "foo"), clause.Eq("id3", "baz")),
       );
@@ -278,7 +318,7 @@ describe("postgres", () => {
     });
 
     test("composite or with sensitive value in there", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Or(
           clause.Eq("id2", "foo"),
@@ -295,7 +335,7 @@ describe("postgres", () => {
 
   describe("nested and/or", () => {
     test("OR nested in AND", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id3", "bar"),
         clause.Or(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo")),
       );
@@ -307,7 +347,7 @@ describe("postgres", () => {
     });
 
     test("AND nested in Or", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id3", "bar"),
         clause.And(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo")),
       );
@@ -319,7 +359,7 @@ describe("postgres", () => {
     });
 
     test("Or nested in AND nested in OR", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id4", "baz"),
         clause.And(
           clause.Eq("id3", "bar"),
@@ -338,7 +378,7 @@ describe("postgres", () => {
     });
 
     test("And nested in OR nested in AND", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id4", "baz"),
         clause.Or(
           clause.Eq("id3", "bar"),
@@ -357,7 +397,7 @@ describe("postgres", () => {
     });
 
     test("complexx ", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id4", "baz"),
         clause.Or(
           clause.Eq("id3", "bar"),
@@ -402,7 +442,7 @@ describe("postgres", () => {
 
   describe("null on null", () => {
     test("OR nested in AND", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id3", null),
         clause.Or(clause.Eq("id1", null), clause.Eq("id2", "foo")),
       );
@@ -416,7 +456,7 @@ describe("postgres", () => {
     });
 
     test("AND nested in OR", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id3", null),
         clause.And(clause.Eq("id1", null), clause.Eq("id2", "foo")),
       );
@@ -430,7 +470,7 @@ describe("postgres", () => {
     });
 
     test("Or nested in AND nested in OR", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id4", "baz"),
         clause.And(
           clause.Eq("id3", null),
@@ -449,7 +489,7 @@ describe("postgres", () => {
     });
 
     test("complexx ", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id4", "baz"),
         clause.Or(
           clause.Eq("id3", null),
@@ -497,7 +537,7 @@ describe("postgres", () => {
 
   describe("In", () => {
     test("1 arg", () => {
-      const cls = clause.In("id", 1);
+      const cls = clause.In<ExampleData>("id", 1);
       expect(cls.clause(1)).toBe("id = $1");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1]);
@@ -506,7 +546,7 @@ describe("postgres", () => {
     });
 
     test("spread args", () => {
-      const cls = clause.In("id", 1, 2, 3);
+      const cls = clause.In<ExampleData>("id", 1, 2, 3);
       expect(cls.clause(1)).toBe("id IN ($1, $2, $3)");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1, 2, 3]);
@@ -515,7 +555,7 @@ describe("postgres", () => {
     });
 
     test("spread args with sensitive value", () => {
-      const cls = clause.In("id", 1, 2, clause.sensitiveValue(3));
+      const cls = clause.In<ExampleData>("id", 1, 2, clause.sensitiveValue(3));
       expect(cls.clause(1)).toBe("id IN ($1, $2, $3)");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1, 2, 3]);
@@ -524,7 +564,7 @@ describe("postgres", () => {
     });
 
     test("list", () => {
-      const cls = clause.In("id", ...[1, 2, 3]);
+      const cls = clause.In<ExampleData>("id", ...[1, 2, 3]);
       expect(cls.clause(1)).toBe("id IN ($1, $2, $3)");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1, 2, 3]);
@@ -533,7 +573,10 @@ describe("postgres", () => {
     });
 
     test("list with sensitive value", () => {
-      const cls = clause.In("id", ...[1, clause.sensitiveValue(2), 3]);
+      const cls = clause.In<ExampleData>(
+        "id",
+        ...[1, clause.sensitiveValue(2), 3],
+      );
       expect(cls.clause(1)).toBe("id IN ($1, $2, $3)");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1, 2, 3]);
@@ -553,7 +596,7 @@ describe("postgres", () => {
       test("uuid implicit", () => {
         const ids = [1, 2, 3, 4, 5].map((_) => v1());
 
-        const cls = clause.In("id", ids);
+        const cls = clause.In<ExampleData>("id", ids);
         expect(cls.clause(1)).toBe(
           "id IN (VALUES($1::uuid), ($2), ($3), ($4), ($5))",
         );
@@ -566,7 +609,7 @@ describe("postgres", () => {
       test("int", () => {
         const ids = [1, 2, 3, 4, 5];
 
-        const cls = clause.In("id", ids, "int");
+        const cls = clause.In<ExampleData>("id", ids, "int");
         expect(cls.clause(1)).toBe(
           "id IN (VALUES($1::int), ($2), ($3), ($4), ($5))",
         );
@@ -579,7 +622,7 @@ describe("postgres", () => {
       test("integer", () => {
         const ids = [1, 2, 3, 4, 5];
 
-        const cls = clause.In("id", ids, "integer");
+        const cls = clause.In<ExampleData>("id", ids, "integer");
         expect(cls.clause(1)).toBe(
           "id IN (VALUES($1::integer), ($2), ($3), ($4), ($5))",
         );
@@ -592,7 +635,7 @@ describe("postgres", () => {
       test("uuid explicit", () => {
         const ids = [1, 2, 3, 4, 5].map((_) => v1());
 
-        const cls = clause.In("id", ids, "uuid");
+        const cls = clause.In<ExampleData>("id", ids, "uuid");
         expect(cls.clause(1)).toBe(
           "id IN (VALUES($1::uuid), ($2), ($3), ($4), ($5))",
         );
@@ -606,7 +649,7 @@ describe("postgres", () => {
 
   describe("array", () => {
     test("eq", () => {
-      const cls = clause.ArrayEq("ids", 3);
+      const cls = clause.ArrayEq<ExampleData>("ids", 3);
       expect(cls.clause(1)).toBe("$1 = ANY(ids)");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([3]);
@@ -615,7 +658,7 @@ describe("postgres", () => {
     });
 
     test("ne", () => {
-      const cls = clause.ArrayNotEq("ids", 3);
+      const cls = clause.ArrayNotEq<ExampleData>("ids", 3);
       expect(cls.clause(1)).toBe("$1 != ANY(ids)");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([3]);
@@ -624,7 +667,7 @@ describe("postgres", () => {
     });
 
     test("contains val", () => {
-      const cls = clause.PostgresArrayContainsValue("ids", 3);
+      const cls = clause.PostgresArrayContainsValue<ExampleData>("ids", 3);
       expect(cls.clause(1)).toBe("ids @> $1");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([`{3}`]);
@@ -633,7 +676,7 @@ describe("postgres", () => {
     });
 
     test("contains val:string", () => {
-      const cls = clause.PostgresArrayContainsValue("ids", "foo");
+      const cls = clause.PostgresArrayContainsValue<ExampleData>("ids", "foo");
       expect(cls.clause(1)).toBe("ids @> $1");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([`{foo}`]);
@@ -642,7 +685,7 @@ describe("postgres", () => {
     });
 
     test("contains list", () => {
-      const cls = clause.PostgresArrayContains("ids", [3, 4]);
+      const cls = clause.PostgresArrayContains<ExampleData>("ids", [3, 4]);
       expect(cls.clause(1)).toBe("ids @> $1");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([`{3, 4}`]);
@@ -651,7 +694,10 @@ describe("postgres", () => {
     });
 
     test("contains list string", () => {
-      const cls = clause.PostgresArrayContains("ids", ["foo", "bar"]);
+      const cls = clause.PostgresArrayContains<ExampleData>("ids", [
+        "foo",
+        "bar",
+      ]);
       expect(cls.clause(1)).toBe("ids @> $1");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([`{foo, bar}`]);
@@ -660,7 +706,7 @@ describe("postgres", () => {
     });
 
     test("not contains val", () => {
-      const cls = clause.PostgresArrayNotContainsValue("ids", 3);
+      const cls = clause.PostgresArrayNotContainsValue<ExampleData>("ids", 3);
       expect(cls.clause(1)).toBe("NOT ids @> $1");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([`{3}`]);
@@ -669,7 +715,7 @@ describe("postgres", () => {
     });
 
     test("not contains list", () => {
-      const cls = clause.PostgresArrayNotContains("ids", [3, 4]);
+      const cls = clause.PostgresArrayNotContains<ExampleData>("ids", [3, 4]);
       expect(cls.clause(1)).toBe("NOT ids @> $1");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([`{3, 4}`]);
@@ -678,7 +724,7 @@ describe("postgres", () => {
     });
 
     test("overlaps", () => {
-      const cls = clause.PostgresArrayOverlaps("ids", [3, 4]);
+      const cls = clause.PostgresArrayOverlaps<ExampleData>("ids", [3, 4]);
       expect(cls.clause(1)).toBe("ids && $1");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([`{3, 4}`]);
@@ -687,7 +733,7 @@ describe("postgres", () => {
     });
 
     test("not overlaps", () => {
-      const cls = clause.PostgresArrayNotOverlaps("ids", [3, 4]);
+      const cls = clause.PostgresArrayNotOverlaps<ExampleData>("ids", [3, 4]);
       expect(cls.clause(1)).toBe("NOT ids && $1");
       expect(cls.columns()).toStrictEqual(["ids"]);
       expect(cls.values()).toStrictEqual([`{3, 4}`]);
@@ -698,7 +744,12 @@ describe("postgres", () => {
 
   describe("jsonb", () => {
     test("eq", () => {
-      const cls = clause.JSONPathValuePredicate("jsonb", "$.*", 3, "==");
+      const cls = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.*",
+        3,
+        "==",
+      );
       expect(cls.clause(1)).toBe("jsonb @@ $1");
       expect(cls.columns()).toStrictEqual(["jsonb"]);
       expect(cls.values()).toStrictEqual(["$.* == 3"]);
@@ -707,7 +758,12 @@ describe("postgres", () => {
     });
 
     test("eq string", () => {
-      const cls = clause.JSONPathValuePredicate("jsonb", "$.*", "hello", "==");
+      const cls = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.*",
+        "hello",
+        "==",
+      );
       expect(cls.clause(1)).toBe("jsonb @@ $1");
       expect(cls.columns()).toStrictEqual(["jsonb"]);
       expect(cls.values()).toStrictEqual(['$.* == "hello"']);
@@ -716,7 +772,12 @@ describe("postgres", () => {
     });
 
     test("ge", () => {
-      const cls = clause.JSONPathValuePredicate("jsonb", "$.*", 3, ">");
+      const cls = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.*",
+        3,
+        ">",
+      );
       expect(cls.clause(1)).toBe("jsonb @@ $1");
       expect(cls.columns()).toStrictEqual(["jsonb"]);
       expect(cls.values()).toStrictEqual(["$.* > 3"]);
@@ -725,7 +786,12 @@ describe("postgres", () => {
     });
 
     test("ne", () => {
-      const cls = clause.JSONPathValuePredicate("jsonb", "$.*", 3, "!=");
+      const cls = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.*",
+        3,
+        "!=",
+      );
       expect(cls.clause(1)).toBe("jsonb @@ $1");
       expect(cls.columns()).toStrictEqual(["jsonb"]);
       expect(cls.values()).toStrictEqual(["$.* != 3"]);
@@ -734,7 +800,12 @@ describe("postgres", () => {
     });
 
     test("specific path", () => {
-      const cls = clause.JSONPathValuePredicate("jsonb", "$.col", 3, "!=");
+      const cls = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.col",
+        3,
+        "!=",
+      );
       expect(cls.clause(1)).toBe("jsonb @@ $1");
       expect(cls.columns()).toStrictEqual(["jsonb"]);
       expect(cls.values()).toStrictEqual(["$.col != 3"]);
@@ -743,7 +814,12 @@ describe("postgres", () => {
     });
 
     test("specific path arr idx", () => {
-      const cls = clause.JSONPathValuePredicate("jsonb", "$.col[*]", 3, "!=");
+      const cls = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.col[*]",
+        3,
+        "!=",
+      );
       expect(cls.clause(1)).toBe("jsonb @@ $1");
       expect(cls.columns()).toStrictEqual(["jsonb"]);
       expect(cls.values()).toStrictEqual(["$.col[*] != 3"]);
@@ -754,7 +830,7 @@ describe("postgres", () => {
 
   describe("full text", () => {
     test("tsquery string", () => {
-      const cls = clause.TsQuery("name_idx", "value");
+      const cls = clause.TsQuery<FullTextData>("name_idx", "value");
       expect(cls.clause(1)).toBe("name_idx @@ to_tsquery('english', $1)");
       expect(cls.columns()).toStrictEqual(["name_idx"]);
       expect(cls.values()).toStrictEqual(["value"]);
@@ -763,7 +839,7 @@ describe("postgres", () => {
     });
 
     test("tsquery complex", () => {
-      const cls = clause.TsQuery("name_idx", {
+      const cls = clause.TsQuery<FullTextData>("name_idx", {
         language: "simple",
         value: "value",
       });
@@ -775,7 +851,7 @@ describe("postgres", () => {
     });
 
     test("plainto_tsquery string", () => {
-      const cls = clause.PlainToTsQuery("name_idx", "value");
+      const cls = clause.PlainToTsQuery<FullTextData>("name_idx", "value");
       expect(cls.clause(1)).toBe("name_idx @@ plainto_tsquery('english', $1)");
       expect(cls.columns()).toStrictEqual(["name_idx"]);
       expect(cls.values()).toStrictEqual(["value"]);
@@ -786,7 +862,7 @@ describe("postgres", () => {
     });
 
     test("plainto_tsquery complex", () => {
-      const cls = clause.PlainToTsQuery("name_idx", {
+      const cls = clause.PlainToTsQuery<FullTextData>("name_idx", {
         language: "simple",
         value: "value",
       });
@@ -800,7 +876,7 @@ describe("postgres", () => {
     });
 
     test("phraseto_tsquery string", () => {
-      const cls = clause.PhraseToTsQuery("name_idx", "value");
+      const cls = clause.PhraseToTsQuery<FullTextData>("name_idx", "value");
       expect(cls.clause(1)).toBe("name_idx @@ phraseto_tsquery('english', $1)");
       expect(cls.columns()).toStrictEqual(["name_idx"]);
       expect(cls.values()).toStrictEqual(["value"]);
@@ -811,7 +887,7 @@ describe("postgres", () => {
     });
 
     test("phraseto_tsquery complex", () => {
-      const cls = clause.PhraseToTsQuery("name_idx", {
+      const cls = clause.PhraseToTsQuery<FullTextData>("name_idx", {
         language: "simple",
         value: "value",
       });
@@ -825,7 +901,7 @@ describe("postgres", () => {
     });
 
     test("websearch_to_tsquery string", () => {
-      const cls = clause.WebsearchToTsQuery("name_idx", "value");
+      const cls = clause.WebsearchToTsQuery<FullTextData>("name_idx", "value");
       expect(cls.clause(1)).toBe(
         "name_idx @@ websearch_to_tsquery('english', $1)",
       );
@@ -838,7 +914,7 @@ describe("postgres", () => {
     });
 
     test("websearch_to_tsquery complex", () => {
-      const cls = clause.WebsearchToTsQuery("name_idx", {
+      const cls = clause.WebsearchToTsQuery<FullTextData>("name_idx", {
         language: "simple",
         value: "value",
       });
@@ -854,7 +930,7 @@ describe("postgres", () => {
     });
 
     test("tsvectorcol_tsquery string", () => {
-      const cls = clause.TsVectorColTsQuery("name_idx", "value");
+      const cls = clause.TsVectorColTsQuery<FullTextData>("name_idx", "value");
       expect(cls.clause(1)).toBe(
         "to_tsvector(name_idx) @@ to_tsquery('english', $1)",
       );
@@ -867,7 +943,7 @@ describe("postgres", () => {
     });
 
     test("tsvectorcol_tsquery complex", () => {
-      const cls = clause.TsVectorColTsQuery("name_idx", {
+      const cls = clause.TsVectorColTsQuery<FullTextData>("name_idx", {
         language: "simple",
         value: "value",
       });
@@ -883,7 +959,10 @@ describe("postgres", () => {
     });
 
     test("tsvectorcol_plainto_tsquery string", () => {
-      const cls = clause.TsVectorPlainToTsQuery("name_idx", "value");
+      const cls = clause.TsVectorPlainToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+      );
       expect(cls.clause(1)).toBe(
         "to_tsvector(name_idx) @@ plainto_tsquery('english', $1)",
       );
@@ -896,7 +975,7 @@ describe("postgres", () => {
     });
 
     test("tsvectorcol_plainto_tsquery complex", () => {
-      const cls = clause.TsVectorPlainToTsQuery("name_idx", {
+      const cls = clause.TsVectorPlainToTsQuery<FullTextData>("name_idx", {
         language: "simple",
         value: "value",
       });
@@ -912,7 +991,10 @@ describe("postgres", () => {
     });
 
     test("tsvectorcol__phraseto_tsquery string", () => {
-      const cls = clause.TsVectorPhraseToTsQuery("name_idx", "value");
+      const cls = clause.TsVectorPhraseToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+      );
       expect(cls.clause(1)).toBe(
         "to_tsvector(name_idx) @@ phraseto_tsquery('english', $1)",
       );
@@ -941,7 +1023,10 @@ describe("postgres", () => {
     });
 
     test("tsvectorcol_websearch_to_tsquery string", () => {
-      const cls = clause.TsVectorWebsearchToTsQuery("name_idx", "value");
+      const cls = clause.TsVectorWebsearchToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+      );
       expect(cls.clause(1)).toBe(
         "to_tsvector(name_idx) @@ websearch_to_tsquery('english', $1)",
       );
@@ -954,7 +1039,7 @@ describe("postgres", () => {
     });
 
     test("websearch_to_tsquery complex", () => {
-      const cls = clause.TsVectorWebsearchToTsQuery("name_idx", {
+      const cls = clause.TsVectorWebsearchToTsQuery<FullTextData>("name_idx", {
         language: "simple",
         value: "value",
       });
@@ -972,7 +1057,7 @@ describe("postgres", () => {
 
   describe("pagination multiple cols query", () => {
     test(">", () => {
-      const cls = clause.PaginationMultipleColsSubQuery(
+      const cls = clause.PaginationMultipleColsSubQuery<EventData>(
         "start_time",
         ">",
         "events",
@@ -989,7 +1074,7 @@ describe("postgres", () => {
     });
 
     test("> clause 3", () => {
-      const cls = clause.PaginationMultipleColsSubQuery(
+      const cls = clause.PaginationMultipleColsSubQuery<EventData>(
         "start_time",
         ">",
         "events",
@@ -1006,7 +1091,7 @@ describe("postgres", () => {
     });
 
     test("<", () => {
-      const cls = clause.PaginationMultipleColsSubQuery(
+      const cls = clause.PaginationMultipleColsSubQuery<EventData>(
         "start_time",
         "<",
         "events",
@@ -1025,7 +1110,7 @@ describe("postgres", () => {
 
   describe("rhs", () => {
     test("add", () => {
-      const cls = clause.Add("balance", 4);
+      const cls = clause.Add<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance + $1");
       expect(cls.clause(2)).toBe("balance + $2");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1035,7 +1120,7 @@ describe("postgres", () => {
     });
 
     test("subtract", () => {
-      const cls = clause.Subtract("balance", 4);
+      const cls = clause.Subtract<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance - $1");
       expect(cls.clause(2)).toBe("balance - $2");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1045,7 +1130,7 @@ describe("postgres", () => {
     });
 
     test("divide", () => {
-      const cls = clause.Divide("balance", 4);
+      const cls = clause.Divide<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance / $1");
       expect(cls.clause(2)).toBe("balance / $2");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1055,7 +1140,7 @@ describe("postgres", () => {
     });
 
     test("multiply", () => {
-      const cls = clause.Multiply("balance", 4);
+      const cls = clause.Multiply<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance * $1");
       expect(cls.clause(2)).toBe("balance * $2");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1065,7 +1150,7 @@ describe("postgres", () => {
     });
 
     test("modulo", () => {
-      const cls = clause.Modulo("balance", 4);
+      const cls = clause.Modulo<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance % $1");
       expect(cls.clause(2)).toBe("balance % $2");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1085,7 +1170,7 @@ describe("sqlite", () => {
 
   describe("Eq", () => {
     test("normal", () => {
-      const cls = clause.Eq("id", 4);
+      const cls = clause.Eq<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id = ?");
       expect(cls.clause(2)).toBe("id = ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1095,7 +1180,7 @@ describe("sqlite", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.Eq("id", clause.sensitiveValue(4));
+      const cls = clause.Eq<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id = ?");
       expect(cls.clause(2)).toBe("id = ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1107,7 +1192,7 @@ describe("sqlite", () => {
 
   describe("Greater", () => {
     test("normal", () => {
-      const cls = clause.Greater("id", 4);
+      const cls = clause.Greater<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id > ?");
       expect(cls.clause(2)).toBe("id > ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1117,7 +1202,7 @@ describe("sqlite", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.Greater("id", clause.sensitiveValue(4));
+      const cls = clause.Greater<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id > ?");
       expect(cls.clause(2)).toBe("id > ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1129,7 +1214,7 @@ describe("sqlite", () => {
 
   describe("Less", () => {
     test("normal", () => {
-      const cls = clause.Less("id", 4);
+      const cls = clause.Less<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id < ?");
       expect(cls.clause(2)).toBe("id < ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1139,7 +1224,7 @@ describe("sqlite", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.Less("id", clause.sensitiveValue(4));
+      const cls = clause.Less<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id < ?");
       expect(cls.clause(2)).toBe("id < ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1151,7 +1236,7 @@ describe("sqlite", () => {
 
   describe("GreaterEq", () => {
     test("normal", () => {
-      const cls = clause.GreaterEq("id", 4);
+      const cls = clause.GreaterEq<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id >= ?");
       expect(cls.clause(2)).toBe("id >= ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1161,7 +1246,7 @@ describe("sqlite", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.GreaterEq("id", clause.sensitiveValue(4));
+      const cls = clause.GreaterEq<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id >= ?");
       expect(cls.clause(2)).toBe("id >= ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1173,7 +1258,7 @@ describe("sqlite", () => {
 
   describe("LessEq", () => {
     test("normal", () => {
-      const cls = clause.LessEq("id", 4);
+      const cls = clause.LessEq<ExampleData>("id", 4);
       expect(cls.clause(1)).toBe("id <= ?");
       expect(cls.clause(2)).toBe("id <= ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1183,7 +1268,7 @@ describe("sqlite", () => {
     });
 
     test("sensitive value", () => {
-      const cls = clause.LessEq("id", clause.sensitiveValue(4));
+      const cls = clause.LessEq<ExampleData>("id", clause.sensitiveValue(4));
       expect(cls.clause(1)).toBe("id <= ?");
       expect(cls.clause(2)).toBe("id <= ?");
       expect(cls.columns()).toStrictEqual(["id"]);
@@ -1195,7 +1280,10 @@ describe("sqlite", () => {
 
   describe("And", () => {
     test("2 items", () => {
-      const cls = clause.And(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo"));
+      const cls = clause.And<EdgeData>(
+        clause.Eq("id1", "iddd"),
+        clause.Eq("id2", "foo"),
+      );
       expect(cls.clause(1)).toBe("id1 = ? AND id2 = ?");
       expect(cls.columns()).toStrictEqual(["id1", "id2"]);
       expect(cls.values()).toStrictEqual(["iddd", "foo"]);
@@ -1204,7 +1292,7 @@ describe("sqlite", () => {
     });
 
     test("3 items", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Eq("id2", "foo"),
         clause.Eq("id3", "baz"),
@@ -1230,7 +1318,7 @@ describe("sqlite", () => {
     });
 
     test("composite And with And first", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.And(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo")),
         clause.Eq("id3", "baz"),
       );
@@ -1242,7 +1330,7 @@ describe("sqlite", () => {
     });
 
     test("composite And with And after", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.And(clause.Eq("id2", "foo"), clause.Eq("id3", "baz")),
       );
@@ -1254,7 +1342,7 @@ describe("sqlite", () => {
     });
 
     test("composite And with sensitive value in there", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.And(
           clause.Eq("id2", "foo"),
@@ -1271,7 +1359,10 @@ describe("sqlite", () => {
 
   describe("Or", () => {
     test("2 items", () => {
-      const cls = clause.Or(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo"));
+      const cls = clause.Or<EdgeData>(
+        clause.Eq("id1", "iddd"),
+        clause.Eq("id2", "foo"),
+      );
       expect(cls.clause(1)).toBe("id1 = ? OR id2 = ?");
       expect(cls.columns()).toStrictEqual(["id1", "id2"]);
       expect(cls.values()).toStrictEqual(["iddd", "foo"]);
@@ -1280,7 +1371,7 @@ describe("sqlite", () => {
     });
 
     test("3 items", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Eq("id2", "foo"),
         clause.Eq("id3", "baz"),
@@ -1293,7 +1384,7 @@ describe("sqlite", () => {
     });
 
     test("3 items. one sensitive value", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Eq("id2", clause.sensitiveValue("foo")),
         clause.Eq("id3", "baz"),
@@ -1306,7 +1397,7 @@ describe("sqlite", () => {
     });
 
     test("composite Or with Or first", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Or(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo")),
         clause.Eq("id3", "baz"),
       );
@@ -1318,7 +1409,7 @@ describe("sqlite", () => {
     });
 
     test("composite Or with Or after", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Or(clause.Eq("id2", "foo"), clause.Eq("id3", "baz")),
       );
@@ -1330,7 +1421,7 @@ describe("sqlite", () => {
     });
 
     test("composite or with sensitive value in there", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id1", "iddd"),
         clause.Or(
           clause.Eq("id2", "foo"),
@@ -1347,7 +1438,7 @@ describe("sqlite", () => {
 
   describe("nested and/or", () => {
     test("OR nested in AND", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id3", "bar"),
         clause.Or(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo")),
       );
@@ -1359,7 +1450,7 @@ describe("sqlite", () => {
     });
 
     test("AND nested in Or", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id3", "bar"),
         clause.And(clause.Eq("id1", "iddd"), clause.Eq("id2", "foo")),
       );
@@ -1371,7 +1462,7 @@ describe("sqlite", () => {
     });
 
     test("Or nested in AND nested in OR", () => {
-      const cls = clause.Or(
+      const cls = clause.Or<EdgeData>(
         clause.Eq("id4", "baz"),
         clause.And(
           clause.Eq("id3", "bar"),
@@ -1390,7 +1481,7 @@ describe("sqlite", () => {
     });
 
     test("And nested in OR nested in AND", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id4", "baz"),
         clause.Or(
           clause.Eq("id3", "bar"),
@@ -1409,7 +1500,7 @@ describe("sqlite", () => {
     });
 
     test("complexx ", () => {
-      const cls = clause.And(
+      const cls = clause.And<EdgeData>(
         clause.Eq("id4", "baz"),
         clause.Or(
           clause.Eq("id3", "bar"),
@@ -1454,7 +1545,7 @@ describe("sqlite", () => {
 
   describe("In", () => {
     test("1 arg", () => {
-      const cls = clause.In("id", 1);
+      const cls = clause.In<ExampleData>("id", 1);
       expect(cls.clause(1)).toBe("id = ?");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1]);
@@ -1463,7 +1554,7 @@ describe("sqlite", () => {
     });
 
     test("spread args", () => {
-      const cls = clause.In("id", 1, 2, 3);
+      const cls = clause.In<ExampleData>("id", 1, 2, 3);
       expect(cls.clause(1)).toBe("id IN (?, ?, ?)");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1, 2, 3]);
@@ -1472,7 +1563,7 @@ describe("sqlite", () => {
     });
 
     test("spread args with sensitive value", () => {
-      const cls = clause.In("id", 1, 2, clause.sensitiveValue(3));
+      const cls = clause.In<ExampleData>("id", 1, 2, clause.sensitiveValue(3));
       expect(cls.clause(1)).toBe("id IN (?, ?, ?)");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1, 2, 3]);
@@ -1481,7 +1572,7 @@ describe("sqlite", () => {
     });
 
     test("list", () => {
-      const cls = clause.In("id", ...[1, 2, 3]);
+      const cls = clause.In<ExampleData>("id", ...[1, 2, 3]);
       expect(cls.clause(1)).toBe("id IN (?, ?, ?)");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1, 2, 3]);
@@ -1490,7 +1581,10 @@ describe("sqlite", () => {
     });
 
     test("list with sensitive value", () => {
-      const cls = clause.In("id", ...[1, clause.sensitiveValue(2), 3]);
+      const cls = clause.In<ExampleData>(
+        "id",
+        ...[1, clause.sensitiveValue(2), 3],
+      );
       expect(cls.clause(1)).toBe("id IN (?, ?, ?)");
       expect(cls.columns()).toStrictEqual(["id"]);
       expect(cls.values()).toStrictEqual([1, 2, 3]);
@@ -1501,7 +1595,7 @@ describe("sqlite", () => {
 
   describe("pagination multiple cols query", () => {
     test(">", () => {
-      const cls = clause.PaginationMultipleColsSubQuery(
+      const cls = clause.PaginationMultipleColsSubQuery<EventData>(
         "start_time",
         ">",
         "events",
@@ -1518,7 +1612,7 @@ describe("sqlite", () => {
     });
 
     test("> clause 3", () => {
-      const cls = clause.PaginationMultipleColsSubQuery(
+      const cls = clause.PaginationMultipleColsSubQuery<EventData>(
         "start_time",
         ">",
         "events",
@@ -1535,7 +1629,7 @@ describe("sqlite", () => {
     });
 
     test("<", () => {
-      const cls = clause.PaginationMultipleColsSubQuery(
+      const cls = clause.PaginationMultipleColsSubQuery<EventData>(
         "start_time",
         "<",
         "events",
@@ -1554,7 +1648,7 @@ describe("sqlite", () => {
 
   describe("rhs", () => {
     test("add", () => {
-      const cls = clause.Add("balance", 4);
+      const cls = clause.Add<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance + ?");
       expect(cls.clause(2)).toBe("balance + ?");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1564,7 +1658,7 @@ describe("sqlite", () => {
     });
 
     test("subtract", () => {
-      const cls = clause.Subtract("balance", 4);
+      const cls = clause.Subtract<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance - ?");
       expect(cls.clause(2)).toBe("balance - ?");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1574,7 +1668,7 @@ describe("sqlite", () => {
     });
 
     test("divide", () => {
-      const cls = clause.Divide("balance", 4);
+      const cls = clause.Divide<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance / ?");
       expect(cls.clause(2)).toBe("balance / ?");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1584,7 +1678,7 @@ describe("sqlite", () => {
     });
 
     test("multiply", () => {
-      const cls = clause.Multiply("balance", 4);
+      const cls = clause.Multiply<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance * ?");
       expect(cls.clause(2)).toBe("balance * ?");
       expect(cls.columns()).toStrictEqual(["balance"]);
@@ -1594,7 +1688,7 @@ describe("sqlite", () => {
     });
 
     test("modulo", () => {
-      const cls = clause.Modulo("balance", 4);
+      const cls = clause.Modulo<BalanceData>("balance", 4);
       expect(cls.clause(1)).toBe("balance % ?");
       expect(cls.clause(2)).toBe("balance % ?");
       expect(cls.columns()).toStrictEqual(["balance"]);

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -536,16 +536,19 @@ interface parameterizedQueryOptions {
   logValues?: any[];
 }
 
-export type CustomQuery =
+export type CustomQuery<T extends Data = Data, K = keyof T> =
   | string
   | parameterizedQueryOptions
-  | clause.Clause
+  | clause.Clause<T, K>
   | QueryDataOptions;
 
-function isClause(
-  opts: clause.Clause | QueryDataOptions | parameterizedQueryOptions,
-): opts is clause.Clause {
-  const cls = opts as clause.Clause;
+function isClause<T extends Data = Data, K = keyof T>(
+  opts:
+    | clause.Clause<T, K>
+    | QueryDataOptions<T, K>
+    | parameterizedQueryOptions,
+): opts is clause.Clause<T, K> {
+  const cls = opts as clause.Clause<T, K>;
 
   return cls.clause !== undefined && cls.values !== undefined;
 }
@@ -580,11 +583,11 @@ function isParameterizedQuery(
  *   disableTransformations: false
  *  }) // doesn't change the query
  */
-export async function loadCustomData(
+export async function loadCustomData<T extends Data = Data, K = keyof T>(
   options: SelectCustomDataOptions,
-  query: CustomQuery,
+  query: CustomQuery<T, K>,
   context: Context | undefined,
-): Promise<Data[]> {
+): Promise<T[]> {
   const rows = await loadCustomDataImpl(options, query, context);
 
   // prime the data so that subsequent fetches of the row with this id are a cache hit.
@@ -603,9 +606,9 @@ interface CustomCountOptions extends DataOptions {}
 
 // NOTE: if you use a raw query or paramterized query with this,
 // you should use `SELECT count(*) as count...`
-export async function loadCustomCount(
+export async function loadCustomCount<T extends Data = Data, K = keyof T>(
   options: CustomCountOptions,
-  query: CustomQuery,
+  query: CustomQuery<T, K>,
   context: Context | undefined,
 ): Promise<number> {
   // TODO also need to loaderify this in case we're querying for this a lot...
@@ -634,12 +637,12 @@ interface SelectCustomDataOptionsImpl extends SelectBaseDataOptions {
   loaderFactory?: LoaderFactoryWithOptions;
 }
 
-async function loadCustomDataImpl(
+async function loadCustomDataImpl<T extends Data = Data, K = keyof T>(
   options: SelectCustomDataOptionsImpl,
-  query: CustomQuery,
+  query: CustomQuery<T, K>,
   context: Context | undefined,
-): Promise<Data[]> {
-  function getClause(cls: clause.Clause) {
+): Promise<T[]> {
+  function getClause(cls: clause.Clause<T, K>): clause.Clause<T, K> {
     let optClause = options.loaderFactory?.options?.clause;
     if (typeof optClause === "function") {
       optClause = optClause();
@@ -648,12 +651,14 @@ async function loadCustomDataImpl(
       return cls;
     }
 
+    // @ts-expect-error string|ID mismatch
     return clause.And(cls, optClause);
   }
 
   if (typeof query === "string") {
     // no caching, perform raw query
-    return performRawQuery(query, [], []);
+    return performRawQuery(query, [], []) as Promise<T[]>;
+    // @ts-ignore
   } else if (isClause(query)) {
     // if a Clause is passed in and we have a default clause
     // associated with the query, pass that in
@@ -662,15 +667,21 @@ async function loadCustomDataImpl(
     // this will have rudimentary caching but nothing crazy
     return loadRows({
       ...options,
+      // @ts-ignore
       clause: getClause(query),
       context: context,
-    });
+    }) as Promise<T[]>;
   } else if (isParameterizedQuery(query)) {
     // no caching, perform raw query
-    return performRawQuery(query.query, query.values || [], query.logValues);
+    return performRawQuery(
+      query.query,
+      query.values || [],
+      query.logValues,
+    ) as Promise<T[]>;
   } else {
     let cls = query.clause;
     if (!query.disableTransformations) {
+      // @ts-ignore
       cls = getClause(cls);
     }
     // this will have rudimentary caching but nothing crazy
@@ -679,7 +690,7 @@ async function loadCustomDataImpl(
       ...options,
       context: context,
       clause: cls,
-    });
+    }) as Promise<T[]>;
   }
 }
 
@@ -931,27 +942,27 @@ export function buildQuery(options: QueryableDataOptions): string {
   return query;
 }
 
-interface GroupQueryOptions {
+interface GroupQueryOptions<T extends Data, K = keyof T> {
   tableName: string;
 
   // extra clause to join
-  clause?: clause.Clause;
-  groupColumn: string;
-  fields: string[];
+  clause?: clause.Clause<T, K>;
+  groupColumn: K;
+  fields: K[];
   values: any[];
   orderby?: string;
   limit: number;
 }
 
 // this is used for queries when we select multiple ids at once
-export function buildGroupQuery(
-  options: GroupQueryOptions,
-): [string, clause.Clause] {
+export function buildGroupQuery<T extends Data = Data, K = keyof T>(
+  options: GroupQueryOptions<T, K>,
+): [string, clause.Clause<T, K>] {
   const fields = [...options.fields, "row_number()"];
 
-  let cls = clause.In(options.groupColumn, ...options.values);
+  let cls = clause.In<T, K>(options.groupColumn, ...options.values);
   if (options.clause) {
-    cls = clause.And(cls, options.clause);
+    cls = clause.And<T, K>(cls, options.clause);
   }
   let orderby = "";
   if (options.orderby) {
@@ -1101,6 +1112,7 @@ export class EditNodeOperation<T extends Ent> implements DataOperation {
         optionClause = opts.clause;
       }
       if (optionClause) {
+        // @ts-expect-error ID|string mismatch
         cls = clause.And(cls, optionClause);
       }
     }
@@ -2107,7 +2119,7 @@ export function getEdgeClauseAndFields(
     if (!options.disableTransformations) {
       cls = clause.And(cls, transformClause);
     }
-    fields = edgeFields.concat(transformClause.columns());
+    fields = edgeFields.concat(transformClause.columns() as string[]);
   }
   return {
     cls,

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -520,12 +520,18 @@ export async function loadEntsFromClause<
 export async function loadCustomEnts<
   TEnt extends Ent<TViewer>,
   TViewer extends Viewer,
+  TData extends Data = Data,
+  TKey = keyof TData,
 >(
   viewer: TViewer,
   options: LoadCustomEntOptions<TEnt, TViewer>,
-  query: CustomQuery,
+  query: CustomQuery<TData, TKey>,
 ) {
-  const rows = await loadCustomData(options, query, viewer.context);
+  const rows = await loadCustomData<TData, TKey>(
+    options,
+    query,
+    viewer.context,
+  );
 
   return applyPrivacyPolicyForRows(viewer, rows, options);
 }

--- a/ts/src/core/loaders/object_loader.ts
+++ b/ts/src/core/loaders/object_loader.ts
@@ -31,6 +31,7 @@ async function loadRowsForLoader<K, V = Data>(
       optionClause = options.clause;
     }
     if (optionClause) {
+      // @ts-expect-error id/string mismatch
       cls = clause.And(cls, optionClause);
     }
   }


### PR DESCRIPTION
fixes https://github.com/lolopinto/ent/issues/1231

so that incorrect columns can't be passed to the queries. better to catch earlier if possible