### PR TITLE
[auto_schema] case insensitive coaelsce check

### DIFF
--- a/python/auto_schema/auto_schema/compare.py
+++ b/python/auto_schema/auto_schema/compare.py
@@ -659,7 +659,8 @@ def _parse_cols_from(curr: str):
         if not s:
             continue
         s = s.strip().strip('(').strip(')')
-        if s.startswith('COALESCE'):
+        # TODO we should test against different db versions. this is too brittle
+        if s.startswith('COALESCE') or s.startswith('coalesce'):
             s = s[8:]
         if s.endswith('::text'):
             s = s[:-6]

--- a/python/auto_schema/setup.py
+++ b/python/auto_schema/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 # https://test.pypi.org/project/auto-schema-test/#history
 setuptools.setup(
     name="auto_schema",  # auto_schema_test to test
-    version="0.0.27",  # 0.0.24 was last test version
+    version="0.0.28",  # 0.0.24 was last test version
     author="Ola Okelola",
     author_email="email@email.com",
     description="auto schema for a db",


### PR DESCRIPTION
simple check across versions shows COALESCE in postgres 14 and coalesce in 13.

follow-up to https://github.com/lolopinto/ent/pull/1442