### PR TITLE
cleanup NodeInstance in generated code

### DIFF
--- a/examples/ent-rsvp/backend/src/graphql/generated/mutations/address/address_edit_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/mutations/address/address_edit_type.ts
@@ -105,6 +105,6 @@ export const AddressEditType: GraphQLFieldConfig<
         ownerType: input.ownerType,
       },
     );
-    return { address: address };
+    return { address };
   },
 };

--- a/examples/ent-rsvp/backend/src/graphql/generated/mutations/event_activity/event_activity_add_invite_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/mutations/event_activity/event_activity_add_invite_type.ts
@@ -73,6 +73,6 @@ export const EventActivityAddInviteType: GraphQLFieldConfig<
       mustDecodeIDFromGQLID(input.id),
       mustDecodeIDFromGQLID(input.inviteID),
     );
-    return { eventActivity: eventActivity };
+    return { eventActivity };
   },
 };

--- a/examples/ent-rsvp/backend/src/graphql/generated/mutations/event_activity/event_activity_edit_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/mutations/event_activity/event_activity_edit_type.ts
@@ -112,6 +112,6 @@ export const EventActivityEditType: GraphQLFieldConfig<
         inviteAllGuests: input.inviteAllGuests,
       },
     );
-    return { eventActivity: eventActivity };
+    return { eventActivity };
   },
 };

--- a/examples/ent-rsvp/backend/src/graphql/generated/mutations/event_activity/event_activity_remove_invite_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/mutations/event_activity/event_activity_remove_invite_type.ts
@@ -73,6 +73,6 @@ export const EventActivityRemoveInviteType: GraphQLFieldConfig<
       mustDecodeIDFromGQLID(input.id),
       mustDecodeIDFromGQLID(input.inviteID),
     );
-    return { eventActivity: eventActivity };
+    return { eventActivity };
   },
 };

--- a/examples/ent-rsvp/backend/src/graphql/generated/mutations/event_activity/event_activity_rsvp_status_edit_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/mutations/event_activity/event_activity_rsvp_status_edit_type.ts
@@ -88,6 +88,6 @@ export const EventActivityRsvpStatusEditType: GraphQLFieldConfig<
         dietaryRestrictions: input.dietaryRestrictions,
       },
     );
-    return { eventActivity: eventActivity };
+    return { eventActivity };
   },
 };

--- a/examples/ent-rsvp/backend/src/graphql/generated/mutations/guest/guest_edit_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/mutations/guest/guest_edit_type.ts
@@ -81,6 +81,6 @@ export const GuestEditType: GraphQLFieldConfig<
         emailAddress: input.emailAddress,
       },
     );
-    return { guest: guest };
+    return { guest };
   },
 };

--- a/examples/ent-rsvp/backend/src/graphql/generated/mutations/guest_group/guest_group_edit_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/mutations/guest_group/guest_group_edit_type.ts
@@ -77,6 +77,6 @@ export const GuestGroupEditType: GraphQLFieldConfig<
         invitationName: input.invitationName,
       },
     );
-    return { guestGroup: guestGroup };
+    return { guestGroup };
   },
 };

