### PR TITLE
clone data before we do field privacy and maybe set some fields to null

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha144",
+  "version": "0.1.0-alpha145",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -785,11 +785,12 @@ async function doFieldPrivacy<
   }
   const promises: Promise<void>[] = [];
   let somethingChanged = false;
+  const clone = { ...data };
   const origData = {
     ...data,
   };
   for (const [k, policy] of options.fieldPrivacy) {
-    const curr = data[k];
+    const curr = clone[k];
     if (curr === null || curr === undefined) {
       continue;
     }
@@ -799,7 +800,7 @@ async function doFieldPrivacy<
         // don't do anything if key is null or for some reason missing
         const r = await applyPrivacyPolicy(viewer, policy, ent);
         if (!r) {
-          data[k] = null;
+          clone[k] = null;
           somethingChanged = true;
         }
       })(),
@@ -808,7 +809,7 @@ async function doFieldPrivacy<
   await Promise.all(promises);
   if (somethingChanged) {
     // have to create new instance
-    const ent = new options.ent(viewer, data);
+    const ent = new options.ent(viewer, clone);
     ent.__setRawDBData(origData);
     return ent;
   }

--- a/ts/src/core/ent_data.test.ts
+++ b/ts/src/core/ent_data.test.ts
@@ -712,11 +712,11 @@ function commonTests() {
 
       const [ent1, ent2] = await testEnt(vc);
 
-      // // same context, change viewer
+      // same context, change viewer
       const vc2 = getIDViewer(1, ctx);
 
-      // // we still reuse the same raw-data query since it's viewer agnostic
-      // // context cache works as viewer is changed
+      // we still reuse the same raw-data query since it's viewer agnostic
+      // context cache works as viewer is changed
       const [ent3, ent4] = await testEnt(vc2);
 
       // no viewer, nothing loaded
@@ -824,18 +824,18 @@ function commonTests() {
 
       const [ent1, ent2] = await testEnt(vc);
 
-      // // same context, change viewer
+      // same context, change viewer
       const vc2 = getIDViewer(2, ctx);
 
-      // // we still reuse the same raw-data query since it's viewer agnostic
-      // // context cache works as viewer is changed
+      // we still reuse the same raw-data query since it's viewer agnostic
+      // context cache works as viewer is changed
       const [ent3, ent4] = await testEnt(vc2);
 
-      // // same context, change viewer
+      // same context, change viewer
       const vc3 = getIDViewer(3, ctx);
 
-      // // we still reuse the same raw-data query since it's viewer agnostic
-      // // context cache works as viewer is changed
+      // we still reuse the same raw-data query since it's viewer agnostic
+      // context cache works as viewer is changed
       const [ent5, ent6] = await testEnt(vc3);
 
       expect(ent1).not.toBe(null);

--- a/ts/src/core/ent_data.test.ts
+++ b/ts/src/core/ent_data.test.ts
@@ -589,11 +589,11 @@ function commonTests() {
 
       const [ent1, ent2] = await testEnt(vc);
 
-      // // same context, change viewer
+      // same context, change viewer
       const vc2 = getIDViewer(1, ctx);
 
-      // // we still reuse the same raw-data query since it's viewer agnostic
-      // // context cache works as viewer is changed
+      // we still reuse the same raw-data query since it's viewer agnostic
+      // context cache works as viewer is changed
       const [ent3, ent4] = await testEnt(vc2);
 
       // no viewer, nothing loaded


### PR DESCRIPTION
fixes issue where if we reload an ent with a different viewer with the same context and the previous viewer couldn't see a field, the new viewer will also not be able to see said field because we were operating on the same row

```ts
// assume context in both
const vc1 = new IDViewer(1);
const vc2 = new IDViewer(2);

await loadEnt(vc1, id); // can't see field foo 

await loadEnt(vc2,id); // should be able to see field foo. foo will be null here when it shouldn't be
```