### PR TITLE
allow enums to be args in custom queries and mutations

### DIFF
--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.0-rc1",
+        "@snowtop/ent": "^0.1.4",
         "@snowtop/ent-email": "^0.1.0-rc1",
         "@snowtop/ent-passport": "^0.1.0-rc1",
         "@snowtop/ent-password": "^0.1.0-rc1",
@@ -1233,9 +1233,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.0-rc1",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-rc1.tgz",
-      "integrity": "sha512-ln/fhvdyPthW7aTUeew9zSuGfs6bkgCuG7qEHHIU86u730GFnHyMjDN0I20rdBnC6VwoSmjKswvQg/fxaQxIWQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.4.tgz",
+      "integrity": "sha512-MSbFv09KK51fie6IrViiyg87JcV1S1NU1SoDh38QYUd7lWg2CnVfx5k++NQ6opbcqpNdQByTieHsSpISXX1ZGg==",
       "dependencies": {
         "@types/node": "^20.2.5",
         "camel-case": "^4.1.2",
@@ -7413,9 +7413,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.0-rc1",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.0-rc1.tgz",
-      "integrity": "sha512-ln/fhvdyPthW7aTUeew9zSuGfs6bkgCuG7qEHHIU86u730GFnHyMjDN0I20rdBnC6VwoSmjKswvQg/fxaQxIWQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.4.tgz",
+      "integrity": "sha512-MSbFv09KK51fie6IrViiyg87JcV1S1NU1SoDh38QYUd7lWg2CnVfx5k++NQ6opbcqpNdQByTieHsSpISXX1ZGg==",
       "requires": {
         "@types/node": "^20.2.5",
         "camel-case": "^4.1.2",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -33,7 +33,7 @@
     "tsconfig-paths": "^3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.0-rc1",
+    "@snowtop/ent": "^0.1.4",
     "@snowtop/ent-email": "^0.1.0-rc1",
     "@snowtop/ent-passport": "^0.1.0-rc1",
     "@snowtop/ent-password": "^0.1.0-rc1",

--- a/examples/simple/src/graphql/generated/mutations/bulk_upload_contact_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/bulk_upload_contact_type.ts
@@ -39,7 +39,7 @@ export const BulkUploadContactType: GraphQLFieldConfig<
     },
     defaultLabel: {
       description: "",
-      type: new GraphQLNonNull(ContactLabelType),
+      type: ContactLabelType,
     },
   },
   resolve: async (

--- a/examples/simple/src/graphql/generated/mutations/bulk_upload_contact_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/bulk_upload_contact_type.ts
@@ -12,13 +12,14 @@ import {
 import { GraphQLUpload } from "graphql-upload";
 import { RequestContext } from "@snowtop/ent";
 import { mustDecodeIDFromGQLID } from "@snowtop/ent/graphql";
-import { UserType } from "../../resolvers";
+import { ContactLabelType, UserType } from "../../resolvers";
 import { ExampleViewer as ExampleViewerAlias } from "../../../viewer/viewer";
 import { ImportContactResolver } from "../../mutations/import_contact";
 
 interface BulkUploadContactArgs {
   userID: any;
   file: any;
+  defaultLabel: any;
 }
 
 export const BulkUploadContactType: GraphQLFieldConfig<
@@ -36,6 +37,10 @@ export const BulkUploadContactType: GraphQLFieldConfig<
       description: "",
       type: new GraphQLNonNull(GraphQLUpload),
     },
+    defaultLabel: {
+      description: "",
+      type: new GraphQLNonNull(ContactLabelType),
+    },
   },
   resolve: async (
     _source,
@@ -48,6 +53,7 @@ export const BulkUploadContactType: GraphQLFieldConfig<
       context,
       mustDecodeIDFromGQLID(args.userID),
       args.file,
+      args.defaultLabel,
     );
   },
 };

