### PR TITLE
Update auto schema deps to latest 

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -8,11 +8,11 @@ pytest = "*"
 autopep8 = ""
 
 [packages]
-alembic = "==1.8.1"
+alembic = "==1.11.1"
 datetime = "==4.3"
-sqlalchemy = "==1.4.44"
-psycopg2 = "==2.9.5"
-autopep8 = "==2.0.0"
+sqlalchemy = "==2.0.18"
+psycopg2 = "==2.9.6"
+autopep8 = "==2.0.2"
 python-dateutil= "==2.8.2"
 
 [requires]

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7b336d1051b15f10165b8d58c7577cbb86b3412670eb09bb4060a3b73fe80384"
+            "sha256": "5e7221e40d68bc2f05a41f06a5c9d82564a3d937bfd22eb358133a66fe31baf2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:0a024d7f2de88d738d7395ff866997314c837be6104e90c5724350313dee4da4",
-                "sha256:cd0b5e45b14b706426b833f06369b9a6d5ee03f826ec3238723ce8caaf6e5ffa"
+                "sha256:6a810a6b012c88b33458fceb869aef09ac75d6ace5291915ba7fae44de372c01",
+                "sha256:dc871798a601fab38332e38d6ddb38d5e734f60034baeb8e2db5b642fccd8ab8"
             ],
             "index": "pypi",
