### PR TITLE
misc context | cache fixes

### DIFF
--- a/ts/src/action/operations.ts
+++ b/ts/src/action/operations.ts
@@ -516,7 +516,7 @@ export class EdgeOperation implements DataOperation {
   ): Promise<void> {
     const params = this.getDeleteRowParams(edgeData, edge, context);
     if (params.op === SQLStatementOperation.Delete) {
-      return deleteRows(q, params.options, params.clause);
+      return deleteRows(q, { ...params.options, context }, params.clause);
     } else {
       if (params.op !== SQLStatementOperation.Update) {
         throw new Error(`invalid operation ${params.op}`);
@@ -539,7 +539,7 @@ export class EdgeOperation implements DataOperation {
   ): void {
     const params = this.getDeleteRowParams(edgeData, edge, context);
     if (params.op === SQLStatementOperation.Delete) {
-      return deleteRowsSync(q, params.options, params.clause);
+      return deleteRowsSync(q, { ...params.options, context }, params.clause);
     } else {
       if (params.op !== SQLStatementOperation.Update) {
         throw new Error(`invalid operation ${params.op}`);

--- a/ts/src/action/operations.ts
+++ b/ts/src/action/operations.ts
@@ -526,6 +526,7 @@ export class EdgeOperation implements DataOperation {
         whereClause: params.clause,
         fields: params.updateData!,
         fieldsToLog: params.updateData!,
+        context,
       });
     }
   }
@@ -547,6 +548,7 @@ export class EdgeOperation implements DataOperation {
         tableName: params.options.tableName,
         whereClause: params.clause,
         fields: params.updateData!,
+        context,
       });
     }
   }

--- a/ts/src/action/transformed_orchestrator.test.ts
+++ b/ts/src/action/transformed_orchestrator.test.ts
@@ -20,7 +20,7 @@ import { createRowForTest } from "../testutils/write";
 import * as clause from "../core/clause";
 import { snakeCase } from "snake-case";
 import DB, { Dialect } from "../core/db";
