### PR TITLE
change orderby in QueryDataOptions so that nullsPlacement can be configured for Foo.loadCustom queries

### DIFF
--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -1,5 +1,6 @@
 import * as clause from "./clause";
 import { ObjectLoaderFactory } from "./loaders";
+import { OrderBy } from "./query_impl";
 
 // Loader is the primitive data fetching abstraction in the framework
 // implementation details up to each instance
@@ -84,7 +85,7 @@ interface queryOptions {
   fields: string[];
   tableName: string;
   clause: clause.Clause;
-  orderby?: string;
+  orderby?: OrderBy;
 }
 
 export interface Context<TViewer extends Viewer = Viewer> {
@@ -172,7 +173,7 @@ export interface QueryableDataOptions
 export interface QueryDataOptions<T extends Data = Data, K = keyof T> {
   distinct?: boolean;
   clause: clause.Clause<T, K>;
-  orderby?: string; // this technically doesn't make sense when querying just one row but whatevs
+  orderby?: OrderBy; // this technically doesn't make sense when querying just one row but whatevs
   groupby?: K;
   limit?: number;
   disableTransformations?: boolean;

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -36,6 +36,7 @@ import * as clause from "./clause";
 import { log, logEnabled, logTrace } from "./logger";
 import DataLoader from "dataloader";
 import { __getGlobalSchema } from "./global_schema";
+import { OrderBy, getOrderByPhrase } from "./query_impl";
 
 // TODO kill this and createDataLoader
 class cacheMap {
@@ -936,7 +937,7 @@ export function buildQuery(options: QueryableDataOptions): string {
     parts.push(`GROUP BY ${options.groupby}`);
   }
   if (options.orderby) {
-    parts.push(`ORDER BY ${options.orderby}`);
+    parts.push(`ORDER BY ${getOrderByPhrase(options.orderby)}`);
   }
   if (options.limit) {
     parts.push(`LIMIT ${options.limit}`);
@@ -952,7 +953,7 @@ interface GroupQueryOptions<T extends Data, K = keyof T> {
   groupColumn: K;
   fields: K[];
   values: any[];
-  orderby?: string;
+  orderby?: OrderBy;
   limit: number;
 }
 
@@ -968,7 +969,7 @@ export function buildGroupQuery<T extends Data = Data, K = keyof T>(
   }
   let orderby = "";
   if (options.orderby) {
-    orderby = `ORDER BY ${options.orderby}`;
+    orderby = `ORDER BY ${getOrderByPhrase(options.orderby)}`;
   }
 
   // window functions work in sqlite!

--- a/ts/src/core/loaders/query_loader.ts
+++ b/ts/src/core/loaders/query_loader.ts
@@ -19,10 +19,14 @@ import { logEnabled } from "../logger";
 import { cacheMap, getCustomLoader, getLoader } from "./loader";
 import memoizee from "memoizee";
 import { ObjectLoaderFactory } from "./object_loader";
+import { OrderBy, getOrderByPhrase } from "../query_impl";
 
-export function getOrderBy(sortCol: string, orderby?: string) {
+export function getQueryLoaderOrderByDeprecated(
+  sortCol: string,
+  orderby?: OrderBy,
+) {
   if (orderby) {
-    return orderby;
+    return getOrderByPhrase(orderby);
   }
   let sortColLower = sortCol.toLowerCase();
   let orderbyDirection = " DESC";
@@ -57,7 +61,7 @@ async function simpleCase<K extends any>(
   return await loadRows({
     ...options,
     clause: cls,
-    orderby: getOrderBy(sortCol, queryOptions?.orderby),
+    orderby: getQueryLoaderOrderByDeprecated(sortCol, queryOptions?.orderby),
     limit: queryOptions?.limit || getDefaultLimit(),
   });
 }
@@ -109,7 +113,7 @@ function createLoader<K extends any>(
       tableName: options.tableName,
       fields: options.fields,
       values: keys,
-      orderby: getOrderBy(sortCol, queryOptions?.orderby),
+      orderby: getQueryLoaderOrderByDeprecated(sortCol, queryOptions?.orderby),
       limit: queryOptions?.limit || getDefaultLimit(),
       groupColumn: col,
       clause: extraClause,

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -14,7 +14,7 @@ import {
   loadRows,
 } from "../ent";
 
-import { getOrderBy } from "../loaders/query_loader";
+import { getQueryLoaderOrderByDeprecated } from "../loaders/query_loader";
 import { BaseEdgeQuery, IDInfo } from "./query";
 
 export interface CustomClauseQueryOptions<
@@ -124,7 +124,10 @@ export class CustomClauseQuery<
       tableName: this.options.loadEntOptions.tableName,
       fields: this.options.loadEntOptions.fields,
       clause: AndOptional(this.clause, options.clause),
-      orderby: getOrderBy(this.getSortCol(), options?.orderby),
+      orderby: getQueryLoaderOrderByDeprecated(
+        this.getSortCol(),
+        options?.orderby,
+      ),
       limit: options?.limit || getDefaultLimit(),
       context: this.viewer.context,
     });

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -1,0 +1,30 @@
+interface OrderByOptions {
+  column: string;
+  direction: "asc" | "desc";
+  nullsPlacement?: "first" | "last";
+}
+
+export type OrderBy = string | OrderByOptions[];
+
+export function getOrderByPhrase(orderby: OrderBy): string {
+  let ret = "";
+  if (Array.isArray(orderby)) {
+    ret = orderby
+      .map((v) => {
+        let nullsPlacement = "";
+        switch (v.nullsPlacement) {
+          case "first":
+            nullsPlacement = " NULLS FIRST";
+            break;
+          case "last":
+            nullsPlacement = " NULLS LAST";
+            break;
+        }
+        return `${v.column} ${v.direction}${nullsPlacement}`;
+      })
+      .join(", ");
+  } else {
+    ret = orderby;
+  }
+  return ret;
+}


### PR DESCRIPTION
was initially going to add a `nullsPlacement` field but that was becoming ugly so finally changed `orderby` to something that's more flexible, supports multiple columns and easier to use

this should be ported back to loaders and ent queries

follow-up to https://github.com/lolopinto/ent/pull/1493
