### PR TITLE
misc auto_schema changes

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -8,11 +8,13 @@ pytest = "*"
 autopep8 = ""
 
 [packages]
-alembic = "==1.11.1"
+#alembic = "==1.12.0"
+#alembic = "==git+https://github.com/sqlalchemy/alembic.git@dbdec2661b8a01132ea3f7a027f85fed2eaf5e54"
+lolopinto-alembic-fork = "==0.0.1.dev0"
 datetime = "==4.3"
 sqlalchemy = "==2.0.18"
 psycopg2 = "==2.9.6"
-autopep8 = "==2.0.2"
+ruff = "==0.0.285"
 python-dateutil= "==2.8.2"
 
 [requires]

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -5,11 +5,11 @@ verify_ssl = true
 
 [dev-packages]
 pytest = "*"
-autopep8 = ""
 
 [packages]
 #alembic = "==1.12.0"
-#alembic = "==git+https://github.com/sqlalchemy/alembic.git@dbdec2661b8a01132ea3f7a027f85fed2eaf5e54"
+# use a fork until alembic 1.12.0 is released and can use that
+# needed for ruff support
 lolopinto-alembic-fork = "==0.0.1.dev0"
 datetime = "==4.3"
 sqlalchemy = "==2.0.18"

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5e7221e40d68bc2f05a41f06a5c9d82564a3d937bfd22eb358133a66fe31baf2"
+            "sha256": "2ad189482185772e4aa8b26546bac0149e2a37c3d2e9d4f6abb5ad4e073638f5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,22 +16,6 @@
         ]
     },
     "default": {
-        "alembic": {
-            "hashes": [
-                "sha256:6a810a6b012c88b33458fceb869aef09ac75d6ace5291915ba7fae44de372c01",
-                "sha256:dc871798a601fab38332e38d6ddb38d5e734f60034baeb8e2db5b642fccd8ab8"
-            ],
-            "index": "pypi",
-            "version": "==1.11.1"
-        },
-        "autopep8": {
-            "hashes": [
-                "sha256:86e9303b5e5c8160872b2f5ef611161b2893e9bfe8ccc7e2f76385947d57a2f1",
-                "sha256:f9849cdd62108cb739dbcdbfb7fdcc9a30d1b63c4cc3e1c1f893b5360941b61c"
-            ],
-            "index": "pypi",
-            "version": "==2.0.2"
-        },
         "datetime": {
             "hashes": [
                 "sha256:371dba07417b929a4fa685c2f7a3eaa6a62d60c02947831f97d4df9a9e70dfd0",
@@ -39,6 +23,14 @@
             ],
             "index": "pypi",
             "version": "==4.3"
+        },
+        "lolopinto-alembic-fork": {
+            "hashes": [
+                "sha256:6d95de0b1f2165da5049dbdd7d91631853f2b579531607cc6bcd1616754efef1",
+                "sha256:cecb23a7cbcaee806aa2994337bd1afc4ab6a5688d80944353dbe06854c499db"
+            ],
+            "index": "pypi",
+            "version": "==0.0.1.dev0"
         },
         "mako": {
             "hashes": [
@@ -123,14 +115,6 @@
             "index": "pypi",
             "version": "==2.9.6"
         },
-        "pycodestyle": {
-            "hashes": [
-                "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0",
-                "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.11.0"
-        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
@@ -145,6 +129,29 @@
                 "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"
             ],
             "version": "==2023.3"
+        },
+        "ruff": {
+            "hashes": [
+                "sha256:0d9ab6ad16742eb78919e0fba09f914f042409df40ad63423c34bb20d350162a",
+                "sha256:1d2a60c102e7a5e147b58fc2cbea12a563c565383effc527c987ea2086a05742",
+                "sha256:2933cc9631f453305399c7b8fb72b113ad76b49ae1d7103cc4afd3a423bed164",
+                "sha256:45866048d1dcdcc80855998cb26c4b2b05881f9e043d2e3bfe1aa36d9a2e8f28",
+                "sha256:5473a4c6cac34f583bff08c5f63b8def5599a0ea4dc96c0302fbd2cc0b3ecbad",
+                "sha256:5977ce304da35c263f5e082901bd7ac0bd2be845a8fcfd1a29e4d6680cddb307",
+                "sha256:6c48926156288b8ac005eb1db5e77c15e8a37309ae49d9fb6771d5cf5f777590",
+                "sha256:72a087712d474fa17b915d7cb9ef807e1256182b12ddfafb105eb00aeee48d1a",
+                "sha256:72a3a0936369b986b0e959f9090206ed3c18f9e5e439ea5b8e6867c6707aded5",
+                "sha256:770c5eb6376de024111443022cda534fb28980a9dd3b4abc83992a8770167ba6",
+                "sha256:7ce67736cd8dfe97162d1e7adfc2d9a1bac0efb9aaaff32e4042c7cde079f54b",
+                "sha256:80effdf4fe69763d69eb4ab9443e186fd09e668b59fe70ba4b49f4c077d15a1b",
+                "sha256:a8c6ad6b9cd77489bf6d1510950cbbe47a843aa234adff0960bae64bd06c3b6d",
+                "sha256:b02aae62f922d088bb01943e1dbd861688ada13d735b78b8348a7d90121fd292",
+                "sha256:de44fbc6c3b25fccee473ddf851416fd4e246fc6027b2197c395b1b3b3897921",
+                "sha256:e6b1c961d608d373a032f047a20bf3c55ad05f56c32e7b96dcca0830a2a72348",
+                "sha256:f572c4296d8c7ddd22c3204de4031965be524fdd1fdaaef273945932912b28c5"
+            ],
+            "index": "pypi",
+            "version": "==0.0.285"
         },
         "setuptools": {
             "hashes": [
@@ -257,11 +264,12 @@
     "develop": {
         "autopep8": {
             "hashes": [
-                "sha256:86e9303b5e5c8160872b2f5ef611161b2893e9bfe8ccc7e2f76385947d57a2f1",
-                "sha256:f9849cdd62108cb739dbcdbfb7fdcc9a30d1b63c4cc3e1c1f893b5360941b61c"
+                "sha256:ba4901621c7f94c6fce134437d577009886d5e3bfa46ee64e1d1d864a5b93cc2",
+                "sha256:ca72bd1e3bf0aa40636860fa07e3f1a762a18d0943cf359b3de09221059ffbd9"
             ],
             "index": "pypi",
-            "version": "==2.0.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.3"
         },
         "iniconfig": {
             "hashes": [

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2ad189482185772e4aa8b26546bac0149e2a37c3d2e9d4f6abb5ad4e073638f5"
+            "sha256": "ff359870e92e31906edc531f37f48da65f5760cd584a7d3652f08ea8a9a910ca"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -262,15 +262,6 @@
         }
     },
     "develop": {
-        "autopep8": {
-            "hashes": [
-                "sha256:ba4901621c7f94c6fce134437d577009886d5e3bfa46ee64e1d1d864a5b93cc2",
-                "sha256:ca72bd1e3bf0aa40636860fa07e3f1a762a18d0943cf359b3de09221059ffbd9"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.3"
-        },
         "iniconfig": {
             "hashes": [
                 "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
@@ -294,14 +285,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.2.0"
-        },
-        "pycodestyle": {
-            "hashes": [
-                "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0",
-                "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.11.0"
         },
         "pytest": {
             "hashes": [

--- a/python/auto_schema/RELEASING.MD
+++ b/python/auto_schema/RELEASING.MD
@@ -18,7 +18,11 @@ Steps to release new version:
 * Bump version in `setup.py`
 * Run the following command from `python/auto_schema` (where `setup.py` is located): `python3 setup.py sdist bdist_wheel`.
 * Run `python3 -m twine upload --repository pypi dist/*` to upload to pypi OR `python3 -m twine upload --repository testpypi dist/*`. You need to be added to the project and have a [token](https://pypi.org/help/#apitoken) (or [test token](https://test.pypi.org/help/#apitoken))  in `~/.pypirc` or equivalent location.
-* Recommend cleaning up after by running `rm -rf dist/`
+* Recommend cleaning up after by running the following:
+
+ 1. `rm -rf dist/`
+ 2. `rm -rf auto_schema.egg-info`
+ 3. `rm -rf auto_schema_test.egg-info`
 
 ## Testing
 

--- a/python/auto_schema/auto_schema/command.py
+++ b/python/auto_schema/auto_schema/command.py
@@ -29,13 +29,13 @@ class Command(object):
             "alembic:exclude", "tables", runner.Runner.exclude_tables())
 
         # for default formatting
-        alembic_cfg.set_section_option('post_write_hooks', 'hooks', 'autopep8')
+        alembic_cfg.set_section_option('post_write_hooks', 'hooks', 'ruff')
         alembic_cfg.set_section_option(
-            'post_write_hooks', 'autopep8.type', 'console_scripts')
+            'post_write_hooks', 'ruff.type', 'exec')
         alembic_cfg.set_section_option(
-            'post_write_hooks', 'autopep8.entrypoint', 'autopep8')
+            'post_write_hooks', 'ruff.executable', 'ruff')
         alembic_cfg.set_section_option(
-            'post_write_hooks', 'autopep8.options', '--in-place')
+            'post_write_hooks', 'ruff.options', '--fix REVISION_SCRIPT_FILENAME --silent')
 
         self.alembic_cfg = alembic_cfg
 

--- a/python/auto_schema/auto_schema/script.py.mako
+++ b/python/auto_schema/auto_schema/script.py.mako
@@ -7,7 +7,7 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
-from alembic import op
+from alembic import op #noqa
 import sqlalchemy as sa
 import auto_schema
 ## TODO: for down commands when removing edges, we add "UUID()" which is broken and unncessary :(

--- a/python/auto_schema/setup.py
+++ b/python/auto_schema/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="auto_schema_test",  # auto_schema_test to test
     # 0.0.29 production
-    version="0.0.31",  # 0.0.26 was last test version
+    version="0.0.32",  # 0.0.26 was last test version
     author="Ola Okelola",
     author_email="email@email.com",
     description="auto schema for a db",
@@ -23,10 +23,11 @@ setuptools.setup(
     ],
     python_requires='==3.11',
     install_requires=["sqlalchemy==2.0.18",
-                      "alembic==1.11.1",
+                    #   "alembic @ git+https://github.com/sqlalchemy/alembic.git@dbdec2661b8a01132ea3f7a027f85fed2eaf5e54#egg=alembic",
+                      "lolopinto-alembic-fork==0.0.1.dev0",
                       "datetime==4.3",
                       "psycopg2==2.9.6",
-                      "autopep8==2.0.2",
+                      "ruff==0.0.285",
                       "python-dateutil==2.8.2"
                       ],
     entry_points={'console_scripts': ["auto_schema = auto_schema.cli:main"]},

--- a/python/auto_schema/setup.py
+++ b/python/auto_schema/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="auto_schema_test",  # auto_schema_test to test
     # 0.0.29 production
-    version="0.0.30",  # 0.0.26 was last test version
+    version="0.0.31",  # 0.0.26 was last test version
     author="Ola Okelola",
     author_email="email@email.com",
     description="auto schema for a db",

--- a/python/auto_schema/setup.py
+++ b/python/auto_schema/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="auto_schema_test",  # auto_schema_test to test
     # 0.0.29 production
-    version="0.0.28",  # 0.0.26 was last test version
+    version="0.0.29",  # 0.0.26 was last test version
     author="Ola Okelola",
     author_email="email@email.com",
     description="auto schema for a db",

--- a/python/auto_schema/setup.py
+++ b/python/auto_schema/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="auto_schema_test",  # auto_schema_test to test
     # 0.0.29 production
-    version="0.0.29",  # 0.0.26 was last test version
+    version="0.0.30",  # 0.0.26 was last test version
     author="Ola Okelola",
     author_email="email@email.com",
     description="auto schema for a db",

--- a/python/auto_schema/tests/command_test.py
+++ b/python/auto_schema/tests/command_test.py
@@ -526,6 +526,8 @@ CREATE OR REPLACE TRIGGER events_name_change_trigger BEFORE UPDATE
             {
                 "change": ChangeType.EXECUTE_SQL,
                 "tables": ['accounts', 'events'],
+                # by the time we're editing the file, we have run ruff and removed the file
+                # so we need to do something similar to what happens with alembic
                 "runner_lambda": lambda r: testingutils.create_custom_revision(
                     r,
                     "custom change again",

--- a/python/auto_schema/tests/command_test.py
+++ b/python/auto_schema/tests/command_test.py
@@ -526,8 +526,6 @@ CREATE OR REPLACE TRIGGER events_name_change_trigger BEFORE UPDATE
             {
                 "change": ChangeType.EXECUTE_SQL,
                 "tables": ['accounts', 'events'],
-                # by the time we're editing the file, we have run ruff and removed the file
-                # so we need to do something similar to what happens with alembic
                 "runner_lambda": lambda r: testingutils.create_custom_revision(
                     r,
                     "custom change again",


### PR DESCRIPTION
* create `__init__.py` for `auto_schema/util` added in https://github.com/lolopinto/ent/pull/1621
* use `ruff` for formatting to speed up squash_all when there's a huge file generated
* use a fork of `alembic` for now to get `ruff` support until `1.12.0` comes out
* add `#noqa` to `script.py.mako` so that custom revisions can still use `op.{method}` without having to add anything
  * needed for tests to work without many changes to how tests work