### PR TITLE
fix edge case after downgrade

### DIFF
--- a/internal/build_info/build_info.go
+++ b/internal/build_info/build_info.go
@@ -47,6 +47,10 @@ func (bi *BuildInfo) PrevGraphQLMutationName() codegenapi.GraphQLMutationName {
 	return bi.prev.DefaultGraphQLMutationName
 }
 
+func (bi *BuildInfo) PrevHasForceWriteAll() bool {
+	return bi.prev != nil && bi.prev.ForceWriteAllNextTime
+}
+
 type Config interface {
 	file.Config
 	GetPathToBuildFile() string

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -198,6 +198,10 @@ func (p *Processor) Run(steps []Step, step string, options ...Option) error {
 	})
 }
 
+func (p *Processor) GetBuildInfo() *build_info.BuildInfo {
+	return p.buildInfo
+}
+
 func (p *Processor) FormatTS() error {
 	if p.Config.forcePrettier {
 		return p.formatWithPrettier()


### PR DESCRIPTION
if someone downgrades and then undoes the changes in the schema file but keeps schema.py and schema.sql, we'll give an error

this makes sure we don't do that

previous steps that led to error:

1. make a change e.g. event_schema.ts
2. run codegen
3. downgrade -- -1
4. comment out change in event_schema.ts
5. run codegen. this errors

this wouldn't have erorred

1. make a change e.g. event_schema.ts
2. run codegen
3. downgrade -- -1
4. git checkout src/schema
5. run codegen

difference is in step 4, we kept schema.py and schema.sql

follow-up to https://github.com/lolopinto/ent/issues/1441