-import { ObjectLoader } from "../core/loaders";
+import { ObjectLoader, ObjectLoaderFactory } from "../core/loaders";
 import { TestContext } from "../testutils/context/test_context";
 import {
   assoc_edge_config_table,
@@ -269,73 +269,86 @@ describe("sqlite", () => {
   commonTests();
 });
 
+const usersLoaderFactory = new ObjectLoaderFactory(
+  {
+    tableName: "users",
+    fields: ["id", "first_name", "last_name", "deleted_at"],
+    key: "id",
+    clause: clause.Eq("deleted_at", null),
+  });
+
+  const accountsLoaderFactory = new ObjectLoaderFactory(
+  {
+    tableName: "accounts",
+    fields: ["id", "first_name", "last_name", "deleted_at"],
+    key: "id",
+    clause: clause.Eq("deleted_at", null),
+    });
+  
+      const contactsLoaderFactory = new ObjectLoaderFactory(
+  {
+    tableName: "contacts",
+    fields: ["id", "first_name", "last_name", "deleted_at"],
+    key: "id",
+    clause: clause.Eq("deleted_at", null),
+        });
+    
+        const usersLoaderFactoryNoClause = new ObjectLoaderFactory(
+  {
+    tableName: "users",
+    fields: ["id", "first_name", "last_name", "deleted_at"],
+    key: "id",
+  });
+
+  const accountsLoaderFactoryNoClause = new ObjectLoaderFactory(
+  {
+    tableName: "accounts",
+    fields: ["id", "first_name", "last_name", "deleted_at"],
+    key: "id",
+    });
+  
+      const contactsLoaderFactoryNoClause = new ObjectLoaderFactory(
+  {
+    tableName: "contacts",
+    fields: ["id", "first_name", "last_name", "deleted_at"],
+    key: "id",
+        });
+
 const getNewLoader = (context: boolean = true) => {
-  return new ObjectLoader(
-    {
-      tableName: "users",
-      fields: ["id", "first_name", "last_name", "deleted_at"],
-      key: "id",
-      clause: clause.Eq("deleted_at", null),
-    },
+  return usersLoaderFactory.createLoader(
     context ? new TestContext() : undefined,
   );
 };
 
 const getAccountNewLoader = (context: boolean = true) => {
-  return new ObjectLoader(
-    {
-      tableName: "accounts",
-      fields: ["id", "first_name", "last_name", "deleted_at"],
-      key: "id",
-      clause: clause.Eq("deleted_at", null),
-    },
+  return accountsLoaderFactory.createLoader(
     context ? new TestContext() : undefined,
   );
 };
 
 const getContactNewLoader = (context: boolean = true) => {
-  return new ObjectLoader(
-    {
-      tableName: "contacts",
-      fields: ["id", "first_name", "last_name", "deleted_at"],
-      key: "id",
-      clause: clause.Eq("deleted_at", null),
-    },
+    return contactsLoaderFactory.createLoader(
     context ? new TestContext() : undefined,
   );
+
 };
 
 // deleted_at field but no custom_clause
 // behavior when we're ignoring deleted_at. exception...
 const getNewLoaderNoCustomClause = (context: boolean = true) => {
-  return new ObjectLoader(
-    {
-      tableName: "users",
-      fields: ["id", "first_name", "last_name", "deleted_at"],
-      key: "id",
-    },
+  return usersLoaderFactoryNoClause.createLoader(
     context ? new TestContext() : undefined,
   );
 };
 
 const getContactNewLoaderNoCustomClause = (context: boolean = true) => {
-  return new ObjectLoader(
-    {
-      tableName: "contacts",
-      fields: ["id", "first_name", "last_name", "deleted_at"],
-      key: "id",
-    },
+  return contactsLoaderFactoryNoClause.createLoader(
     context ? new TestContext() : undefined,
   );
 };
 
 const getAccountNewLoaderNoCustomClause = (context: boolean = true) => {
-  return new ObjectLoader(
-    {
-      tableName: "accounts",
-      fields: ["id", "first_name", "last_name", "deleted_at"],
-      key: "id",
-    },
+  return accountsLoaderFactoryNoClause.createLoader(
     context ? new TestContext() : undefined,
   );
 };

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -68,7 +68,10 @@ export interface PrimableLoader<K, V> extends Loader<K, V> {
   primeAll?(d: V): void;
 }
 
-export type QueryOptions = Required<Pick<LoadRowsOptions, "clause" | "fields" | 'tableName'>> & Pick<LoadRowsOptions, 'orderby' | 'join'>;
+export type QueryOptions = Required<
+  Pick<LoadRowsOptions, "clause" | "fields" | "tableName">
+> &
+  Pick<LoadRowsOptions, "orderby" | "join">;
 
 interface cache {
   getLoader<K, V>(name: string, create: () => Loader<K, V>): Loader<K, V>;
@@ -172,7 +175,7 @@ export interface QueryableDataOptions
 interface JoinOptions<T2 extends Data = Data, K2 = keyof T2> {
   tableName: string;
   alias?: string;
-  clause: clause.Clause<T2,K2>;
+  clause: clause.Clause<T2, K2>;
 }
 
 export interface QueryDataOptions<T extends Data = Data, K = keyof T> {
@@ -182,7 +185,7 @@ export interface QueryDataOptions<T extends Data = Data, K = keyof T> {
   groupby?: K;
   limit?: number;
   disableTransformations?: boolean;
-  join?:JoinOptions;
+  join?: JoinOptions;
 }
 
 // For loading data from database

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -68,24 +68,19 @@ export interface PrimableLoader<K, V> extends Loader<K, V> {
   primeAll?(d: V): void;
 }
 
+export type QueryOptions = Required<Pick<LoadRowsOptions, "clause" | "fields" | 'tableName'>> & Pick<LoadRowsOptions, 'orderby' | 'join'>;
+
 interface cache {
   getLoader<K, V>(name: string, create: () => Loader<K, V>): Loader<K, V>;
   getLoaderWithLoadMany<K, V>(
     name: string,
     create: () => LoaderWithLoadMany<K, V>,
   ): LoaderWithLoadMany<K, V>;
-  getCachedRows(options: queryOptions): Data[] | null;
-  getCachedRow(options: queryOptions): Data | null;
-  primeCache(options: queryOptions, rows: Data[]): void;
-  primeCache(options: queryOptions, rows: Data): void;
+  getCachedRows(options: QueryOptions): Data[] | null;
+  getCachedRow(options: QueryOptions): Data | null;
+  primeCache(options: QueryOptions, rows: Data[]): void;
+  primeCache(options: QueryOptions, rows: Data): void;
   clearCache(): void;
-}
-
-interface queryOptions {
-  fields: string[];
-  tableName: string;
-  clause: clause.Clause;
-  orderby?: OrderBy;
 }
 
 export interface Context<TViewer extends Viewer = Viewer> {

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -106,7 +106,7 @@ class simpleClause<T extends Data, K = keyof T> implements Clause<T, K> {
 }
 
 // NB: we're not using alias in this class in clause method
-// if we end up with a subclass that does, we need to handle it 
+// if we end up with a subclass that does, we need to handle it
 class queryClause<T extends Data, K = keyof T> implements Clause<T, K> {
   constructor(
     protected dependentQueryOptions: QueryableDataOptions, // private value: any, // private op: string, // private handleNull?: Clause<T, K>,

--- a/ts/src/core/ent_custom_data.test.ts
+++ b/ts/src/core/ent_custom_data.test.ts
@@ -9,7 +9,6 @@ import {
   Allow,
   Skip,
   LoadCustomEntOptions,
-  QueryableDataOptions,
 } from "./base";
 import { LoggedOutViewer, IDViewer } from "./viewer";
 import { AlwaysDenyRule } from "./privacy";
@@ -257,7 +256,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  ctx.cache?.clearCache();
   clearLogLevels();
 });
 

--- a/ts/src/core/ent_data.test.ts
+++ b/ts/src/core/ent_data.test.ts
@@ -228,7 +228,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  ctx.cache?.clearCache();
   clearLogLevels();
 });
 

--- a/ts/src/core/loaders/assoc_count_loader.test.ts
+++ b/ts/src/core/loaders/assoc_count_loader.test.ts
@@ -30,23 +30,33 @@ import {
   setupTempDB,
   tempDBTables,
 } from "../../testutils/fake_data/test_helpers";
-import { AssocEdgeCountLoader, AssocEdgeCountLoaderFactory } from "./assoc_count_loader";
+import {
+  AssocEdgeCountLoader,
+  AssocEdgeCountLoaderFactory,
+} from "./assoc_count_loader";
 import { testEdgeGlobalSchema } from "../../testutils/test_edge_global_schema";
 import { SimpleAction } from "../../testutils/builder";
 
 const ml = new MockLogs();
 
-const assocEdgeLoaderFactory = new AssocEdgeCountLoaderFactory(EdgeType.UserToContacts);
+const assocEdgeLoaderFactory = new AssocEdgeCountLoaderFactory(
+  EdgeType.UserToContacts,
+);
 
 const getNewLoader = (context: boolean = true) => {
-  return assocEdgeLoaderFactory.createLoader(context ? new TestContext() : undefined);
+  return assocEdgeLoaderFactory.createLoader(
+    context ? new TestContext() : undefined,
+  );
 };
 
 const getConfigurableLoader = (
   context: boolean = true,
   opts: EdgeQueryableDataOptionsConfigureLoader,
 ) => {
-  return assocEdgeLoaderFactory.createConfigurableLoader(opts, context ? new TestContext() : undefined);
+  return assocEdgeLoaderFactory.createConfigurableLoader(
+    opts,
+    context ? new TestContext() : undefined,
+  );
 };
 
 describe("postgres", () => {
@@ -257,11 +267,11 @@ async function verifySingleIDHit(
   verifyPostFirstQuery: (id: ID) => void,
   verifyPostSecondQuery: (id: ID) => void,
 ) {
-  const [user, contacts] = await createAllContacts();
+  const loader = loaderFn();
+  const [user, contacts] = await createAllContacts({ ctx: loader.context });
   // clear post creation
   ml.clear();
 
-  const loader = loaderFn();
   const count = await loader.load(user.id);
   expect(count).toBe(contacts.length);
 
@@ -332,9 +342,14 @@ async function testMultiQueryDataAvail(
   const m = new Map<ID, FakeContact[]>();
   const ids: ID[] = [];
 
+  const loader = loaderFn();
+
   await Promise.all(
     [1, 2, 3, 4, 5].map(async (count, idx) => {
-      const [user, contacts] = await createAllContacts({ slice: count });
+      const [user, contacts] = await createAllContacts({
+        slice: count,
+        ctx: loader.context,
+      });
 
       m.set(user.id, contacts);
       ids[idx] = user.id;
@@ -342,8 +357,6 @@ async function testMultiQueryDataAvail(
   );
 
   ml.clear();
-
-  const loader = loaderFn();
 
   const counts = await Promise.all(ids.map(async (id) => loader.load(id)));
   for (let i = 0; i < ids.length; i++) {
@@ -378,9 +391,15 @@ async function testWithDeleteMultiQueryDataAvail(
   const ids: ID[] = [];
   const users: FakeUser[] = [];
 
+  // pass context to createAllContacts
+  const loader = loaderFn();
+
   await Promise.all(
     [1, 2, 3, 4, 5].map(async (count, idx) => {
-      const [user, contacts] = await createAllContacts({ slice: count });
+      const [user, contacts] = await createAllContacts({
+        slice: count,
+        ctx: loader.context,
+      });
 
       m.set(user.id, contacts);
       ids[idx] = user.id;
@@ -389,8 +408,6 @@ async function testWithDeleteMultiQueryDataAvail(
   );
 
   ml.clear();
-
-  const loader = loaderFn();
 
   const counts = await Promise.all(ids.map(async (id) => loader.load(id)));
   for (let i = 0; i < ids.length; i++) {
@@ -419,7 +436,6 @@ async function testWithDeleteMultiQueryDataAvail(
   await action.saveX();
   // clear the logs
   ml.clear();
-  loader.clearAll();
 
   // re-load
   const counts2 = await Promise.all(ids.map(async (id) => loader.load(id)));
@@ -447,9 +463,14 @@ async function testWithDeleteMultiQueryDataLoadDeleted(
   const ids: ID[] = [];
   const users: FakeUser[] = [];
 
+  const loader = loaderFn({});
+
   await Promise.all(
     [1, 2, 3, 4, 5].map(async (count, idx) => {
-      const [user, contacts] = await createAllContacts({ slice: count });
+      const [user, contacts] = await createAllContacts({
+        slice: count,
+        ctx: loader.context,
+      });
 
       m.set(user.id, contacts);
       ids[idx] = user.id;
@@ -458,8 +479,6 @@ async function testWithDeleteMultiQueryDataLoadDeleted(
   );
 
   ml.clear();
-
-  const loader = loaderFn({});
 
   const counts = await Promise.all(ids.map(async (id) => loader.load(id)));
   for (let i = 0; i < ids.length; i++) {
@@ -488,7 +507,6 @@ async function testWithDeleteMultiQueryDataLoadDeleted(
   await action.saveX();
   // clear the logs
   ml.clear();
-  loader.clearAll();
 
   const loader2 = loaderFn({
     disableTransformations: true,
@@ -511,11 +529,10 @@ async function testWithDeleteSingleQueryDataLoadDeleted(
   verifyPostFirstQuery: (ids: ID[]) => void,
   verifyPostSecondQuery: (ids: ID[], disableTransformations?: boolean) => void,
 ) {
-  const [user, contacts] = await createAllContacts();
+  const loader = loaderFn({});
+  const [user, contacts] = await createAllContacts({ ctx: loader.context });
 
   ml.clear();
-
-  const loader = loaderFn({});
 
   const counts = await loader.load(user.id);
   expect(counts).toBe(contacts.length);
@@ -538,7 +555,6 @@ async function testWithDeleteSingleQueryDataLoadDeleted(
   await action.saveX();
   // clear the logs
   ml.clear();
-  loader.clearAll();
 
   const loader2 = loaderFn({
     disableTransformations: true,

--- a/ts/src/core/loaders/assoc_count_loader.test.ts
+++ b/ts/src/core/loaders/assoc_count_loader.test.ts
@@ -30,28 +30,23 @@ import {
   setupTempDB,
   tempDBTables,
 } from "../../testutils/fake_data/test_helpers";
-import { AssocEdgeCountLoader } from "./assoc_count_loader";
+import { AssocEdgeCountLoader, AssocEdgeCountLoaderFactory } from "./assoc_count_loader";
 import { testEdgeGlobalSchema } from "../../testutils/test_edge_global_schema";
 import { SimpleAction } from "../../testutils/builder";
 
 const ml = new MockLogs();
 
+const assocEdgeLoaderFactory = new AssocEdgeCountLoaderFactory(EdgeType.UserToContacts);
+
 const getNewLoader = (context: boolean = true) => {
-  return new AssocEdgeCountLoader(
-    EdgeType.UserToContacts,
-    context ? new TestContext() : undefined,
-  );
+  return assocEdgeLoaderFactory.createLoader(context ? new TestContext() : undefined);
 };
 
 const getConfigurableLoader = (
   context: boolean = true,
   opts: EdgeQueryableDataOptionsConfigureLoader,
 ) => {
-  return new AssocEdgeCountLoader(
-    EdgeType.UserToContacts,
-    context ? new TestContext() : undefined,
-    opts,
-  );
+  return assocEdgeLoaderFactory.createConfigurableLoader(opts, context ? new TestContext() : undefined);
 };
 
 describe("postgres", () => {

--- a/ts/src/core/loaders/assoc_edge_loader.test.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.test.ts
@@ -47,32 +47,43 @@ const ml = new MockLogs();
 
 let ctx: TestContext;
 
-// TODO these and how it's used with the loaders below
+const userToContactsLoader = new AssocEdgeLoaderFactory(
+  EdgeType.UserToContacts,
+  AssocEdge,
+);
+
+const userToContactsCustomLoader = new AssocEdgeLoaderFactory(
+  EdgeType.UserToContacts,
+  CustomEdge,
+);
+
+const userToFollowingCustomLoader = new AssocEdgeLoaderFactory(
+  EdgeType.UserToFollowing,
+  CustomEdge,
+);
+
 const getNewContactsLoader = (context: boolean = true) => {
-  return new AssocEdgeLoaderFactory(
-    EdgeType.UserToContacts,
-    AssocEdge,
-  ).createLoader(context ? ctx : undefined);
+  return userToContactsLoader.createLoader(context ? ctx : undefined);
 };
 
 const getConfigurableContactsLoader = (
   context: boolean,
   options: EdgeQueryableDataOptions,
 ) => {
-  return new AssocEdgeLoaderFactory(
-    EdgeType.UserToContacts,
-    CustomEdge,
-  ).createConfigurableLoader(options, context ? ctx : undefined);
+  return userToContactsCustomLoader.createConfigurableLoader(
+    options,
+    context ? ctx : undefined,
+  );
 };
 
 const getConfigurableFollowingLoader = (
   context: boolean,
   options: EdgeQueryableDataOptions,
 ) => {
-  return new AssocEdgeLoaderFactory(
-    EdgeType.UserToFollowing,
-    CustomEdge,
-  ).createConfigurableLoader(options, context ? ctx : undefined);
+  return userToFollowingCustomLoader.createConfigurableLoader(
+    options,
+    context ? ctx : undefined,
+  );
 };
 
 describe("postgres", () => {

--- a/ts/src/core/loaders/assoc_edge_loader.test.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.test.ts
@@ -41,6 +41,7 @@ const ml = new MockLogs();
 
 let ctx: TestContext;
 
+// TODO these and how it's used with the loaders below
 const getNewContactsLoader = (context: boolean = true) => {
   return new AssocEdgeLoaderFactory(
     EdgeType.UserToContacts,

--- a/ts/src/core/loaders/assoc_edge_loader.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.ts
@@ -24,8 +24,6 @@ import { logEnabled } from "../logger";
 import { CacheMap, getCustomLoader } from "./loader";
 import memoizee from "memoizee";
 
-// any loader created here or in places like this doesn't get context cache cleared...
-// so any manual createLoader needs to be changed and added to ContextCache so that ContextCache.clearAll() works
 function createLoader<T extends AssocEdge>(
   options: EdgeQueryableDataOptions,
   edgeType: string,

--- a/ts/src/core/loaders/object_loader.test.ts
+++ b/ts/src/core/loaders/object_loader.test.ts
@@ -41,26 +41,29 @@ const usersLoaderFactory = new ObjectLoaderFactory<LoaderRow>({
   key: "id",
 });
 
-const usersLoaderFactoryDeleted = new ObjectLoaderFactory<LoaderRowWithCustomClause>({
-  tableName: "users",
-  fields: ["id", "first_name", "deleted_at"],
-  key: "id",
-  clause: clause.Eq("deleted_at", null),
-});
+const usersLoaderFactoryDeleted =
+  new ObjectLoaderFactory<LoaderRowWithCustomClause>({
+    tableName: "users",
+    fields: ["id", "first_name", "deleted_at"],
+    key: "id",
+    clause: clause.Eq("deleted_at", null),
+  });
 
-const usersLoaderFactoryDeletedNoClause = new ObjectLoaderFactory<LoaderRowWithCustomClause>({
-  tableName: "users",
-  fields: ["id", "first_name", "deleted_at"],
-  key: "id",
-});
+const usersLoaderFactoryDeletedNoClause =
+  new ObjectLoaderFactory<LoaderRowWithCustomClause>({
+    tableName: "users",
+    fields: ["id", "first_name", "deleted_at"],
+    key: "id",
+  });
 
-const usersLoaderFactoryDeletedFunc = new ObjectLoaderFactory<LoaderRowWithCustomClause>({
-  tableName: "users",
-  fields: ["id", "first_name", "deleted_at"],
-  key: "id",
-  clause: () => clause.Eq("deleted_at", null),
-  instanceKey: "users:transformedReadClause",
-});
+const usersLoaderFactoryDeletedFunc =
+  new ObjectLoaderFactory<LoaderRowWithCustomClause>({
+    tableName: "users",
+    fields: ["id", "first_name", "deleted_at"],
+    key: "id",
+    clause: () => clause.Eq("deleted_at", null),
+    instanceKey: "users:transformedReadClause",
+  });
 
 const getNewLoader = (context: boolean | TestContext = true) => {
   return usersLoaderFactory.createLoader(
@@ -137,7 +140,9 @@ const getNewCountLoaderWithCustomClauseFunc = (
 // deleted_at field but no custom_clause
 // behavior when we're ignoring deleted_at. exception...
 const getNewLoaderWithDeletedAtField = (context: boolean = true) => {
-  return usersLoaderFactoryDeletedNoClause.createLoader(context ? new TestContext() : undefined);
+  return usersLoaderFactoryDeletedNoClause.createLoader(
+    context ? new TestContext() : undefined,
+  );
 };
 
 async function create(id?: ID) {
@@ -980,7 +985,9 @@ function commonTests() {
 
     ml.clear();
 
-    await newUserEmailAddressLoaderFactory.createLoader(ctx).load(user.emailAddress);
+    await newUserEmailAddressLoaderFactory
+      .createLoader(ctx)
+      .load(user.emailAddress);
     expect(ml.logs.length).toEqual(1);
 
     const emailQuery = buildQuery({

--- a/ts/src/core/loaders/object_loader.test.ts
+++ b/ts/src/core/loaders/object_loader.test.ts
@@ -773,9 +773,9 @@ function commonTests() {
       fields: {
         deleted_at: new Date(),
       },
+      context: ctx,
     });
 
-    ctx.cache.clearCache();
     const rowPostDelete = await loader.load(1);
     expect(rowPostDelete).toEqual({ id: 1, first_name: "Jon" });
 

--- a/ts/src/core/loaders/query_loader.test.ts
+++ b/ts/src/core/loaders/query_loader.test.ts
@@ -87,11 +87,6 @@ describe("postgres", () => {
     tdb = await setupTempDB();
   });
 
-  beforeEach(() => {
-    // reset context for each test
-    ctx?.cache.clearCache();
-  });
-
   afterEach(() => {
     ml.clear();
   });
@@ -109,14 +104,6 @@ describe("sqlite", () => {
   beforeAll(async () => {
     setLogLevels(["query", "error", "cache"]);
     ml.mock();
-  });
-
-  beforeEach(async () => {
-    // reset context for each test
-    ctx?.cache.clearCache();
-
-    // create once
-    //    await createEdges();
   });
 
   afterEach(() => {

--- a/ts/src/core/loaders/raw_count_loader.test.ts
+++ b/ts/src/core/loaders/raw_count_loader.test.ts
@@ -22,12 +22,13 @@ import { clear } from "jest-date-mock";
 
 const ml = new MockLogs();
 
+const fakeContactsLoader = new RawCountLoaderFactory({
+  tableName: "fake_contacts",
+  groupCol: "user_id",
+});
+
 const getNewLoader = (context: boolean = true) => {
-  return new RawCountLoader(
-    {
-      tableName: "fake_contacts",
-      groupCol: "user_id",
-    },
+  return fakeContactsLoader.createLoader(
     context ? new TestContext() : undefined,
   );
 };
@@ -248,13 +249,14 @@ function commonTests() {
     const INTERVAL = 24 * 60 * 60 * 1000;
 
     const getNonGroupableLoader = (id: ID, context: boolean = true) => {
-      return new RawCountLoader(
+      // unclear if there's benefit of using factory here but we're consistent with API access patterns this way
+      const fakeEventsLoaderFactory = new RawCountLoaderFactory(
         {
           tableName: "fake_events",
           clause: getCompleteClause(id),
-        },
-        context ? new TestContext() : undefined,
+        }
       );
+      return fakeEventsLoaderFactory.createLoader(context ? new TestContext() : undefined);
     };
 
     test("single id. with context", async () => {

--- a/ts/src/core/loaders/raw_count_loader.test.ts
+++ b/ts/src/core/loaders/raw_count_loader.test.ts
@@ -250,13 +250,13 @@ function commonTests() {
 
     const getNonGroupableLoader = (id: ID, context: boolean = true) => {
       // unclear if there's benefit of using factory here but we're consistent with API access patterns this way
-      const fakeEventsLoaderFactory = new RawCountLoaderFactory(
-        {
-          tableName: "fake_events",
-          clause: getCompleteClause(id),
-        }
+      const fakeEventsLoaderFactory = new RawCountLoaderFactory({
+        tableName: "fake_events",
+        clause: getCompleteClause(id),
+      });
+      return fakeEventsLoaderFactory.createLoader(
+        context ? new TestContext() : undefined,
       );
-      return fakeEventsLoaderFactory.createLoader(context ? new TestContext() : undefined);
     };
 
     test("single id. with context", async () => {

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -34,6 +34,11 @@ export function reverseOrderBy(orderby: OrderBy): OrderBy {
   });
 }
 
+export function getJoinPhrase(join: NonNullable<QueryableDataOptions['join']>,  clauseIdx = 1): string {
+  const joinTable = join.alias ? `${join.tableName} ${join.alias}` : join.tableName;
+  return `${joinTable} ON ${join.clause.clause(clauseIdx)}`;
+}
+
 export function buildQuery(options: QueryableDataOptions): string {
   const fields = options.alias
     ? options.fields.map((f) => `${options.alias}.${f}`).join(", ")
@@ -48,8 +53,7 @@ export function buildQuery(options: QueryableDataOptions): string {
 
   let whereStart = 1;
   if (options.join) {
-    const joinTable = options.join.alias ? `${options.join.tableName} ${options.join.alias}` : options.join.tableName;
-    parts.push(`JOIN ${joinTable} ON ${options.join.clause.clause(1)}`);
+    parts.push(`JOIN ${getJoinPhrase(options.join, 1)}`);
     whereStart += options.join.clause.values().length;
   }
   

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -34,8 +34,13 @@ export function reverseOrderBy(orderby: OrderBy): OrderBy {
   });
 }
 
-export function getJoinPhrase(join: NonNullable<QueryableDataOptions['join']>,  clauseIdx = 1): string {
-  const joinTable = join.alias ? `${join.tableName} ${join.alias}` : join.tableName;
+export function getJoinPhrase(
+  join: NonNullable<QueryableDataOptions["join"]>,
+  clauseIdx = 1,
+): string {
+  const joinTable = join.alias
+    ? `${join.tableName} ${join.alias}`
+    : join.tableName;
   return `${joinTable} ON ${join.clause.clause(clauseIdx)}`;
 }
 
@@ -56,7 +61,7 @@ export function buildQuery(options: QueryableDataOptions): string {
     parts.push(`JOIN ${getJoinPhrase(options.join, 1)}`);
     whereStart += options.join.clause.values().length;
   }
-  
+
   parts.push(`WHERE ${options.clause.clause(whereStart, options.alias)}`);
   if (options.groupby) {
     parts.push(`GROUP BY ${options.groupby}`);


### PR DESCRIPTION
follow-up to https://github.com/lolopinto/ent/pull/1635

* use context in a few places that were missing e.g. `operations.ts`
* consolidate types in one place 
* add `join` to cache.QueryOptions and what it's checking
* use loader factory instead of loader in a bunch of tests so it's similar to production use cases 
* clear out as many manual cache clearing as possible. if the cache has to be manually cleared, it's a sign that something is broken and fixed it e.g. missing context or context not threaded through
* probably more

may be worth doing a breaking change to make Context required but cache can be optional to imrp