### PR TITLE
change swc to not be enabled by default

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-alpha159",
+        "@snowtop/ent": "^0.1.0-alpha160-test4",
         "@snowtop/ent-email": "^0.1.0-alpha1",
         "@snowtop/ent-passport": "^0.1.0-alpha3",
         "@snowtop/ent-password": "^0.1.0-alpha1",
@@ -1233,11 +1233,10 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-alpha159",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha159.tgz",
-      "integrity": "sha512-rdyj/yiNqpvaI+H+VmUOvNWmPs4nPrtJx/v5XJvsv0Rz0i1F27ho7IZEXLee1bhzDNVFrtfoLIb+8g8shZ96dQ==",
+      "version": "0.1.0-alpha160-test4",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha160-test4.tgz",
+      "integrity": "sha512-tvWfaJbFwLIbrXkosPEbcUTIBo+cIYyWYMaWZ8lP0oY+JvHYOE3B75Wp1+XgcMSunSJUWxHozdDBFs9NOMyg7w==",
       "dependencies": {
-        "@swc-node/register": "^1.6.5",
         "@types/node": "^20.2.5",
         "camel-case": "^4.1.2",
         "cosmiconfig": "^8.1.3",
@@ -1264,13 +1263,17 @@
         "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=16.0"
       },
       "peerDependencies": {
-        "better-sqlite3": "^7.4.1",
+        "@swc-node/register": "^1.6.5",
+        "better-sqlite3": "^8.4.0",
         "graphql": "^16.5.0"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         }
