### PR TITLE
cleanup query from code in field

### DIFF
--- a/internal/field/field.go
+++ b/internal/field/field.go
@@ -441,14 +441,6 @@ func (f *Field) QueryFromEntName() string {
 	return ret
 }
 
-// TODO probably gonna collapse into above
-func (f *Field) QueryFrom() bool {
-	if !f.index || f.polymorphic != nil {
-		return false
-	}
-	return !strings.HasSuffix(f.FieldName, "ID")
-}
-
 func (f *Field) Nullable() bool {
 	return f.nullable
 }

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -407,7 +407,6 @@ implements {{useImport "Ent"}}<{{$viewerType}}>
       ): {{$queryName}} {
         return {{$queryName}}.query(viewer, ent);
       }
-    {{ else if $field.QueryFrom -}}
     {{end}}
   {{end -}}
 


### PR DESCRIPTION
https://github.com/lolopinto/ent/issues/288 is wontfix so this code is dead. only automatically generating loaders for id fields. everything else is custom code with `Foo.loadCustom` or custom ent queries