--- a/examples/ent-rsvp/backend/src/graphql/generated/resolvers/address_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/resolvers/address_type.ts
@@ -22,12 +22,8 @@ export const AddressType = new GraphQLObjectType({
   fields: (): GraphQLFieldConfigMap<Address, RequestContext<Viewer>> => ({
     owner: {
       type: GraphQLNodeInterface,
-      resolve: (
-        address: Address,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return address.loadOwner();
+      resolve: (obj: Address, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadOwner();
       },
     },
     id: {
@@ -69,15 +65,11 @@ export const AddressType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        address: Address,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Address, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          address.viewer,
-          address,
-          (v, address: Address) => AddressToLocatedAtQuery.query(v, address),
+          obj.viewer,
+          obj,
+          (v, obj: Address) => AddressToLocatedAtQuery.query(v, obj),
           args,
         );
       },

--- a/examples/ent-rsvp/backend/src/graphql/generated/resolvers/event_activity_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/resolvers/event_activity_type.ts
@@ -39,25 +39,25 @@ import {
 class EventActivityCanViewerDo {
   constructor(
     private context: RequestContext<Viewer>,
-    private eventActivity: EventActivity,
+    private ent: EventActivity,
   ) {}
 
   async eventActivityAddInvite(args: any): Promise<boolean> {
     const action = EventActivityAddInviteAction.create(
       this.context.getViewer(),
-      this.eventActivity,
+      this.ent,
     );
     return applyPrivacyPolicy(
       this.context.getViewer(),
       action.getPrivacyPolicy(),
-      this.eventActivity,
+      this.ent,
     );
   }
 
   async eventActivityRsvpStatusEdit(args: any): Promise<boolean> {
     const action = EditEventActivityRsvpStatusAction.create(
       this.context.getViewer(),
-      this.eventActivity,
+      this.ent,
       {
         ...args,
         rsvpStatus: args.rsvpStatus,
@@ -68,7 +68,7 @@ class EventActivityCanViewerDo {
     return applyPrivacyPolicy(
       this.context.getViewer(),
       action.getPrivacyPolicy(),
-      this.eventActivity,
+      this.ent,
     );
   }
 }
@@ -79,21 +79,21 @@ export const EventActivityType = new GraphQLObjectType({
     address: {
       type: AddressType,
       resolve: (
-        eventActivity: EventActivity,
+        obj: EventActivity,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return eventActivity.loadAddress();
+        return obj.loadAddress();
       },
     },
     event: {
       type: EventType,
       resolve: (
-        eventActivity: EventActivity,
+        obj: EventActivity,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return eventActivity.loadEvent();
+        return obj.loadEvent();
       },
     },
     id: {
@@ -139,15 +139,15 @@ export const EventActivityType = new GraphQLObjectType({
         },
       },
       resolve: (
-        eventActivity: EventActivity,
+        obj: EventActivity,
         args: any,
         context: RequestContext<Viewer>,
       ) => {
         return new GraphQLEdgeConnection(
-          eventActivity.viewer,
-          eventActivity,
-          (v, eventActivity: EventActivity) =>
-            EventActivityToAttendingQuery.query(v, eventActivity),
+          obj.viewer,
+          obj,
+          (v, obj: EventActivity) =>
+            EventActivityToAttendingQuery.query(v, obj),
           args,
         );
       },
@@ -173,15 +173,14 @@ export const EventActivityType = new GraphQLObjectType({
         },
       },
       resolve: (
-        eventActivity: EventActivity,
+        obj: EventActivity,
         args: any,
         context: RequestContext<Viewer>,
       ) => {
         return new GraphQLEdgeConnection(
-          eventActivity.viewer,
-          eventActivity,
-          (v, eventActivity: EventActivity) =>
-            EventActivityToDeclinedQuery.query(v, eventActivity),
+          obj.viewer,
+          obj,
+          (v, obj: EventActivity) => EventActivityToDeclinedQuery.query(v, obj),
           args,
         );
       },
@@ -207,15 +206,14 @@ export const EventActivityType = new GraphQLObjectType({
         },
       },
       resolve: (
-        eventActivity: EventActivity,
+        obj: EventActivity,
         args: any,
         context: RequestContext<Viewer>,
       ) => {
         return new GraphQLEdgeConnection(
-          eventActivity.viewer,
-          eventActivity,
-          (v, eventActivity: EventActivity) =>
-            EventActivityToInvitesQuery.query(v, eventActivity),
+          obj.viewer,
+          obj,
+          (v, obj: EventActivity) => EventActivityToInvitesQuery.query(v, obj),
           args,
         );
       },
@@ -229,32 +227,32 @@ export const EventActivityType = new GraphQLObjectType({
         },
       },
       resolve: async (
-        eventActivity: EventActivity,
+        obj: EventActivity,
         args: any,
         context: RequestContext<Viewer>,
       ) => {
         const ent = await Guest.loadX(context.getViewer(), args.id);
-        return eventActivity.rsvpStatusFor(ent);
+        return obj.rsvpStatusFor(ent);
       },
     },
     canViewerDo: {
       type: new GraphQLNonNull(EventActivityCanViewerDoType),
       resolve: (
-        eventActivity: EventActivity,
+        obj: EventActivity,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return new EventActivityCanViewerDo(context, eventActivity);
+        return new EventActivityCanViewerDo(context, obj);
       },
     },
     addressFromOwner: {
       type: AddressType,
       resolve: async (
-        eventActivity: EventActivity,
+        obj: EventActivity,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return eventActivity.address();
+        return obj.address();
       },
     },
   }),
@@ -273,11 +271,11 @@ export const EventActivityCanViewerDoType = new GraphQLObjectType({
     eventActivityAddInvite: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: async (
-        eventActivity: EventActivityCanViewerDo,
+        obj: EventActivityCanViewerDo,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return eventActivity.eventActivityAddInvite(args);
+        return obj.eventActivityAddInvite(args);
       },
     },
     eventActivityRsvpStatusEdit: {
@@ -297,11 +295,11 @@ export const EventActivityCanViewerDoType = new GraphQLObjectType({
         },
       },
       resolve: async (
-        eventActivity: EventActivityCanViewerDo,
+        obj: EventActivityCanViewerDo,
         args: any,
         context: RequestContext<Viewer>,
       ) => {
-        return eventActivity.eventActivityRsvpStatusEdit(args);
+        return obj.eventActivityRsvpStatusEdit(args);
       },
     },
   }),

--- a/examples/ent-rsvp/backend/src/graphql/generated/resolvers/event_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/resolvers/event_type.ts
@@ -32,8 +32,8 @@ export const EventType = new GraphQLObjectType({
   fields: (): GraphQLFieldConfigMap<Event, RequestContext<Viewer>> => ({
     creator: {
       type: UserType,
-      resolve: (event: Event, args: {}, context: RequestContext<Viewer>) => {
-        return event.loadCreator();
+      resolve: (obj: Event, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadCreator();
       },
     },
     id: {
@@ -66,11 +66,11 @@ export const EventType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (event: Event, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: Event, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          event.viewer,
-          event,
-          (v, event: Event) => EventToEventActivitiesQuery.query(v, event),
+          obj.viewer,
+          obj,
+          (v, obj: Event) => EventToEventActivitiesQuery.query(v, obj),
           args,
         );
       },
@@ -95,11 +95,11 @@ export const EventType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (event: Event, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: Event, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          event.viewer,
-          event,
-          (v, event: Event) => EventToGuestGroupsQuery.query(v, event),
+          obj.viewer,
+          obj,
+          (v, obj: Event) => EventToGuestGroupsQuery.query(v, obj),
           args,
         );
       },
@@ -124,11 +124,11 @@ export const EventType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (event: Event, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: Event, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          event.viewer,
-          event,
-          (v, event: Event) => EventToGuestsQuery.query(v, event),
+          obj.viewer,
+          obj,
+          (v, obj: Event) => EventToGuestsQuery.query(v, obj),
           args,
         );
       },

--- a/examples/ent-rsvp/backend/src/graphql/generated/resolvers/guest_group_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/resolvers/guest_group_type.ts
@@ -30,12 +30,8 @@ export const GuestGroupType = new GraphQLObjectType({
   fields: (): GraphQLFieldConfigMap<GuestGroup, RequestContext<Viewer>> => ({
     event: {
       type: EventType,
-      resolve: (
-        guestGroup: GuestGroup,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return guestGroup.loadEvent();
+      resolve: (obj: GuestGroup, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadEvent();
       },
     },
     id: {
@@ -66,15 +62,14 @@ export const GuestGroupType = new GraphQLObjectType({
         },
       },
       resolve: (
-        guestGroup: GuestGroup,
+        obj: GuestGroup,
         args: any,
         context: RequestContext<Viewer>,
       ) => {
         return new GraphQLEdgeConnection(
-          guestGroup.viewer,
-          guestGroup,
-          (v, guestGroup: GuestGroup) =>
-            GuestGroupToInvitedEventsQuery.query(v, guestGroup),
+          obj.viewer,
+          obj,
+          (v, obj: GuestGroup) => GuestGroupToInvitedEventsQuery.query(v, obj),
           args,
         );
       },
@@ -100,15 +95,14 @@ export const GuestGroupType = new GraphQLObjectType({
         },
       },
       resolve: (
-        guestGroup: GuestGroup,
+        obj: GuestGroup,
         args: any,
         context: RequestContext<Viewer>,
       ) => {
         return new GraphQLEdgeConnection(
-          guestGroup.viewer,
-          guestGroup,
-          (v, guestGroup: GuestGroup) =>
-            GuestGroupToGuestsQuery.query(v, guestGroup),
+          obj.viewer,
+          obj,
+          (v, obj: GuestGroup) => GuestGroupToGuestsQuery.query(v, obj),
           args,
         );
       },

--- a/examples/ent-rsvp/backend/src/graphql/generated/resolvers/guest_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/resolvers/guest_type.ts
@@ -32,20 +32,20 @@ export const GuestType = new GraphQLObjectType({
   fields: (): GraphQLFieldConfigMap<Guest, RequestContext<Viewer>> => ({
     address: {
       type: AddressType,
-      resolve: (guest: Guest, args: {}, context: RequestContext<Viewer>) => {
-        return guest.loadAddress();
+      resolve: (obj: Guest, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadAddress();
       },
     },
     event: {
       type: EventType,
-      resolve: (guest: Guest, args: {}, context: RequestContext<Viewer>) => {
-        return guest.loadEvent();
+      resolve: (obj: Guest, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadEvent();
       },
     },
     guestGroup: {
       type: GuestGroupType,
-      resolve: (guest: Guest, args: {}, context: RequestContext<Viewer>) => {
-        return guest.loadGuestGroup();
+      resolve: (obj: Guest, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadGuestGroup();
       },
     },
     id: {
@@ -85,11 +85,11 @@ export const GuestType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (guest: Guest, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: Guest, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          guest.viewer,
-          guest,
-          (v, guest: Guest) => GuestToAttendingEventsQuery.query(v, guest),
+          obj.viewer,
+          obj,
+          (v, obj: Guest) => GuestToAttendingEventsQuery.query(v, obj),
           args,
         );
       },
@@ -114,11 +114,11 @@ export const GuestType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (guest: Guest, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: Guest, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          guest.viewer,
-          guest,
-          (v, guest: Guest) => GuestToDeclinedEventsQuery.query(v, guest),
+          obj.viewer,
+          obj,
+          (v, obj: Guest) => GuestToDeclinedEventsQuery.query(v, obj),
           args,
         );
       },

--- a/examples/ent-rsvp/backend/src/graphql/generated/resolvers/user_type.ts
+++ b/examples/ent-rsvp/backend/src/graphql/generated/resolvers/user_type.ts
@@ -53,11 +53,11 @@ export const UserType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (user: User, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: User, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          user.viewer,
-          user,
-          (v, user: User) => UserToEventsQuery.query(v, user),
+          obj.viewer,
+          obj,
+          (v, obj: User) => UserToEventsQuery.query(v, obj),
           args,
         );
       },

--- a/examples/simple/src/ent/contact_types.ts
+++ b/examples/simple/src/ent/contact_types.ts
@@ -12,12 +12,12 @@ export class EmailInfo {
   })
   emails: ContactEmail[];
 
-  @gqlField({ class: "EmailInfo", type: GraphQLString })
-  firstEmail: string;
+  @gqlField({ class: "EmailInfo", type: GraphQLString, name: "firstEmail" })
+  email1: string;
 
   constructor(emails: ContactEmail[], firstEmail: string) {
     this.emails = emails;
-    this.firstEmail = firstEmail;
+    this.email1 = firstEmail;
   }
 }
 

--- a/examples/simple/src/ent/user.ts
+++ b/examples/simple/src/ent/user.ts
@@ -111,7 +111,7 @@ export class User extends UserBase {
       if (info.contact.id == selfContactEdge?.id2) {
         continue;
       }
-      if (domain === this.getDomainFromEmail(info.contactInfo.firstEmail)) {
+      if (domain === this.getDomainFromEmail(info.contactInfo.email1)) {
         return info.contact;
       }
     }
@@ -133,8 +133,7 @@ export class User extends UserBase {
     const contactInfos = await this.queryContactInfos();
     return contactInfos.filterMap((info) => {
       return {
-        include:
-          domain === this.getDomainFromEmail(info.contactInfo.firstEmail),
+        include: domain === this.getDomainFromEmail(info.contactInfo.email1),
         return: info.contact,
       };
     });
@@ -156,8 +155,7 @@ export class User extends UserBase {
     const contactInfos = await this.queryContactInfos();
     return contactInfos.filterMap((info) => {
       return {
-        include:
-          domain === this.getDomainFromEmail(info.contactInfo.firstEmail),
+        include: domain === this.getDomainFromEmail(info.contactInfo.email1),
         return: info.contact,
       };
     });
@@ -181,7 +179,7 @@ export class User extends UserBase {
       return {
         include:
           this.id !== info.contact.userID &&
-          domain === this.getDomainFromEmail(info.contactInfo.firstEmail),
+          domain === this.getDomainFromEmail(info.contactInfo.email1),
         return: info.contact,
       };
     });
@@ -208,7 +206,7 @@ export class User extends UserBase {
     }
     let contactInfos = await this.queryContactInfos();
     return contactInfos.map((info) => {
-      let contactDomain = this.getDomainFromEmail(info.contactInfo.firstEmail);
+      let contactDomain = this.getDomainFromEmail(info.contactInfo.email1);
       if (contactDomain === domain) {
         return info.contact;
       }
@@ -233,7 +231,7 @@ export class User extends UserBase {
     }
     const contactInfos = await this.queryContactInfos();
     return contactInfos.map((info) => {
-      let contactDomain = this.getDomainFromEmail(info.contactInfo.firstEmail);
+      let contactDomain = this.getDomainFromEmail(info.contactInfo.email1);
       if (contactDomain === domain) {
         return info.contact;
       }

--- a/examples/simple/src/graphql/generated/mutations/comment/comment_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/comment/comment_edit_type.ts
@@ -111,6 +111,6 @@ export const CommentEditType: GraphQLFieldConfig<
         stickerType: input.stickerType,
       },
     );
-    return { comment: comment };
+    return { comment };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/contact/contact_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/contact/contact_edit_type.ts
@@ -98,6 +98,6 @@ export const ContactEditType: GraphQLFieldConfig<
         lastName: input.lastName,
       },
     );
-    return { contact: contact };
+    return { contact };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/contact_email/contact_email_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/contact_email/contact_email_edit_type.ts
@@ -90,6 +90,6 @@ export const ContactEmailEditType: GraphQLFieldConfig<
         label: input.label,
       },
     );
-    return { contactEmail: contactEmail };
+    return { contactEmail };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/contact_phone_number/contact_phone_number_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/contact_phone_number/contact_phone_number_edit_type.ts
@@ -91,6 +91,6 @@ export const ContactPhoneNumberEditType: GraphQLFieldConfig<
         label: input.label,
       },
     );
-    return { contactPhoneNumber: contactPhoneNumber };
+    return { contactPhoneNumber };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/event/event_add_host_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/event/event_add_host_type.ts
@@ -77,6 +77,6 @@ export const EventAddHostType: GraphQLFieldConfig<
       mustDecodeIDFromGQLID(input.id),
       mustDecodeIDFromGQLID(input.hostID),
     );
-    return { event: event };
+    return { event };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/event/event_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/event/event_edit_type.ts
@@ -103,6 +103,6 @@ export const EventEditType: GraphQLFieldConfig<
         addressID: mustDecodeNullableIDFromGQLID(input.addressID),
       },
     );
-    return { event: event };
+    return { event };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/event/event_remove_host_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/event/event_remove_host_type.ts
@@ -77,6 +77,6 @@ export const EventRemoveHostType: GraphQLFieldConfig<
       mustDecodeIDFromGQLID(input.id),
       mustDecodeIDFromGQLID(input.hostID),
     );
-    return { event: event };
+    return { event };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/event/event_rsvp_status_clear_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/event/event_rsvp_status_clear_type.ts
@@ -81,6 +81,6 @@ export const EventRsvpStatusClearType: GraphQLFieldConfig<
         userID: mustDecodeIDFromGQLID(input.userID),
       },
     );
-    return { event: event };
+    return { event };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/event/event_rsvp_status_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/event/event_rsvp_status_edit_type.ts
@@ -86,6 +86,6 @@ export const EventRsvpStatusEditType: GraphQLFieldConfig<
         userID: mustDecodeIDFromGQLID(input.userID),
       },
     );
-    return { event: event };
+    return { event };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/user/confirm_email_address_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/user/confirm_email_address_edit_type.ts
@@ -86,6 +86,6 @@ export const ConfirmEmailAddressEditType: GraphQLFieldConfig<
         code: input.code,
       },
     );
-    return { user: user };
+    return { user };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/user/confirm_phone_number_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/user/confirm_phone_number_edit_type.ts
@@ -86,6 +86,6 @@ export const ConfirmPhoneNumberEditType: GraphQLFieldConfig<
         code: input.code,
       },
     );
-    return { user: user };
+    return { user };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/user/email_address_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/user/email_address_edit_type.ts
@@ -81,6 +81,6 @@ export const EmailAddressEditType: GraphQLFieldConfig<
         newEmail: input.newEmail,
       },
     );
-    return { user: user };
+    return { user };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/user/phone_number_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/user/phone_number_edit_type.ts
@@ -81,6 +81,6 @@ export const PhoneNumberEditType: GraphQLFieldConfig<
         newPhoneNumber: input.newPhoneNumber,
       },
     );
-    return { user: user };
+    return { user };
   },
 };