-            "version": "==1.8.1"
+            "version": "==1.11.1"
         },
         "autopep8": {
             "hashes": [
-                "sha256:8b1659c7f003e693199f52caffdc06585bb0716900bbc6a7442fd931d658c077",
-                "sha256:ad924b42c2e27a1ac58e432166cc4588f5b80747de02d0d35b1ecbd3e7d57207"
+                "sha256:86e9303b5e5c8160872b2f5ef611161b2893e9bfe8ccc7e2f76385947d57a2f1",
+                "sha256:f9849cdd62108cb739dbcdbfb7fdcc9a30d1b63c4cc3e1c1f893b5360941b61c"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==2.0.2"
         },
         "datetime": {
             "hashes": [
@@ -50,76 +50,86 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
-                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
-                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
-                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
-                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
-                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
-                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
-                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
-                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
-                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
-                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
-                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
-                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
-                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
-                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
-                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
-                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
-                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
-                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
-                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
-                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
-                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
-                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
-                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
-                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
-                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
-                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
-                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
-                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
-                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
-                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
-                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
-                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
-                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
-                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
-                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
-                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
-                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
-                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
-                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
+                "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+                "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
+                "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
+                "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+                "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
+                "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+                "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
+                "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
+                "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
+                "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9",
+                "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
+                "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
+                "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+                "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
+                "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
+                "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
+                "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac",
+                "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52",
+                "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
+                "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
+                "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+                "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
+                "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
+                "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
+                "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0",
+                "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
+                "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
+                "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+                "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
+                "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+                "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+                "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
+                "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
+                "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
+                "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
+                "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee",
+                "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc",
+                "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2",
+                "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48",
+                "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7",
+                "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e",
+                "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b",
+                "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa",
+                "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5",
+                "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e",
+                "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb",
+                "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
+                "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
+                "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
+                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.1.1"
+            "version": "==2.1.3"
         },
         "psycopg2": {
             "hashes": [
-                "sha256:093e3894d2d3c592ab0945d9eba9d139c139664dcf83a1c440b8a7aa9bb21955",
-                "sha256:190d51e8c1b25a47484e52a79638a8182451d6f6dff99f26ad9bd81e5359a0fa",
-                "sha256:1a5c7d7d577e0eabfcf15eb87d1e19314c8c4f0e722a301f98e0e3a65e238b4e",
-                "sha256:1e5a38aa85bd660c53947bd28aeaafb6a97d70423606f1ccb044a03a1203fe4a",
-                "sha256:322fd5fca0b1113677089d4ebd5222c964b1760e361f151cbb2706c4912112c5",
-                "sha256:4cb9936316d88bfab614666eb9e32995e794ed0f8f6b3b718666c22819c1d7ee",
-                "sha256:920bf418000dd17669d2904472efeab2b20546efd0548139618f8fa305d1d7ad",
-                "sha256:922cc5f0b98a5f2b1ff481f5551b95cd04580fd6f0c72d9b22e6c0145a4840e0",
-                "sha256:a5246d2e683a972e2187a8714b5c2cf8156c064629f9a9b1a873c1730d9e245a",
-                "sha256:b9ac1b0d8ecc49e05e4e182694f418d27f3aedcfca854ebd6c05bb1cffa10d6d",
-                "sha256:d3ef67e630b0de0779c42912fe2cbae3805ebaba30cda27fea2a3de650a9414f",
-                "sha256:f5b6320dbc3cf6cfb9f25308286f9f7ab464e65cfb105b64cc9c52831748ced2",
-                "sha256:fc04dd5189b90d825509caa510f20d1d504761e78b8dfb95a0ede180f71d50e5"
+                "sha256:11aca705ec888e4f4cea97289a0bf0f22a067a32614f6ef64fcf7b8bfbc53744",
+                "sha256:1861a53a6a0fd248e42ea37c957d36950da00266378746588eab4f4b5649e95f",
+                "sha256:2362ee4d07ac85ff0ad93e22c693d0f37ff63e28f0615a16b6635a645f4b9214",
+                "sha256:36c941a767341d11549c0fbdbb2bf5be2eda4caf87f65dfcd7d146828bd27f39",
+                "sha256:53f4ad0a3988f983e9b49a5d9765d663bbe84f508ed655affdb810af9d0972ad",
+                "sha256:869776630c04f335d4124f120b7fb377fe44b0a7645ab3c34b4ba42516951889",
+                "sha256:a8ad4a47f42aa6aec8d061fdae21eaed8d864d4bb0f0cade5ad32ca16fcd6258",
+                "sha256:b81fcb9ecfc584f661b71c889edeae70bae30d3ef74fa0ca388ecda50b1222b7",
+                "sha256:d24ead3716a7d093b90b27b3d73459fe8cd90fd7065cf43b3c40966221d8c394",
+                "sha256:ded2faa2e6dfb430af7713d87ab4abbfc764d8d7fb73eafe96a24155f906ebf5",
+                "sha256:f15158418fd826831b28585e2ab48ed8df2d0d98f502a2b4fe619e7d5ca29011",
+                "sha256:f75001a1cbbe523e00b0ef896a5a1ada2da93ccd752b7636db5a99bc57c44494",
+                "sha256:f7a7a5ee78ba7dc74265ba69e010ae89dae635eea0e97b055fb641a01a31d2b1"
             ],
             "index": "pypi",
-            "version": "==2.9.5"
+            "version": "==2.9.6"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
-                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
+                "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053",
+                "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.9.1"
+            "version": "==2.10.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -131,10 +141,18 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
-                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
+                "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588",
+                "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"
             ],
-            "version": "==2022.6"
+            "version": "==2023.3"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
+                "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==68.0.0"
         },
         "six": {
             "hashes": [
@@ -146,176 +164,144 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:0be9b479c5806cece01f1581726573a8d6515f8404e082c375b922c45cfc2a7b",
-                "sha256:17aee7bfcef7bf0dea92f10e5dfdd67418dcf6fe0759f520e168b605855c003e",
-                "sha256:21f3df74a0ab39e1255e94613556e33c1dc3b454059fe0b365ec3bbb9ed82e4a",
-                "sha256:237067ba0ef45a518b64606e1807f7229969ad568288b110ed5f0ca714a3ed3a",
-                "sha256:2dda5f96719ae89b3ec0f1b79698d86eb9aecb1d54e990abb3fdd92c04b46a90",
-                "sha256:393f51a09778e8984d735b59a810731394308b4038acdb1635397c2865dae2b6",
-                "sha256:3ca21b35b714ce36f4b8d1ee8d15f149db8eb43a472cf71600bf18dae32286e7",
-                "sha256:3cbdbed8cdcae0f83640a9c44fa02b45a6c61e149c58d45a63c9581aba62850f",
-                "sha256:3eba07f740488c3a125f17c092a81eeae24a6c7ec32ac9dbc52bf7afaf0c4f16",
-                "sha256:3f68eab46649504eb95be36ca529aea16cd199f080726c28cbdbcbf23d20b2a2",
-                "sha256:4c56e6899fa6e767e4be5d106941804a4201c5cb9620a409c0b80448ec70b656",
-                "sha256:53f90a2374f60e703c94118d21533765412da8225ba98659de7dd7998641ab17",
-                "sha256:595b185041a4dc5c685283ea98c2f67bbfa47bb28e4a4f5b27ebf40684e7a9f8",
-                "sha256:65a0ad931944fcb0be12a8e0ac322dbd3ecf17c53f088bc10b6da8f0caac287b",
-                "sha256:68e0cd5d32a32c4395168d42f2fefbb03b817ead3a8f3704b8bd5697c0b26c24",
-                "sha256:6a06c2506c41926d2769f7968759995f2505e31c5b5a0821e43ca5a3ddb0e8ae",
-                "sha256:6d7e1b28342b45f19e3dea7873a9479e4a57e15095a575afca902e517fb89652",
-                "sha256:6f0ea4d7348feb5e5d0bf317aace92e28398fa9a6e38b7be9ec1f31aad4a8039",
-                "sha256:7313e4acebb9ae88dbde14a8a177467a7625b7449306c03a3f9f309b30e163d0",
-                "sha256:7cf7c7adbf4417e3f46fc5a2dbf8395a5a69698217337086888f79700a12e93a",
-                "sha256:80ead36fb1d676cc019586ffdc21c7e906ce4bf243fe4021e4973dae332b6038",
-                "sha256:9470633395e5f24d6741b4c8a6e905bce405a28cf417bba4ccbaadf3dab0111d",
-                "sha256:94c0093678001f5d79f2dcbf3104c54d6c89e41ab50d619494c503a4d3f1aef2",
-                "sha256:95f4f8d62589755b507218f2e3189475a4c1f5cc9db2aec772071a7dc6cd5726",
-                "sha256:9c857676d810ca196be73c98eb839125d6fa849bfa3589be06201a6517f9961c",
-                "sha256:a22208c1982f1fe2ae82e5e4c3d4a6f2445a7a0d65fb7983a3d7cbbe3983f5a4",
-                "sha256:ad5f966623905ee33694680dda1b735544c99c7638f216045d21546d3d8c6f5b",
-                "sha256:ae1ed1ebc407d2f66c6f0ec44ef7d56e3f455859df5494680e2cf89dad8e3ae0",
-                "sha256:afd1ac99179d1864a68c06b31263a08ea25a49df94e272712eb2824ef151e294",
-                "sha256:b6a337a2643a41476fb6262059b8740f4b9a2ec29bf00ffb18c18c080f6e0aed",
-                "sha256:b737fbeb2f78926d1f59964feb287bbbd050e7904766f87c8ce5cfb86e6d840c",
-                "sha256:c46322354c58d4dc039a2c982d28284330f8919f31206894281f4b595b9d8dbe",
-                "sha256:c7e3b9e01fdbe1ce3a165cc7e1ff52b24813ee79c6df6dee0d1e13888a97817e",
-                "sha256:c9aa372b295a36771cffc226b6517df3011a7d146ac22d19fa6a75f1cdf9d7e6",
-                "sha256:d3b6d4588994da73567bb00af9d7224a16c8027865a8aab53ae9be83f9b7cbd1",
-                "sha256:d3b9ac11f36ab9a726097fba7c7f6384f0129aedb017f1d4d1d4fce9052a1320",
-                "sha256:d654870a66027af3a26df1372cf7f002e161c6768ebe4c9c6fdc0da331cb5173",
-                "sha256:d8080bc51a775627865e0f1dbfc0040ff4ace685f187f6036837e1727ba2ed10",
-                "sha256:da60b98b0f6f0df9fbf8b72d67d13b73aa8091923a48af79a951d4088530a239",
-                "sha256:f5e8ed9cde48b76318ab989deeddc48f833d2a6a7b7c393c49b704f67dedf01d",
-                "sha256:f8e5443295b218b08bef8eb85d31b214d184b3690d99a33b7bd8e5591e2b0aa1"
+                "sha256:00aa050faf24ce5f2af643e2b86822fa1d7149649995f11bc1e769bbfbf9010b",
+                "sha256:09397a18733fa2a4c7680b746094f980060666ee549deafdb5e102a99ce4619b",
+                "sha256:0f7fdcce52cd882b559a57b484efc92e108efeeee89fab6b623aba1ac68aad2e",
+                "sha256:10514adc41fc8f5922728fbac13d401a1aefcf037f009e64ca3b92464e33bf0e",
+                "sha256:10e001a84f820fea2640e4500e12322b03afc31d8f4f6b813b44813b2a7c7e0d",
+                "sha256:194f2d5a7cb3739875c4d25b3fe288ab0b3dc33f7c857ba2845830c8c51170a0",
+                "sha256:1aac42a21a7fa6c9665392c840b295962992ddf40aecf0a88073bc5c76728117",
+                "sha256:1fb792051db66e09c200e7bc3bda3b1eb18a5b8eb153d2cedb2b14b56a68b8cb",
+                "sha256:2756485f49e7df5c2208bdc64263d19d23eba70666f14ad12d6d8278a2fff65f",
+                "sha256:2b791577c546b6bbd7b43953565fcb0a2fec63643ad605353dd48afbc3c48317",
+                "sha256:420bc6d06d4ae7fb6921524334689eebcbea7bf2005efef070a8562cc9527a37",
+                "sha256:45b07470571bda5ee7f5ec471271bbde97267cc8403fce05e280c36ea73f4754",
+                "sha256:4ebc542d2289c0b016d6945fd07a7e2e23f4abc41e731ac8ad18a9e0c2fd0ec2",
+                "sha256:556dc18e39b6edb76239acfd1c010e37395a54c7fde8c57481c15819a3ffb13e",
+                "sha256:589aba9a35869695b319ed76c6f673d896cd01a7ff78054be1596df7ad9b096f",
+                "sha256:5c95e3e7cc6285bf7ff263eabb0d3bfe3def9a1ff98124083d45e5ece72f4579",
+                "sha256:5dd574a37be388512c72fe0d7318cb8e31743a9b2699847a025e0c08c5bf579d",
+                "sha256:67fbb40db3985c0cfb942fe8853ad94a5e9702d2987dec03abadc2f3b6a24afb",
+                "sha256:6852cd34d96835e4c9091c1e6087325efb5b607b75fd9f7075616197d1c4688a",
+                "sha256:69ae0e9509c43474e33152abe1385b8954922544616426bf793481e1a37e094f",
+                "sha256:6c5bae4c288bda92a7550fe8de9e068c0a7cd56b1c5d888aae5b40f0e13b40bd",
+                "sha256:774bd401e7993452ba0596e741c0c4d6d22f882dd2a798993859181dbffadc62",
+                "sha256:79228a7b90d95957354f37b9d46f2cc8926262ae17b0d3ed8f36c892f2a37e06",
+                "sha256:7b8cba5a25e95041e3413d91f9e50616bcfaec95afa038ce7dc02efefe576745",
+                "sha256:7db97eabd440327c35b751d5ebf78a107f505586485159bcc87660da8bb1fdca",
+                "sha256:7ddd6d35c598af872f9a0a5bce7f7c4a1841684a72dab3302e3df7f17d1b5249",
+                "sha256:82edf3a6090554a83942cec79151d6b5eb96e63d143e80e4cf6671e5d772f6be",
+                "sha256:8b7b3ebfa9416c8eafaffa65216e229480c495e305a06ba176dcac32710744e6",
+                "sha256:8da677135eff43502b7afab5a1e641edfb2dc734ba7fc146e9b1b86817a728e2",
+                "sha256:908c850b98cac1e203ababd4ba76868d19ae0d7172cdc75d3f1b7829b16837d2",
+                "sha256:9da4ee8f711e077633730955c8f3cd2485c9abf5ea0f80aac23221a3224b9a8c",
+                "sha256:a6f1d8256d06f58e6ece150fbe05c63c7f9510df99ee8ac37423f5476a2cebb4",
+                "sha256:afb322ca05e2603deedbcd2e9910f11a3fd2f42bdeafe63018e5641945c7491c",
+                "sha256:b52c6741073de5a744d27329f9803938dcad5c9fee7e61690c705f72973f4175",
+                "sha256:ba633b51835036ff0f402c21f3ff567c565a22ff0a5732b060a68f4660e2a38f",
+                "sha256:bfa1a0f83bdf8061db8d17c2029454722043f1e4dd1b3d3d3120d1b54e75825a",
+                "sha256:bffd6cd47c2e68970039c0d3e355c9ed761d3ca727b204e63cd294cad0e3df90",
+                "sha256:d7a2c1e711ce59ac9d0bba780318bcd102d2958bb423209f24c6354d8c4da930",
+                "sha256:da46beef0ce882546d92b7b2e8deb9e04dbb8fec72945a8eb28b347ca46bc15a",
+                "sha256:ebdd2418ab4e2e26d572d9a1c03877f8514a9b7436729525aa571862507b3fea",
+                "sha256:fc44e50f9d5e96af1a561faa36863f9191f27364a4df3eb70bca66e9370480b6"
             ],
             "index": "pypi",
-            "version": "==1.4.44"
+            "version": "==2.0.18"
         },
-        "tomli": {
+        "typing-extensions": {
             "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
+                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.1"
+            "version": "==4.7.1"
         },
         "zope.interface": {
             "hashes": [
-                "sha256:026e7da51147910435950a46c55159d68af319f6e909f14873d35d411f4961db",
-                "sha256:061a41a3f96f076686d7f1cb87f3deec6f0c9f0325dcc054ac7b504ae9bb0d82",
-                "sha256:0eda7f61da6606a28b5efa5d8ad79b4b5bb242488e53a58993b2ec46c924ffee",
-                "sha256:13a7c6e3df8aa453583412de5725bf761217d06f66ff4ed776d44fbcd13ec4e4",
-                "sha256:185f0faf6c3d8f2203e8755f7ca16b8964d97da0abde89c367177a04e36f2568",
-                "sha256:2204a9d545fdbe0d9b0bf4d5e2fc67e7977de59666f7131c1433fde292fc3b41",
-                "sha256:27c53aa2f46d42940ccdcb015fd525a42bf73f94acd886296794a41f229d5946",
-                "sha256:3c293c5c0e1cabe59c33e0d02fcee5c3eb365f79a20b8199a26ca784e406bd0d",
-                "sha256:3e42b1c3f4fd863323a8275c52c78681281a8f2e1790f0e869d911c1c7b25c46",
-                "sha256:3e5540b7d703774fd171b7a7dc2a3cb70e98fc273b8b260b1bf2f7d3928f125b",
-                "sha256:4477930451521ac7da97cc31d49f7b83086d5ae76e52baf16aac659053119f6d",
-                "sha256:475b6e371cdbeb024f2302e826222bdc202186531f6dc095e8986c034e4b7961",
-                "sha256:489c4c46fcbd9364f60ff0dcb93ec9026eca64b2f43dc3b05d0724092f205e27",
-                "sha256:509a8d39b64a5e8d473f3f3db981f3ca603d27d2bc023c482605c1b52ec15662",
-                "sha256:58331d2766e8e409360154d3178449d116220348d46386430097e63d02a1b6d2",
-                "sha256:59a96d499ff6faa9b85b1309f50bf3744eb786e24833f7b500cbb7052dc4ae29",
-                "sha256:6cb8f9a1db47017929634264b3fc7ea4c1a42a3e28d67a14f14aa7b71deaa0d2",
-                "sha256:6d678475fdeb11394dc9aaa5c564213a1567cc663082e0ee85d52f78d1fbaab2",
-                "sha256:72a93445937cc71f0b8372b0c9e7c185328e0db5e94d06383a1cb56705df1df4",
-                "sha256:76cf472c79d15dce5f438a4905a1309be57d2d01bc1de2de30bda61972a79ab4",
-                "sha256:7b4547a2f624a537e90fb99cec4d8b3b6be4af3f449c3477155aae65396724ad",
-                "sha256:7f2e4ebe0a000c5727ee04227cf0ff5ae612fe599f88d494216e695b1dac744d",
-                "sha256:8343536ea4ee15d6525e3e726bb49ffc3f2034f828a49237a36be96842c06e7c",
-                "sha256:8de7bde839d72d96e0c92e8d1fdb4862e89b8fc52514d14b101ca317d9bcf87c",
-                "sha256:90f611d4cdf82fb28837fe15c3940255755572a4edf4c72e2306dbce7dcb3092",
-                "sha256:9ad58724fabb429d1ebb6f334361f0a3b35f96be0e74bfca6f7de8530688b2df",
-                "sha256:a1393229c9c126dd1b4356338421e8882347347ab6fe3230cb7044edc813e424",
-                "sha256:a20fc9cccbda2a28e8db8cabf2f47fead7e9e49d317547af6bf86a7269e4b9a1",
-                "sha256:a69f6d8b639f2317ba54278b64fef51d8250ad2c87acac1408b9cc461e4d6bb6",
-                "sha256:a6f51ffbdcf865f140f55c484001415505f5e68eb0a9eab1d37d0743b503b423",
-                "sha256:c9552ee9e123b7997c7630fb95c466ee816d19e721c67e4da35351c5f4032726",
-                "sha256:cd423d49abcf0ebf02c29c3daffe246ff756addb891f8aab717b3a4e2e1fd675",
-                "sha256:d0587d238b7867544134f4dcca19328371b8fd03fc2c56d15786f410792d0a68",
-                "sha256:d1f2d91c9c6cd54d750fa34f18bd73c71b372d0e6d06843bc7a5f21f5fd66fe0",
-                "sha256:d743b03a72fefed807a4512c079fb1aa5e7777036cc7a4b6ff79ae4650a14f73",
-                "sha256:dd4b9251e95020c3d5d104b528dbf53629d09c146ce9c8dfaaf8f619ae1cce35",
-                "sha256:e4988d94962f517f6da2d52337170b84856905b31b7dc504ed9c7b7e4bab2fc3",
-                "sha256:e6a923d2dec50f2b4d41ce198af3516517f2e458220942cf393839d2f9e22000",
-                "sha256:e8c8764226daad39004b7873c3880eb4860c594ff549ea47c045cdf313e1bad5"
+                "sha256:042f2381118b093714081fd82c98e3b189b68db38ee7d35b63c327c470ef8373",
+                "sha256:0ec9653825f837fbddc4e4b603d90269b501486c11800d7c761eee7ce46d1bbb",
+                "sha256:12175ca6b4db7621aedd7c30aa7cfa0a2d65ea3a0105393e05482d7a2d367446",
+                "sha256:1592f68ae11e557b9ff2bc96ac8fc30b187e77c45a3c9cd876e3368c53dc5ba8",
+                "sha256:23ac41d52fd15dd8be77e3257bc51bbb82469cf7f5e9a30b75e903e21439d16c",
+                "sha256:424d23b97fa1542d7be882eae0c0fc3d6827784105264a8169a26ce16db260d8",
+                "sha256:4407b1435572e3e1610797c9203ad2753666c62883b921318c5403fb7139dec2",
+                "sha256:48f4d38cf4b462e75fac78b6f11ad47b06b1c568eb59896db5b6ec1094eb467f",
+                "sha256:4c3d7dfd897a588ec27e391edbe3dd320a03684457470415870254e714126b1f",
+                "sha256:5171eb073474a5038321409a630904fd61f12dd1856dd7e9d19cd6fe092cbbc5",
+                "sha256:5a158846d0fca0a908c1afb281ddba88744d403f2550dc34405c3691769cdd85",
+                "sha256:6ee934f023f875ec2cfd2b05a937bd817efcc6c4c3f55c5778cbf78e58362ddc",
+                "sha256:790c1d9d8f9c92819c31ea660cd43c3d5451df1df61e2e814a6f99cebb292788",
+                "sha256:809fe3bf1a91393abc7e92d607976bbb8586512913a79f2bf7d7ec15bd8ea518",
+                "sha256:87b690bbee9876163210fd3f500ee59f5803e4a6607d1b1238833b8885ebd410",
+                "sha256:89086c9d3490a0f265a3c4b794037a84541ff5ffa28bb9c24cc9f66566968464",
+                "sha256:99856d6c98a326abbcc2363827e16bd6044f70f2ef42f453c0bd5440c4ce24e5",
+                "sha256:aab584725afd10c710b8f1e6e208dbee2d0ad009f57d674cb9d1b3964037275d",
+                "sha256:af169ba897692e9cd984a81cb0f02e46dacdc07d6cf9fd5c91e81f8efaf93d52",
+                "sha256:b39b8711578dcfd45fc0140993403b8a81e879ec25d53189f3faa1f006087dca",
+                "sha256:b3f543ae9d3408549a9900720f18c0194ac0fe810cecda2a584fd4dca2eb3bb8",
+                "sha256:d0583b75f2e70ec93f100931660328965bb9ff65ae54695fb3fa0a1255daa6f2",
+                "sha256:dfbbbf0809a3606046a41f8561c3eada9db811be94138f42d9135a5c47e75f6f",
+                "sha256:e538f2d4a6ffb6edfb303ce70ae7e88629ac6e5581870e66c306d9ad7b564a58",
+                "sha256:eba51599370c87088d8882ab74f637de0c4f04a6d08a312dce49368ba9ed5c2a",
+                "sha256:ee4b43f35f5dc15e1fec55ccb53c130adb1d11e8ad8263d68b1284b66a04190d",
+                "sha256:f2363e5fd81afb650085c6686f2ee3706975c54f331b426800b53531191fdf28",
+                "sha256:f299c020c6679cb389814a3b81200fe55d428012c5e76da7e722491f5d205990",
+                "sha256:f72f23bab1848edb7472309e9898603141644faec9fd57a823ea6b4d1c4c8995",
+                "sha256:fa90bac61c9dc3e1a563e5babb3fd2c0c1c80567e815442ddbe561eadc803b30"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==5.5.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0"
         }
     },
     "develop": {
-        "attrs": {
-            "hashes": [
-                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
-                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==22.1.0"
-        },
         "autopep8": {
             "hashes": [
-                "sha256:8b1659c7f003e693199f52caffdc06585bb0716900bbc6a7442fd931d658c077",
-                "sha256:ad924b42c2e27a1ac58e432166cc4588f5b80747de02d0d35b1ecbd3e7d57207"
+                "sha256:86e9303b5e5c8160872b2f5ef611161b2893e9bfe8ccc7e2f76385947d57a2f1",
+                "sha256:f9849cdd62108cb739dbcdbfb7fdcc9a30d1b63c4cc3e1c1f893b5360941b61c"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==2.0.2"
         },
         "iniconfig": {
             "hashes": [
-                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
             ],
-            "version": "==1.1.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
+                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1"
         },
         "pluggy": {
             "hashes": [
-                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
-                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+                "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849",
+                "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.0.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.0"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
-                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
+                "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053",
+                "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.9.1"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
-            ],
-            "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
+            "version": "==2.10.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71",
-                "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"
+                "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
+                "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
             ],
             "index": "pypi",
-            "version": "==7.2.0"
-        },
-        "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.1"
+            "version": "==7.4.0"
         }
     }
 }

--- a/python/auto_schema/auto_schema/compare.py
+++ b/python/auto_schema/auto_schema/compare.py
@@ -577,29 +577,33 @@ def _compare_indexes(autogen_context: AutogenContext,
 
         # pass
 
-    # for name, index in meta_indexes.items():
+    for name, index in meta_indexes.items():
 
-    #     # TODO this is for handling changes where we have to drop and re-create the index
+        # TODO this is for handling changes where we have to drop and re-create the index
 
-    #     # if index is there and postgresql_using changes, drop the index and add it again
-    #     # should hopefully be a one-time migration change...
-    #     # if name in conn_indexes and isinstance(index, sa.Index):
-    #     #     meta_postgresql_using = index.kwargs.get('postgresql_using')
-    #     #     conn_idx = conn_indexes[name]
-    #     #     print(conn_idx.expressions)
-    #     #     conn_postgresql_using = normalize_clause_text(
-    #     #         conn_idx.expressions[0], None)
-    #     #     # conn_postgresql_using = all_conn_indexes.get(
-    #     #     #     name, {}).get('postgresql_using')
-    #     #     if isinstance(meta_postgresql_using, str) and conn_postgresql_using is not None and meta_postgresql_using != conn_postgresql_using:
-    #     #         conn_index = conn_indexes[name]
-    #     #         conn_index.kwargs['postgresql_using'] = conn_postgresql_using
+        # if index is there and postgresql_using changes, drop the index and add it again
+        # should hopefully be a one-time migration change...
+        if name in conn_indexes and isinstance(index, sa.Index):
+            meta_postgresql_using = index.kwargs.get('postgresql_using')
+            conn_idx = conn_indexes[name]
+            # print(conn_idx.expressions)
+            # conn_postgresql_using = normalize_clause_text(
+            #     conn_idx.expressions[0], None)
+            # using this still works
+            # print(conn_idx.kwargs.get('postgresql_using'), conn_idx.)
+            # print(dir(conn_idx))
+            conn_postgresql_using = all_conn_indexes.get(
+                name, {}).get('postgresql_using')
+            # print(meta_postgresql_using, conn_postgresql_using)
+            if isinstance(meta_postgresql_using, str) and conn_postgresql_using is not None and meta_postgresql_using != conn_postgresql_using:
+                conn_index = conn_indexes[name]
+                conn_index.kwargs['postgresql_using'] = conn_postgresql_using
 
-    #     #         modify_table_ops.ops.append(
-    #     #             alembicops.DropIndexOp.from_index(conn_index))
+                modify_table_ops.ops.append(
+                    alembicops.DropIndexOp.from_index(conn_index))
 
-    #     #         modify_table_ops.ops.append(
-    #     #             alembicops.CreateIndexOp(name, index.table.name, index.columns, postgresql_using=index.kwargs.get('postgresql_using')))
+                modify_table_ops.ops.append(
+                    alembicops.CreateIndexOp(name, index.table.name, index.columns, postgresql_using=index.kwargs.get('postgresql_using')))
 
     #     # this is false since it'll always be there now
     #     # if not name in conn_indexes and isinstance(index, FullTextIndex):

--- a/python/auto_schema/auto_schema/compare.py
+++ b/python/auto_schema/auto_schema/compare.py
@@ -447,11 +447,8 @@ def _compare_indexes(autogen_context: AutogenContext,
                      metadata_table: sa.Table,
                      ):
 
-    # return
-
     raw_db_indexes = _get_raw_db_indexes(
         autogen_context, conn_table)
-    missing_conn_indexes = raw_db_indexes.get('missing')
     all_conn_indexes = raw_db_indexes.get('all')
     conn_indexes = {}
     meta_indexes = {}
@@ -466,54 +463,15 @@ def _compare_indexes(autogen_context: AutogenContext,
     if conn_table is not None:
         conn_indexes = {
             index.name: index for index in conn_table.indexes}
-        # for index in conn_table.indexes:
-        #     print('column', index.name, index.expressions,
-        #           isinstance(index, FullTextIndex))
-        #     if isinstance(index, FullTextIndex):
-        #         print(index.info)
-        # print(conn_table.indexes)
 
     if metadata_table is not None:
         meta_indexes = {
             index.name: index for index in metadata_table.indexes}
-        # print(metadata_table.indexes)
-        # for index in metadata_table.indexes:
-        #     print('meta', index.name, index.expressions,
-        #           isinstance(index, FullTextIndex))
 
-    # not getting this conn index from db. maybe related
-    # print('missing conn', missing_conn_indexes)
-    # print(metadata_table.indexes)
-
-    print('ops', modify_table_ops.ops)
-
-    for name, index in conn_indexes.items():
-        # has_expressions = len(index.expressions) == 1 and isinstance(
-        #     index.expressions[0], TextClause)
-        # full text index and not in meta index, drop it
-        # print("conn idx", name, is_full_text_index(index), name in meta_indexes)
-        if is_full_text_index(index) and not name in meta_indexes:
-            # if has_expressions or not name in meta_indexes and isinstance(index, FullTextIndex):
-            print("dropping idx", index.name)
-            # modify_table_ops.ops.append(
-            #     ops.DropFullTextIndexOp(
-            #         index.name,
-            #         index.table.name,
-            #         info=index.info,
-            #         table=conn_table,
-            #     )
-            # )
-
-    # for name, v in missing_conn_indexes.items():
-    #     if not name in meta_indexes:
-    #         modify_table_ops.ops.append(
-    #             ops.DropFullTextIndexOp(
-    #                 name,
-    #                 conn_table.name,
-    #                 table=conn_table,
-    #                 info=v,
-    #             )
-    #         )
+    # sqlalchemy correctly reflects these expressions now but
+    # alembic doesn't necessarily autogenerate these correctly so we go through
+    # and make the right changes to these FullText indexes
+    # https://github.com/sqlalchemy/alembic/issues/1098
 
     to_remove_list = []
     for i in range(len(modify_table_ops.ops)):
@@ -522,16 +480,11 @@ def _compare_indexes(autogen_context: AutogenContext,
             index = meta_indexes[op.index_name]
 
             if is_full_text_index(index):
-                # to_remove = name in missing_conn_indexes
-                # to_remove = name in conn_indexes
                 # automerge trying to add it again, remove it from here...
                 to_remove = op.index_name in conn_indexes
-                # to_remove = False
-                print("adding full text index", index, to_remove)
-                # TODO is this correct???
+
                 if to_remove:
                     to_remove_list.append(op)
-                    # modify_table_ops.ops.pop(i)
                 else:
                     modify_table_ops.ops[i] = ops.CreateFullTextIndexOp(
                         index.name,
@@ -545,14 +498,10 @@ def _compare_indexes(autogen_context: AutogenContext,
 
         if isinstance(op, alembicops.DropIndexOp) and op.index_name in conn_indexes:
             conn_index = conn_indexes.get(op.index_name, None)
-            # dropping index...
             if is_full_text_index(conn_index):
-                print("candidate to replace and drop", op.index_name, op.table_name, meta_indexes.get(
-                    op.index_name, None), conn_indexes.get(op.index_name, None))
-
+                # automerge trying to drop it again, remove it from here...
                 to_remove = op.index_name in meta_indexes
                 if to_remove:
-                    # modify_table_ops.ops.pop(i)
                     to_remove_list.append(op)
                 else:
                     conn_postgresql_using = normalize_clause_text(
@@ -575,26 +524,17 @@ def _compare_indexes(autogen_context: AutogenContext,
     for op in to_remove_list:
         modify_table_ops.ops.remove(op)
 
-        # pass
-
     for name, index in meta_indexes.items():
-
-        # TODO this is for handling changes where we have to drop and re-create the index
 
         # if index is there and postgresql_using changes, drop the index and add it again
         # should hopefully be a one-time migration change...
         if name in conn_indexes and isinstance(index, sa.Index):
             meta_postgresql_using = index.kwargs.get('postgresql_using')
-            conn_idx = conn_indexes[name]
-            # print(conn_idx.expressions)
-            # conn_postgresql_using = normalize_clause_text(
-            #     conn_idx.expressions[0], None)
-            # using this still works
-            # print(conn_idx.kwargs.get('postgresql_using'), conn_idx.)
-            # print(dir(conn_idx))
+
+            # TODO there's probably a better way to get this from the index now that sqlachemy is reflecting these
             conn_postgresql_using = all_conn_indexes.get(
                 name, {}).get('postgresql_using')
-            # print(meta_postgresql_using, conn_postgresql_using)
+
             if isinstance(meta_postgresql_using, str) and conn_postgresql_using is not None and meta_postgresql_using != conn_postgresql_using:
                 conn_index = conn_indexes[name]
                 conn_index.kwargs['postgresql_using'] = conn_postgresql_using
@@ -604,37 +544,6 @@ def _compare_indexes(autogen_context: AutogenContext,
 
                 modify_table_ops.ops.append(
                     alembicops.CreateIndexOp(name, index.table.name, index.columns, postgresql_using=index.kwargs.get('postgresql_using')))
-
-    #     # this is false since it'll always be there now
-    #     # if not name in conn_indexes and isinstance(index, FullTextIndex):
-    #     if is_full_text_index(index):
-
-    #         # TODO new logic for to_remove
-    #         # to_remove = name in missing_conn_indexes
-    #         # TODO is this correct???
-    #         to_remove = name in conn_indexes
-    #         idx = None
-    #         for i in range(len(modify_table_ops.ops)):
-    #             op = modify_table_ops.ops[i]
-    #             if isinstance(op, alembicops.CreateIndexOp) and op.index_name == index.name:
-    #                 idx = i
-    #                 break
-
-    #         # find existing create index op and replace with ours
-    #         if idx is not None:
-    #             # not in conn.indexes but in missing_conn_indexes,
-    #             # automerge not aware of it and tries to add it again so we need to remove it instead
-    #             if to_remove:
-    #                 modify_table_ops.ops.pop(idx)
-    #             else:
-    #                 modify_table_ops.ops[idx] = ops.CreateFullTextIndexOp(
-    #                     index.name,
-    #                     index.table.name,
-    #                     schema=schema,
-    #                     table=index.table,
-    #                     unique=index.unique,
-    #                     info=index.info,
-    #                 )
 
 
 index_regex = re.compile('CREATE INDEX (.+) USING (gin|btree)(.+)')

--- a/python/auto_schema/auto_schema/compare.py
+++ b/python/auto_schema/auto_schema/compare.py
@@ -31,8 +31,8 @@ def compare_edges(autogen_context, upgrade_ops, schemas):
 
         # get existing edges from db
         query = "SELECT * FROM assoc_edge_config"
-        for row in autogen_context.connection.execute(query):
-            edge = dict(row)
+        for row in autogen_context.connection.execute(sa.text(query)):
+            edge = row._asdict()
             existing_edges[edge['edge_name']] = edge
 
         db_edges[_get_schema_key(sch)] = existing_edges
@@ -127,18 +127,18 @@ def _table_exists(autogen_context: AutogenContext):
 
 
 def _execute_postgres_dialect(connection: sa.engine.Connection):
-    row = connection.execute(
+    row = connection.execute(sa.text(
         "SELECT to_regclass('%s') IS NOT NULL as exists" % (
-            "assoc_edge_config")
+            "assoc_edge_config"))
     )
-    res = row.first()
-    return res['exists']
+    res = row.first()._asdict()
+    return res["exists"]
 
 
 def _execute_sqlite_dialect(connection: sa.engine.Connection):
-    row = connection.execute(
+    row = connection.execute(sa.text(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='%s'" % (
-            "assoc_edge_config")
+            "assoc_edge_config"))
     )
     res = row.first()
     return res is not None
@@ -168,7 +168,7 @@ def _create_tuple_key(row, pkeys):
     return tuple(l)
 
 
-@comparators.dispatch_for('schema')
+@ comparators.dispatch_for('schema')
 def compare_data(autogen_context, upgrade_ops, schemas):
     # TODO not using schema correctly
     # https: // github.com/lolopinto/ent/issues/123
@@ -215,8 +215,8 @@ def _compare_db_values(autogen_context, upgrade_ops, table_name, pkeys, data_row
     query = 'SELECT * FROM %s' % table_name
 
     db_rows = {}
-    for row in connection.execute(query):
-        d = dict(row)
+    for row in connection.execute(sa.text(query)):
+        d = row._asdict()
         t = _create_tuple_key(d, pkeys)
         db_rows[t] = d
 
@@ -260,7 +260,7 @@ def _compare_db_values(autogen_context, upgrade_ops, table_name, pkeys, data_row
             table_name, pkeys, modified_new_rows, modified_old_rows))
 
 
-@comparators.dispatch_for("schema")
+@ comparators.dispatch_for("schema")
 def compare_schema(autogen_context, upgrade_ops, schemas):
     inspector = autogen_context.inspector
 
@@ -435,7 +435,7 @@ def _check_if_enum_values_changed(upgrade_ops, conn_column, metadata_column, sch
                 )
 
 
-@comparators.dispatch_for("table")
+@ comparators.dispatch_for("table")
 def _compare_indexes(autogen_context: AutogenContext,
                      modify_table_ops: alembicops.ModifyTableOps,
                      schema,
@@ -530,49 +530,53 @@ def _compare_indexes(autogen_context: AutogenContext,
 index_regex = re.compile('CREATE INDEX (.+) USING (gin|btree)(.+)')
 
 # this handles computed columns changing and so drops and re-creates the column.
-@comparators.dispatch_for("table")
+
+
+@ comparators.dispatch_for("table")
 def _compare_generated_column(autogen_context: AutogenContext,
-                     modify_table_ops: alembicops.ModifyTableOps,
-                     schema,
-                     tname: str,
-                     conn_table: Optional[sa.Table],
-                     metadata_table: Optional[sa.Table],
-                     ) -> None:
-    
+                              modify_table_ops: alembicops.ModifyTableOps,
+                              schema,
+                              tname: str,
+                              conn_table: Optional[sa.Table],
+                              metadata_table: Optional[sa.Table],
+                              ) -> None:
+
     if conn_table is None or metadata_table is None:
         return
-    
+
     col_to_index = {}
-    
+
     for idx in metadata_table.indexes:
         if len(idx.columns) == 1:
             col_to_index[idx.columns[0].name] = idx
 
-
     for conn_col in conn_table.columns:
         if not conn_col.computed:
             continue
-        
-        index = col_to_index.get(conn_col.name, None) 
+
+        index = col_to_index.get(conn_col.name, None)
         if index is None:
             continue
 
         index_type = index.kwargs.get('postgresql_using')
-        
+
         for meta_col in metadata_table.columns:
             if meta_col.name == conn_col.name and meta_col.computed is not None:
-        
-                conn_info = _parse_postgres_using_internals(str(conn_col.computed.sqltext), index_type)
-                meta_info =_parse_postgres_using_internals(str(meta_col.computed.sqltext), index_type)
-                
+
+                conn_info = _parse_postgres_using_internals(
+                    str(conn_col.computed.sqltext), index_type)
+                meta_info = _parse_postgres_using_internals(
+                    str(meta_col.computed.sqltext), index_type)
+
                 # this is using underlying columns so we use drop and create directly
                 if conn_info['columns'] != meta_info['columns']:
                     # we'll have to change the entire beh
-                    create_index = alembicops.CreateIndexOp(index.name, index.table.name, index.columns, postgresql_using=index_type)
+                    create_index = alembicops.CreateIndexOp(
+                        index.name, index.table.name, index.columns, postgresql_using=index_type)
 
                     modify_table_ops.ops.append(
                         alembicops.DropIndexOp(
-                            index.name, 
+                            index.name,
                             conn_table.name,
                             schema=schema,
                             info={
@@ -582,7 +586,7 @@ def _compare_generated_column(autogen_context: AutogenContext,
                             # also pass this here so that downgrade does the right thing
                             # TODO need to make sure we test upgrade/downgrade paths are the same.
                             postgresql_using=index_type,
-                            )
+                        )
                     )
                     modify_table_ops.ops.append(
                         alembicops.DropColumnOp.from_column_and_tablename(
@@ -594,12 +598,10 @@ def _compare_generated_column(autogen_context: AutogenContext,
                             schema, tname, meta_col
                         )
                     )
-                    
+
                     modify_table_ops.ops.append(
                         create_index
                     )
-
-
 
 
 # sqlalchemy doesn't reflect postgres indexes that have expressions in them so have to manually
@@ -647,8 +649,8 @@ def _get_raw_db_indexes(autogen_context: AutogenContext, conn_table: Optional[sa
 # use a cache so we only hit the db once for each table
 # @functools.lru_cache()
 def get_db_indexes_for_table(connection: sa.engine.Connection, tname: str):
-    res = connection.execute(
-        "SELECT indexname, indexdef from pg_indexes where tablename = '%s'" % tname)
+    res = connection.execute(sa.text(
+        "SELECT indexname, indexdef from pg_indexes where tablename = '%s'" % tname))
     return res
 
 
@@ -673,36 +675,37 @@ def _parse_cols_from(curr: str):
             cols.append(s2)
 
     return cols
-    
+
+
 sqltext_regex = re.compile(r"to_tsvector\((.+?), (.+)\)")
 
 
 # 3 is tricky
 # to_tsvector('english'::regconfig, ((((first_name || ' '::text) || last_name) || ' '::text) || (email_address)::text))
 def _parse_postgres_using_internals(internals: str, index_type: str):
-        # single-col to_tsvector('english'::regconfig, first_name)
-        # multi-col to_tsvector('english'::regconfig, ((first_name || ' '::text) || last_name))
-        m = sqltext_regex.match(internals)
-        if m:
-            groups = m.groups()
-            lang = groups[0].rstrip("::regconfig").strip("'")
+    # single-col to_tsvector('english'::regconfig, first_name)
+    # multi-col to_tsvector('english'::regconfig, ((first_name || ' '::text) || last_name))
+    m = sqltext_regex.match(internals)
+    if m:
+        groups = m.groups()
+        lang = groups[0].rstrip("::regconfig").strip("'")
 
-            cols = _parse_cols_from(groups[1])
+        cols = _parse_cols_from(groups[1])
 
-            if len(cols) > 0:
-                return {
-                    'columns': cols,
-                    'fulltext': {
-                        'language': lang,
-                        'indexType': index_type,
-                    }
-                }
-
-        cols = [col.strip() for col in internals.split(',')]
-        # multi-column index
-        if len(cols) > 1:
+        if len(cols) > 0:
             return {
                 'columns': cols,
+                'fulltext': {
+                    'language': lang,
+                    'indexType': index_type,
+                }
             }
 
-        return {}
+    cols = [col.strip() for col in internals.split(',')]
+    # multi-column index
+    if len(cols) > 1:
+        return {
+            'columns': cols,
+        }
+
+    return {}

--- a/python/auto_schema/auto_schema/env.py
+++ b/python/auto_schema/auto_schema/env.py
@@ -128,7 +128,7 @@ def run_migrations_online():
         include_object=runner.Runner.include_object,
         compare_server_default=runner.Runner.compare_server_default,
         render_item=runner.Runner.render_item,
-        transaction_per_migration=True
+        transaction_per_migration=True,
     )
 
     with context.begin_transaction():

--- a/python/auto_schema/auto_schema/env.py
+++ b/python/auto_schema/auto_schema/env.py
@@ -62,8 +62,9 @@ dictConfig(log_config)
 target_metadata = config.metadata
 
 # connection engine...
-#engine = config.engine
+engine = config.engine
 connection = config.connection
+
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
@@ -121,18 +122,22 @@ def run_migrations_online():
 
     """
 
-    context.configure(
-        connection=connection,
-        target_metadata=target_metadata,
-        compare_type=runner.Runner.compare_type,
-        include_object=runner.Runner.include_object,
-        compare_server_default=runner.Runner.compare_server_default,
-        render_item=runner.Runner.render_item,
-        transaction_per_migration=True,
-    )
+    # engine = engine_from_config(
+    #     config.get_section(config.config_ini_section), prefix='sa.')
 
-    with context.begin_transaction():
-        context.run_migrations()
+    with engine.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=runner.Runner.compare_type,
+            include_object=runner.Runner.include_object,
+            compare_server_default=runner.Runner.compare_server_default,
+            render_item=runner.Runner.render_item,
+            transaction_per_migration=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
 
 
 if context.is_offline_mode():

--- a/python/auto_schema/auto_schema/env.py
+++ b/python/auto_schema/auto_schema/env.py
@@ -122,9 +122,6 @@ def run_migrations_online():
 
     """
 
-    # engine = engine_from_config(
-    #     config.get_section(config.config_ini_section), prefix='sa.')
-
     with engine.connect() as connection:
         context.configure(
             connection=connection,

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -304,7 +304,7 @@ class Runner(object):
         connection = engine.connect()
 
         metadata = sa.MetaData()
-        metadata.reflect(connection)
+        metadata.reflect(bind=connection)
         if len(metadata.sorted_tables) != 0:
             raise Exception("to compare from base tables, cannot have any tables in database. have %d" % len(
                 metadata.sorted_tables))

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -46,8 +46,6 @@ class Runner(object):
         if sql is not None and sql.lower() != 'true':
             config.output_buffer = open(sql, 'w')
 
-        # TODO do we still want connection here?
-
         self.mc = MigrationContext.configure(
             connection=self.connection,
             # note that any change here also needs a comparable change in env.py

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -31,18 +31,22 @@ from . import util
 
 
 class Runner(object):
-    def __init__(self, metadata, connection, schema_path, args: Optional[Dict] = None):
+    def __init__(self, metadata, engine, connection, schema_path, args: Optional[Dict] = None):
         self.metadata = metadata
         self.schema_path = schema_path
+        self.engine = engine
         self.connection = connection
         self.args = args or {}
 
         config.metadata = self.metadata
+        config.engine = self.engine
         config.connection = connection
 
         sql = self.args.get('sql', None)
         if sql is not None and sql.lower() != 'true':
             config.output_buffer = open(sql, 'w')
+
+        # TODO do we still want connection here?
 
         self.mc = MigrationContext.configure(
             connection=self.connection,
@@ -62,7 +66,7 @@ class Runner(object):
         engine = sa.create_engine(args.engine)
         connection = engine.connect()
         metadata.bind = connection
-        return Runner(metadata, connection, args.schema, args=args.__dict__)
+        return Runner(metadata, engine, connection, args.schema, args=args.__dict__)
 
     @classmethod
     def fix_edges(cls, metadata, args):

--- a/python/auto_schema/auto_schema/script.py.mako
+++ b/python/auto_schema/auto_schema/script.py.mako
@@ -9,6 +9,7 @@ Create Date: ${create_date}
 """
 from alembic import op
 import sqlalchemy as sa
+import auto_schema
 ## TODO: for down commans when removing edges, we add "UUID()" which is broken and unncessary :(
 ## from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.dialects import postgresql

--- a/python/auto_schema/tests/command_test.py
+++ b/python/auto_schema/tests/command_test.py
@@ -15,7 +15,7 @@ import os
 
 # there doesn't seem to be an api for this
 def get_stamped_alembic_versions(r: runner.Runner):
-    return [row['version_num'] for row in r.get_connection().execute(sa.text('select * from alembic_version'))]
+    return [row._asdict()['version_num'] for row in r.get_connection().execute(sa.text('select * from alembic_version'))]
 
 
 def stash_new_files(r: runner.Runner, l: List[String], l2: List[String]):

--- a/python/auto_schema/tests/command_test.py
+++ b/python/auto_schema/tests/command_test.py
@@ -15,7 +15,7 @@ import os
 
 # there doesn't seem to be an api for this
 def get_stamped_alembic_versions(r: runner.Runner):
-    return [row['version_num'] for row in r.get_connection().execute('select * from alembic_version')]
+    return [row['version_num'] for row in r.get_connection().execute(sa.text('select * from alembic_version'))]
 
 
 def stash_new_files(r: runner.Runner, l: List[String], l2: List[String]):
@@ -142,7 +142,7 @@ def _create_parallel_changes(new_test_runner, metadata_with_table):
     assert len(files3c) == 3
 
     # reflect to reload
-    r3.metadata.reflect()
+    r3.metadata.reflect(bind=r3.get_connection())
 
     return {
         # most-recent runner
@@ -338,7 +338,7 @@ class CommandTest(object):
         testingutils.assert_num_files(r3, 3)
         testingutils.validate_metadata_after_change(r3, new_metadata)
 
-        r3.metadata.reflect()
+        r3.metadata.reflect(bind=r3.get_connection())
         if squash_raises:
             with pytest.raises(ValueError):
                 r3.squash(squash_val)
@@ -347,7 +347,7 @@ class CommandTest(object):
 
         # should be squashed down to X files after change
         testingutils.assert_num_files(r3, files_left)
-        r3.metadata.reflect()
+        r3.metadata.reflect(bind=r3.get_connection())
         testingutils.validate_metadata_after_change(r3, new_metadata)
 
 

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -90,22 +90,26 @@ class Postgres:
 class SQLite:
 
     def __init__(self) -> None:
-        self._conn = None
+        self._connInfo = None
 
     def _get_url(self, schema_path):
         return "sqlite:///%s/%s" % (schema_path, "foo.db")
         # return "sqlite:///bar.db"  # if you want a local file to inspect for whatever reason
 
     def create_connection(self, schema_path):
+        # no need to create a new connection if we already have one
+        if self._connInfo is not None:
+            return self._connInfo
+
         url = self._get_url(schema_path)
         engine = sa.create_engine(self._get_url(schema_path))
-        self._conn = engine.connect()
-        return ConnInfo(engine, url, self._conn)
-        # return [engine, self._conn]
+        conn = engine.connect()
+        self._connInfo = ConnInfo(engine, url, conn)
+        return self._connInfo
 
     def get_finalizer(self):
         def fn():
-            self._conn.close()
+            self._connInfo.connection.close()
 
         return fn
 

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -172,8 +172,8 @@ def new_test_runner(request):
             path = r.get_schema_path()
 
             # delete temp directory which was created
-            if os.path.isdir(path):
-                shutil.rmtree(path)
+            # if os.path.isdir(path):
+            #     shutil.rmtree(path)
 
         request.addfinalizer(delete_path)
 

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -172,8 +172,8 @@ def new_test_runner(request):
             path = r.get_schema_path()
 
             # delete temp directory which was created
-            # if os.path.isdir(path):
-            #     shutil.rmtree(path)
+            if os.path.isdir(path):
+                shutil.rmtree(path)
 
         request.addfinalizer(delete_path)
 

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from auto_schema import runner
 from typing import List
 
-from auto_schema.schema_item import FullTextIndex
+from auto_schema import schema_item
 from auto_schema import compare
 
 
@@ -41,7 +41,8 @@ class Postgres:
                                isolation_level='AUTOCOMMIT')
         self._globalEngine = engine
         self._globalConnection = engine.connect()
-        self._globalConnection.execute('CREATE DATABASE %s' % self._randomDB)
+        self._globalConnection.execute(
+            sa.text('CREATE DATABASE %s' % self._randomDB))
         engine = create_engine("%s/%s" %
                                (self._get_url(schema_path), self._randomDB))
         self._engine = engine
@@ -54,7 +55,8 @@ class Postgres:
             self._conn.close()
             self._engine.dispose()
 
-            self._globalConnection.execute('DROP DATABASE %s' % self._randomDB)
+            self._globalConnection.execute(
+                sa.text('DROP DATABASE %s' % self._randomDB))
             self._globalConnection.close()
             self._globalEngine.dispose()
 
@@ -694,13 +696,13 @@ def metadata_with_multi_column_index(metadata_with_table):
 def metadata_with_fulltext_search_index(metadata_with_table):
     sa.Table('accounts',
              metadata_with_table,
-             FullTextIndex("accounts_first_name_idx",
-                           info={
-                               'postgresql_using': 'gin',
-                               'postgresql_using_internals': "to_tsvector('english', first_name)",
-                               'column': 'first_name',
-                           }
-                           ),
+             schema_item.FullTextIndex("accounts_first_name_idx",
+                                       info={
+                                           'postgresql_using': 'gin',
+                                           'postgresql_using_internals': "to_tsvector('english', first_name)",
+                                           'column': 'first_name',
+                                       }
+                                       ),
              extend_existing=True
              )
     return metadata_with_table
@@ -709,13 +711,13 @@ def metadata_with_fulltext_search_index(metadata_with_table):
 def metadata_with_multicolumn_fulltext_search_index(metadata_with_table):
     sa.Table('accounts',
              metadata_with_table,
-             FullTextIndex("accounts_full_text_idx",
-                           info={
-                               'postgresql_using': 'gin',
-                               'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
-                               'columns': ['first_name', 'last_name'],
-                           }
-                           ),
+             schema_item.FullTextIndex("accounts_full_text_idx",
+                                       info={
+                                           'postgresql_using': 'gin',
+                                           'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
+                                           'columns': ['first_name', 'last_name'],
+                                       }
+                                       ),
              extend_existing=True
              )
     return metadata_with_table
@@ -726,13 +728,13 @@ def metadata_with_multicolumn_fulltext_search():
     metadata = metadata_with_base_table_restored()
     sa.Table('accounts',
              metadata,
-             FullTextIndex("accounts_full_text_idx",
-                           info={
-                               'postgresql_using': 'gin',
-                               'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
-                               'columns': ['first_name', 'last_name'],
-                           }
-                           ),
+             schema_item.FullTextIndex("accounts_full_text_idx",
+                                       info={
+                                           'postgresql_using': 'gin',
+                                           'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
+                                           'columns': ['first_name', 'last_name'],
+                                       }
+                                       ),
              extend_existing=True
              )
     return metadata
@@ -741,13 +743,13 @@ def metadata_with_multicolumn_fulltext_search():
 def metadata_with_multicolumn_fulltext_search_index_gist(metadata_with_table):
     sa.Table('accounts',
              metadata_with_table,
-             FullTextIndex("accounts_full_text_idx",
-                           info={
-                               'postgresql_using': 'gist',
-                               'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
-                               'columns': ['first_name', 'last_name'],
-                           }
-                           ),
+             schema_item.FullTextIndex("accounts_full_text_idx",
+                                       info={
+                                           'postgresql_using': 'gist',
+                                           'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
+                                           'columns': ['first_name', 'last_name'],
+                                       }
+                                       ),
              extend_existing=True
              )
     return metadata_with_table
@@ -756,13 +758,13 @@ def metadata_with_multicolumn_fulltext_search_index_gist(metadata_with_table):
 def metadata_with_multicolumn_fulltext_search_index_btree(metadata_with_table):
     sa.Table('accounts',
              metadata_with_table,
-             FullTextIndex("accounts_full_text_idx",
-                           info={
-                               'postgresql_using': 'btree',
-                               'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
-                               'columns': ['first_name', 'last_name'],
-                           }
-                           ),
+             schema_item.FullTextIndex("accounts_full_text_idx",
+                                       info={
+                                           'postgresql_using': 'btree',
+                                           'postgresql_using_internals': "to_tsvector('english', first_name || ' ' || last_name)",
+                                           'columns': ['first_name', 'last_name'],
+                                       }
+                                       ),
              extend_existing=True
              )
     return metadata_with_table
@@ -792,6 +794,7 @@ def metadata_with_generated_col_fulltext_search_index_gist(metadata_with_table):
 
     return metadata_with_table
 
+
 def metadata_with_generated_col_extra_col_fulltext_search_index(metadata_with_table):
     sa.Table('accounts', metadata_with_table,
              sa.Column('full_name', postgresql.TSVECTOR(), sa.Computed(
@@ -803,6 +806,7 @@ def metadata_with_generated_col_extra_col_fulltext_search_index(metadata_with_ta
 
     return metadata_with_table
 
+
 def metadata_with_generated_col_extra_col_fulltext_search_index_gist(metadata_with_table):
     sa.Table('accounts', metadata_with_table,
              sa.Column('full_name', postgresql.TSVECTOR(), sa.Computed(
@@ -813,7 +817,6 @@ def metadata_with_generated_col_extra_col_fulltext_search_index_gist(metadata_wi
              extend_existing=True)
 
     return metadata_with_table
-
 
 
 @ pytest.fixture
@@ -1322,6 +1325,7 @@ def metadata_with_enum_col():
 def metadata_with_server_default_changed_enum_type(metadata):
     return _metadata_with_server_default_changed(metadata, 'rainbow', 'accounts', 'violet')
 
+
 def metadata_with_uuid_col():
     metadata = sa.MetaData()
 
@@ -1332,8 +1336,10 @@ def metadata_with_uuid_col():
              )
     return metadata
 
+
 def metadata_with_server_default_changed_uuid_type(metadata):
     return _metadata_with_server_default_changed(metadata, 'other_id', 'accounts', FOLLOWERS_EDGE)
+
 
 def metadata_with_server_default_changed_uuid_type_in_practice(metadata):
     # in practice, we never have UUID objects but strings as uuid

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -63,22 +63,14 @@ class Postgres:
 
         return ConnInfo(engine, url, conn)
 
-        # self._engines.append(engine)
-        # conn = engine.connect()
-        # self._conns.append(conn)
-
-        # return [engine, conn]
-
     def get_finalizer(self):
         def fn():
-            # print('conn finalizer called')
             for conn in self._conns:
                 conn.close()
 
             for engine in self._engines:
                 engine.dispose()
 
-            # print(self._randomDB)
             self._globalConnection.execute(
                 sa.text('DROP DATABASE %s' % self._randomDB))
             self._globalConnection.close()
@@ -146,25 +138,8 @@ def new_test_runner(request):
             connection = prev_runner.get_connection()
             connection.commit()
 
+        # use a new connection for each runner
         info = dialect.create_connection(schema_path)
-        # engine = l[
-        # connection = l[1]
-        # bind here and then where else??
-        # metadata.bind = info.connection
-        # metadata.reflect(bind=info.connection)
-
-        # else:
-        #     # commit old conn
-        #     connection = prev_runner.get_connection()
-        #     connection.commit()
-        #     # connection.close()
-        #     # connection.dispose()
-
-        #     connection = dialect.create_connection(schema_path)
-        #     # print(connection)
-        #     metadata.bind = connection
-        #     metadata.reflect(bind=connection)
-        #     # request.addfinalizer(dialect.get_finalizer())
 
         r = runner.Runner(metadata, info.engine, info.connection, schema_path)
 

--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -684,14 +684,16 @@ class BaseTestRunner(object):
         conn = r.get_connection()
         conn.execute(sa.text('delete from assoc_edge_config'))
 
+        # commit in between. not 100% sure why we need it but we also do it in conftest.py
+        conn.commit()
+
         # validate edges fails because edges incorrect
         with pytest.raises(AssertionError):
             testingutils.validate_edges_from_metadata(
                 metadata_with_one_edge, r)
 
         # re-run again. it fixes
-        runner.Runner.fix_edges(metadata_with_one_edge, {
-                                'connection': r.connection})
+        runner.Runner.fix_edges(metadata_with_one_edge, {'connection': conn})
 
         # no changes
         testingutils.run_edge_metadata_script(

--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -10,6 +10,8 @@ from . import testingutils
 from auto_schema import runner
 from auto_schema import ops
 
+from typing import Any, Optional, Callable
+
 
 class BaseTestRunner(object):
 
@@ -1058,13 +1060,13 @@ class TestPostgresRunner(BaseTestRunner):
         'new_metadata_func, expected_diff',
         [
             (conftest.metadata_with_new_enum_value, 1),
-            # (conftest.metadata_with_multiple_new_enum_values, 2),
-            # (conftest.metadata_with_enum_value_before_first_pos, 1),
-            # (conftest.metadata_with_multiple_new_enum_values_at_diff_pos, 2),
-            # (conftest.metadata_with_multiple_new_values_before, 2),
+            (conftest.metadata_with_multiple_new_enum_values, 2),
+            (conftest.metadata_with_enum_value_before_first_pos, 1),
+            (conftest.metadata_with_multiple_new_enum_values_at_diff_pos, 2),
+            (conftest.metadata_with_multiple_new_values_before, 2),
         ]
     )
-    def test_enum_additions(self, new_test_runner, metadata_with_enum_type, new_metadata_func, expected_diff):
+    def test_enum_additions(self, new_test_runner: Callable[[Any, Optional[Any]], runner.Runner], metadata_with_enum_type, new_metadata_func, expected_diff):
         r = new_test_runner(metadata_with_enum_type)
         testingutils.run_and_validate_with_standard_metadata_tables(
             r, metadata_with_enum_type)
@@ -1081,7 +1083,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.validate_metadata_after_change(
             r2, metadata_with_enum_type)
 
-    @pytest.mark.usefixtures("metadata_with_enum_type")
+    @ pytest.mark.usefixtures("metadata_with_enum_type")
     def test_remove_enum_value(self, new_test_runner, metadata_with_enum_type):
         r = new_test_runner(metadata_with_enum_type)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1093,7 +1095,7 @@ class TestPostgresRunner(BaseTestRunner):
         with pytest.raises(ValueError, match="postgres doesn't support enum removals"):
             r2.compute_changes()
 
-    @pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.usefixtures("metadata_with_table")
     def test_remove_column(self, new_test_runner, metadata_with_table):
         r = new_test_runner(metadata_with_table)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1127,7 +1129,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 2)
         testingutils.validate_metadata_after_change(r2, new_metadata)
 
-    @pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.usefixtures("metadata_with_table")
     def test_add_multiple_cols(self, new_test_runner, metadata_with_table):
         r = new_test_runner(metadata_with_table)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1147,7 +1149,7 @@ class TestPostgresRunner(BaseTestRunner):
             assert change['change'] == ChangeType.ADD_COLUMN
             assert change['col'] in ['new_column', 'rainbow']
 
-    @pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.usefixtures("metadata_with_table")
     def test_new_enum_column_added_then_removed(self, new_test_runner, metadata_with_table):
         r = new_test_runner(metadata_with_table)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1210,7 +1212,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r3, 3)
         testingutils.validate_metadata_after_change(r3, metadata_with_table)
 
-    @pytest.mark.usefixtures("metadata_with_enum_type")
+    @ pytest.mark.usefixtures("metadata_with_enum_type")
     def test_drop_table_with_enum(self, new_test_runner, metadata_with_enum_type):
         r = new_test_runner(metadata_with_enum_type)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1238,13 +1240,13 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 2)
         testingutils.validate_metadata_after_change(r2, new_metadata)
 
-    @pytest.mark.usefixtures("metadata_with_arrays")
+    @ pytest.mark.usefixtures("metadata_with_arrays")
     def test_tables_with_arrays(self, new_test_runner, metadata_with_arrays):
         r = new_test_runner(metadata_with_arrays)
         testingutils.run_and_validate_with_standard_metadata_tables(
             r, metadata_with_arrays, new_table_names=['tbl'])
 
-    @pytest.mark.usefixtures("metadata_with_arrays")
+    @ pytest.mark.usefixtures("metadata_with_arrays")
     def test_change_array_index_type_explicit(self, new_test_runner, metadata_with_arrays):
         r = new_test_runner(metadata_with_arrays)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1273,7 +1275,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 2)
         testingutils.validate_metadata_after_change(r2, r2.get_metadata())
 
-    @pytest.mark.usefixtures("metadata_with_arrays")
+    @ pytest.mark.usefixtures("metadata_with_arrays")
     def test_change_array_index_type_no_explicit(self, new_test_runner, metadata_with_arrays):
         r = new_test_runner(metadata_with_arrays)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1303,7 +1305,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 2)
         testingutils.validate_metadata_after_change(r2, r2.get_metadata())
 
-    @pytest.mark.usefixtures("metadata_with_arrays")
+    @ pytest.mark.usefixtures("metadata_with_arrays")
     def test_change_array_index_type_implicit_explicit_btree(self, new_test_runner, metadata_with_arrays):
         r = new_test_runner(metadata_with_arrays)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1326,13 +1328,13 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 1)
         testingutils.validate_metadata_after_change(r2, r2.get_metadata())
 
-    @pytest.mark.usefixtures("metadata_with_json")
+    @ pytest.mark.usefixtures("metadata_with_json")
     def test_tables_with_json(self, new_test_runner, metadata_with_json):
         r = new_test_runner(metadata_with_json)
         testingutils.run_and_validate_with_standard_metadata_tables(
             r, metadata_with_json, new_table_names=['tbl'])
 
-    @pytest.mark.usefixtures("metadata_with_json")
+    @ pytest.mark.usefixtures("metadata_with_json")
     def test_change_jsonb_index_type_explicit(self, new_test_runner, metadata_with_json):
         r = new_test_runner(metadata_with_json)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1361,7 +1363,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 2)
         testingutils.validate_metadata_after_change(r2, r2.get_metadata())
 
-    @pytest.mark.usefixtures("metadata_with_json")
+    @ pytest.mark.usefixtures("metadata_with_json")
     def test_change_jsonb_index_type_no_explicit(self, new_test_runner, metadata_with_json):
         r = new_test_runner(metadata_with_json)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1391,7 +1393,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 2)
         testingutils.validate_metadata_after_change(r2, r2.get_metadata())
 
-    @pytest.mark.usefixtures("metadata_with_json")
+    @ pytest.mark.usefixtures("metadata_with_json")
     def test_change_jsonb_index_type_implicit_explicit_btree(self, new_test_runner, metadata_with_json):
         r = new_test_runner(metadata_with_json)
         testingutils.run_and_validate_with_standard_metadata_tables(
@@ -1414,7 +1416,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r2, 1)
         testingutils.validate_metadata_after_change(r2, r2.get_metadata())
 
-    @pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.usefixtures("metadata_with_table")
     def test_full_text_index_added_and_removed(self, new_test_runner, metadata_with_table):
         testingutils.make_changes_and_restore(
             new_test_runner,
@@ -1426,18 +1428,18 @@ class TestPostgresRunner(BaseTestRunner):
             validate_schema=False
         )
 
-    @pytest.mark.usefixtures("metadata_with_multicolumn_fulltext_search")
+    @ pytest.mark.usefixtures("metadata_with_multicolumn_fulltext_search")
     # TODO this is failed because of index comparisons
     # this doesn't work because indexes are wrong. why we have validate false in
     # make_changes_and_restore
-    @pytest.mark.xfail()
+    @ pytest.mark.xfail()
     def test_multi_col_full_text_create(self, new_test_runner, metadata_with_multicolumn_fulltext_search):
         r = new_test_runner(
             metadata_with_multicolumn_fulltext_search)
         testingutils.run_and_validate_with_standard_metadata_tables(
             r, metadata_with_multicolumn_fulltext_search)
 
-    @pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.usefixtures("metadata_with_table")
     def test_multi_col_full_text_index_added_and_removed(self, new_test_runner, metadata_with_table):
         testingutils.make_changes_and_restore(
             new_test_runner,
@@ -1449,8 +1451,8 @@ class TestPostgresRunner(BaseTestRunner):
             validate_schema=False
         )
 
-    @pytest.mark.usefixtures("metadata_with_table")
-    @pytest.mark.xfail()
+    @ pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.xfail()
     # not sure why this fails for gist but not gin|btree
     # TODO https://github.com/lolopinto/ent/issues/848
     def test_multi_col_full_text_index_added_and_removed_gist(self, new_test_runner, metadata_with_table):
@@ -1464,7 +1466,7 @@ class TestPostgresRunner(BaseTestRunner):
             validate_schema=False
         )
 
-    @pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.usefixtures("metadata_with_table")
     def test_multi_col_full_text_index_added_and_removed_btree(self, new_test_runner, metadata_with_table):
         testingutils.make_changes_and_restore(
             new_test_runner,
@@ -1476,7 +1478,7 @@ class TestPostgresRunner(BaseTestRunner):
             validate_schema=False
         )
 
-    @pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.usefixtures("metadata_with_table")
     def test_full_text_index_with_generated_column(self, new_test_runner, metadata_with_table):
         testingutils.make_changes_and_restore(
             new_test_runner,
@@ -1488,8 +1490,8 @@ class TestPostgresRunner(BaseTestRunner):
             validate_schema=False
         )
 
-    @pytest.mark.usefixtures("metadata_with_table")
-    @pytest.mark.parametrize(
+    @ pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.parametrize(
         'metadata_func, metadata_func_extra_col',
         [
             (conftest.metadata_with_generated_col_fulltext_search_index_gist,
@@ -1555,7 +1557,7 @@ class TestPostgresRunner(BaseTestRunner):
         testingutils.assert_num_files(r4, 4)
         testingutils.assert_num_tables(r4, 2, ['accounts', 'alembic_version'])
 
-    @pytest.mark.usefixtures("metadata_with_table")
+    @ pytest.mark.usefixtures("metadata_with_table")
     def test_full_text_index_with_generated_column_gist(self, new_test_runner, metadata_with_table):
         testingutils.make_changes_and_restore(
             new_test_runner,

--- a/python/auto_schema/tests/testingutils.py
+++ b/python/auto_schema/tests/testingutils.py
@@ -60,8 +60,8 @@ def validate_edges_from_metadata(metadata: sa.MetaData, r: runner.Runner):
         edges_from_metadata = edges_from_metadata['public']
 
     db_edges = {}
-    for row in r.get_connection().execute("SELECT * FROM assoc_edge_config"):
-        row_dict = dict(row)
+    for row in r.get_connection().execute(sa.text("SELECT * FROM assoc_edge_config")):
+        row_dict = row._asdict()
         db_edges[row_dict['edge_name']] = row_dict
 
     # same number of edges
@@ -100,8 +100,8 @@ def validate_data_from_metadata(metadata: sa.MetaData, r: runner.Runner):
 
         db_rows = []
         db_keys = []
-        for row in r.get_connection().execute('SELECT * FROM %s' % table_name):
-            row_dict = dict(row)
+        for row in r.get_connection().execute(sa.text('SELECT * FROM %s' % table_name)):
+            row_dict = row._asdict()
             if len(db_keys) == 0:
                 db_keys = row_dict.keys()
             db_rows.append(row_dict)
@@ -168,8 +168,7 @@ def new_runner_from_old(prev_runner: runner.Runner, new_test_runner, new_metadat
 
 
 def recreate_metadata_fixture(new_test_runner, metadata: sa.MetaData, prev_runner: runner.Runner) -> runner.Runner:
-    metadata.bind = prev_runner.get_connection()
-    metadata.reflect()
+    metadata.reflect(bind=prev_runner.get_connection())
 
     r = new_test_runner(metadata, prev_runner)
     return r
@@ -224,7 +223,7 @@ def _validate_columns(schema_table: sa.Table, db_table: sa.Table, metadata: sa.M
 
 def _validate_column(schema_column: sa.Column, db_column: sa.Column, metadata: sa.MetaData, dialect: String):
     assert schema_column != db_column
-    assert(id(schema_column)) != id(db_column)
+    assert (id(schema_column)) != id(db_column)
 
     assert schema_column.name == db_column.name
     _validate_column_type(schema_column, db_column, metadata, dialect)
@@ -308,7 +307,7 @@ def _validate_column_type_impl(schema_column_type, db_column_type, metadata: sa.
 
 def _validate_enum_column_type(metadata: sa.MetaData, db_column: sa.Column, schema_column: sa.Column):
     # has to be same length
-    assert(len(schema_column.type.enums) == len(db_column.type.enums))
+    assert (len(schema_column.type.enums) == len(db_column.type.enums))
 
     # if equal, nothing to do here, we're done
     if schema_column.type.enums == db_column.type.enums:
@@ -319,8 +318,8 @@ def _validate_enum_column_type(metadata: sa.MetaData, db_column: sa.Column, sche
     # https://www.postgresql.org/docs/9.5/functions-enum.html
     query = "select unnest(enum_range(enum_first(null::%s)));" % (
         db_column.type.name)
-    for row in metadata.bind.execute(query):
-        db_sorted_enums.append(dict(row)['unnest'])
+    for row in metadata.bind.execute(sa.text(query)):
+        db_sorted_enums.append(row._asdict()['unnest'])
 
     assert schema_column.type.enums == db_sorted_enums
 
@@ -472,6 +471,7 @@ def make_changes_and_restore(
         new_test_runner, conftest.metadata_with_base_table_restored(), r2)
 
     message = r3.revision_message()
+    print(message, r3_message)
     assert message == r3_message
 
     r3.run()

--- a/python/auto_schema/tests/testingutils.py
+++ b/python/auto_schema/tests/testingutils.py
@@ -446,6 +446,8 @@ def make_changes_and_restore(
         r, new_test_runner, metadata_with_table, metadata_change_func)
 
     message = r2.revision_message()
+    print(message, r2_message)
+
     assert message == r2_message
 
     r2.run()
@@ -471,7 +473,7 @@ def make_changes_and_restore(
         new_test_runner, conftest.metadata_with_base_table_restored(), r2)
 
     message = r3.revision_message()
-    print(message, r3_message)
+    print("message", message, "r3_message", r3_message)
     assert message == r3_message
 
     r3.run()

--- a/python/auto_schema/tests/testingutils.py
+++ b/python/auto_schema/tests/testingutils.py
@@ -446,8 +446,6 @@ def make_changes_and_restore(
         r, new_test_runner, metadata_with_table, metadata_change_func)
 
     message = r2.revision_message()
-    print(message, r2_message)
-
     assert message == r2_message
 
     r2.run()
@@ -473,7 +471,6 @@ def make_changes_and_restore(
         new_test_runner, conftest.metadata_with_base_table_restored(), r2)
 
     message = r3.revision_message()
-    print("message", message, "r3_message", r3_message)
     assert message == r3_message
 
     r3.run()


### PR DESCRIPTION
and make a bunch of changes to how things work because of that

* connection.execute() doesn't take string anymore. have to wrap in `sa.text()`
* `env.py`, wrap context configuration in `engine.connect()` 
* use `row._asdict()` to get rows whenever we query
* change tests to use new connections in `conftest.py` anytime we use `new_test_runner`
* change how we do full text indices logic since sqlalchemy added support for expression-based indices https://github.com/sqlalchemy/sqlalchemy/issues/7442
alembic still doesn't do it so still need to handle it https://github.com/sqlalchemy/alembic/issues/1098

Test Plan:
pytest

for example, delete the db and run upgrade and confirm it works

in examples/simple, `dropdb tsent_test`, `createdb tsent_test` and then `LOCAL_AUTO_SCHEMA=true tsent upgrade`
in examples/ent-rsvp/backend, `dropdb ent-rsvp`, `createdb ent-rsvp` and then `LOCAL_AUTO_SCHEMA=true tsent upgrade`
in examples/todo-sqlite, `rm todo.db` and then `LOCAL_AUTO_SCHEMA=true DB_CONNECTION_STRING=sqlite:///todo.db tsent codegen`
