### PR TITLE
change generated index edge to be opt-in

### DIFF
--- a/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
+++ b/examples/simple/src/ent/generated/user/actions/create_user_action_base.ts
@@ -96,7 +96,7 @@ type OneOf<T extends {}[]> = {
   >;
 }[number];
 export type CreateUserActionUpsertOptions = { update_cols?: string[] } & OneOf<
-  [{ column: UpsertCols }, { constraint: UpsertConstraints }]
+  [{ constraint: UpsertConstraints }, { column: UpsertCols }]
 >;
 
 export class CreateUserActionBase

--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -320,6 +320,7 @@ func (e *EdgeInfo) AddFieldEdgeFromFieldEdgeInfo(
 
 	if fieldEdgeInfo.IndexEdge != nil {
 		// set the name based on this...
+		// and generate the edge based on this
 		edge.UserGivenEdgeName = fieldEdgeInfo.IndexEdge.Name
 	}
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1316,15 +1316,17 @@ func (s *Schema) addLinkedEdges(cfg codegenapi.Config, info *NodeDataInfo) error
 				return fmt.Errorf("couldn't find config for typ %s", e.NodeInfo.Node)
 			}
 
-			if err := fNode.NodeData.EdgeInfo.AddDestinationEdgeFromNonPolymorphicOptions(
-				cfg,
-				f.TsFieldName(cfg),
-				f.GetQuotedDBColName(),
-				nodeData.Node,
-				fNode.NodeData.Node,
-				e.UserGivenEdgeName,
-			); err != nil {
-				return err
+			if e.UserGivenEdgeName != "" {
+				if err := fNode.NodeData.EdgeInfo.AddDestinationEdgeFromNonPolymorphicOptions(
+					cfg,
+					f.TsFieldName(cfg),
+					f.GetQuotedDBColName(),
+					nodeData.Node,
+					fNode.NodeData.Node,
+					e.UserGivenEdgeName,
+				); err != nil {
+					return err
+				}
 			}
 			continue
 		}

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -430,8 +430,6 @@ export interface InverseFieldEdge {
 }
 
 export interface IndexEdgeOptions {
-  // same philosophy as PolymorphicOptions.name
-  // defaults to pluralize(schema) if not provided
   name: string;
 }
 
@@ -442,10 +440,11 @@ export interface FieldEdge {
   // this makes it so that we can define and write the edge from this schema
   inverseEdge?: string | InverseFieldEdge;
 
-  // if an indexed edge, we generate an inverse
-  // TODO this might make more sense to be {
-  // index: { name: "name" }
-  // }
+  // this *intentionally* breaks the mold from what we do for polymorphic edges
+  // TODO: *also* make that opt-in.
+  // if provided, we generate a query|connection for this edge.
+  // name given is used for the name of the query|connection e.g. 'todos_assigned' gives
+  // queryTodosAssigned() and a 'todos_assigned' field which points to a generated connection.
   indexEdge?: IndexEdgeOptions;
 
   // if enforceSchema. implement the valid type.


### PR DESCRIPTION
follow-up to https://github.com/lolopinto/ent/pull/1452

it's annoying to have this change come in and codegen starts breaking and it seems very likely for there to be multiple ent schemas with multiple uuid indices to the same profile.

instead of doing it automatically, make the presence of `indexEdge` be the deciding factor for creating

e.g.
```ts
assignee_id: UUIDType({
  index: true,
  fieldEdge: {
    schema: 'User',
       // create edge `todos_assigned` in `User` so that we generate `queryTodosAssigned` and `todos_assigned` field in graphql
    indexEdge: {
      name: "todos_assigned",
    },
  },
})
```