--- a/examples/simple/src/graphql/generated/mutations/user/user_edit_type.ts
+++ b/examples/simple/src/graphql/generated/mutations/user/user_edit_type.ts
@@ -85,6 +85,6 @@ export const UserEditType: GraphQLFieldConfig<
         lastName: input.lastName,
       },
     );
-    return { user: user };
+    return { user };
   },
 };

--- a/examples/simple/src/graphql/generated/resolvers/address_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/address_type.ts
@@ -70,14 +70,14 @@ export const AddressType = new GraphQLObjectType({
         },
       },
       resolve: (
-        address: Address,
+        obj: Address,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          address.viewer,
-          address,
-          (v, address: Address) => AddressToHostedEventsQuery.query(v, address),
+          obj.viewer,
+          obj,
+          (v, obj: Address) => AddressToHostedEventsQuery.query(v, obj),
           args,
         );
       },

--- a/examples/simple/src/graphql/generated/resolvers/can_viewer_do_query_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/can_viewer_do_query_type.ts
@@ -67,11 +67,11 @@ export const GlobalCanViewerDoType = new GraphQLObjectType({
         },
       },
       resolve: async (
-        global: GlobalCanViewerDo,
+        obj: GlobalCanViewerDo,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return global.contactCreate(args);
+        return obj.contactCreate(args);
       },
     },
     contactEmailCreate: {
@@ -95,11 +95,11 @@ export const GlobalCanViewerDoType = new GraphQLObjectType({
         },
       },
       resolve: async (
-        global: GlobalCanViewerDo,
+        obj: GlobalCanViewerDo,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return global.contactEmailCreate(args);
+        return obj.contactEmailCreate(args);
       },
     },
   }),