@@ -7410,11 +7413,10 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-alpha159",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha159.tgz",
-      "integrity": "sha512-rdyj/yiNqpvaI+H+VmUOvNWmPs4nPrtJx/v5XJvsv0Rz0i1F27ho7IZEXLee1bhzDNVFrtfoLIb+8g8shZ96dQ==",
+      "version": "0.1.0-alpha160-test4",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-alpha160-test4.tgz",
+      "integrity": "sha512-tvWfaJbFwLIbrXkosPEbcUTIBo+cIYyWYMaWZ8lP0oY+JvHYOE3B75Wp1+XgcMSunSJUWxHozdDBFs9NOMyg7w==",
       "requires": {
-        "@swc-node/register": "^1.6.5",
         "@types/node": "^20.2.5",
         "camel-case": "^4.1.2",
         "cosmiconfig": "^8.1.3",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -33,7 +33,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-alpha159",
+    "@snowtop/ent": "^0.1.0-alpha160-test4",
     "@snowtop/ent-email": "^0.1.0-alpha1",
     "@snowtop/ent-passport": "^0.1.0-alpha3",
     "@snowtop/ent-password": "^0.1.0-alpha1",

--- a/examples/simple/src/graphql/generated/resolvers/comment_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/comment_list_deprecated_query_type.ts
@@ -31,7 +31,7 @@ export const CommentListDeprecatedQueryType: GraphQLFieldConfig<
   RequestContext<ExampleViewerAlias>,
   CommentListDeprecatedArgs
 > = {
-  type: new GraphQLList(new GraphQLNonNull(CommentType)),
+  type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CommentType))),
   args: {
     id: {
       description: "",

--- a/examples/simple/src/graphql/generated/resolvers/contact_email_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_email_list_deprecated_query_type.ts
@@ -31,7 +31,9 @@ export const ContactEmailListDeprecatedQueryType: GraphQLFieldConfig<
   RequestContext<ExampleViewerAlias>,
   ContactEmailListDeprecatedArgs
 > = {
-  type: new GraphQLList(new GraphQLNonNull(ContactEmailType)),
+  type: new GraphQLNonNull(
+    new GraphQLList(new GraphQLNonNull(ContactEmailType)),
+  ),
   args: {
     id: {
       description: "",

--- a/examples/simple/src/graphql/generated/resolvers/contact_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_list_deprecated_query_type.ts
@@ -31,7 +31,7 @@ export const ContactListDeprecatedQueryType: GraphQLFieldConfig<
   RequestContext<ExampleViewerAlias>,
   ContactListDeprecatedArgs
 > = {
-  type: new GraphQLList(new GraphQLNonNull(ContactType)),
+  type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ContactType))),
   args: {
     id: {
       description: "",

--- a/examples/simple/src/graphql/generated/resolvers/contact_phone_number_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_phone_number_list_deprecated_query_type.ts
@@ -31,7 +31,9 @@ export const ContactPhoneNumberListDeprecatedQueryType: GraphQLFieldConfig<
   RequestContext<ExampleViewerAlias>,
   ContactPhoneNumberListDeprecatedArgs
 > = {
-  type: new GraphQLList(new GraphQLNonNull(ContactPhoneNumberType)),
+  type: new GraphQLNonNull(
+    new GraphQLList(new GraphQLNonNull(ContactPhoneNumberType)),
+  ),
   args: {
     id: {
       description: "",

--- a/examples/simple/src/graphql/generated/resolvers/event_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/event_list_deprecated_query_type.ts
@@ -31,7 +31,7 @@ export const EventListDeprecatedQueryType: GraphQLFieldConfig<
   RequestContext<ExampleViewerAlias>,
   EventListDeprecatedArgs
 > = {
-  type: new GraphQLList(new GraphQLNonNull(EventType)),
+  type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(EventType))),
   args: {
     id: {
       description: "",

--- a/examples/simple/src/graphql/generated/resolvers/holiday_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/holiday_list_deprecated_query_type.ts
@@ -31,7 +31,7 @@ export const HolidayListDeprecatedQueryType: GraphQLFieldConfig<
   RequestContext<ExampleViewerAlias>,
   HolidayListDeprecatedArgs
 > = {
-  type: new GraphQLList(new GraphQLNonNull(HolidayType)),
+  type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(HolidayType))),
   args: {
     id: {
       description: "",

--- a/examples/simple/src/graphql/generated/resolvers/hours_of_operation_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/hours_of_operation_list_deprecated_query_type.ts
@@ -31,7 +31,9 @@ export const HoursOfOperationListDeprecatedQueryType: GraphQLFieldConfig<
   RequestContext<ExampleViewerAlias>,
   HoursOfOperationListDeprecatedArgs
 > = {
-  type: new GraphQLList(new GraphQLNonNull(HoursOfOperationType)),
+  type: new GraphQLNonNull(
+    new GraphQLList(new GraphQLNonNull(HoursOfOperationType)),
+  ),
   args: {
     id: {
       description: "",

--- a/examples/simple/src/graphql/generated/resolvers/user_list_deprecated_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/user_list_deprecated_query_type.ts
@@ -31,7 +31,7 @@ export const UserListDeprecatedQueryType: GraphQLFieldConfig<
   RequestContext<ExampleViewerAlias>,
   UserListDeprecatedArgs
 > = {
-  type: new GraphQLList(new GraphQLNonNull(UserType)),
+  type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(UserType))),
   args: {
     id: {
       description: "",

--- a/examples/simple/src/graphql/generated/schema.gql
+++ b/examples/simple/src/graphql/generated/schema.gql
@@ -1416,23 +1416,23 @@ input UserSuperNestedObjectInput {
 type Query {
   can_viewer_do: GlobalCanViewerDo
   comment_connection(ids: [ID!], sortCol: CommentSortColumn, query: CommentArgInput, first: Int, after: String, last: Int, before: String): RootToCommentConnection!
-  comment_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [Comment!]
+  comment_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [Comment!]!
   contact_connection(ids: [ID!], sortCol: ContactSortColumn, query: ContactArgInput, first: Int, after: String, last: Int, before: String): RootToContactConnection!
   contact_email_connection(ids: [ID!], sortCol: ContactEmailSortColumn, query: ContactEmailArgInput, first: Int, after: String, last: Int, before: String): RootToContactEmailConnection!
-  contact_email_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [ContactEmail!]
-  contact_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [Contact!]
+  contact_email_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [ContactEmail!]!
+  contact_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [Contact!]!
   contact_phone_number_connection(ids: [ID!], sortCol: ContactPhoneNumberSortColumn, query: ContactPhoneNumberArgInput, first: Int, after: String, last: Int, before: String): RootToContactPhoneNumberConnection!
-  contact_phone_number_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [ContactPhoneNumber!]
+  contact_phone_number_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [ContactPhoneNumber!]!
   event_connection(ids: [ID!], sortCol: EventSortColumn, query: EventArgInput, first: Int, after: String, last: Int, before: String): RootToEventConnection!
-  event_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [Event!]
+  event_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [Event!]!
   holiday_connection(ids: [ID!], sortCol: HolidaySortColumn, query: HolidayArgInput, first: Int, after: String, last: Int, before: String): RootToHolidayConnection!
-  holiday_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [Holiday!]
+  holiday_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [Holiday!]!
   hours_of_operation_connection(ids: [ID!], sortCol: HoursOfOperationSortColumn, query: HoursOfOperationArgInput, first: Int, after: String, last: Int, before: String): RootToHoursOfOperationConnection!
-  hours_of_operation_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [HoursOfOperation!]
+  hours_of_operation_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [HoursOfOperation!]!
   node(id: ID!): Node
   timeDiff(time: Time!, log: JSON!): String!
   user_connection(ids: [ID!], sortCol: UserSortColumn, query: UserArgInput, first: Int, after: String, last: Int, before: String): RootToUserConnection!
-  user_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [User!]
+  user_list_deprecated(id: ID, ids: [ID!], extra: Boolean): [User!]!
   viewer: Viewer!
 }
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -29,7 +29,7 @@ func GetArgsForTsNodeScript(rootPath string) []string {
 }
 
 func UseSwc() bool {
-	return !util.EnvIsTrue("DISABLE_SWC")
+	return util.EnvIsTrue("ENABLE_SWC")
 }
 
 type CommandInfo struct {
@@ -75,8 +75,8 @@ func GetCommandInfo(dirPath string, fromTest bool) *CommandInfo {
 		cmdArgs = append(cmdArgs, "-r", GetTsconfigPaths())
 	}
 
-	if !useSwc {
-		env = append(env, "DISABLE_SWC=true")
+	if useSwc {
+		env = append(env, "ENABLE_SWC=true")
 	}
 
 	// append LOCAL_SCRIPT_PATH so we know. in typescript...

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.0-alpha159",
+  "version": "0.1.0-alpha160-test4",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",
@@ -8,7 +8,6 @@
     "example": "examples"
   },
   "dependencies": {
-    "@swc-node/register": "^1.6.5",
     "@types/node": "^20.2.5",
     "camel-case": "^4.1.2",
     "cosmiconfig": "^8.1.3",
@@ -31,11 +30,15 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
+    "@swc-node/register": "^1.6.5",
     "better-sqlite3": "^8.4.0",
     "graphql": "^16.5.0"
   },
   "peerDependenciesMeta": {
     "better-sqlite3": {
+      "optional": true
+    },
+    "@swc-node/register": {
       "optional": true
     }
   },

--- a/ts/src/scripts/custom_graphql.ts
+++ b/ts/src/scripts/custom_graphql.ts
@@ -172,21 +172,20 @@ async function captureDynamic(filePath: string, gqlCapture: typeof GQLCapture) {
   if (!filePath) {
     return;
   }
-  return await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     let cmd = "";
     const args: string[] = [];
     const env = {
       ...process.env,
     };
-    // really only exists if there's a bug with swc or something. we should almost always be using swc
-    if (process.env.DISABLE_SWC) {
-      cmd = "ts-node";
-      args.push("--transpileOnly");
-    } else {
+    if (process.env.ENABLE_SWC) {
       cmd = "node";
       // we seem to get tsconfig-paths by default because child process but not 100% sure...
       args.push("-r", "@swc-node/register");
       env.SWCRC = "true";
+    } else {
+      cmd = "ts-node";
+      args.push("--transpileOnly");
     }
     args.push(filePath);
     const r = spawn(cmd, args, {


### PR DESCRIPTION
when there's a mismatch between host environment and platform, we run into issues

there's ways around it but that seems annoying to recommend by default so changing the default and now swc can be opted into with `ENABLE_SWC`

changes `@swc-node/register` into an optional peer dependency 

follow-up to https://github.com/lolopinto/ent/pull/1417 and https://github.com/lolopinto/ent/pull/1422

addresses issue discussed in https://github.com/lolopinto/ent/issues/1496

tried a bunch of other things: [ts-node fork](https://github.com/lolopinto/ent/tree/ts-node-swc-patch), [assume yarn](https://github.com/lolopinto/ent/tree/yarn-changes), [moving installs around](https://github.com/lolopinto/ent/pull/1503  which didn't solve the issue