### PR TITLE
release client in actions before running observers

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha135",
+  "version": "0.1.0-alpha136",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -11,7 +11,6 @@ import {
   Contact,
   SimpleBuilder,
   SimpleAction,
-  BuilderSchema,
 } from "../testutils/builder";
 import { LoggedOutViewer, IDViewer } from "../core/viewer";
 
@@ -798,113 +797,5 @@ function commonTests() {
     const editedGroup = await action.editedEnt();
     expect(editedGroup).toBeInstanceOf(Group);
     expect(editedGroup?.data["fun_field"]).toBe("22");
-  });
-
-  test("nested + Promise.all with lots of actions", async () => {
-    const NUM_USERS = 1000;
-    const host = await createUser();
-    const users: User[] = [];
-    for (let i = 0; i < NUM_USERS; i++) {
-      users.push(await createUser());
-    }
-
-    class SendWelcomeGroupMessageAction extends SimpleAction<Group> {
-      constructor(
-        public viewer: Viewer,
-        schema: BuilderSchema<Group>,
-        fields: Map<string, any>,
-        existingEnt: Group,
-        host: User,
-        users: User[],
-      ) {
-        super(viewer, schema, fields, WriteOperation.Edit, existingEnt);
-        this.builder.storeData("host", host);
-        this.builder.storeData("users", users);
-      }
-
-      getObservers = () => [
-        {
-          async observe(builder, input) {
-            const host = builder.getStoredData("host") as User;
-            const users = builder.getStoredData("users") as User[];
-
-            await Promise.all(
-              users.map(async (user) => {
-                // create welcome message to each user from host
-                const action = new CreateMessageAction(
-                  builder.viewer,
-                  new Map<string, any>([
-                    ["sender", host.id],
-                    ["recipient", user.id],
-                    ["message", "Welcome to the group!"],
-                    ["transient", false],
-                    ["expiresAt", new Date()],
-                  ]),
-                  WriteOperation.Insert,
-                  null,
-                );
-                await action.saveX();
-              }),
-            );
-          },
-        },
-      ];
-    }
-
-    class DeliverMessageAction extends MessageAction {
-      getObservers = () => [
-        {
-          async observe(builder, input) {
-            // deliver message to recipient
-            const message = await builder.editedEntX();
-
-            const action = new MessageAction(
-              builder.viewer,
-              new Map([["delivered", true]]),
-              WriteOperation.Edit,
-              message,
-            );
-            await action.saveX();
-          },
-        },
-      ];
-    }
-
-    class CreateMessageAction extends MessageAction {
-      getObservers = () => [
-        {
-          async observe(builder, input) {
-            const message = await builder.editedEntX();
-            // deliver the notif
-            const action = new DeliverMessageAction(
-              builder.viewer,
-              new Map(),
-              WriteOperation.Edit,
-              message,
-            );
-            await action.saveX();
-          },
-        },
-      ];
-    }
-
-    const group = await createGroup();
-    const action = new SendWelcomeGroupMessageAction(
-      new LoggedOutViewer(),
-      GroupSchema,
-      new Map(),
-      group,
-      host,
-      users,
-    );
-    await action.saveX();
-
-    const messages = await loadRows({
-      clause: clause.Eq("sender", host.id),
-      fields: ["*"],
-      tableName: "messages",
-    });
-    expect(messages.length).toBe(NUM_USERS);
-    expect(messages.every((message) => message.delivered)).toBeTruthy();
   });
 }

--- a/ts/src/action/executor.test.ts
+++ b/ts/src/action/executor.test.ts
@@ -11,6 +11,7 @@ import {
   Contact,
   SimpleBuilder,
   SimpleAction,
+  BuilderSchema,
 } from "../testutils/builder";
 import { LoggedOutViewer, IDViewer } from "../core/viewer";
 