--- a/examples/simple/src/graphql/generated/resolvers/comment_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/comment_type.ts
@@ -38,41 +38,41 @@ export const CommentType = new GraphQLObjectType({
     article: {
       type: GraphQLNodeInterface,
       resolve: (
-        comment: Comment,
+        obj: Comment,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return comment.loadArticle();
+        return obj.loadArticle();
       },
     },
     attachment: {
       type: GraphQLNodeInterface,
       resolve: (
-        comment: Comment,
+        obj: Comment,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return comment.loadAttachment();
+        return obj.loadAttachment();
       },
     },
     author: {
       type: UserType,
       resolve: (
-        comment: Comment,
+        obj: Comment,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return comment.loadAuthor();
+        return obj.loadAuthor();
       },
     },
     sticker: {
       type: GraphQLNodeInterface,
       resolve: (
-        comment: Comment,
+        obj: Comment,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return comment.loadSticker();
+        return obj.loadSticker();
       },
     },
     id: {
@@ -103,14 +103,14 @@ export const CommentType = new GraphQLObjectType({
         },
       },
       resolve: (
-        comment: Comment,
+        obj: Comment,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          comment.viewer,
-          comment,
-          (v, comment: Comment) => CommentToPostQuery.query(v, comment),
+          obj.viewer,
+          obj,
+          (v, obj: Comment) => CommentToPostQuery.query(v, obj),
           args,
         );
       },
@@ -136,15 +136,14 @@ export const CommentType = new GraphQLObjectType({
         },
       },
       resolve: (
-        comment: Comment,
+        obj: Comment,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          comment.viewer,
-          comment,
-          (v, comment: Comment) =>
-            CommentArticleToCommentsQuery.query(v, comment),
+          obj.viewer,
+          obj,
+          (v, obj: Comment) => CommentArticleToCommentsQuery.query(v, obj),
           args,
         );
       },

--- a/examples/simple/src/graphql/generated/resolvers/contact_email_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_email_type.ts
@@ -26,19 +26,19 @@ import { ExampleViewer as ExampleViewerAlias } from "../../../viewer/viewer";
 class ContactEmailCanViewerDo {
   constructor(
     private context: RequestContext<ExampleViewerAlias>,
-    private contactEmail: ContactEmail,
+    private ent: ContactEmail,
   ) {}
 
   async contactEmailEdit(args: any): Promise<boolean> {
     const action = EditContactEmailAction.create(
       this.context.getViewer(),
-      this.contactEmail,
+      this.ent,
       args,
     );
     return applyPrivacyPolicy(
       this.context.getViewer(),
       action.getPrivacyPolicy(),
-      this.contactEmail,
+      this.ent,
     );
   }
 }
@@ -52,11 +52,11 @@ export const ContactEmailType = new GraphQLObjectType({
     contact: {
       type: ContactType,
       resolve: (
-        contactEmail: ContactEmail,
+        obj: ContactEmail,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contactEmail.loadContact();
+        return obj.loadContact();
       },
     },
     id: {
@@ -75,11 +75,11 @@ export const ContactEmailType = new GraphQLObjectType({
     canViewerDo: {
       type: new GraphQLNonNull(ContactEmailCanViewerDoType),
       resolve: (
-        contactEmail: ContactEmail,
+        obj: ContactEmail,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return new ContactEmailCanViewerDo(context, contactEmail);
+        return new ContactEmailCanViewerDo(context, obj);
       },
     },
   }),
@@ -98,11 +98,11 @@ export const ContactEmailCanViewerDoType = new GraphQLObjectType({
     contactEmailEdit: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: async (
-        contactEmail: ContactEmailCanViewerDo,
+        obj: ContactEmailCanViewerDo,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contactEmail.contactEmailEdit(args);
+        return obj.contactEmailEdit(args);
       },
     },
   }),

--- a/examples/simple/src/graphql/generated/resolvers/contact_item_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_item_type.ts
@@ -22,11 +22,11 @@ export const ContactItemType = new GraphQLInterfaceType({
     contact: {
       type: ContactType,
       resolve: (
-        contactItem: ContactItem,
+        obj: ContactItem,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contactItem.contact();
+        return obj.contact();
       },
     },
     label: {

--- a/examples/simple/src/graphql/generated/resolvers/contact_phone_number_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_phone_number_type.ts
@@ -30,11 +30,11 @@ export const ContactPhoneNumberType = new GraphQLObjectType({
     contact: {
       type: ContactType,
       resolve: (
-        contactPhoneNumber: ContactPhoneNumber,
+        obj: ContactPhoneNumber,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contactPhoneNumber.loadContact();
+        return obj.loadContact();
       },
     },
     id: {

--- a/examples/simple/src/graphql/generated/resolvers/contact_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/contact_type.ts
@@ -48,11 +48,11 @@ export const ContactType = new GraphQLObjectType({
         new GraphQLList(new GraphQLNonNull(ContactEmailType)),
       ),
       resolve: (
-        contact: Contact,
+        obj: Contact,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contact.loadEmails();
+        return obj.loadEmails();
       },
     },
     phoneNumbers: {
@@ -60,21 +60,21 @@ export const ContactType = new GraphQLObjectType({
         new GraphQLList(new GraphQLNonNull(ContactPhoneNumberType)),
       ),
       resolve: (
-        contact: Contact,
+        obj: Contact,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contact.loadPhoneNumbers();
+        return obj.loadPhoneNumbers();
       },
     },
     user: {
       type: UserType,
       resolve: (
-        contact: Contact,
+        obj: Contact,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contact.loadUser();
+        return obj.loadUser();
       },
     },
     id: {
@@ -108,14 +108,14 @@ export const ContactType = new GraphQLObjectType({
         },
       },
       resolve: (
-        contact: Contact,
+        obj: Contact,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          contact.viewer,
-          contact,
-          (v, contact: Contact) => ContactToCommentsQuery.query(v, contact),
+          obj.viewer,
+          obj,
+          (v, obj: Contact) => ContactToCommentsQuery.query(v, obj),
           args,
         );
       },
@@ -141,14 +141,14 @@ export const ContactType = new GraphQLObjectType({
         },
       },
       resolve: (
-        contact: Contact,
+        obj: Contact,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          contact.viewer,
-          contact,
-          (v, contact: Contact) => ContactToLikersQuery.query(v, contact),
+          obj.viewer,
+          obj,
+          (v, obj: Contact) => ContactToLikersQuery.query(v, obj),
           args,
         );
       },
@@ -174,15 +174,14 @@ export const ContactType = new GraphQLObjectType({
         },
       },
       resolve: (
-        contact: Contact,
+        obj: Contact,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          contact.viewer,
-          contact,
-          (v, contact: Contact) =>
-            ContactCommentsFromAttachmentQuery.query(v, contact),
+          obj.viewer,
+          obj,
+          (v, obj: Contact) => ContactCommentsFromAttachmentQuery.query(v, obj),
           args,
         );
       },
@@ -193,11 +192,11 @@ export const ContactType = new GraphQLObjectType({
     plusEmails: {
       type: new GraphQLNonNull(EmailInfoType),
       resolve: async (
-        contact: Contact,
+        obj: Contact,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contact.queryPlusEmails();
+        return obj.queryPlusEmails();
       },
     },
     contactItems: {
@@ -211,11 +210,11 @@ export const ContactType = new GraphQLObjectType({
         },
       },
       resolve: async (
-        contact: Contact,
+        obj: Contact,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return contact.queryContactItems(args.filter);
+        return obj.queryContactItems(args.filter);
       },
     },
   }),
@@ -238,6 +237,13 @@ export const EmailInfoType = new GraphQLObjectType({
     },
     firstEmail: {
       type: new GraphQLNonNull(GraphQLString),
+      resolve: (
+        obj: EmailInfo,
+        args: {},
+        context: RequestContext<ExampleViewerAlias>,
+      ) => {
+        return obj.email1;
+      },
     },
   }),
   isTypeOf(obj) {

--- a/examples/simple/src/graphql/generated/resolvers/event_type.ts
+++ b/examples/simple/src/graphql/generated/resolvers/event_type.ts
@@ -49,21 +49,21 @@ export const EventType = new GraphQLObjectType({
     address: {
       type: AddressType,
       resolve: (
-        event: Event,
+        obj: Event,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return event.loadAddress();
+        return obj.loadAddress();
       },
     },
     creator: {
       type: UserType,
       resolve: (
-        event: Event,
+        obj: Event,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return event.loadCreator();
+        return obj.loadCreator();
       },
     },
     id: {
@@ -82,11 +82,11 @@ export const EventType = new GraphQLObjectType({
     eventLocation: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: (
-        event: Event,
+        obj: Event,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return event.location;
+        return obj.location;
       },
     },
     attending: {
@@ -110,14 +110,14 @@ export const EventType = new GraphQLObjectType({
         },
       },
       resolve: (
-        event: Event,
+        obj: Event,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          event.viewer,
-          event,
-          (v, event: Event) => EventToAttendingQuery.query(v, event),
+          obj.viewer,
+          obj,
+          (v, obj: Event) => EventToAttendingQuery.query(v, obj),
           args,
         );
       },
@@ -143,14 +143,14 @@ export const EventType = new GraphQLObjectType({
         },
       },
       resolve: (
-        event: Event,
+        obj: Event,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          event.viewer,
-          event,
-          (v, event: Event) => EventToDeclinedQuery.query(v, event),
+          obj.viewer,
+          obj,
+          (v, obj: Event) => EventToDeclinedQuery.query(v, obj),
           args,
         );
       },
@@ -176,14 +176,14 @@ export const EventType = new GraphQLObjectType({
         },
       },
       resolve: (
-        event: Event,
+        obj: Event,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          event.viewer,
-          event,
-          (v, event: Event) => EventToHostsQuery.query(v, event),
+          obj.viewer,
+          obj,
+          (v, obj: Event) => EventToHostsQuery.query(v, obj),
           args,
         );
       },
@@ -209,14 +209,14 @@ export const EventType = new GraphQLObjectType({
         },
       },
       resolve: (
-        event: Event,
+        obj: Event,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          event.viewer,
-          event,
-          (v, event: Event) => EventToInvitedQuery.query(v, event),
+          obj.viewer,
+          obj,
+          (v, obj: Event) => EventToInvitedQuery.query(v, obj),
           args,
         );
       },
@@ -242,14 +242,14 @@ export const EventType = new GraphQLObjectType({
         },
       },
       resolve: (
-        event: Event,
+        obj: Event,
         args: any,
         context: RequestContext<ExampleViewerAlias>,
       ) => {
         return new GraphQLEdgeConnection(
-          event.viewer,
-          event,
-          (v, event: Event) => EventToMaybeQuery.query(v, event),
+          obj.viewer,
+          obj,
+          (v, obj: Event) => EventToMaybeQuery.query(v, obj),
           args,
         );
       },
@@ -260,11 +260,11 @@ export const EventType = new GraphQLObjectType({
     canViewerSeeInfo: {
       type: new GraphQLNonNull(EventCanViewerSeeType),
       resolve: (
-        event: Event,
+        obj: Event,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return event.canViewerSeeInfo();
+        return obj.canViewerSeeInfo();
       },
     },
   }),
@@ -283,11 +283,11 @@ export const EventCanViewerSeeType = new GraphQLObjectType({
     address: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: async (
-        event: EventCanViewerSee,
+        obj: EventCanViewerSee,
         args: {},
         context: RequestContext<ExampleViewerAlias>,
       ) => {
-        return event.addressID();
+        return obj.addressID();
       },
     },
   }),

--- a/examples/todo-sqlite/src/ent/generated/account_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account_base.ts
@@ -272,11 +272,7 @@ export class AccountBase
     id: ID,
     context?: Context,
   ): Promise<AccountDBData | null> {
-    const row = await accountLoader.createLoader(context).load(id);
-    if (!row) {
-      return null;
-    }
-    return row;
+    return accountLoader.createLoader(context).load(id);
   }
 
   static async loadRawDataX<T extends AccountBase>(
@@ -344,13 +340,7 @@ export class AccountBase
     phoneNumber: string,
     context?: Context,
   ): Promise<AccountDBData | null> {
-    const row = await accountPhoneNumberLoader
-      .createLoader(context)
-      .load(phoneNumber);
-    if (!row) {
-      return null;
-    }
-    return row;
+    return accountPhoneNumberLoader.createLoader(context).load(phoneNumber);
   }
 
   static loaderOptions<T extends AccountBase>(

--- a/examples/todo-sqlite/src/ent/generated/tag_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/tag_base.ts
@@ -204,11 +204,7 @@ export class TagBase implements Ent<Viewer> {
     id: ID,
     context?: Context,
   ): Promise<TagDBData | null> {
-    const row = await tagLoader.createLoader(context).load(id);
-    if (!row) {
-      return null;
-    }
-    return row;
+    return tagLoader.createLoader(context).load(id);
   }
 
   static async loadRawDataX<T extends TagBase>(

--- a/examples/todo-sqlite/src/ent/generated/todo_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/todo_base.ts
@@ -221,11 +221,7 @@ export class TodoBase implements Ent<Viewer> {
     id: ID,
     context?: Context,
   ): Promise<TodoDBData | null> {
-    const row = await todoLoader.createLoader(context).load(id);
-    if (!row) {
-      return null;
-    }
-    return row;
+    return todoLoader.createLoader(context).load(id);
   }
 
   static async loadRawDataX<T extends TodoBase>(

--- a/examples/todo-sqlite/src/ent/generated/workspace_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/workspace_base.ts
@@ -221,11 +221,7 @@ export class WorkspaceBase
     id: ID,
     context?: Context,
   ): Promise<WorkspaceDBData | null> {
-    const row = await workspaceLoader.createLoader(context).load(id);
-    if (!row) {
-      return null;
-    }
-    return row;
+    return workspaceLoader.createLoader(context).load(id);
   }
 
   static async loadRawDataX<T extends WorkspaceBase>(
@@ -291,11 +287,7 @@ export class WorkspaceBase
     slug: string,
     context?: Context,
   ): Promise<WorkspaceDBData | null> {
-    const row = await workspaceSlugLoader.createLoader(context).load(slug);
-    if (!row) {
-      return null;
-    }
-    return row;
+    return workspaceSlugLoader.createLoader(context).load(slug);
   }
 
   static loaderOptions<T extends WorkspaceBase>(

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/account_transfer_credits_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/account_transfer_credits_type.ts
@@ -82,6 +82,6 @@ export const AccountTransferCreditsType: GraphQLFieldConfig<
         amount: input.amount,
       },
     );
-    return { account: account };
+    return { account };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/account_update_balance_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/account_update_balance_type.ts
@@ -76,6 +76,6 @@ export const AccountUpdateBalanceType: GraphQLFieldConfig<
         credits: input.credits,
       },
     );
-    return { account: account };
+    return { account };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/edit_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/edit_account_type.ts
@@ -103,6 +103,6 @@ export const EditAccountType: GraphQLFieldConfig<
         accountPrefsList: input.account_prefs_list,
       },
     );
-    return { account: account };
+    return { account };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/todo_status_account_edit_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/todo_status_account_edit_type.ts
@@ -84,6 +84,6 @@ export const TodoStatusAccountEditType: GraphQLFieldConfig<
         todoID: input.todo_id,
       },
     );
-    return { account: account };
+    return { account };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/add_todo_tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/add_todo_tag_type.ts
@@ -72,6 +72,6 @@ export const AddTodoTagType: GraphQLFieldConfig<
       input.id,
       input.tag_id,
     );
-    return { todo: todo };
+    return { todo };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/change_todo_bounty_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/change_todo_bounty_type.ts
@@ -76,6 +76,6 @@ export const ChangeTodoBountyType: GraphQLFieldConfig<
         bounty: input.bounty,
       },
     );
