### PR TITLE
fix nulls first|last query when sort column is same as cursor col

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha151",
+  "version": "0.1.0-alpha152",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -212,7 +212,7 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
         );
       }
     } else {
-      options.orderby = `${this.sortCol}${nullsPlacement} ${orderby}`;
+      options.orderby = `${this.sortCol} ${orderby}${nullsPlacement}`;
 
       if (this.offset) {
         let clauseFn = less ? clause.Less : clause.Greater;


### PR DESCRIPTION
wrong construction led to sadness in generated query

apparently, didn't have a test for this case

follow-up to https://github.com/lolopinto/ent/pull/1493