### PR TITLE
[auto_schema] handle slight changes in json when comparing server_default

### DIFF
--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -165,6 +165,12 @@ class Runner(object):
             new_metadata_default = cls.convert_postgres_boolean(
                 new_metadata_default)
 
+
+        if isinstance(metadata_column.type, postgresql.JSON) or isinstance(metadata_column.type, postgresql.JSONB):
+            if (new_inspected_default is None and new_metadata_default is not None) or (new_inspected_default is not None and new_metadata_default is None):
+                return True
+            return json.loads(new_inspected_default) != json.loads(new_metadata_default)
+
         if new_inspected_default != new_metadata_default:
             # specific case. not sure why this is needed
             # can be generalized at some point in the future

--- a/python/auto_schema/pyproject.toml
+++ b/python/auto_schema/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 # auto_schema_test https://test.pypi.org/project/auto-schema-test/
 name = "auto_schema_test"
-version = "0.0.35"
+version = "0.0.36"
 # production https://pypi.org/project/auto-schema/
 # name = "auto_schema"
 # version = "0.0.31"

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -483,6 +483,9 @@ def metadata_with_json_column():
              )
     return metadata
 
+@pytest.fixture()
+def metadata_with_json_column_fixture():
+    return metadata_with_json_column()
 
 def metadata_with_server_default_changed_json(metadata):
     return _metadata_with_server_default_changed(metadata, 'col', 'tbl', server_default_json_value())

--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -824,6 +824,39 @@ class TestPostgresRunner(BaseTestRunner):
 
         # nothing changed, we should have no changes
         assert len(diff) == 0
+        
+    @pytest.mark.usefixtures("metadata_with_json_column_fixture")
+    def test_server_default_no_real_change_json(self, new_test_runner, metadata_with_json_column_fixture):
+        r = new_test_runner(metadata_with_json_column_fixture)
+
+        testingutils.run_and_validate_with_standard_metadata_tables(
+            r, metadata_with_json_column_fixture, ['tbl'])
+
+
+        conftest._metadata_with_server_default_changed(metadata_with_json_column_fixture, 'col', 'tbl', '{"col":"val"}')
+
+        r2 = new_test_runner(metadata_with_json_column_fixture, r)
+        diff = r2.compute_changes()
+
+        # 1 change. add server default
+        assert len(diff) == 1
+        
+        r2.run()
+        testingutils.assert_num_files(r2, 2)
+        
+        # fix the json 
+        conftest._metadata_with_server_default_changed(metadata_with_json_column_fixture, 'col', 'tbl', '{"col": "val"}')
+
+        r3 = new_test_runner(metadata_with_json_column_fixture, r2)
+        diff = r3.compute_changes()
+
+        # nothing changed, we should have no changes
+        assert len(diff) == 0
+        
+        r3.run()
+        testingutils.assert_num_files(r3, 2)
+
+
 
     @pytest.mark.parametrize(
         "new_metadata_func, table_name, change_metadata_func, expected_message",


### PR DESCRIPTION
not sure how this happens but ran into this. this only saves an extra schema file since the next time things should be equal but it was confusing to me when i encountered this so fixing