### PR TITLE
update imports to expose gqlInterfaceType and gqlUnionType

### DIFF
--- a/ts/src/graphql/index.ts
+++ b/ts/src/graphql/index.ts
@@ -13,6 +13,8 @@ export {
   GQLCapture,
   gqlFileUpload,
   CustomType,
+  gqlInterfaceType,
+  gqlUnionType,
 } from "./graphql";
 
 export { GraphQLTime } from "./scalars/time";


### PR DESCRIPTION
`@snowtop/ent/graphql` didn't have these imports