### PR TITLE
new v0.1.0 docker release

### DIFF
--- a/release_image/main.go
+++ b/release_image/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 // next tag to use
-const TAG = "0.1.0-rc1"
+const TAG = "0.1.0"
 
 // current node gets latest tag...
 const CURRENT_NODE_VERSION = 18
@@ -33,7 +33,7 @@ var NODE_VERSIONS = []int{
 }
 
 const AUTO_SCHEMA_VERSION = "0.0.28"
-const TSENT_VERSION = "v0.1.0-rc1"
+const TSENT_VERSION = "v0.1.0"
 
 var SUFFIXES = []string{
 	"dev",


### PR DESCRIPTION
remove the alpha. it's been in production for almost a year. should be v1.0 based on semver but still have so many things to add, doesn't feel v1.0 yet