--- a/examples/simple/src/graphql/generated/schema.gql
+++ b/examples/simple/src/graphql/generated/schema.gql
@@ -1438,7 +1438,7 @@ type Query {
 
 type Mutation {
   addressCreate(input: AddressCreateInput!): AddressCreatePayload!
-  bulkUploadContact(userID: ID!, file: Upload!): User!
+  bulkUploadContact(userID: ID!, file: Upload!, defaultLabel: ContactLabel!): User!
   commentCreate(input: CommentCreateInput!): CommentCreatePayload!
   commentEdit(input: CommentEditInput!): CommentEditPayload!
   confirmEmailAddressEdit(input: ConfirmEditEmailAddressInput!): ConfirmEditEmailAddressPayload!

--- a/examples/simple/src/graphql/generated/schema.gql
+++ b/examples/simple/src/graphql/generated/schema.gql
@@ -1438,7 +1438,7 @@ type Query {
 
 type Mutation {
   addressCreate(input: AddressCreateInput!): AddressCreatePayload!
-  bulkUploadContact(userID: ID!, file: Upload!, defaultLabel: ContactLabel!): User!
+  bulkUploadContact(userID: ID!, file: Upload!, defaultLabel: ContactLabel): User!
   commentCreate(input: CommentCreateInput!): CommentCreatePayload!
   commentEdit(input: CommentEditInput!): CommentEditPayload!
   confirmEmailAddressEdit(input: ConfirmEditEmailAddressInput!): ConfirmEditEmailAddressPayload!

--- a/examples/simple/src/graphql/mutations/import_contact.ts
+++ b/examples/simple/src/graphql/mutations/import_contact.ts
@@ -34,6 +34,7 @@ export class ImportContactResolver {
       {
         name: "defaultLabel",
         type: "ContactLabel",
+        nullable: true,
       },
     ],
     async: true,

--- a/examples/simple/src/graphql/mutations/import_contact.ts
+++ b/examples/simple/src/graphql/mutations/import_contact.ts
@@ -31,6 +31,10 @@ export class ImportContactResolver {
         name: "file",
         type: gqlFileUpload,
       },
+      {
+        name: "defaultLabel",
+        type: "ContactLabel",
+      },
     ],
     async: true,
   })
@@ -38,6 +42,7 @@ export class ImportContactResolver {
     context: RequestContext<ExampleViewer>,
     userID: ID,
     file: Promise<FileUpload>,
+    label?: ContactLabel,
   ) {
     const file2 = await file;
 
@@ -61,7 +66,7 @@ export class ImportContactResolver {
           emails: [
             {
               emailAddress: record.emailAddress,
-              label: ContactLabel.Default,
+              label: label ?? ContactLabel.Default,
             },
           ],
           userID: user.id,

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/graphql/graphql.test.ts
+++ b/ts/src/graphql/graphql.test.ts
@@ -909,7 +909,7 @@ describe("function", () => {
     } catch (error) {
       // TODO need a better message here
       expect(error.message).toMatch(
-        /arg searchArgs of field search needs resolving. should not be possible/,
+        /arg searchArgs of field search with type SearchArgs needs resolving. should not be possible/,
       );
     }
     validateNoCustom(CustomObjectTypes.Field);

--- a/ts/src/graphql/graphql.ts
+++ b/ts/src/graphql/graphql.ts
@@ -804,6 +804,9 @@ export class GQLCapture {
     let baseArgs = new Map<string, boolean>();
     this.customArgs.forEach((_val, key) => baseArgs.set(key, true));
     this.customInputObjects.forEach((_val, key) => baseArgs.set(key, true));
+    // add all objects as arg types because it can include enums
+    // depend on graphql to throw error if it's not a valid input type
+    objects.map((object) => baseArgs.set(object, true));
     baseArgs.set("Context", true);
     this.customTypes.forEach((_val, key) => baseArgs.set(key, true));
 
@@ -831,7 +834,7 @@ export class GQLCapture {
               arg.needsResolving = false;
             } else {
               throw new Error(
-                `arg ${arg.name} of field ${field.functionName} needs resolving. should not be possible`,
+                `arg ${arg.name} of field ${field.functionName} with type ${arg.type} needs resolving. should not be possible`,
               );
             }
           }


### PR DESCRIPTION
accompaniment to https://github.com/lolopinto/ent/pull/1567/files

even after passing global enums to be resolved, we still need to allow it as valid argument

this also allows nodes as argument but the resulting schema will be invalid so that's fine

long-term, we can address this by changing data sent down if this becomes an issue