### PR TITLE
fix optional in action only field not being serialized well

### DIFF
--- a/internal/schema/input/input.go
+++ b/internal/schema/input/input.go
@@ -748,9 +748,11 @@ func (f *ActionField) MarshalJSON() ([]byte, error) {
 	var af actionField
 	af.List = f.list
 	af.Name = f.Name
+	af.Optional = f.Optional
 	af.ActionName = f.ActionName
 	af.Type = f.Type
 	af.ExcludedFields = f.ExcludedFields
+	af.HideFromGraphQL = f.HideFromGraphQL
 
 	if f.Nullable && f.nullableContents {
 		af.Nullable = NullableContentsAndList


### PR DESCRIPTION
was debugging something and saw that `CreateHolidayAction` in examples/simple seemed to always be modified

tracked it down to this field not being saved properly in `.ent/schema.json` because of the weird serialization being done with ActionField.MarshalJSON

fixes issue from https://github.com/lolopinto/ent/pull/1366