-    return { todo: todo };
+    return { todo };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/change_todo_status_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/change_todo_status_type.ts
@@ -76,6 +76,6 @@ export const ChangeTodoStatusType: GraphQLFieldConfig<
         completed: input.completed,
       },
     );
-    return { todo: todo };
+    return { todo };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/remove_todo_tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/remove_todo_tag_type.ts
@@ -72,6 +72,6 @@ export const RemoveTodoTagType: GraphQLFieldConfig<
       input.id,
       input.tag_id,
     );
-    return { todo: todo };
+    return { todo };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/rename_todo_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/rename_todo_type.ts
@@ -82,6 +82,6 @@ export const RenameTodoType: GraphQLFieldConfig<
         reasonForChange: input.reason_for_change,
       },
     );
-    return { todo: todo };
+    return { todo };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/mutations/workspace/edit_workspace_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/workspace/edit_workspace_type.ts
@@ -80,6 +80,6 @@ export const EditWorkspaceType: GraphQLFieldConfig<
         slug: input.slug,
       },
     );
-    return { workspace: workspace };
+    return { workspace };
   },
 };

--- a/examples/todo-sqlite/src/graphql/generated/resolvers/account_prefs_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/resolvers/account_prefs_type.ts
@@ -16,31 +16,31 @@ export const AccountPrefsType = new GraphQLObjectType({
     finished_nux: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: (
-        accountPrefs: AccountPrefs,
+        obj: AccountPrefs,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return accountPrefs.finishedNux;
+        return obj.finishedNux;
       },
     },
     enable_notifs: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: (
-        accountPrefs: AccountPrefs,
+        obj: AccountPrefs,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return accountPrefs.enableNotifs;
+        return obj.enableNotifs;
       },
     },
     preferred_language: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: (
-        accountPrefs: AccountPrefs,
+        obj: AccountPrefs,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return accountPrefs.preferredLanguage;
+        return obj.preferredLanguage;
       },
     },
   }),

