### PR TITLE
dataloader caching for custom queries with a Clause

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.3.0",
         "@sentry/tracing": "^6.3.0",
-        "@snowtop/ent": "^0.1.0-alpha117",
+        "@snowtop/ent": "^0.1.0-alpha124",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1218,9 +1218,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha117",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha117.tgz",
-      "integrity": "sha512-Khr+C4RPHNt28VcAIvGGSNbJsKSe037NlRlG7CL+70fOAxLh4LnIv6dkQWMAwAE2y85/6/E0hO+sFmEyeoWOsg==",
+      "version": "0.1.0-alpha124",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha124.tgz",
+      "integrity": "sha512-Sth7kT1rIbrxup9Z7vP4skdgFw/JmCOGcp2+XMTwoPGtJDWOx8Pn96oMaHzGN3jmfSKrjG4d1Z/xAShi4qvtgA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",
@@ -7146,9 +7146,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha117",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha117.tgz",
-      "integrity": "sha512-Khr+C4RPHNt28VcAIvGGSNbJsKSe037NlRlG7CL+70fOAxLh4LnIv6dkQWMAwAE2y85/6/E0hO+sFmEyeoWOsg==",
+      "version": "0.1.0-alpha124",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha124.tgz",
+      "integrity": "sha512-Sth7kT1rIbrxup9Z7vP4skdgFw/JmCOGcp2+XMTwoPGtJDWOx8Pn96oMaHzGN3jmfSKrjG4d1Z/xAShi4qvtgA==",
       "requires": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "^6.3.0",
     "@sentry/tracing": "^6.3.0",
