### PR TITLE
use node instead of ts-node with swc

### DIFF
--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.3.0",
         "@sentry/tracing": "^6.3.0",
-        "@snowtop/ent": "^0.1.0-alpha136",
+        "@snowtop/ent": "^0.1.0-alpha137",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1218,9 +1218,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha136",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha136.tgz",
-      "integrity": "sha512-YQA8RfCRvQHrVc7JCZKI61AiD+pXL57DKFIJYwEwfgMEZR46qpHuOHR2QNiGLqLFkZqmikfMo16vCYGKNLqC1Q==",
+      "version": "0.1.0-alpha137",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha137.tgz",
+      "integrity": "sha512-ja71QteNZA18sVMW4u00NuRaDud7Sv7tR814RtTzTa+4r7TKYA5vJGrNOskly9IpKTijoXfcxMlWMh/v06oN3g==",
       "dependencies": {
         "@swc-node/register": "^1.6.5",
         "@types/node": "^18.11.18",
@@ -7235,9 +7235,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha136",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha136.tgz",
-      "integrity": "sha512-YQA8RfCRvQHrVc7JCZKI61AiD+pXL57DKFIJYwEwfgMEZR46qpHuOHR2QNiGLqLFkZqmikfMo16vCYGKNLqC1Q==",
+      "version": "0.1.0-alpha137",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha137.tgz",
+      "integrity": "sha512-ja71QteNZA18sVMW4u00NuRaDud7Sv7tR814RtTzTa+4r7TKYA5vJGrNOskly9IpKTijoXfcxMlWMh/v06oN3g==",
       "requires": {
         "@swc-node/register": "^1.6.5",
         "@types/node": "^18.11.18",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "^6.3.0",
     "@sentry/tracing": "^6.3.0",
-    "@snowtop/ent": "^0.1.0-alpha136",
+    "@snowtop/ent": "^0.1.0-alpha137",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha135",
+        "@snowtop/ent": "^0.1.0-alpha137",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha135",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha135.tgz",
-      "integrity": "sha512-6GnYCgg+iRh9ytPhFhB6vCfkqxNxhWdY3uiv2d1RAd6PrYfSqc9OxmjC+X3DFlq0G4wEPOmMidOLCvyBivO1Mw==",
+      "version": "0.1.0-alpha137",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha137.tgz",
+      "integrity": "sha512-ja71QteNZA18sVMW4u00NuRaDud7Sv7tR814RtTzTa+4r7TKYA5vJGrNOskly9IpKTijoXfcxMlWMh/v06oN3g==",
       "dependencies": {
         "@swc-node/register": "^1.6.5",
         "@types/node": "^18.11.18",
@@ -7091,9 +7091,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha135",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha135.tgz",
-      "integrity": "sha512-6GnYCgg+iRh9ytPhFhB6vCfkqxNxhWdY3uiv2d1RAd6PrYfSqc9OxmjC+X3DFlq0G4wEPOmMidOLCvyBivO1Mw==",
+      "version": "0.1.0-alpha137",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha137.tgz",
+      "integrity": "sha512-ja71QteNZA18sVMW4u00NuRaDud7Sv7tR814RtTzTa+4r7TKYA5vJGrNOskly9IpKTijoXfcxMlWMh/v06oN3g==",
       "requires": {
         "@swc-node/register": "^1.6.5",
         "@types/node": "^18.11.18",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -33,7 +33,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha135",
+    "@snowtop/ent": "^0.1.0-alpha137",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha136",
+  "version": "0.1.0-alpha137",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/scripts/custom_graphql.ts
+++ b/ts/src/scripts/custom_graphql.ts
@@ -158,19 +158,26 @@ async function captureDynamic(filePath: string, gqlCapture: typeof GQLCapture) {
     return;
   }
   return await new Promise((resolve, reject) => {
-    // we seem to get tsconfig-paths by default because child process but not 100% sure...
-    const args = ["--transpileOnly"];
+    let cmd = "";
+    const args: string[] = [];
     const env = {
       ...process.env,
     };
-    if (!process.env.DISABLE_SWC) {
+    // really only exists if there's a bug with swc or something. we should almost always be using swc
+    if (process.env.DISABLE_SWC) {
+      cmd = "ts-node";
+      args.push("--transpileOnly");
+    } else {
+      cmd = "node";
+      // we seem to get tsconfig-paths by default because child process but not 100% sure...
       args.push("-r", "@swc-node/register");
       env.SWCRC = "true";
     }
     args.push(filePath);
-    const r = spawn("ts-node", args, {
+    const r = spawn(cmd, args, {
       env,
     });
+
     const datas: string[] = [];
     r.stdout.on("data", (data) => {
       datas.push(data.toString());

--- a/tsent/cmd/migrate_v0.1.go
+++ b/tsent/cmd/migrate_v0.1.go
@@ -131,7 +131,7 @@ func fullCodegen(s *schema.Schema) error {
 func runNodeJSMigrateStep(p *codegen.Processor, step string) error {
 	scriptPath := util.GetPathToScript("scripts/migrate_v0.1.ts", false)
 	cmdArgs := append(
-		cmd2.GetArgsForScript(p.Config.GetAbsPathToRoot()),
+		cmd2.GetArgsForTsNodeScript(p.Config.GetAbsPathToRoot()),
 		"--swc",
 		scriptPath,
 		step,

--- a/tsent/cmd/run_script.go
+++ b/tsent/cmd/run_script.go
@@ -25,7 +25,7 @@ var runScriptCmd = &cobra.Command{
 		scriptPath := util.GetPathToScript(script, false)
 
 		cmdArgs := append(
-			cmd2.GetArgsForScript(cfg.GetAbsPathToRoot()),
+			cmd2.GetArgsForTsNodeScript(cfg.GetAbsPathToRoot()),
 			// "--swc",
 			scriptPath,
 		)


### PR DESCRIPTION
the ts-node infrastructure seems to be much slower and we don't need it

`node -r @swc-node/register -r tsconfig-paths` seems to do what I want when dealing with paths

followup to https://github.com/lolopinto/ent/pull/1417