--- a/examples/todo-sqlite/src/graphql/generated/resolvers/account_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/resolvers/account_type.ts
@@ -54,42 +54,26 @@ export const AccountType = new GraphQLObjectType({
     },
     phone_number: {
       type: GraphQLString,
-      resolve: (
-        account: Account,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return account.phoneNumber;
+      resolve: (obj: Account, args: {}, context: RequestContext<Viewer>) => {
+        return obj.phoneNumber;
       },
     },
     account_prefs: {
       type: AccountPrefsType,
-      resolve: (
-        account: Account,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return account.accountPrefs;
+      resolve: (obj: Account, args: {}, context: RequestContext<Viewer>) => {
+        return obj.accountPrefs;
       },
     },
     account_prefs_3: {
       type: AccountPrefsType,
-      resolve: (
-        account: Account,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return account.accountPrefs3;
+      resolve: (obj: Account, args: {}, context: RequestContext<Viewer>) => {
+        return obj.accountPrefs3;
       },
     },
     account_prefs_list: {
       type: new GraphQLList(new GraphQLNonNull(AccountPrefsType)),
-      resolve: (
-        account: Account,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return account.accountPrefsList;
+      resolve: (obj: Account, args: {}, context: RequestContext<Viewer>) => {
+        return obj.accountPrefsList;
       },
     },
     credits: {
@@ -115,16 +99,11 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) =>
-            AccountToClosedTodosDupQuery.query(v, account),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => AccountToClosedTodosDupQuery.query(v, obj),
           args,
         );
       },
@@ -149,16 +128,11 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) =>
-            AccountToCreatedWorkspacesQuery.query(v, account),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => AccountToCreatedWorkspacesQuery.query(v, obj),
           args,
         );
       },
@@ -183,15 +157,11 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) => AccountToOpenTodosDupQuery.query(v, account),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => AccountToOpenTodosDupQuery.query(v, obj),
           args,
         );
       },
@@ -216,15 +186,11 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) => AccountToScopedTodosQuery.query(v, account),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => AccountToScopedTodosQuery.query(v, obj),
           args,
         );
       },
@@ -249,15 +215,11 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) => AccountToWorkspacesQuery.query(v, account),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => AccountToWorkspacesQuery.query(v, obj),
           args,
         );
       },
@@ -282,15 +244,11 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) => AccountToTagsQuery.query(v, account),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => AccountToTagsQuery.query(v, obj),
           args,
         );
       },
@@ -315,15 +273,11 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) => AccountToTodosQuery.query(v, account),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => AccountToTodosQuery.query(v, obj),
           args,
         );
       },
@@ -348,15 +302,11 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) => AssigneeToTodosQuery.query(v, account),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => AssigneeToTodosQuery.query(v, obj),
           args,
         );
       },
@@ -370,32 +320,28 @@ export const AccountType = new GraphQLObjectType({
         },
       },
       resolve: async (
-        account: Account,
+        obj: Account,
         args: any,
         context: RequestContext<Viewer>,
       ) => {
         const ent = await Todo.loadX(context.getViewer(), args.id);
-        return account.todoStatusFor(ent);
+        return obj.todoStatusFor(ent);
       },
     },
     can_viewer_see_info: {
       type: new GraphQLNonNull(AccountCanViewerSeeType),
-      resolve: (
-        account: Account,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return account.canViewerSeeInfo();
+      resolve: (obj: Account, args: {}, context: RequestContext<Viewer>) => {
+        return obj.canViewerSeeInfo();
       },
     },
     open_todos_plural: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TodoType))),
       resolve: async (
-        account: Account,
+        obj: Account,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return account.openTodosPlural();
+        return obj.openTodosPlural();
       },
     },
     open_todos: {
@@ -418,21 +364,17 @@ export const AccountType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        account: Account,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Account, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          account.viewer,
-          account,
-          (v, account: Account) => account.openTodos(),
+          obj.viewer,
+          obj,
+          (v, obj: Account) => obj.openTodos(),
           args,
         );
       },
     },
   }),
-  interfaces: [GraphQLNodeInterface],
+  interfaces: () => [GraphQLNodeInterface],
   isTypeOf(obj) {
     return obj instanceof Account;
   },
@@ -447,31 +389,31 @@ export const AccountCanViewerSeeType = new GraphQLObjectType({
     phone_number: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: async (
-        account: AccountCanViewerSee,
+        obj: AccountCanViewerSee,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return account.phoneNumber();
+        return obj.phoneNumber();
       },
     },
     account_prefs_3: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: async (
-        account: AccountCanViewerSee,
+        obj: AccountCanViewerSee,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return account.accountPrefs3();
+        return obj.accountPrefs3();
       },
     },
     credits: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: async (
-        account: AccountCanViewerSee,
+        obj: AccountCanViewerSee,
         args: {},
         context: RequestContext<Viewer>,
       ) => {
-        return account.credits();
+        return obj.credits();
       },
     },
   }),