@@ -797,5 +798,113 @@ function commonTests() {
     const editedGroup = await action.editedEnt();
     expect(editedGroup).toBeInstanceOf(Group);
     expect(editedGroup?.data["fun_field"]).toBe("22");
+  });
+
+  test("nested + Promise.all with lots of actions", async () => {
+    const NUM_USERS = 1000;
+    const host = await createUser();
+    const users: User[] = [];
+    for (let i = 0; i < NUM_USERS; i++) {
+      users.push(await createUser());
+    }
+
+    class SendWelcomeGroupMessageAction extends SimpleAction<Group> {
+      constructor(
+        public viewer: Viewer,
+        schema: BuilderSchema<Group>,
+        fields: Map<string, any>,
+        existingEnt: Group,
+        host: User,
+        users: User[],
+      ) {
+        super(viewer, schema, fields, WriteOperation.Edit, existingEnt);
+        this.builder.storeData("host", host);
+        this.builder.storeData("users", users);
+      }
+
+      getObservers = () => [
+        {
+          async observe(builder, input) {
+            const host = builder.getStoredData("host") as User;
+            const users = builder.getStoredData("users") as User[];
+
+            await Promise.all(
+              users.map(async (user) => {
+                // create welcome message to each user from host
+                const action = new CreateMessageAction(
+                  builder.viewer,
+                  new Map<string, any>([
+                    ["sender", host.id],
+                    ["recipient", user.id],
+                    ["message", "Welcome to the group!"],
+                    ["transient", false],
+                    ["expiresAt", new Date()],
+                  ]),
+                  WriteOperation.Insert,
+                  null,
+                );
+                await action.saveX();
+              }),
+            );
+          },
+        },
+      ];
+    }
+
+    class DeliverMessageAction extends MessageAction {
+      getObservers = () => [
+        {
+          async observe(builder, input) {
+            // deliver message to recipient
+            const message = await builder.editedEntX();
+
+            const action = new MessageAction(
+              builder.viewer,
+              new Map([["delivered", true]]),
+              WriteOperation.Edit,
+              message,
+            );
+            await action.saveX();
+          },
+        },
+      ];
+    }
+
+    class CreateMessageAction extends MessageAction {
+      getObservers = () => [
+        {
+          async observe(builder, input) {
+            const message = await builder.editedEntX();
+            // deliver the notif
+            const action = new DeliverMessageAction(
+              builder.viewer,
+              new Map(),
+              WriteOperation.Edit,
+              message,
+            );
+            await action.saveX();
+          },
+        },
+      ];
+    }
+
+    const group = await createGroup();
+    const action = new SendWelcomeGroupMessageAction(
+      new LoggedOutViewer(),
+      GroupSchema,
+      new Map(),
+      group,
+      host,
+      users,
+    );
+    await action.saveX();
+
+    const messages = await loadRows({
+      clause: clause.Eq("sender", host.id),
+      fields: ["*"],
+      tableName: "messages",
+    });
+    expect(messages.length).toBe(NUM_USERS);
+    expect(messages.every((message) => message.delivered)).toBeTruthy();
   });
 }

