### PR TITLE
defaultValueOnEdit change behavior

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha118",
+  "version": "0.1.0-alpha119",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -823,6 +823,8 @@ export class Orchestrator<
       let defaultValue: any = undefined;
       let dbKey = this.getStorageKey(fieldName);
 
+      let updateOnlyIfOther = field.onlyUpdateIfOtherFieldsBeingSet_BETA;
+
       if (value === undefined) {
         if (this.actualOperation === WriteOperation.Insert) {
           if (field.defaultToViewerOnCreate && field.defaultValueOnCreate) {
@@ -863,7 +865,13 @@ export class Orchestrator<
 
       if (defaultValue !== undefined) {
         updateInput = true;
-        defaultData[dbKey] = defaultValue;
+
+        if (updateOnlyIfOther) {
+          defaultData[dbKey] = defaultValue;
+        } else {
+          data[dbKey] = defaultValue;
+        }
+
         this.defaultFieldsByFieldName[fieldName] = defaultValue;
         this.defaultFieldsByTSName[this.getInputKey(fieldName)] = defaultValue;
       }

--- a/ts/src/schema/base_schema.ts
+++ b/ts/src/schema/base_schema.ts
@@ -17,6 +17,7 @@ let tsFields: FieldMap = {
     defaultValueOnCreate: () => {
       return new Date();
     },
+    onlyUpdateIfOtherFieldsBeingSet_BETA: true,
     defaultValueOnEdit: () => {
       return new Date();
     },

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -480,6 +480,11 @@ export interface FieldOptions {
   // shorthand for defaultValueOnCreate: (builder)=>builder.viewer.viewerID;
   // exists for common scenario to set a field to the logged in viewerID.
   defaultToViewerOnCreate?: boolean;
+
+  // goes along with defaultValueOnEdit
+  // flag that indicates that if this is the only field being updated,
+  // don't update the ent, only if other fields are being updated, should this be updated
+  onlyUpdateIfOtherFieldsBeingSet_BETA?: boolean;
   defaultValueOnEdit?(builder: Builder<Ent>, input: Data): any;
   // this is very specific.
   // maybe there's a better way to indicate this


### PR DESCRIPTION
followup to https://github.com/lolopinto/ent/pull/671

allow fields with `defaultValueOnEdit` to be updated and have `updateInput` called so that if we call `getInput` in triggers/observers, we see the input

added a flag to schema.ts `onlyUpdateIfOtherFieldsBeingSet_BETA` so that the default `updatedAt` field behavior doesn't change