--- a/examples/todo-sqlite/src/graphql/generated/resolvers/tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/resolvers/tag_type.ts
@@ -25,14 +25,14 @@ export const TagType = new GraphQLObjectType({
   fields: (): GraphQLFieldConfigMap<Tag, RequestContext<Viewer>> => ({
     owner: {
       type: AccountType,
-      resolve: (tag: Tag, args: {}, context: RequestContext<Viewer>) => {
-        return tag.loadOwner();
+      resolve: (obj: Tag, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadOwner();
       },
     },
     related_tags: {
       type: new GraphQLList(new GraphQLNonNull(TagType)),
-      resolve: (tag: Tag, args: {}, context: RequestContext<Viewer>) => {
-        return tag.loadRelatedTags();
+      resolve: (obj: Tag, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadRelatedTags();
       },
     },
     id: {
@@ -40,14 +40,14 @@ export const TagType = new GraphQLObjectType({
     },
     display_name: {
       type: new GraphQLNonNull(GraphQLString),
-      resolve: (tag: Tag, args: {}, context: RequestContext<Viewer>) => {
-        return tag.displayName;
+      resolve: (obj: Tag, args: {}, context: RequestContext<Viewer>) => {
+        return obj.displayName;
       },
     },
     canonical_name: {
       type: new GraphQLNonNull(GraphQLString),
-      resolve: (tag: Tag, args: {}, context: RequestContext<Viewer>) => {
-        return tag.canonicalName;
+      resolve: (obj: Tag, args: {}, context: RequestContext<Viewer>) => {
+        return obj.canonicalName;
       },
     },
     todos: {
@@ -70,17 +70,17 @@ export const TagType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (tag: Tag, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: Tag, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          tag.viewer,
-          tag,
-          (v, tag: Tag) => TagToTodosQuery.query(v, tag),
+          obj.viewer,
+          obj,
+          (v, obj: Tag) => TagToTodosQuery.query(v, obj),
           args,
         );
       },
     },
   }),
-  interfaces: [GraphQLNodeInterface],
+  interfaces: () => [GraphQLNodeInterface],
   isTypeOf(obj) {
     return obj instanceof Tag;
   },

--- a/examples/todo-sqlite/src/graphql/generated/resolvers/todo_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/resolvers/todo_type.ts
@@ -27,20 +27,20 @@ export const TodoType = new GraphQLObjectType({
   fields: (): GraphQLFieldConfigMap<Todo, RequestContext<Viewer>> => ({
     assignee: {
       type: AccountType,
-      resolve: (todo: Todo, args: {}, context: RequestContext<Viewer>) => {
-        return todo.loadAssignee();
+      resolve: (obj: Todo, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadAssignee();
       },
     },
     creator: {
       type: AccountType,
-      resolve: (todo: Todo, args: {}, context: RequestContext<Viewer>) => {
-        return todo.loadCreator();
+      resolve: (obj: Todo, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadCreator();
       },
     },
     scope: {
       type: GraphQLNodeInterface,
-      resolve: (todo: Todo, args: {}, context: RequestContext<Viewer>) => {
-        return todo.loadScope();
+      resolve: (obj: Todo, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadScope();
       },
     },
     id: {
@@ -54,8 +54,8 @@ export const TodoType = new GraphQLObjectType({
     },
     completed_date: {
       type: GraphQLTime,
-      resolve: (todo: Todo, args: {}, context: RequestContext<Viewer>) => {
-        return todo.completedDate;
+      resolve: (obj: Todo, args: {}, context: RequestContext<Viewer>) => {
+        return obj.completedDate;
       },
     },
     bounty: {
@@ -81,11 +81,11 @@ export const TodoType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (todo: Todo, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: Todo, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          todo.viewer,
-          todo,
-          (v, todo: Todo) => TodoToTagsQuery.query(v, todo),
+          obj.viewer,
+          obj,
+          (v, obj: Todo) => TodoToTagsQuery.query(v, obj),
           args,
         );
       },
@@ -110,17 +110,17 @@ export const TodoType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (todo: Todo, args: any, context: RequestContext<Viewer>) => {
+      resolve: (obj: Todo, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          todo.viewer,
-          todo,
-          (v, todo: Todo) => TodoToTodoScopeQuery.query(v, todo),
+          obj.viewer,
+          obj,
+          (v, obj: Todo) => TodoToTodoScopeQuery.query(v, obj),
           args,
         );
       },
     },
   }),
-  interfaces: [GraphQLNodeInterface],
+  interfaces: () => [GraphQLNodeInterface],
   isTypeOf(obj) {
     return obj instanceof Todo;
   },

--- a/examples/todo-sqlite/src/graphql/generated/resolvers/workspace_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/resolvers/workspace_type.ts
@@ -29,22 +29,14 @@ export const WorkspaceType = new GraphQLObjectType({
   fields: (): GraphQLFieldConfigMap<Workspace, RequestContext<Viewer>> => ({
     creator: {
       type: AccountType,
-      resolve: (
-        workspace: Workspace,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return workspace.loadCreator();
+      resolve: (obj: Workspace, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadCreator();
       },
     },
     viewer_creator: {
       type: AccountType,
-      resolve: (
-        workspace: Workspace,
-        args: {},
-        context: RequestContext<Viewer>,
-      ) => {
-        return workspace.loadViewerCreator();
+      resolve: (obj: Workspace, args: {}, context: RequestContext<Viewer>) => {
+        return obj.loadViewerCreator();
       },
     },
     id: {
@@ -76,16 +68,11 @@ export const WorkspaceType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        workspace: Workspace,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Workspace, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          workspace.viewer,
-          workspace,
-          (v, workspace: Workspace) =>
-            WorkspaceToMembersQuery.query(v, workspace),
+          obj.viewer,
+          obj,
+          (v, obj: Workspace) => WorkspaceToMembersQuery.query(v, obj),
           args,
         );
       },
@@ -110,22 +97,17 @@ export const WorkspaceType = new GraphQLObjectType({
           type: GraphQLString,
         },
       },
-      resolve: (
-        workspace: Workspace,
-        args: any,
-        context: RequestContext<Viewer>,
-      ) => {
+      resolve: (obj: Workspace, args: any, context: RequestContext<Viewer>) => {
         return new GraphQLEdgeConnection(
-          workspace.viewer,
-          workspace,
-          (v, workspace: Workspace) =>
-            WorkspaceToScopedTodosQuery.query(v, workspace),
+          obj.viewer,
+          obj,
+          (v, obj: Workspace) => WorkspaceToScopedTodosQuery.query(v, obj),
           args,
         );
       },
     },
   }),
-  interfaces: [GraphQLNodeInterface],
+  interfaces: () => [GraphQLNodeInterface],
   isTypeOf(obj) {
     return obj instanceof Workspace;
   },

--- a/internal/graphql/custom_ts.go
+++ b/internal/graphql/custom_ts.go
@@ -238,11 +238,10 @@ func processFields(processor *codegen.Processor, cd *CustomData, s *gqlSchema, c
 			ObjData: &gqlobjectData{
 				interfaces: interfaces,
 				// TODO kill node and NodeInstance they don't make sense here...
-				Node:         field.Node,
-				NodeInstance: "obj",
-				GQLNodes:     objTypes,
-				FieldConfig:  fieldConfig,
-				Package:      processor.Config.GetImportPackage(),
+				Node:        field.Node,
+				GQLNodes:    objTypes,
+				FieldConfig: fieldConfig,
+				Package:     processor.Config.GetImportPackage(),
 			},
 			FilePath:    filePath,
 			Field:       &field,
@@ -757,14 +756,13 @@ func processCustomFields(processor *codegen.Processor, cd *CustomData, s *gqlSch
 		customEdge := s.edgeNames[nodeName]
 
 		var obj *objectType
-		var instance string
+		instance := "obj"
 		var nodeData *schema.NodeData
 		if nodeInfo != nil {
 			objData := nodeInfo.ObjData
 			nodeData = objData.NodeData
 			// always has a node for now
 			obj = objData.GQLNodes[0]
-			instance = nodeData.NodeInstance
 		} else if customEdge {
 			// create new obj
 			obj = newObjectType(&objectType{
@@ -784,7 +782,7 @@ func processCustomFields(processor *codegen.Processor, cd *CustomData, s *gqlSch
 			if field.Connection {
 				customEdge := getGQLEdge(processor.Config, field, nodeName)
 				nodeInfo.connections = append(nodeInfo.connections, getGqlConnection(nodeData.PackageName, customEdge, processor))
-				if err := addConnection(processor, nodeData, customEdge, obj, nodeData.NodeInstance, &field); err != nil {
+				if err := addConnection(processor, nodeData, customEdge, obj, &field); err != nil {
 					return err
 				}
 				continue
@@ -846,6 +844,8 @@ func isConnection(field *CustomField) bool {
 	return field.Results[0].Connection
 }
 
+// should be obj except if it's nested...
+// eg obj.edge for edges
 func getCustomGQLField(processor *codegen.Processor, cd *CustomData, field CustomField, s *gqlSchema, instance string) (*fieldType, error) {
 	if field.Connection {
 		return nil, fmt.Errorf("field is a connection. this should be handled elsewhere")
@@ -1020,10 +1020,9 @@ func processCustomStructType(processor *codegen.Processor, s *gqlSchema, typ *Cu
 
 	gqlNode := &gqlNode{
 		ObjData: &gqlobjectData{
-			Node:         obj.NodeName,
-			NodeInstance: "obj",
-			GQLNodes:     []*objectType{objType},
-			Package:      processor.Config.GetImportPackage(),
+			Node:     obj.NodeName,
+			GQLNodes: []*objectType{objType},
+			Package:  processor.Config.GetImportPackage(),
 		},
 		FilePath: filePath,
 	}
@@ -1071,10 +1070,9 @@ func processCustomUnions(processor *codegen.Processor, cd *CustomData, s *gqlSch
 
 		node := &gqlNode{
 			ObjData: &gqlobjectData{
-				Node:         union.NodeName,
-				NodeInstance: strcase.ToLowerCamel(union.NodeName),
-				GQLNodes:     []*objectType{obj},
-				Package:      processor.Config.GetImportPackage(),
+				Node:     union.NodeName,
+				GQLNodes: []*objectType{obj},
+				Package:  processor.Config.GetImportPackage(),
 			},
 			FilePath: getFilePathForUnionInterfaceFile(processor.Config, union.NodeName),
 		}
@@ -1102,7 +1100,7 @@ func processCustomInterfaces(processor *codegen.Processor, cd *CustomData, s *gq
 		}
 
 		for _, f := range fields {
-			gqlField, err := getCustomGQLField(processor, cd, f, s, strcase.ToLowerCamel(inter.NodeName))
+			gqlField, err := getCustomGQLField(processor, cd, f, s, "obj")
 			if err != nil {
 				return err
 			}
@@ -1120,10 +1118,9 @@ func processCustomInterfaces(processor *codegen.Processor, cd *CustomData, s *gq
 
 		node := &gqlNode{
 			ObjData: &gqlobjectData{
-				Node:         inter.NodeName,
-				NodeInstance: strcase.ToLowerCamel(inter.NodeName),
-				GQLNodes:     []*objectType{obj},
-				Package:      processor.Config.GetImportPackage(),
+				Node:     inter.NodeName,
+				GQLNodes: []*objectType{obj},
+				Package:  processor.Config.GetImportPackage(),
 			},
 			FilePath: filePath,
 		}
@@ -1148,10 +1145,9 @@ func processCustomArgs(processor *codegen.Processor, cd *CustomData, s *gqlSchem
 		}
 		gqlNode := &gqlNode{
 			ObjData: &gqlobjectData{
-				Node:         arg.NodeName,
-				NodeInstance: "obj",
-				GQLNodes:     []*objectType{objType},
-				Package:      processor.Config.GetImportPackage(),
+				Node:     arg.NodeName,
+				GQLNodes: []*objectType{objType},
+				Package:  processor.Config.GetImportPackage(),
 			},
 			FilePath: filePath,
 		}
@@ -1180,10 +1176,9 @@ func processDanglingCustomObject(processor *codegen.Processor, cd *CustomData, s
 
 	gqlNode := &gqlNode{
 		ObjData: &gqlobjectData{
-			Node:         obj.NodeName,
-			NodeInstance: "obj",
-			GQLNodes:     []*objectType{objType},
-			Package:      processor.Config.GetImportPackage(),
+			Node:     obj.NodeName,
+			GQLNodes: []*objectType{objType},
+			Package:  processor.Config.GetImportPackage(),
 		},
 		FilePath: filePath,
 	}

--- a/internal/graphql/custom_ts_test.go
+++ b/internal/graphql/custom_ts_test.go
@@ -149,7 +149,6 @@ func TestCustomMutation(t *testing.T) {
 	require.NotNil(t, objData)
 	assert.Nil(t, objData.NodeData)
 	assert.Equal(t, objData.Node, "AuthResolver")
-	assert.Equal(t, objData.NodeInstance, "obj")
 	assert.Len(t, objData.Enums, 0)
 	assert.Len(t, objData.GQLNodes, 0)
 
@@ -292,7 +291,6 @@ func TestCustomQuery(t *testing.T) {
 	require.NotNil(t, objData)
 	assert.Nil(t, objData.NodeData)
 	assert.Equal(t, objData.Node, "AuthResolver")
-	assert.Equal(t, objData.NodeInstance, "obj")
 	assert.Len(t, objData.Enums, 0)
 	assert.Len(t, objData.GQLNodes, 0)
 
@@ -424,7 +422,6 @@ func TestCustomListQuery(t *testing.T) {
 	require.NotNil(t, objData)
 	assert.Nil(t, objData.NodeData)
 	assert.Equal(t, objData.Node, "AuthResolver")
-	assert.Equal(t, objData.NodeInstance, "obj")
 	assert.Len(t, objData.Enums, 0)
 	assert.Len(t, objData.GQLNodes, 0)
 
@@ -588,7 +585,6 @@ func TestCustomQueryReferencesExistingObject(t *testing.T) {
 	require.NotNil(t, objData)
 	assert.Nil(t, objData.NodeData)
 	assert.Equal(t, objData.Node, "UsernameResolver")
-	assert.Equal(t, objData.NodeInstance, "obj")
 	assert.Len(t, objData.Enums, 0)
 	assert.Len(t, objData.GQLNodes, 0)
 
@@ -721,7 +717,6 @@ func TestCustomUploadType(t *testing.T) {
 	require.NotNil(t, objData)
 	assert.Nil(t, objData.NodeData)
 	assert.Equal(t, objData.Node, "ProfilePicResolver")
-	assert.Equal(t, objData.NodeInstance, "obj")
 	assert.Len(t, objData.Enums, 0)
 	assert.Len(t, objData.GQLNodes, 0)
 

--- a/internal/graphql/ts_templates/object.tmpl
+++ b/internal/graphql/ts_templates/object.tmpl
@@ -37,7 +37,7 @@
   {{ template "enum.tmpl" . -}}
 {{ end -}}
 
-{{$nodeInstance := $baseObj.NodeInstance}}
+{{$nodeInstance := "obj"}}
 
 {{ range $gqlNode := $baseObj.GQLNodes -}}
   {{if eq $gqlNode.GQLType "GraphQLUnionType" -}}


### PR DESCRIPTION
it's annoying, have had to clean it up/maintain it as we support different types use "obj" consistently instead of trying to map it to the type of ent

this also fixes a weird bug if a separate object was defined in another file and has a field whose graphql name is different from the field name e.g. `EmailInfoType.firstName`  in `contact_type.ts` where the NodeInstance value wasn't consistent because the file is passing "contact" and the code was expecting "obj"

the types are currently defined in the base ent file if they are returned from a custom field in that.

it's just sadness over time as things changed/evolved/haven't been cleaned up yet.