--- a/ts/src/action/executor_long.test.ts
+++ b/ts/src/action/executor_long.test.ts
@@ -32,7 +32,7 @@ describe("sqlite", () => {
 
 function commonTests() {
   test("nested + Promise.all with lots of actions", async () => {
-    const NUM_USERS = 1000;
+    const NUM_USERS = 500;
     const host = await createUser();
     const users: User[] = [];
     for (let i = 0; i < NUM_USERS; i++) {

--- a/ts/src/action/executor_long.test.ts
+++ b/ts/src/action/executor_long.test.ts
@@ -6,7 +6,7 @@ import { WriteOperation } from "../action/action";
 import { User, Group, SimpleAction, BuilderSchema } from "../testutils/builder";
 import { LoggedOutViewer } from "../core/viewer";
 
-import { setupPostgres, setupSqlite } from "../testutils/db/temp_db";
+import { setupPostgres } from "../testutils/db/temp_db";
 import {
   createGroup,
   createUser,
@@ -18,124 +18,115 @@ import {
 
 setupTest();
 
-jest.setTimeout(10 * 1000);
+jest.setTimeout(30 * 1000);
 
-describe("postgres", () => {
-  setupPostgres(getTables);
-  commonTests();
-});
+// only doing postgres because don't think we get much benefit from both
+setupPostgres(getTables);
 
-describe("sqlite", () => {
-  setupSqlite(`sqlite:///executor-test.db`, getTables);
-  commonTests();
-});
+test("nested + Promise.all with lots of actions", async () => {
+  const NUM_USERS = 500;
+  const host = await createUser();
+  const users: User[] = [];
+  for (let i = 0; i < NUM_USERS; i++) {
+    users.push(await createUser());
+  }
 
-function commonTests() {
-  test("nested + Promise.all with lots of actions", async () => {
-    const NUM_USERS = 500;
-    const host = await createUser();
-    const users: User[] = [];
-    for (let i = 0; i < NUM_USERS; i++) {
-      users.push(await createUser());
+  class SendWelcomeGroupMessageAction extends SimpleAction<Group> {
+    constructor(
+      public viewer: Viewer,
+      schema: BuilderSchema<Group>,
+      fields: Map<string, any>,
+      existingEnt: Group,
+      host: User,
+      users: User[],
+    ) {
+      super(viewer, schema, fields, WriteOperation.Edit, existingEnt);
+      this.builder.storeData("host", host);
+      this.builder.storeData("users", users);
     }
 
-    class SendWelcomeGroupMessageAction extends SimpleAction<Group> {
-      constructor(
-        public viewer: Viewer,
-        schema: BuilderSchema<Group>,
-        fields: Map<string, any>,
-        existingEnt: Group,
-        host: User,
-        users: User[],
-      ) {
-        super(viewer, schema, fields, WriteOperation.Edit, existingEnt);
-        this.builder.storeData("host", host);
-        this.builder.storeData("users", users);
-      }
+    getObservers = () => [
+      {
+        async observe(builder, input) {
+          const host = builder.getStoredData("host") as User;
+          const users = builder.getStoredData("users") as User[];
 
-      getObservers = () => [
-        {
-          async observe(builder, input) {
-            const host = builder.getStoredData("host") as User;
-            const users = builder.getStoredData("users") as User[];
-
-            await Promise.all(
-              users.map(async (user) => {
-                // create welcome message to each user from host
-                const action = new CreateMessageAction(
-                  builder.viewer,
-                  new Map<string, any>([
-                    ["sender", host.id],
-                    ["recipient", user.id],
-                    ["message", "Welcome to the group!"],
-                    ["transient", false],
-                    ["expiresAt", new Date()],
-                  ]),
-                  WriteOperation.Insert,
-                  null,
-                );
-                await action.saveX();
-              }),
-            );
-          },
+          await Promise.all(
+            users.map(async (user) => {
+              // create welcome message to each user from host
+              const action = new CreateMessageAction(
+                builder.viewer,
+                new Map<string, any>([
+                  ["sender", host.id],
+                  ["recipient", user.id],
+                  ["message", "Welcome to the group!"],
+                  ["transient", false],
+                  ["expiresAt", new Date()],
+                ]),
+                WriteOperation.Insert,
+                null,
+              );
+              await action.saveX();
+            }),
+          );
         },
-      ];
-    }
+      },
+    ];
+  }
 
-    class DeliverMessageAction extends MessageAction {
-      getObservers = () => [
-        {
-          async observe(builder, input) {
-            // deliver message to recipient
-            const message = await builder.editedEntX();
+  class DeliverMessageAction extends MessageAction {
+    getObservers = () => [
+      {
+        async observe(builder, input) {
+          // deliver message to recipient
+          const message = await builder.editedEntX();
 
-            const action = new MessageAction(
-              builder.viewer,
-              new Map([["delivered", true]]),
-              WriteOperation.Edit,
-              message,
-            );
-            await action.saveX();
-          },
+          const action = new MessageAction(
+            builder.viewer,
+            new Map([["delivered", true]]),
+            WriteOperation.Edit,
+            message,
+          );
+          await action.saveX();
         },
-      ];
-    }
+      },
+    ];
+  }
 
-    class CreateMessageAction extends MessageAction {
-      getObservers = () => [
-        {
-          async observe(builder, input) {
-            const message = await builder.editedEntX();
-            // deliver the notif
-            const action = new DeliverMessageAction(
-              builder.viewer,
-              new Map(),
-              WriteOperation.Edit,
-              message,
-            );
-            await action.saveX();
-          },
+  class CreateMessageAction extends MessageAction {
+    getObservers = () => [
+      {
+        async observe(builder, input) {
+          const message = await builder.editedEntX();
+          // deliver the notif
+          const action = new DeliverMessageAction(
+            builder.viewer,
+            new Map(),
+            WriteOperation.Edit,
+            message,
+          );
+          await action.saveX();
         },
-      ];
-    }
+      },
+    ];
+  }
 
-    const group = await createGroup();
-    const action = new SendWelcomeGroupMessageAction(
-      new LoggedOutViewer(),
-      GroupSchema,
-      new Map(),
-      group,
-      host,
-      users,
-    );
-    await action.saveX();
+  const group = await createGroup();
+  const action = new SendWelcomeGroupMessageAction(
+    new LoggedOutViewer(),
+    GroupSchema,
+    new Map(),
+    group,
+    host,
+    users,
+  );
+  await action.saveX();
 
-    const messages = await loadRows({
-      clause: clause.Eq("sender", host.id),
-      fields: ["*"],
-      tableName: "messages",
-    });
-    expect(messages.length).toBe(NUM_USERS);
-    expect(messages.every((message) => message.delivered)).toBeTruthy();
+  const messages = await loadRows({
+    clause: clause.Eq("sender", host.id),
+    fields: ["*"],
+    tableName: "messages",
   });
-}
+  expect(messages.length).toBe(NUM_USERS);
+  expect(messages.every((message) => message.delivered)).toBeTruthy();
+});

--- a/ts/src/action/executor_long.test.ts
+++ b/ts/src/action/executor_long.test.ts
@@ -24,6 +24,10 @@ jest.setTimeout(30 * 1000);
 setupPostgres(getTables);
 
 test("nested + Promise.all with lots of actions", async () => {
+  // TODO eventually figure out how to make this run in ci
+  if (process.env.GITHUB_ACTION !== undefined) {
+    return;
+  }
   const NUM_USERS = 500;
   const host = await createUser();
   const users: User[] = [];

--- a/ts/src/action/executor_long.test.ts
+++ b/ts/src/action/executor_long.test.ts
@@ -1,0 +1,141 @@
+import { Viewer } from "../core/base";
+import { loadRows } from "../core/ent";
+import * as clause from "../core/clause";
+import { WriteOperation } from "../action/action";
+
+import { User, Group, SimpleAction, BuilderSchema } from "../testutils/builder";
+import { LoggedOutViewer } from "../core/viewer";
+
+import { setupPostgres, setupSqlite } from "../testutils/db/temp_db";
+import {
+  createGroup,
+  createUser,
+  getTables,
+  GroupSchema,
+  MessageAction,
+  setupTest,
+} from "../testutils/action/complex_schemas";
+
+setupTest();
+
+jest.setTimeout(10 * 1000);
+
+describe("postgres", () => {
+  setupPostgres(getTables);
+  commonTests();
+});
+
+describe("sqlite", () => {
+  setupSqlite(`sqlite:///executor-test.db`, getTables);
+  commonTests();
+});
+
+function commonTests() {
+  test("nested + Promise.all with lots of actions", async () => {
+    const NUM_USERS = 1000;
+    const host = await createUser();
+    const users: User[] = [];
+    for (let i = 0; i < NUM_USERS; i++) {
+      users.push(await createUser());
+    }
+
+    class SendWelcomeGroupMessageAction extends SimpleAction<Group> {
+      constructor(
+        public viewer: Viewer,
+        schema: BuilderSchema<Group>,
+        fields: Map<string, any>,
+        existingEnt: Group,
+        host: User,
+        users: User[],
+      ) {
+        super(viewer, schema, fields, WriteOperation.Edit, existingEnt);
+        this.builder.storeData("host", host);
+        this.builder.storeData("users", users);
+      }
+
+      getObservers = () => [
+        {
+          async observe(builder, input) {
+            const host = builder.getStoredData("host") as User;
+            const users = builder.getStoredData("users") as User[];
+
+            await Promise.all(
+              users.map(async (user) => {
+                // create welcome message to each user from host
+                const action = new CreateMessageAction(
+                  builder.viewer,
+                  new Map<string, any>([
+                    ["sender", host.id],
+                    ["recipient", user.id],
+                    ["message", "Welcome to the group!"],
+                    ["transient", false],
+                    ["expiresAt", new Date()],
+                  ]),
+                  WriteOperation.Insert,
+                  null,
+                );
+                await action.saveX();
+              }),
+            );
+          },
+        },
+      ];
+    }
+
+    class DeliverMessageAction extends MessageAction {
+      getObservers = () => [
+        {
+          async observe(builder, input) {
+            // deliver message to recipient
+            const message = await builder.editedEntX();
+
+            const action = new MessageAction(
+              builder.viewer,
+              new Map([["delivered", true]]),
+              WriteOperation.Edit,
+              message,
+            );
+            await action.saveX();
+          },
+        },
+      ];
+    }
+
+    class CreateMessageAction extends MessageAction {
+      getObservers = () => [
+        {
+          async observe(builder, input) {
+            const message = await builder.editedEntX();
+            // deliver the notif
+            const action = new DeliverMessageAction(
+              builder.viewer,
+              new Map(),
+              WriteOperation.Edit,
+              message,
+            );
+            await action.saveX();
+          },
+        },
+      ];
+    }
+
+    const group = await createGroup();
+    const action = new SendWelcomeGroupMessageAction(
+      new LoggedOutViewer(),
+      GroupSchema,
+      new Map(),
+      group,
+      host,
+      users,
+    );
+    await action.saveX();
+
+    const messages = await loadRows({
+      clause: clause.Eq("sender", host.id),
+      fields: ["*"],
+      tableName: "messages",
+    });
+    expect(messages.length).toBe(NUM_USERS);
+    expect(messages.every((message) => message.delivered)).toBeTruthy();
+  });
+}

--- a/ts/src/core/db.ts
+++ b/ts/src/core/db.ts
@@ -46,9 +46,7 @@ function parseConnectionString(
       dialect: Dialect.SQLite,
       config: {
         connectionString: str,
-        // TODO would like to do this for other args e.g. max being set but would have to update tests
-        // e.g. src/core/config.test.ts which tests this
-        // ...args?.db,
+        ...args?.cfg,
       },
       filePath,
     };
@@ -57,10 +55,8 @@ function parseConnectionString(
   return {
     dialect: Dialect.Postgres,
     config: {
+      ...args?.cfg,
       connectionString: str,
-      // TODO would like to do this for other args e.g. max being set but would have to update tests
-      // e.g. src/core/config.test.ts which tests this
-      // ...args?.db,
     },
   };
 }
@@ -76,6 +72,7 @@ interface clientConfigArgs {
   connectionString?: string;
   dbFile?: string;
   db?: Database | DBDict;
+  cfg?: PoolConfig;
 }
 // order
 // env variable

--- a/ts/src/testutils/action/complex_schemas.ts
+++ b/ts/src/testutils/action/complex_schemas.ts
@@ -208,11 +208,14 @@ export const ChangelogSchema = getBuilderSchemaFromFields(
 export const MessageSchema = getBuilderSchemaFromFields(
   {
     // TODO both id fields
-    sender: StringType(), // can't use from
+    sender: StringType({
+      index: true,
+    }), // can't use from
     recipient: StringType(), // can't use to in sqlite
     message: StringType(),
     transient: BooleanType({ nullable: true }),
     expiresAt: TimestampType({ nullable: true }),
+    delivered: BooleanType({ defaultValueOnCreate: () => false }),
   },
   Message,
 );
@@ -288,17 +291,20 @@ export class MessageAction extends SimpleAction<Message> {
         changeset: (builder, _input): void => {
           let sender = builder.fields.get("sender");
           let recipient = builder.fields.get("recipient");
-
-          builder.orchestrator.addInboundEdge(
-            sender,
-            "senderToMessage",
-            "user",
-          );
-          builder.orchestrator.addInboundEdge(
-            recipient,
-            "recipientToMessage",
-            "user",
-          );
+          if (sender) {
+            builder.orchestrator.addInboundEdge(
+              sender,
+              "senderToMessage",
+              "user",
+            );
+          }
+          if (recipient) {
+            builder.orchestrator.addInboundEdge(
+              recipient,
+              "recipientToMessage",
+              "user",
+            );
+          }
         },
       },
     ];

--- a/ts/src/testutils/db/temp_db.ts
+++ b/ts/src/testutils/db/temp_db.ts
@@ -465,6 +465,10 @@ export class TempDB {
         }
         DB.initDB({
           connectionString: connStr,
+          cfg: {
+            max: 100,
+            idleTimeoutMillis: 100,
+          },
         });
       } else {
         // will probably be setup via loadConfig


### PR DESCRIPTION
ran into a situation where an action would just hang if we were creating lots of sub actions (which also had its own chain) in the observers below

the issue only applied if the sub-actions were in a `Promise.all`

If the sub-actions were in a good old serial loop, it would be fine
