### PR TITLE
[example] move GQLViewer into its own file

### DIFF
--- a/examples/simple/src/graphql/generated/resolvers/viewer_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/viewer_query_type.ts
@@ -14,7 +14,8 @@ import {
 import { RequestContext } from "@snowtop/ent";
 import { UserType } from "../../resolvers/internal";
 import { ExampleViewer as ExampleViewerAlias } from "../../../viewer/viewer";
-import { GQLViewer, ViewerResolver } from "../../resolvers/viewer";
+import { GQLViewer } from "../../resolvers/gql_viewer";
+import { ViewerResolver } from "../../resolvers/viewer";
 
 export const GQLViewerType = new GraphQLObjectType({
   name: "Viewer",

--- a/examples/simple/src/graphql/resolvers/gql_viewer.ts
+++ b/examples/simple/src/graphql/resolvers/gql_viewer.ts
@@ -1,0 +1,40 @@
+import { gqlField, gqlObjectType, encodeGQLID } from "@snowtop/ent/graphql";
+import { GraphQLID } from "graphql";
+
+import { User } from "../../ent";
+import { ExampleViewer } from "../../viewer/viewer";
+
+@gqlObjectType({ name: "Viewer" })
+// TODO when this wasn't exported, it didn't work...
+// TODO when this is named ViewerType, it breaks
+export class GQLViewer {
+  constructor(private viewer: ExampleViewer) {}
+
+  @gqlField({
+    nodeName: "GQLViewer",
+    type: GraphQLID,
+    nullable: true,
+    async: true,
+  })
+  async viewerID() {
+    const user = await this.user();
+    if (!user) {
+      return null;
+    }
+    return encodeGQLID(user);
+  }
+
+  @gqlField({
+    nodeName: "GQLViewer",
+    type: User,
+    nullable: true,
+    async: true,
+  })
+  async user(): Promise<User | null> {
+    const v = this.viewer.viewerID;
+    if (!v) {
+      return null;
+    }
+    return User.loadX(this.viewer, v);
+  }
+}

--- a/examples/simple/src/graphql/resolvers/viewer.ts
+++ b/examples/simple/src/graphql/resolvers/viewer.ts
@@ -1,51 +1,10 @@
-import {
-  gqlField,
-  gqlObjectType,
-  gqlContextType,
-  gqlQuery,
-  encodeGQLID,
-} from "@snowtop/ent/graphql";
-import { GraphQLID, GraphQLString } from "graphql";
+import { gqlContextType, gqlQuery } from "@snowtop/ent/graphql";
+import { GraphQLString } from "graphql";
 import { RequestContext } from "@snowtop/ent";
 
-import { User } from "../../ent";
 import { ExampleViewer } from "../../viewer/viewer";
 import { DateTime } from "luxon";
-
-@gqlObjectType({ name: "Viewer" })
-// TODO when this wasn't exported, it didn't work...
-// TODO when this is named ViewerType, it breaks
-export class GQLViewer {
-  constructor(private viewer: ExampleViewer) {}
-
-  @gqlField({
-    nodeName: "GQLViewer",
-    type: GraphQLID,
-    nullable: true,
-    async: true,
-  })
-  async viewerID() {
-    const user = await this.user();
-    if (!user) {
-      return null;
-    }
-    return encodeGQLID(user);
-  }
-
-  @gqlField({
-    nodeName: "GQLViewer",
-    type: User,
-    nullable: true,
-    async: true,
-  })
-  async user(): Promise<User | null> {
-    const v = this.viewer.viewerID;
-    if (!v) {
-      return null;
-    }
-    return User.loadX(this.viewer, v);
-  }
-}
+import { GQLViewer } from "./gql_viewer";
 
 export class ViewerResolver {
   @gqlQuery({


### PR DESCRIPTION
```ts
decorator()
export class Foo {}
```
seems to lead to issues in TypeScript

googling points to https://github.com/microsoft/TypeScript/issues/53332