### PR TITLE
decouple canViewerSeeInfo and canViewerSeeEdit into different options

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha147",
+        "@snowtop/ent": "^0.1.0-alpha148",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1233,9 +1233,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha147",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha147.tgz",
-      "integrity": "sha512-Blg8piP7Le+HQ7JOTXKvpIWHwaxlFqiM7MMIF9DcGeme1+b96VR0iWBdQp9rLkpMp6sZZ48lvb4hPRwsQgPIwg==",
+      "version": "0.1.0-alpha148",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha148.tgz",
+      "integrity": "sha512-ioV+omU0fAd2GaTPC4qfayZ79EDwGp3cBJohDQnvxVqshWrn2lwuwgim5joJ/K32ivoAws+5tdBypb8pPoJJ2Q==",
       "dependencies": {
         "@swc-node/register": "^1.6.5",
         "@types/node": "^20.2.5",
@@ -7410,9 +7410,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha147",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha147.tgz",
-      "integrity": "sha512-Blg8piP7Le+HQ7JOTXKvpIWHwaxlFqiM7MMIF9DcGeme1+b96VR0iWBdQp9rLkpMp6sZZ48lvb4hPRwsQgPIwg==",
+      "version": "0.1.0-alpha148",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha148.tgz",
+      "integrity": "sha512-ioV+omU0fAd2GaTPC4qfayZ79EDwGp3cBJohDQnvxVqshWrn2lwuwgim5joJ/K32ivoAws+5tdBypb8pPoJJ2Q==",
       "requires": {
         "@swc-node/register": "^1.6.5",
         "@types/node": "^20.2.5",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -33,7 +33,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha147",
+    "@snowtop/ent": "^0.1.0-alpha148",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/simple/src/schema/event_schema.ts
+++ b/examples/simple/src/schema/event_schema.ts
@@ -14,7 +14,7 @@ import { EdgeType } from "../ent/generated/types";
 
 /// explicit schema
 const EventSchema = new EntSchema({
-  supportCanViewerSee: true,
+  showCanViewerSee: true,
 
   // pre-fields comment. intentionally doesn't parse decorators since we don't need it
   fields: {

--- a/examples/simple/src/schema/user_schema.ts
+++ b/examples/simple/src/schema/user_schema.ts
@@ -36,7 +36,9 @@ const UserSchema = new EntSchema({
 
   supportUpsert: true,
 
-  supportCanViewerSee: true,
+  showCanViewerSee: true,
+
+  showCanViewerEdit: true,
 
   fields: {
     FirstName: StringType(),

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha147",
+        "@snowtop/ent": "^0.1.0-alpha148",
         "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
         "@snowtop/ent-soft-delete": "^0.1.0-alpha5",
         "@types/node": "^15.0.3",
@@ -1193,9 +1193,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha147",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha147.tgz",
-      "integrity": "sha512-Blg8piP7Le+HQ7JOTXKvpIWHwaxlFqiM7MMIF9DcGeme1+b96VR0iWBdQp9rLkpMp6sZZ48lvb4hPRwsQgPIwg==",
+      "version": "0.1.0-alpha148",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha148.tgz",
+      "integrity": "sha512-ioV+omU0fAd2GaTPC4qfayZ79EDwGp3cBJohDQnvxVqshWrn2lwuwgim5joJ/K32ivoAws+5tdBypb8pPoJJ2Q==",
       "dependencies": {
         "@swc-node/register": "^1.6.5",
         "@types/node": "^20.2.5",
@@ -7309,9 +7309,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha147",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha147.tgz",
-      "integrity": "sha512-Blg8piP7Le+HQ7JOTXKvpIWHwaxlFqiM7MMIF9DcGeme1+b96VR0iWBdQp9rLkpMp6sZZ48lvb4hPRwsQgPIwg==",
+      "version": "0.1.0-alpha148",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha148.tgz",
+      "integrity": "sha512-ioV+omU0fAd2GaTPC4qfayZ79EDwGp3cBJohDQnvxVqshWrn2lwuwgim5joJ/K32ivoAws+5tdBypb8pPoJJ2Q==",
       "requires": {
         "@swc-node/register": "^1.6.5",
         "@types/node": "^20.2.5",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -37,7 +37,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha147",
+    "@snowtop/ent": "^0.1.0-alpha148",
     "@snowtop/ent-phonenumber": "^0.1.0-alpha1",
     "@snowtop/ent-soft-delete": "^0.1.0-alpha5",
     "@types/node": "^15.0.3",

--- a/examples/todo-sqlite/src/graphql/generated/schema.gql
+++ b/examples/todo-sqlite/src/graphql/generated/schema.gql
@@ -514,6 +514,9 @@ type Mutation {
   todoStatusAccountEdit(input: TodoStatusAccountEditInput!): TodoStatusAccountEditPayload!
 }
 
+"""The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."""
+scalar JSON
+
 """Time scalar type"""
 scalar Time
 

--- a/examples/todo-sqlite/src/schema/account_schema.ts
+++ b/examples/todo-sqlite/src/schema/account_schema.ts
@@ -13,7 +13,7 @@ import { TodoContainerPattern } from "./patterns/todo_pattern";
 const AccountSchema = new TodoBaseEntSchema({
   patterns: [new TodoContainerPattern()],
 
-  supportCanViewerSee: true,
+  showCanViewerSee: true,
 
   fields: {
     Name: StringType(),

--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -103,7 +103,8 @@ type Node struct {
 	Patterns                []string                  `json:"patternNames,omitempty"`
 	CustomGraphQLInterfaces []string                  `json:"customGraphQLInterfaces,omitempty"`
 	SupportUpsert           bool                      `json:"supportUpsert,omitempty"`
-	SupportCanViewerSee     bool                      `json:"supportCanViewerSee,omitempty"`
+	ShowCanViewerSee        bool                      `json:"showCanViewerSee,omitempty"`
+	ShowCanViewerEdit       bool                      `json:"showCanViewerEdit,omitempty"`
 	// these 2 not used yet so ignoring for now
 	// TransformsInsert bool `json:"transformsInsert,omitempty"`
 	// TransformsUpdate bool `json:"transformsUpdate,omitempty"`

--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -72,7 +72,8 @@ type NodeData struct {
 	PatternsWithMixins      []string
 	CustomGraphQLInterfaces []string
 	SupportUpsert           bool
-	SupportCanViewerSee     bool
+	ShowCanViewerSee        bool
+	ShowCanViewerEdit       bool
 
 	schemaPath string
 
@@ -725,7 +726,7 @@ type CanViewerSeeInfo struct {
 }
 
 func (nodeData *NodeData) GetCanViewerSeeInfo() *CanViewerSeeInfo {
-	if !nodeData.SupportCanViewerSee || !nodeData.FieldsWithFieldPrivacy() {
+	if !nodeData.ShowCanViewerSee || !nodeData.FieldsWithFieldPrivacy() {
 		return nil
 	}
 
@@ -747,7 +748,7 @@ func (nodeData *NodeData) GetCanViewerSeeInfo() *CanViewerSeeInfo {
 }
 
 func (nodeData *NodeData) GetCanViewerEditInfo() *CanViewerSeeInfo {
-	if !nodeData.SupportCanViewerSee || !nodeData.FieldsWithEditFieldPrivacy() {
+	if !nodeData.ShowCanViewerEdit || !nodeData.FieldsWithEditFieldPrivacy() {
 		return nil
 	}
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -425,7 +425,8 @@ func (s *Schema) parseInputSchema(cfg codegenapi.Config, schema *input.Schema, l
 		nodeData.TransformsLoaderCodegen = node.TransformsLoaderCodegen
 		nodeData.CustomGraphQLInterfaces = node.CustomGraphQLInterfaces
 		nodeData.SupportUpsert = node.SupportUpsert
-		nodeData.SupportCanViewerSee = node.SupportCanViewerSee
+		nodeData.ShowCanViewerSee = node.ShowCanViewerSee
+		nodeData.ShowCanViewerEdit = node.ShowCanViewerEdit
 		for _, p := range node.Patterns {
 			pattern := schema.Patterns[p]
 			if pattern == nil || pattern.DisableMixin {

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha147",
+  "version": "0.1.0-alpha148",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/parse_schema/parse.ts
+++ b/ts/src/parse_schema/parse.ts
@@ -444,7 +444,8 @@ export async function parseSchema(
       assocEdgeGroups: [],
       customGraphQLInterfaces: schema.customGraphQLInterfaces,
       supportUpsert: schema.supportUpsert,
-      supportCanViewerSee: schema.supportCanViewerSee,
+      showCanViewerSee: schema.showCanViewerSee,
+      showCanViewerEdit: schema.showCanViewerEdit,
     };
     // let's put patterns first just so we have id, created_at, updated_at first
     // ¯\_(ツ)_/¯

--- a/ts/src/schema/base_schema.ts
+++ b/ts/src/schema/base_schema.ts
@@ -108,7 +108,9 @@ export class EntSchema implements Schema {
 
   supportUpsert?: boolean | undefined;
 
-  supportCanViewerSee?: boolean | undefined;
+  showCanViewerSee?: boolean | undefined;
+
+  showCanViewerEdit?: boolean | undefined;
 
   constructor(cfg: SchemaConfig) {
     this.fields = cfg.fields;
@@ -128,7 +130,8 @@ export class EntSchema implements Schema {
     // TODO annoying that have to list these...
     this.customGraphQLInterfaces = cfg.customGraphQLInterfaces;
     this.supportUpsert = cfg.supportUpsert;
-    this.supportCanViewerSee = cfg.supportCanViewerSee;
+    this.showCanViewerSee = cfg.showCanViewerSee;
+    this.showCanViewerEdit = cfg.showCanViewerEdit;
   }
 }
 
@@ -168,7 +171,9 @@ export class EntSchemaWithTZ implements Schema {
 
   supportUpsert?: boolean | undefined;
 
-  supportCanViewerSee?: boolean | undefined;
+  showCanViewerSee?: boolean | undefined;
+
+  showCanViewerEdit?: boolean | undefined;
 
   constructor(cfg: SchemaConfig) {
     this.fields = cfg.fields;
@@ -188,7 +193,8 @@ export class EntSchemaWithTZ implements Schema {
     // TODO annoying that have to list these...
     this.customGraphQLInterfaces = cfg.customGraphQLInterfaces;
     this.supportUpsert = cfg.supportUpsert;
-    this.supportCanViewerSee = cfg.supportCanViewerSee;
+    this.showCanViewerSee = cfg.showCanViewerSee;
+    this.showCanViewerEdit = cfg.showCanViewerEdit;
   }
 }
 

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -100,7 +100,9 @@ export default interface Schema {
   // if ent has fields which have privacy policies and this is true, we generate a
   // canViewerSeeInfo() function + a graphql field for each field to indicate if it's
   // visible to the viewer
-  supportCanViewerSee?: boolean;
+  showCanViewerSee?: boolean;
+  // above but for editPrivacyPolicy
+  showCanViewerEdit?: boolean;
 }
 
 // An AssocEdge is an edge between 2 ids that has a common table/edge format


### PR DESCRIPTION
use `showFoo` language instead of support to be more consistent with other ent things

follow-ups to https://github.com/lolopinto/ent/pull/1480, https://github.com/lolopinto/ent/pull/1472