### PR TITLE
add reset() to reset Context Cache in websockets instead of just clearCache

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.16-test2",
+  "version": "0.1.16",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.15",
+  "version": "0.1.16-test2",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -84,6 +84,7 @@ interface cache {
   primeCache(options: QueryOptions, rows: Data[]): void;
   primeCache(options: QueryOptions, rows: Data): void;
   clearCache(): void;
+  reset(): void;
 }
 
 export interface Context<TViewer extends Viewer = Viewer> {

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -88,6 +88,11 @@ interface cache {
 }
 
 export interface Context<TViewer extends Viewer = Viewer> {
+  // TODO https://github.com/lolopinto/ent/pull/1658
+  // if we ever make Context required, as part of that breaking change add reset()
+  // method so that we can reset the context for long-running "requests" like websockets
+  // and that'll be the official API/way of doing this
+  // TODO https://github.com/lolopinto/ent/issues/1576
   getViewer(): TViewer;
   // optional per (request)contet
   // absence means we are not doing any caching

--- a/ts/src/core/context.ts
+++ b/ts/src/core/context.ts
@@ -131,4 +131,13 @@ export class ContextCache {
     this.itemMap.clear();
     this.listMap.clear();
   }
+
+  /**
+   * reset clears the cache and resets the discarded loaders
+   * this is used in long-running things like tests or websocket connections where the same Context or ContextCache is being used repeatedly
+   */
+  reset(): void {
+    this.clearCache();
+    this.discardedLoaders = [];
+  }
 }


### PR DESCRIPTION
so that the discardedLoaders doesn't keep growing unbounded

follow-up to https://github.com/lolopinto/ent/pull/1641
fixes issue where websockets can introduce really bad load because the list of discardedLoaders grows forever