-    "@snowtop/ent": "^0.1.0-alpha117",
+    "@snowtop/ent": "^0.1.0-alpha124",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/address_base.ts
@@ -259,7 +259,7 @@ export class AddressBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, AddressDBData> {
     return {
       tableName: addressLoaderInfo.tableName,
       fields: addressLoaderInfo.fields,

--- a/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/auth_code_base.ts
@@ -252,7 +252,7 @@ export class AuthCodeBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, AuthCodeDBData> {
     return {
       tableName: authCodeLoaderInfo.tableName,
       fields: authCodeLoaderInfo.fields,

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity_base.ts
@@ -219,7 +219,7 @@ export class EventActivityBase
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, EventActivityDBData> {
     return {
       tableName: eventActivityLoaderInfo.tableName,
       fields: eventActivityLoaderInfo.fields,

--- a/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_base.ts
@@ -256,7 +256,7 @@ export class EventBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, EventDBData> {
     return {
       tableName: eventLoaderInfo.tableName,
       fields: eventLoaderInfo.fields,

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_base.ts
@@ -211,7 +211,7 @@ export class GuestBase
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, GuestDBData> {
     return {
       tableName: guestLoaderInfo.tableName,
       fields: guestLoaderInfo.fields,

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_data_base.ts
@@ -198,7 +198,7 @@ export class GuestDataBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, GuestDataDBData> {
     return {
       tableName: guestDataLoaderInfo.tableName,
       fields: guestDataLoaderInfo.fields,

--- a/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/guest_group_base.ts
@@ -194,7 +194,7 @@ export class GuestGroupBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, GuestGroupDBData> {
     return {
       tableName: guestGroupLoaderInfo.tableName,
       fields: guestGroupLoaderInfo.fields,

--- a/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/user_base.ts
@@ -256,7 +256,7 @@ export class UserBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, UserDBData> {
     return {
       tableName: userLoaderInfo.tableName,
       fields: userLoaderInfo.fields,

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha123",
+        "@snowtop/ent": "^0.1.0-alpha124",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1194,9 +1194,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha123",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha123.tgz",
-      "integrity": "sha512-IddnWZPhLBxVvcI4w2CgONW4KxU//rCtnBnHRHzWncru1SFJuFLItxUrJlR+0DvTTMcfGstQR08kBRxVPjP0eQ==",
+      "version": "0.1.0-alpha124",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha124.tgz",
+      "integrity": "sha512-Sth7kT1rIbrxup9Z7vP4skdgFw/JmCOGcp2+XMTwoPGtJDWOx8Pn96oMaHzGN3jmfSKrjG4d1Z/xAShi4qvtgA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",
@@ -8007,9 +8007,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha123",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha123.tgz",
-      "integrity": "sha512-IddnWZPhLBxVvcI4w2CgONW4KxU//rCtnBnHRHzWncru1SFJuFLItxUrJlR+0DvTTMcfGstQR08kBRxVPjP0eQ==",
+      "version": "0.1.0-alpha124",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha124.tgz",
+      "integrity": "sha512-Sth7kT1rIbrxup9Z7vP4skdgFw/JmCOGcp2+XMTwoPGtJDWOx8Pn96oMaHzGN3jmfSKrjG4d1Z/xAShi4qvtgA==",
       "requires": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -33,7 +33,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha123",
+    "@snowtop/ent": "^0.1.0-alpha124",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/simple/src/ent/generated/address_base.ts
+++ b/examples/simple/src/ent/generated/address_base.ts
@@ -197,7 +197,7 @@ export class AddressBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, AddressDBData> {
     return {
       tableName: addressLoaderInfo.tableName,
       fields: addressLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/auth_code_base.ts
+++ b/examples/simple/src/ent/generated/auth_code_base.ts
@@ -193,7 +193,7 @@ export class AuthCodeBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, AuthCodeDBData> {
     return {
       tableName: authCodeLoaderInfo.tableName,
       fields: authCodeLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/comment_base.ts
+++ b/examples/simple/src/ent/generated/comment_base.ts
@@ -209,7 +209,7 @@ export class CommentBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, CommentDBData> {
     return {
       tableName: commentLoaderInfo.tableName,
       fields: commentLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/contact_base.ts
+++ b/examples/simple/src/ent/generated/contact_base.ts
@@ -208,7 +208,7 @@ export class ContactBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, ContactDBData> {
     return {
       tableName: contactLoaderInfo.tableName,
       fields: contactLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/contact_email_base.ts
+++ b/examples/simple/src/ent/generated/contact_email_base.ts
@@ -200,7 +200,7 @@ export class ContactEmailBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, ContactEmailDBData> {
     return {
       tableName: contactEmailLoaderInfo.tableName,
       fields: contactEmailLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/contact_phone_number_base.ts
+++ b/examples/simple/src/ent/generated/contact_phone_number_base.ts
@@ -200,7 +200,7 @@ export class ContactPhoneNumberBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, ContactPhoneNumberDBData> {
     return {
       tableName: contactPhoneNumberLoaderInfo.tableName,
       fields: contactPhoneNumberLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/event_base.ts
+++ b/examples/simple/src/ent/generated/event_base.ts
@@ -220,7 +220,7 @@ export class EventBase implements Ent<ExampleViewerAlias> {
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, EventDBData> {
     return {
       tableName: eventLoaderInfo.tableName,
       fields: eventLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/holiday_base.ts
+++ b/examples/simple/src/ent/generated/holiday_base.ts
@@ -196,7 +196,7 @@ export class HolidayBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, HolidayDBData> {
     return {
       tableName: holidayLoaderInfo.tableName,
       fields: holidayLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/hours_of_operation_base.ts
+++ b/examples/simple/src/ent/generated/hours_of_operation_base.ts
@@ -198,7 +198,7 @@ export class HoursOfOperationBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, HoursOfOperationDBData> {
     return {
       tableName: hoursOfOperationLoaderInfo.tableName,
       fields: hoursOfOperationLoaderInfo.fields,

--- a/examples/simple/src/ent/generated/user_base.ts
+++ b/examples/simple/src/ent/generated/user_base.ts
@@ -485,7 +485,7 @@ export class UserBase
       viewer: ExampleViewerAlias,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, ExampleViewerAlias> {
+  ): LoadEntOptions<T, ExampleViewerAlias, UserDBData> {
     return {
       tableName: userLoaderInfo.tableName,
       fields: userLoaderInfo.fields,

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha122",
+        "@snowtop/ent": "^0.1.0-alpha124",
         "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
         "@snowtop/ent-soft-delete": "^0.1.0-alpha5",
         "@types/node": "^15.0.3",
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha122",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha122.tgz",
-      "integrity": "sha512-ULSD49smJe+N9wK1nKKAy01AgpFmbdNipzOxuPclvQVCXcbOF6eiro6yviMAEuqg3XywAXqAxKu3WovBNOG8Yg==",
+      "version": "0.1.0-alpha124",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha124.tgz",
+      "integrity": "sha512-Sth7kT1rIbrxup9Z7vP4skdgFw/JmCOGcp2+XMTwoPGtJDWOx8Pn96oMaHzGN3jmfSKrjG4d1Z/xAShi4qvtgA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",
@@ -6909,9 +6909,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha122",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha122.tgz",
-      "integrity": "sha512-ULSD49smJe+N9wK1nKKAy01AgpFmbdNipzOxuPclvQVCXcbOF6eiro6yviMAEuqg3XywAXqAxKu3WovBNOG8Yg==",
+      "version": "0.1.0-alpha124",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha124.tgz",
+      "integrity": "sha512-Sth7kT1rIbrxup9Z7vP4skdgFw/JmCOGcp2+XMTwoPGtJDWOx8Pn96oMaHzGN3jmfSKrjG4d1Z/xAShi4qvtgA==",
       "requires": {
         "@types/node": "^18.11.18",
         "camel-case": "^4.1.2",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -37,7 +37,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha122",
+    "@snowtop/ent": "^0.1.0-alpha124",
     "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
     "@snowtop/ent-soft-delete": "^0.1.0-alpha5",
     "@types/node": "^15.0.3",

--- a/examples/todo-sqlite/src/ent/generated/account_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_base.ts
@@ -350,7 +350,7 @@ export class AccountBase
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, AccountDBData> {
     return {
       tableName: accountLoaderInfo.tableName,
       fields: accountLoaderInfo.fields,

--- a/examples/todo-sqlite/src/ent/generated/tag_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_base.ts
@@ -231,7 +231,7 @@ export class TagBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, TagDBData> {
     return {
       tableName: tagLoaderInfo.tableName,
       fields: tagLoaderInfo.fields,

--- a/examples/todo-sqlite/src/ent/generated/todo_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_base.ts
@@ -248,7 +248,7 @@ export class TodoBase implements Ent<Viewer> {
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, TodoDBData> {
     return {
       tableName: todoLoaderInfo.tableName,
       fields: todoLoaderInfo.fields,

--- a/examples/todo-sqlite/src/ent/generated/workspace_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace_base.ts
@@ -303,7 +303,7 @@ export class WorkspaceBase
       viewer: Viewer,
       data: Data,
     ) => T,
-  ): LoadEntOptions<T, Viewer> {
+  ): LoadEntOptions<T, Viewer, WorkspaceDBData> {
     return {
       tableName: workspaceLoaderInfo.tableName,
       fields: workspaceLoaderInfo.fields,

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -413,7 +413,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
 
   static loaderOptions<T extends {{$baseClass}}>(
     this: new (viewer: {{$viewerType}}, data: Data) => T,
-  ): {{useImport "LoadEntOptions"}}<T, {{$viewerType}}> {
+  ): {{useImport "LoadEntOptions"}}<T, {{$viewerType}}, {{$dataType}}> {
     return {
       tableName: {{useImport $loaderInfo}}.tableName,
       fields: {{useImport $loaderInfo}}.fields,

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -413,7 +413,7 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
 
   static loaderOptions<T extends {{$baseClass}}>(
     this: new (viewer: {{$viewerType}}, data: Data) => T,
-  ): {{useImport "LoadEntOptions"}}<T, {{$viewerType}}, {{$dataType}}> {
+  ): {{useImport "LoadEntOptions"}}<T, {{$viewerType}}, {{$rawDBDataType}}> {
     return {
       tableName: {{useImport $loaderInfo}}.tableName,
       fields: {{useImport $loaderInfo}}.fields,

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha123",
+  "version": "0.1.0-alpha124",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -1,4 +1,5 @@
 import * as clause from "./clause";
+import { ObjectLoaderFactory } from "./loaders";
 
 // Loader is the primitive data fetching abstraction in the framework
 // implementation details up to each instance
@@ -186,13 +187,14 @@ export interface EditRowOptions extends CreateRowOptions {
 interface LoadableEntOptions<
   TEnt extends Ent,
   TViewer extends Viewer = Viewer,
+  TData extends Data = Data,
 > {
-  loaderFactory: LoaderFactoryWithOptions;
+  loaderFactory: ObjectLoaderFactory<TData>;
   ent: EntConstructor<TEnt, TViewer>;
 }
 
-export interface LoaderFactoryWithOptions
-  extends LoaderFactoryWithLoaderMany<any, Data | null> {
+export interface LoaderFactoryWithOptions<T extends Data = Data>
+  extends LoaderFactoryWithLoaderMany<any, T | null> {
   options?: SelectDataOptions;
 }
 
@@ -200,7 +202,8 @@ export interface LoaderFactoryWithOptions
 export interface LoadEntOptions<
   TEnt extends Ent,
   TViewer extends Viewer = Viewer,
-> extends LoadableEntOptions<TEnt, TViewer>,
+  TData extends Data = Data,
+> extends LoadableEntOptions<TEnt, TViewer, TData>,
     // extending DataOptions and fields is to make APIs like loadEntsFromClause work until we come up with a cleaner API
     SelectBaseDataOptions {
   // if passed in, it means there's field privacy on the ents *and* we want to apply it at ent load
@@ -208,9 +211,10 @@ export interface LoadEntOptions<
   fieldPrivacy?: Map<string, PrivacyPolicy>;
 }
 
-export interface SelectCustomDataOptions extends SelectBaseDataOptions {
+export interface SelectCustomDataOptions<T extends Data = Data>
+  extends SelectBaseDataOptions {
   // main loader factory for the ent, passed in for priming the data so subsequent fetches of this id don't reload
-  loaderFactory: LoaderFactoryWithOptions;
+  loaderFactory: ObjectLoaderFactory<T>;
 
   // should we prime the ent after loading. uses loaderFactory above
   // only pass prime if the fields is equivalent to the ids of the other loader factory
@@ -221,9 +225,10 @@ export interface SelectCustomDataOptions extends SelectBaseDataOptions {
 export interface LoadCustomEntOptions<
     TEnt extends Ent,
     TViewer extends Viewer = Viewer,
+    TData extends Data = Data,
   >
   // extending DataOptions and fields is to make APIs like loadEntsFromClause work until we come up with a cleaner API
-  extends SelectCustomDataOptions {
+  extends SelectCustomDataOptions<TData> {
   ent: EntConstructor<TEnt, TViewer>;
   fieldPrivacy?: Map<string, PrivacyPolicy>;
 }

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -1,4 +1,4 @@
-import { Data } from "./base";
+import { Data, SelectBaseDataOptions, SelectDataOptions } from "./base";
 import DB, { Dialect } from "./db";
 
 // NOTE: we use ? for sqlite dialect even though it supports $1 like postgres so that it'll be easier to support different dialects down the line
@@ -959,4 +959,23 @@ export function Modulo<T extends Data, K = keyof T>(
   value: any,
 ): Clause<T, K> {
   return new simpleClause(col, value, "%", new isNullClause(col));
+}
+
+export function getCombinedClause<V extends Data = Data, K = keyof V>(
+  options: Omit<SelectDataOptions, "key">,
+  cls: Clause<V, K>,
+): Clause<V, K> {
+  if (options.clause) {
+    let optionClause: Clause | undefined;
+    if (typeof options.clause === "function") {
+      optionClause = options.clause();
+    } else {
+      optionClause = options.clause;
+    }
+    if (optionClause) {
+      // @ts-expect-error different types
+      cls = And(cls, optionClause);
+    }
+  }
+  return cls;
 }

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -601,7 +601,6 @@ export async function loadCustomData<
   TResultData extends Data = TQueryData,
   K = keyof TQueryData,
 >(
-  // TODO add a test for this. when we have TQUeryData with extra/different keys
   options: SelectCustomDataOptions<TResultData>,
   query: CustomQuery<TQueryData, K>,
   context: Context | undefined,

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -525,7 +525,7 @@ export async function loadCustomEnts<
   TKey = keyof TQueryData,
 >(
   viewer: TViewer,
-  options: LoadCustomEntOptions<TEnt, TViewer>,
+  options: LoadCustomEntOptions<TEnt, TViewer, TQueryData>,
   query: CustomQuery<TQueryData, TKey>,
 ) {
   const rows = await loadCustomData<TQueryData, TResultData, TKey>(
@@ -547,7 +547,7 @@ export type CustomQuery<T extends Data = Data, K = keyof T> =
   | string
   | parameterizedQueryOptions
   | clause.Clause<T, K>
-  | QueryDataOptions;
+  | QueryDataOptions<T, K>;
 
 function isClause<T extends Data = Data, K = keyof T>(
   opts:
@@ -560,8 +560,8 @@ function isClause<T extends Data = Data, K = keyof T>(
   return cls.clause !== undefined && cls.values !== undefined;
 }
 
-function isParameterizedQuery(
-  opts: QueryDataOptions | parameterizedQueryOptions,
+function isParameterizedQuery<T extends Data = Data, K = keyof T>(
+  opts: QueryDataOptions<T, K> | parameterizedQueryOptions,
 ): opts is parameterizedQueryOptions {
   return (opts as parameterizedQueryOptions).query !== undefined;
 }
@@ -589,13 +589,20 @@ function isParameterizedQuery(
  *   orderby: 'time',
  *   disableTransformations: false
  *  }) // doesn't change the query
+ *
+ * For queries that pass in a clause, we batch them with an underlying dataloader so that multiple queries with the same clause
+ * or parallel queries with the same clause are batched together.
+ *
+ * If a raw or parameterized query is passed in, we don't attempt to batch them together and they're executed as is.
+ * If you end up with a scenario where you may need to coalesce or batch (non-clause) queries here, you should use some kind of memoization here.
  */
 export async function loadCustomData<
   TQueryData extends Data = Data,
   TResultData extends Data = TQueryData,
   K = keyof TQueryData,
 >(
-  options: SelectCustomDataOptions,
+  // TODO add a test for this. when we have TQUeryData with extra/different keys
+  options: SelectCustomDataOptions<TQueryData>,
   query: CustomQuery<TQueryData, K>,
   context: Context | undefined,
 ): Promise<TResultData[]> {
@@ -617,16 +624,18 @@ export async function loadCustomData<
   return rows;
 }
 
-interface CustomCountOptions extends DataOptions {}
-
 // NOTE: if you use a raw query or paramterized query with this,
 // you should use `SELECT count(*) as count...`
 export async function loadCustomCount<T extends Data = Data, K = keyof T>(
-  options: CustomCountOptions,
+  options: SelectCustomDataOptions<T>,
   query: CustomQuery<T, K>,
   context: Context | undefined,
 ): Promise<number> {
-  // TODO also need to loaderify this in case we're querying for this a lot...
+  // if clause, we'll use the loader and strong typing/coalescing it provides
+  if (typeof query !== "string" && isClause(query)) {
+    return options.loaderFactory.createCountLoader<K>(context).load(query);
+  }
+
   const rows = await loadCustomDataImpl(
     {
       ...options,
@@ -648,50 +657,23 @@ function isPrimableLoader(
   return (loader as PrimableLoader<any, Data>) != undefined;
 }
 
-interface SelectCustomDataOptionsImpl extends SelectBaseDataOptions {
-  loaderFactory?: LoaderFactoryWithOptions;
-}
-
 async function loadCustomDataImpl<
   TQueryData extends Data = Data,
   TResultData extends Data = TQueryData,
   K = keyof TQueryData,
 >(
-  options: SelectCustomDataOptionsImpl,
+  options: SelectCustomDataOptions<TQueryData>,
   query: CustomQuery<TQueryData, K>,
   context: Context | undefined,
 ): Promise<TResultData[]> {
-  function getClause(
-    cls: clause.Clause<TQueryData, K>,
-  ): clause.Clause<TQueryData, K> {
-    let optClause = options.loaderFactory?.options?.clause;
-    if (typeof optClause === "function") {
-      optClause = optClause();
-    }
-    if (!optClause) {
-      return cls;
-    }
-
-    // @ts-expect-error string|ID mismatch
-    return clause.And(cls, optClause);
-  }
-
   if (typeof query === "string") {
     // no caching, perform raw query
     return performRawQuery(query, [], []) as Promise<TResultData[]>;
-    // @ts-ignore
   } else if (isClause(query)) {
-    // if a Clause is passed in and we have a default clause
-    // associated with the query, pass that in
-    // if we want to disableTransformations, need to indicate that with
-    // disableTransformations option
-    // this will have rudimentary caching but nothing crazy
-    return loadRows({
-      ...options,
-      // @ts-ignore
-      clause: getClause(query),
-      context: context,
-    }) as Promise<TResultData[]>;
+    const r = await options.loaderFactory
+      .createTypedLoader<K>(context)
+      .load(query);
+    return r as unknown as TResultData[];
   } else if (isParameterizedQuery(query)) {
     // no caching, perform raw query
     return performRawQuery(
@@ -700,16 +682,19 @@ async function loadCustomDataImpl<
       query.logValues,
     ) as Promise<TResultData[]>;
   } else {
+    // this will have rudimentary caching but nothing crazy
     let cls = query.clause;
     if (!query.disableTransformations) {
-      // @ts-ignore
-      cls = getClause(cls);
+      cls = clause.getCombinedClause(
+        options.loaderFactory.options,
+        query.clause,
+      );
     }
-    // this will have rudimentary caching but nothing crazy
     return loadRows({
       ...query,
       ...options,
       context: context,
+      // @ts-expect-error
       clause: cls,
     }) as Promise<TResultData[]>;
   }

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -525,7 +525,7 @@ export async function loadCustomEnts<
   TKey = keyof TQueryData,
 >(
   viewer: TViewer,
-  options: LoadCustomEntOptions<TEnt, TViewer, TQueryData>,
+  options: LoadCustomEntOptions<TEnt, TViewer, TResultData>,
   query: CustomQuery<TQueryData, TKey>,
 ) {
   const rows = await loadCustomData<TQueryData, TResultData, TKey>(
@@ -602,7 +602,7 @@ export async function loadCustomData<
   K = keyof TQueryData,
 >(
   // TODO add a test for this. when we have TQUeryData with extra/different keys
-  options: SelectCustomDataOptions<TQueryData>,
+  options: SelectCustomDataOptions<TResultData>,
   query: CustomQuery<TQueryData, K>,
   context: Context | undefined,
 ): Promise<TResultData[]> {
@@ -662,7 +662,7 @@ async function loadCustomDataImpl<
   TResultData extends Data = TQueryData,
   K = keyof TQueryData,
 >(
-  options: SelectCustomDataOptions<TQueryData>,
+  options: SelectCustomDataOptions<TResultData>,
   query: CustomQuery<TQueryData, K>,
   context: Context | undefined,
 ): Promise<TResultData[]> {
@@ -671,7 +671,7 @@ async function loadCustomDataImpl<
     return performRawQuery(query, [], []) as Promise<TResultData[]>;
   } else if (isClause(query)) {
     const r = await options.loaderFactory
-      .createTypedLoader<K>(context)
+      .createTypedLoader<TQueryData, TResultData, K>(context)
       .load(query);
     return r as unknown as TResultData[];
   } else if (isParameterizedQuery(query)) {

--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -145,10 +145,10 @@ describe("postgres", () => {
     await tdb.afterAll();
   });
 
-  // describe("postgres no soft delete", () => {
-  //   setupPostgresTables(tdb);
-  //   commonTests(options);
-  // });
+  describe("postgres no soft delete", () => {
+    setupPostgresTables(tdb);
+    commonTests(options);
+  });
 
   describe("postgres with soft delete", () => {
     setupPostgresTables(tdb, true);

--- a/ts/src/core/ent_errors.test.ts
+++ b/ts/src/core/ent_errors.test.ts
@@ -8,6 +8,7 @@ import {
   Allow,
   Skip,
   LoadEntOptions,
+  LoadCustomEntOptions,
 } from "./base";
 import { LoggedOutViewer, IDViewer } from "./viewer";
 import { AlwaysDenyRule, EntPrivacyError } from "./privacy";
@@ -65,7 +66,7 @@ const tbl = table(
   text("foo"),
 );
 
-const options: LoadEntOptions<User> = {
+const options: LoadCustomEntOptions<User> = {
   tableName: "users",
   fields: ["*"],
   ent: User,

--- a/ts/src/core/loaders/object_loader.test.ts
+++ b/ts/src/core/loaders/object_loader.test.ts
@@ -49,6 +49,20 @@ const getNewLoader = (context: boolean | TestContext = true) => {
   );
 };
 
+const getNewCountLoader = (context: boolean | TestContext = true) => {
+  return new ObjectLoaderFactory<LoaderRow>({
+    tableName: "users",
+    fields: ["id", "first_name"],
+    key: "id",
+  }).createCountLoader(
+    context
+      ? typeof context === "boolean"
+        ? new TestContext()
+        : context
+      : undefined,
+  );
+};
+
 interface LoaderRowWithCustomClause extends LoaderRow {
   deleted_at: Date;
 }
@@ -70,6 +84,23 @@ const getNewLoaderWithCustomClause = (
   );
 };
 
+const getNewCountLoaderWithCustomClause = (
+  context: boolean | TestContext = true,
+) => {
+  return new ObjectLoaderFactory<LoaderRowWithCustomClause>({
+    tableName: "users",
+    fields: ["id", "first_name", "deleted_at"],
+    key: "id",
+    clause: clause.Eq("deleted_at", null),
+  }).createCountLoader(
+    context
+      ? typeof context === "boolean"
+        ? new TestContext()
+        : context
+      : undefined,
+  );
+};
+
 const getNewLoaderWithCustomClauseFunc = (
   context: boolean | TestContext = true,
 ) => {
@@ -80,6 +111,24 @@ const getNewLoaderWithCustomClauseFunc = (
     clause: () => clause.Eq("deleted_at", null),
     instanceKey: "users:transformedReadClause",
   }).createLoader(
+    context
+      ? typeof context === "boolean"
+        ? new TestContext()
+        : context
+      : undefined,
+  );
+};
+
+const getNewCountLoaderWithCustomClauseFunc = (
+  context: boolean | TestContext = true,
+) => {
+  return new ObjectLoaderFactory<LoaderRowWithCustomClause>({
+    tableName: "users",
+    fields: ["id", "first_name", "deleted_at"],
+    key: "id",
+    clause: () => clause.Eq("deleted_at", null),
+    instanceKey: "users:transformedReadClause",
+  }).createCountLoader(
     context
       ? typeof context === "boolean"
         ? new TestContext()
@@ -1190,6 +1239,257 @@ function commonTests() {
         const expQuery = buildQuery({
           tableName: "users",
           fields: ["id", "first_name", "deleted_at"],
+          clause: clause.And(cls, clause.Eq("deleted_at", null)),
+        });
+        expect(ml.logs).toContainEqual({
+          query: expQuery,
+          values: cls.values(),
+        });
+      }
+    });
+  });
+
+  // TODO do combinations to make sure they all work together
+  describe("count clause", () => {
+    test("cache hit", async () => {
+      await Promise.all(
+        Array.from({ length: 30 }, (_, idx) => create(idx + 1)),
+      );
+
+      const loader = getNewCountLoader(true);
+
+      const res = await loader.load(clause.Greater<LoaderRow>("id", 10));
+      expect(res).toBe(20);
+      const expQuery = buildQuery({
+        tableName: "users",
+        fields: ["count(*) as count"],
+        clause: clause.Greater("id", 10),
+      });
+      expect(ml.logs).toStrictEqual([
+        {
+          query: expQuery,
+          values: [10],
+        },
+      ]);
+
+      const res2 = await loader.load(clause.Greater<LoaderRow>("id", 10));
+      expect(res).toBe(res2);
+
+      expect(ml.logs).toStrictEqual([
+        {
+          query: expQuery,
+          values: [10],
+        },
+        {
+          "dataloader-cache-hit": `${clause
+            .Greater("id", 10)
+            .instanceKey()}:count`,
+          "tableName": "users",
+        },
+      ]);
+    });
+
+    test("query at the same time", async () => {
+      await Promise.all(
+        Array.from({ length: 30 }, (_, idx) => create(idx + 1)),
+      );
+
+      ml.clear();
+
+      const loader = getNewCountLoader(true);
+
+      await Promise.all(
+        Array.from({ length: 100 }, (_) =>
+          loader.load(clause.Greater<LoaderRow>("id", 10)),
+        ),
+      );
+
+      // only 1 query is sent even though we're doing a bunch at the same time
+
+      const expQuery = buildQuery({
+        tableName: "users",
+        fields: ["count(*) as count"],
+        clause: clause.Greater("id", 10),
+      });
+
+      // filter non queries out
+      expect(ml.logs.filter((log) => log.query !== undefined)).toStrictEqual([
+        {
+          query: expQuery,
+          values: [10],
+        },
+      ]);
+    });
+
+    test("loadMany", async () => {
+      await Promise.all(
+        Array.from({ length: 30 }, (_, idx) => create(idx + 1)),
+      );
+
+      ml.clear();
+
+      const loader = getNewCountLoader(true);
+
+      const clauses: clause.Clause<LoaderRow>[] = [
+        clause.Greater("id", 10),
+        clause.Greater("id", 20),
+        clause.LessEq("id", 25),
+      ];
+      await loader.loadMany(clauses);
+
+      expect(ml.logs.length).toBe(3);
+
+      for (const clause of clauses) {
+        const expQuery = buildQuery({
+          tableName: "users",
+          fields: ["count(*) as count"],
+          clause: clause,
+        });
+        expect(ml.logs).toContainEqual({
+          query: expQuery,
+          values: clause.values(),
+        });
+      }
+    });
+
+    test("cache hit with custom clause", async () => {
+      await Promise.all(
+        Array.from({ length: 30 }, (_, idx) =>
+          createWithNullDeletedAt(idx + 1),
+        ),
+      );
+
+      const loader = getNewCountLoaderWithCustomClause(true);
+
+      const res = await loader.load(clause.Greater<LoaderRow>("id", 10));
+      expect(res).toBe(20);
+      const expQuery = buildQuery({
+        tableName: "users",
+        fields: ["count(*) as count"],
+        clause: clause.And(
+          clause.Greater("id", 10),
+          clause.Eq("deleted_at", null),
+        ),
+      });
+      expect(ml.logs).toStrictEqual([
+        {
+          query: expQuery,
+          values: [10],
+        },
+      ]);
+
+      const res2 = await loader.load(clause.Greater<LoaderRow>("id", 10));
+      expect(res).toBe(res2);
+
+      expect(ml.logs).toStrictEqual([
+        {
+          query: expQuery,
+          values: [10],
+        },
+        {
+          "dataloader-cache-hit": `${clause
+            .Greater("id", 10)
+            .instanceKey()}:count`,
+          "tableName": "users",
+        },
+      ]);
+    });
+
+    test("query at the same time with custom clause", async () => {
+      await Promise.all(
+        Array.from({ length: 30 }, (_, idx) =>
+          createWithNullDeletedAt(idx + 1),
+        ),
+      );
+
+      ml.clear();
+
+      const loader = getNewCountLoaderWithCustomClause(true);
+
+      await Promise.all(
+        Array.from({ length: 100 }, (_) =>
+          loader.load(clause.Greater<LoaderRow>("id", 10)),
+        ),
+      );
+
+      // only 1 query is sent even though we're doing a bunch at the same time
+
+      const expQuery = buildQuery({
+        tableName: "users",
+        fields: ["count(*) as count"],
+        clause: clause.And(
+          clause.Greater("id", 10),
+          clause.Eq("deleted_at", null),
+        ),
+      });
+
+      // filter non queries out
+      expect(ml.logs.filter((log) => log.query !== undefined)).toStrictEqual([
+        {
+          query: expQuery,
+          values: [10],
+        },
+      ]);
+    });
+
+    test("loadMany with custom clause", async () => {
+      await Promise.all(
+        Array.from({ length: 30 }, (_, idx) =>
+          createWithNullDeletedAt(idx + 1),
+        ),
+      );
+
+      ml.clear();
+
+      const loader = getNewCountLoaderWithCustomClause(true);
+
+      const clauses: clause.Clause<LoaderRow>[] = [
+        clause.Greater("id", 10),
+        clause.Greater("id", 20),
+        clause.LessEq("id", 25),
+      ];
+      await loader.loadMany(clauses);
+
+      expect(ml.logs.length).toBe(3);
+
+      for (const cls of clauses) {
+        const expQuery = buildQuery({
+          tableName: "users",
+          fields: ["count(*) as count"],
+          clause: clause.And(cls, clause.Eq("deleted_at", null)),
+        });
+        expect(ml.logs).toContainEqual({
+          query: expQuery,
+          values: cls.values(),
+        });
+      }
+    });
+
+    test("loadMany with custom clause func", async () => {
+      await Promise.all(
+        Array.from({ length: 30 }, (_, idx) =>
+          createWithNullDeletedAt(idx + 1),
+        ),
+      );
+
+      ml.clear();
+
+      const loader = getNewCountLoaderWithCustomClauseFunc(true);
+
+      const clauses: clause.Clause<LoaderRow>[] = [
+        clause.Greater("id", 10),
+        clause.Greater("id", 20),
+        clause.LessEq("id", 25),
+      ];
+      const res = await loader.loadMany(clauses);
+      expect(res).toStrictEqual([20, 10, 25]);
+
+      expect(ml.logs.length).toBe(3);
+
+      for (const cls of clauses) {
+        const expQuery = buildQuery({
+          tableName: "users",
+          fields: ["count(*) as count"],
           clause: clause.And(cls, clause.Eq("deleted_at", null)),
         });
         expect(ml.logs).toContainEqual({

--- a/ts/src/core/loaders/object_loader.ts
+++ b/ts/src/core/loaders/object_loader.ts
@@ -120,14 +120,14 @@ function createDataLoader(options: SelectDataOptions) {
 class clauseCacheMap {
   private m = new Map();
 
-  constructor(private options: DataOptions) {}
+  constructor(private options: DataOptions, private count?: boolean) {}
 
   get(key: clause.Clause) {
     const key2 = key.instanceKey();
     const ret = this.m.get(key2);
     if (ret) {
       log("cache", {
-        "dataloader-cache-hit": key2,
+        "dataloader-cache-hit": key2 + (this.count ? ":count" : ""),
         "tableName": this.options.tableName,
       });
     }
@@ -189,7 +189,7 @@ function createClauseCountDataLoader<V extends Data = Data, K = keyof V>(
       return ret;
     },
     {
-      cacheMap: new clauseCacheMap(options),
+      cacheMap: new clauseCacheMap(options, true),
     },
   );
 }


### PR DESCRIPTION
```ts
await Promise.all(
[1, 2,3,4,5].map(() => 
  Foo.loadCustom(viewer, query.Eq('index', val)))
);
```

would previously make 5 queries to the db. After this change, it would make one. 

Now, we put custom clause queries behind a dataloader. We only do that for custom queries that use `Clause`. Not for queries with a raw sql query or a parameterized query

previous context on custom queries: https://github.com/lolopinto/ent/pull/1049, https://github.com/lolopinto/ent/pull/1122