### PR TITLE
ability to specify subscription type in graphql schema

### DIFF
--- a/examples/simple/ent.yml
+++ b/examples/simple/ent.yml
@@ -26,6 +26,9 @@ codegen:
     name: ExampleViewer
     # this is just to show that it works and fine with example code looking 👀
     alias: ExampleViewerAlias
+  subscriptionType:
+    path: src/graphql/resolvers/subscription_type
+    name: SubscriptionType
   userOverridenFiles:
     - src/ent/generated/user_base.ts
     - src/graphql/generated/resolvers/user_type.ts

--- a/examples/simple/src/graphql/generated/schema.ts
+++ b/examples/simple/src/graphql/generated/schema.ts
@@ -233,10 +233,12 @@ import {
   UserToMaybeEventsConnectionType,
   UserType,
 } from "../resolvers";
+import { SubscriptionType } from "../resolvers/subscription_type";
 
 export default new GraphQLSchema({
   query: QueryType,
   mutation: MutationType,
+  subscription: SubscriptionType,
   types: [
     CatBreedType,
     CommentSortColumnType,

--- a/examples/simple/src/graphql/resolvers/subscription_type.ts
+++ b/examples/simple/src/graphql/resolvers/subscription_type.ts
@@ -8,6 +8,7 @@ export const SubscriptionType = new GraphQLObjectType({
       type: GraphQLString,
       // this just tests a subscription type is generated
       // doesn't actually do the bells and whistles of subscriptions
+      // example here from graphql-ws and graphql-sse
       subscribe: async function* (src, args, ctx: RequestContext) {
         for (const hi of ["Hi", "Bonjour", "Hola", "Ciao", "Zdravo"]) {
           yield { greetings: hi };

--- a/examples/simple/src/graphql/resolvers/subscription_type.ts
+++ b/examples/simple/src/graphql/resolvers/subscription_type.ts
@@ -1,0 +1,18 @@
+import { RequestContext } from "@snowtop/ent";
+import { GraphQLObjectType, GraphQLString } from "graphql";
+
+export const SubscriptionType = new GraphQLObjectType({
+  name: "Subscription",
+  fields: () => ({
+    greetings: {
+      type: GraphQLString,
+      // this just tests a subscription type is generated
+      // doesn't actually do the bells and whistles of subscriptions
+      subscribe: async function* (src, args, ctx: RequestContext) {
+        for (const hi of ["Hi", "Bonjour", "Hola", "Ciao", "Zdravo"]) {
+          yield { greetings: hi };
+        }
+      },
+    },
+  }),
+});

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -378,6 +378,13 @@ func (cfg *Config) SchemaSQLFilePath() string {
 	return ""
 }
 
+func (cfg *Config) SubscriptionType() *codegenapi.ImportedObject {
+	if codegen := cfg.getCodegenConfig(); codegen != nil {
+		return codegen.SubscriptionType
+	}
+	return nil
+}
+
 func (cfg *Config) DatabaseToCompareTo() string {
 	if codegen := cfg.getCodegenConfig(); codegen != nil {
 		return codegen.DatabaseToCompareTo
@@ -604,6 +611,7 @@ type CodegenConfig struct {
 	DefaultGraphQLMutationName codegenapi.GraphQLMutationName   `yaml:"defaultGraphQLMutationName"`
 	DefaultGraphQLFieldFormat  codegenapi.GraphQLFieldFormat    `yaml:"defaultGraphQLFieldFormat"`
 	SchemaSQLFilePath          string                           `yaml:"schemaSQLFilePath"`
+	SubscriptionType           *codegenapi.ImportedObject       `yaml:"subscriptionType"`
 	DatabaseToCompareTo        string                           `yaml:"databaseToCompareTo"`
 	FieldPrivacyEvaluated      codegenapi.FieldPrivacyEvaluated `yaml:"fieldPrivacyEvaluated"`
 	TemplatizedViewer          *codegenapi.ImportedObject       `yaml:"templatizedViewer"`
@@ -633,6 +641,7 @@ func (cfg *CodegenConfig) Clone() *CodegenConfig {
 		DefaultGraphQLMutationName: cfg.DefaultGraphQLMutationName,
 		DefaultGraphQLFieldFormat:  cfg.DefaultGraphQLFieldFormat,
 		SchemaSQLFilePath:          cfg.SchemaSQLFilePath,
+		SubscriptionType:           cfg.SubscriptionType,
 		DatabaseToCompareTo:        cfg.DatabaseToCompareTo,
 		FieldPrivacyEvaluated:      cfg.FieldPrivacyEvaluated,
 		TemplatizedViewer:          cloneImportedObject(cfg.TemplatizedViewer),

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -3722,17 +3722,26 @@ func writeRootQueryFile(processor *codegen.Processor, rq *rootQuery) error {
 }
 
 func writeTSSchemaFile(processor *codegen.Processor, s *gqlSchema) error {
-	filePath := getTSSchemaFilePath(processor.Config)
-	imps := tsimport.NewImports(processor.Config, filePath)
+	cfg := processor.Config
+	filePath := getTSSchemaFilePath(cfg)
+	imps := tsimport.NewImports(cfg, filePath)
+
+	var subscription *tsimport.ImportPath
+	if obj := cfg.SubscriptionType(); obj != nil {
+		subscription = obj.GetImportPath()
+	}
+
 	return file.Write((&file.TemplatedBasedFileWriter{
 		Config: processor.Config,
 		Data: struct {
-			HasMutations bool
-			QueryPath    string
-			MutationPath string
-			AllTypes     []typeInfo
+			HasMutations           bool
+			SubscriptionImportPath *tsimport.ImportPath
+			QueryPath              string
+			MutationPath           string
+			AllTypes               []typeInfo
 		}{
 			s.hasMutations,
+			subscription,
 			getQueryImportPath(),
 			getMutationImportPath(),
 			s.allTypes,

--- a/internal/graphql/ts_templates/schema.tmpl
+++ b/internal/graphql/ts_templates/schema.tmpl
@@ -14,6 +14,10 @@ export default new {{useImport "GraphQLSchema"}}({
   {{if .HasMutations -}}
     mutation: {{useImport "MutationType"}},
   {{end -}}
+  {{ if .SubscriptionImportPath -}}
+    {{ reserveImportPath .SubscriptionImportPath false -}}
+    subscription: {{useImport .SubscriptionImportPath.Import }},
+  {{end -}}
   types: [
     {{range $typ := .AllTypes -}}
       {{ if $typ.Exported -}}


### PR DESCRIPTION
subscriptions are complicated and there's a lot involved in it and how it should be implemented. so we just provide a way for the user to implement it themselves with `GraphQLObjectType` and we include in generated schema

addresses part of https://github.com/lolopinto/ent/issues/1544. doubt we'd do more than this in the foreseeable future