### PR TITLE
ability to override the alias of a Clause

### DIFF
--- a/ts/src/core/clause.test.ts
+++ b/ts/src/core/clause.test.ts
@@ -54,6 +54,14 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual([4]);
       expect(cls.instanceKey()).toEqual("id=4");
+
+      const cls2 = clause.Eq<ExampleData>("id", 4, "t2");
+      expect(cls2.clause(2)).toBe("t2.id = $2");
+      expect(cls2.clause(1, "t")).toBe("t2.id = $1");
+      expect(cls2.columns()).toStrictEqual(["id"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual([4]);
+      expect(cls2.instanceKey()).toEqual("t2.id=4");
     });
 
     test("sensitive value", () => {
@@ -66,6 +74,14 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual(["*"]);
       expect(cls.instanceKey()).toEqual("id=4");
+
+      const cls2 = clause.Eq<ExampleData>("id", clause.sensitiveValue(4), "t2");
+      expect(cls2.clause(2)).toBe("t2.id = $2");
+      expect(cls2.clause(1, "t")).toBe("t2.id = $1");
+      expect(cls2.columns()).toStrictEqual(["id"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual(["*"]);
+      expect(cls2.instanceKey()).toEqual("t2.id=4");
     });
   });
 
@@ -611,7 +627,7 @@ describe("postgres", () => {
   });
 
   describe("In|NotIn", () => {
-    test("1 arg", () => {
+    test("In. deprecated. 1 arg", () => {
       const cls = clause.In<ExampleData>("id", 1);
       expect(cls.clause(1)).toBe("id = $1");
       expect(cls.clause(1, "t")).toBe("t.id = $1");
@@ -619,6 +635,24 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([1]);
       expect(cls.logValues()).toStrictEqual([1]);
       expect(cls.instanceKey()).toEqual("in:id:1");
+    });
+
+    test("in. 1 arg", () => {
+      const cls = clause.DBTypeIn<ExampleData>("id", [1], "integer");
+      expect(cls.clause(1)).toBe("id = $1");
+      expect(cls.clause(1, "t")).toBe("t.id = $1");
+      expect(cls.columns()).toStrictEqual(["id"]);
+      expect(cls.values()).toStrictEqual([1]);
+      expect(cls.logValues()).toStrictEqual([1]);
+      expect(cls.instanceKey()).toEqual("in:id:1");
+
+      const cls2 = clause.DBTypeIn<ExampleData>("id", [1], "integer", "t2");
+      expect(cls2.clause(1)).toBe("t2.id = $1");
+      expect(cls2.clause(1, "t")).toBe("t2.id = $1");
+      expect(cls2.columns()).toStrictEqual(["id"]);
+      expect(cls2.values()).toStrictEqual([1]);
+      expect(cls2.logValues()).toStrictEqual([1]);
+      expect(cls2.instanceKey()).toEqual("in:t2.id:1");
     });
 
     test("not in. 1 arg", () => {
@@ -629,6 +663,14 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([1]);
       expect(cls.logValues()).toStrictEqual([1]);
       expect(cls.instanceKey()).toEqual("not in:id:1");
+
+      const cls2 = clause.DBTypeNotIn<ExampleData>("id", [1], "integer", "t2");
+      expect(cls2.clause(1)).toBe("t2.id != $1");
+      expect(cls2.clause(1, "t")).toBe("t2.id != $1");
+      expect(cls2.columns()).toStrictEqual(["id"]);
+      expect(cls2.values()).toStrictEqual([1]);
+      expect(cls2.logValues()).toStrictEqual([1]);
+      expect(cls2.instanceKey()).toEqual("not in:t2.id:1");
     });
 
     test("spread args", () => {
@@ -713,6 +755,18 @@ describe("postgres", () => {
         expect(cls.values()).toStrictEqual(ids);
         expect(cls.logValues()).toStrictEqual(ids);
         expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
+
+        const cls2 = clause.IntegerIn<ExampleData>("id", ids, "t2");
+        expect(cls2.clause(1)).toBe(
+          "t2.id IN (VALUES($1::integer), ($2), ($3), ($4), ($5))",
+        );
+        expect(cls2.clause(1, "t")).toBe(
+          "t2.id IN (VALUES($1::integer), ($2), ($3), ($4), ($5))",
+        );
+        expect(cls2.columns()).toStrictEqual(["id"]);
+        expect(cls2.values()).toStrictEqual(ids);
+        expect(cls2.logValues()).toStrictEqual(ids);
+        expect(cls2.instanceKey()).toEqual(`in:t2.id:${ids.join(",")}`);
       });
 
       test("uuid explicit", () => {
@@ -729,6 +783,18 @@ describe("postgres", () => {
         expect(cls.values()).toStrictEqual(ids);
         expect(cls.logValues()).toStrictEqual(ids);
         expect(cls.instanceKey()).toEqual(`in:id:${ids.join(",")}`);
+
+        const cls2 = clause.UuidIn<ExampleData>("id", ids, "t2");
+        expect(cls2.clause(1)).toBe(
+          "t2.id IN (VALUES($1::uuid), ($2), ($3), ($4), ($5))",
+        );
+        expect(cls2.clause(1, "t")).toBe(
+          "t2.id IN (VALUES($1::uuid), ($2), ($3), ($4), ($5))",
+        );
+        expect(cls2.columns()).toStrictEqual(["id"]);
+        expect(cls2.values()).toStrictEqual(ids);
+        expect(cls2.logValues()).toStrictEqual(ids);
+        expect(cls2.instanceKey()).toEqual(`in:t2.id:${ids.join(",")}`);
       });
 
       test("not in uuid", () => {
@@ -745,6 +811,18 @@ describe("postgres", () => {
         expect(cls.values()).toStrictEqual(ids);
         expect(cls.logValues()).toStrictEqual(ids);
         expect(cls.instanceKey()).toEqual(`not in:id:${ids.join(",")}`);
+
+        const cls2 = clause.UuidNotIn<ExampleData>("id", ids, "t2");
+        expect(cls2.clause(1)).toBe(
+          "t2.id NOT IN (VALUES($1::uuid), ($2), ($3), ($4), ($5))",
+        );
+        expect(cls2.clause(1, "t")).toBe(
+          "t2.id NOT IN (VALUES($1::uuid), ($2), ($3), ($4), ($5))",
+        );
+        expect(cls2.columns()).toStrictEqual(["id"]);
+        expect(cls2.values()).toStrictEqual(ids);
+        expect(cls2.logValues()).toStrictEqual(ids);
+        expect(cls2.instanceKey()).toEqual(`not in:t2.id:${ids.join(",")}`);
       });
 
       test("not in text", () => {
@@ -761,6 +839,18 @@ describe("postgres", () => {
         expect(cls.values()).toStrictEqual(ids);
         expect(cls.logValues()).toStrictEqual(ids);
         expect(cls.instanceKey()).toEqual(`not in:id:${ids.join(",")}`);
+
+        const cls2 = clause.DBTypeNotIn<ExampleData>("id", ids, "text", "t2");
+        expect(cls2.clause(1)).toBe(
+          "t2.id NOT IN (VALUES($1::text), ($2), ($3), ($4), ($5))",
+        );
+        expect(cls2.clause(1, "t")).toBe(
+          "t2.id NOT IN (VALUES($1::text), ($2), ($3), ($4), ($5))",
+        );
+        expect(cls2.columns()).toStrictEqual(["id"]);
+        expect(cls2.values()).toStrictEqual(ids);
+        expect(cls2.logValues()).toStrictEqual(ids);
+        expect(cls2.instanceKey()).toEqual(`not in:t2.id:${ids.join(",")}`);
       });
     });
   });
@@ -794,6 +884,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([`{3}`]);
       expect(cls.logValues()).toStrictEqual([`{3}`]);
       expect(cls.instanceKey()).toEqual("ids@>3");
+
+      const cls2 = clause.PostgresArrayContainsValue<ExampleData>(
+        "ids",
+        3,
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.ids @> $1");
+      expect(cls2.clause(1, "t")).toBe("t2.ids @> $1");
+      expect(cls2.columns()).toStrictEqual(["ids"]);
+      expect(cls2.values()).toStrictEqual([`{3}`]);
+      expect(cls2.logValues()).toStrictEqual([`{3}`]);
+      expect(cls2.instanceKey()).toEqual("t2.ids@>3");
     });
 
     test("contains val:string", () => {
@@ -804,6 +906,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([`{foo}`]);
       expect(cls.logValues()).toStrictEqual([`{foo}`]);
       expect(cls.instanceKey()).toEqual("ids@>foo");
+
+      const cls2 = clause.PostgresArrayContainsValue<ExampleData>(
+        "ids",
+        "foo",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.ids @> $1");
+      expect(cls2.clause(1, "t")).toBe("t2.ids @> $1");
+      expect(cls2.columns()).toStrictEqual(["ids"]);
+      expect(cls2.values()).toStrictEqual([`{foo}`]);
+      expect(cls2.logValues()).toStrictEqual([`{foo}`]);
+      expect(cls2.instanceKey()).toEqual("t2.ids@>foo");
     });
 
     test("contains list", () => {
@@ -814,6 +928,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([`{3, 4}`]);
       expect(cls.logValues()).toStrictEqual([`{3, 4}`]);
       expect(cls.instanceKey()).toEqual("ids@>3,4");
+
+      const cls2 = clause.PostgresArrayContains<ExampleData>(
+        "ids",
+        [3, 4],
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.ids @> $1");
+      expect(cls2.clause(1, "t")).toBe("t2.ids @> $1");
+      expect(cls2.columns()).toStrictEqual(["ids"]);
+      expect(cls2.values()).toStrictEqual([`{3, 4}`]);
+      expect(cls2.logValues()).toStrictEqual([`{3, 4}`]);
+      expect(cls2.instanceKey()).toEqual("t2.ids@>3,4");
     });
 
     test("contains list string", () => {
@@ -827,6 +953,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([`{foo, bar}`]);
       expect(cls.logValues()).toStrictEqual([`{foo, bar}`]);
       expect(cls.instanceKey()).toEqual("ids@>foo,bar");
+
+      const cls2 = clause.PostgresArrayContains<ExampleData>(
+        "ids",
+        ["foo", "bar"],
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.ids @> $1");
+      expect(cls2.clause(1, "t")).toBe("t2.ids @> $1");
+      expect(cls2.columns()).toStrictEqual(["ids"]);
+      expect(cls2.values()).toStrictEqual([`{foo, bar}`]);
+      expect(cls2.logValues()).toStrictEqual([`{foo, bar}`]);
+      expect(cls2.instanceKey()).toEqual("t2.ids@>foo,bar");
     });
 
     test("not contains val", () => {
@@ -837,6 +975,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([`{3}`]);
       expect(cls.logValues()).toStrictEqual([`{3}`]);
       expect(cls.instanceKey()).toEqual("NOT:ids@>3");
+
+      const cls2 = clause.PostgresArrayNotContainsValue<ExampleData>(
+        "ids",
+        3,
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("NOT t2.ids @> $1");
+      expect(cls2.clause(1, "t")).toBe("NOT t2.ids @> $1");
+      expect(cls2.columns()).toStrictEqual(["ids"]);
+      expect(cls2.values()).toStrictEqual([`{3}`]);
+      expect(cls2.logValues()).toStrictEqual([`{3}`]);
+      expect(cls2.instanceKey()).toEqual("NOT:t2.ids@>3");
     });
 
     test("not contains list", () => {
@@ -847,6 +997,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([`{3, 4}`]);
       expect(cls.logValues()).toStrictEqual([`{3, 4}`]);
       expect(cls.instanceKey()).toEqual("NOT:ids@>3,4");
+
+      const cls2 = clause.PostgresArrayNotContains<ExampleData>(
+        "ids",
+        [3, 4],
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("NOT t2.ids @> $1");
+      expect(cls2.clause(1, "t")).toBe("NOT t2.ids @> $1");
+      expect(cls2.columns()).toStrictEqual(["ids"]);
+      expect(cls2.values()).toStrictEqual([`{3, 4}`]);
+      expect(cls2.logValues()).toStrictEqual([`{3, 4}`]);
+      expect(cls2.instanceKey()).toEqual("NOT:t2.ids@>3,4");
     });
 
     test("overlaps", () => {
@@ -857,6 +1019,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([`{3, 4}`]);
       expect(cls.logValues()).toStrictEqual([`{3, 4}`]);
       expect(cls.instanceKey()).toEqual("ids&&3,4");
+
+      const cls2 = clause.PostgresArrayOverlaps<ExampleData>(
+        "ids",
+        [3, 4],
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.ids && $1");
+      expect(cls2.clause(1, "t")).toBe("t2.ids && $1");
+      expect(cls2.columns()).toStrictEqual(["ids"]);
+      expect(cls2.values()).toStrictEqual([`{3, 4}`]);
+      expect(cls2.logValues()).toStrictEqual([`{3, 4}`]);
+      expect(cls2.instanceKey()).toEqual("t2.ids&&3,4");
     });
 
     test("not overlaps", () => {
@@ -867,6 +1041,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([`{3, 4}`]);
       expect(cls.logValues()).toStrictEqual([`{3, 4}`]);
       expect(cls.instanceKey()).toEqual("NOT:ids&&3,4");
+
+      const cls2 = clause.PostgresArrayNotOverlaps<ExampleData>(
+        "ids",
+        [3, 4],
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("NOT t2.ids && $1");
+      expect(cls2.clause(1, "t")).toBe("NOT t2.ids && $1");
+      expect(cls2.columns()).toStrictEqual(["ids"]);
+      expect(cls2.values()).toStrictEqual([`{3, 4}`]);
+      expect(cls2.logValues()).toStrictEqual([`{3, 4}`]);
+      expect(cls2.instanceKey()).toEqual("NOT:t2.ids&&3,4");
     });
   });
 
@@ -884,6 +1070,20 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["$.* == 3"]);
       expect(cls.logValues()).toStrictEqual(["$.* == 3"]);
       expect(cls.instanceKey()).toEqual("jsonb$.*3==");
+
+      const cls2 = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.*",
+        3,
+        "==",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.jsonb @@ $1");
+      expect(cls2.clause(1, "t")).toBe("t2.jsonb @@ $1");
+      expect(cls2.columns()).toStrictEqual(["jsonb"]);
+      expect(cls2.values()).toStrictEqual(["$.* == 3"]);
+      expect(cls2.logValues()).toStrictEqual(["$.* == 3"]);
+      expect(cls2.instanceKey()).toEqual("t2.jsonb$.*3==");
     });
 
     test("eq string", () => {
@@ -899,6 +1099,20 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(['$.* == "hello"']);
       expect(cls.logValues()).toStrictEqual(['$.* == "hello"']);
       expect(cls.instanceKey()).toEqual("jsonb$.*hello==");
+
+      const cls2 = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.*",
+        "hello",
+        "==",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.jsonb @@ $1");
+      expect(cls2.clause(1, "t")).toBe("t2.jsonb @@ $1");
+      expect(cls2.columns()).toStrictEqual(["jsonb"]);
+      expect(cls2.values()).toStrictEqual(['$.* == "hello"']);
+      expect(cls2.logValues()).toStrictEqual(['$.* == "hello"']);
+      expect(cls2.instanceKey()).toEqual("t2.jsonb$.*hello==");
     });
 
     test("ge", () => {
@@ -914,6 +1128,20 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["$.* > 3"]);
       expect(cls.logValues()).toStrictEqual(["$.* > 3"]);
       expect(cls.instanceKey()).toEqual("jsonb$.*3>");
+
+      const cls2 = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.*",
+        3,
+        ">",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.jsonb @@ $1");
+      expect(cls2.clause(1, "t")).toBe("t2.jsonb @@ $1");
+      expect(cls2.columns()).toStrictEqual(["jsonb"]);
+      expect(cls2.values()).toStrictEqual(["$.* > 3"]);
+      expect(cls2.logValues()).toStrictEqual(["$.* > 3"]);
+      expect(cls2.instanceKey()).toEqual("t2.jsonb$.*3>");
     });
 
     test("ne", () => {
@@ -929,6 +1157,20 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["$.* != 3"]);
       expect(cls.logValues()).toStrictEqual(["$.* != 3"]);
       expect(cls.instanceKey()).toEqual("jsonb$.*3!=");
+
+      const cls2 = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.*",
+        3,
+        "!=",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.jsonb @@ $1");
+      expect(cls2.clause(1, "t")).toBe("t2.jsonb @@ $1");
+      expect(cls2.columns()).toStrictEqual(["jsonb"]);
+      expect(cls2.values()).toStrictEqual(["$.* != 3"]);
+      expect(cls2.logValues()).toStrictEqual(["$.* != 3"]);
+      expect(cls2.instanceKey()).toEqual("t2.jsonb$.*3!=");
     });
 
     test("specific path", () => {
@@ -944,6 +1186,20 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["$.col != 3"]);
       expect(cls.logValues()).toStrictEqual(["$.col != 3"]);
       expect(cls.instanceKey()).toEqual("jsonb$.col3!=");
+
+      const cls2 = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.col",
+        3,
+        "!=",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.jsonb @@ $1");
+      expect(cls2.clause(1, "t")).toBe("t2.jsonb @@ $1");
+      expect(cls2.columns()).toStrictEqual(["jsonb"]);
+      expect(cls2.values()).toStrictEqual(["$.col != 3"]);
+      expect(cls2.logValues()).toStrictEqual(["$.col != 3"]);
+      expect(cls2.instanceKey()).toEqual("t2.jsonb$.col3!=");
     });
 
     test("specific path arr idx", () => {
@@ -959,6 +1215,20 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["$.col[*] != 3"]);
       expect(cls.logValues()).toStrictEqual(["$.col[*] != 3"]);
       expect(cls.instanceKey()).toEqual("jsonb$.col[*]3!=");
+
+      const cls2 = clause.JSONPathValuePredicate<JSONData>(
+        "jsonb",
+        "$.col[*]",
+        3,
+        "!=",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.jsonb @@ $1");
+      expect(cls2.clause(1, "t")).toBe("t2.jsonb @@ $1");
+      expect(cls2.columns()).toStrictEqual(["jsonb"]);
+      expect(cls2.values()).toStrictEqual(["$.col[*] != 3"]);
+      expect(cls2.logValues()).toStrictEqual(["$.col[*] != 3"]);
+      expect(cls2.instanceKey()).toEqual("t2.jsonb$.col[*]3!=");
     });
   });
 
@@ -973,6 +1243,18 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["value"]);
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual("name_idx@@to_tsquery:english:value");
+
+      const cls2 = clause.TsQuery<FullTextData>("name_idx", "value", "t2");
+      expect(cls2.clause(1)).toBe("t2.name_idx @@ to_tsquery('english', $1)");
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.name_idx @@ to_tsquery('english', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.name_idx@@to_tsquery:english:value",
+      );
     });
 
     test("tsquery complex", () => {
@@ -986,6 +1268,25 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["value"]);
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual("name_idx@@to_tsquery:simple:value");
+
+      const cls2 = clause.TsQuery<FullTextData>(
+        "name_idx",
+        {
+          language: "simple",
+          value: "value",
+        },
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe("t2.name_idx @@ to_tsquery('simple', $1)");
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.name_idx @@ to_tsquery('simple', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.name_idx@@to_tsquery:simple:value",
+      );
     });
 
     test("plainto_tsquery string", () => {
@@ -999,6 +1300,24 @@ describe("postgres", () => {
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual(
         "name_idx@@plainto_tsquery:english:value",
+      );
+
+      const cls2 = clause.PlainToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "t2.name_idx @@ plainto_tsquery('english', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.name_idx @@ plainto_tsquery('english', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.name_idx@@plainto_tsquery:english:value",
       );
     });
 
@@ -1017,6 +1336,27 @@ describe("postgres", () => {
       expect(cls.instanceKey()).toEqual(
         "name_idx@@plainto_tsquery:simple:value",
       );
+
+      const cls2 = clause.PlainToTsQuery<FullTextData>(
+        "name_idx",
+        {
+          language: "simple",
+          value: "value",
+        },
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "t2.name_idx @@ plainto_tsquery('simple', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.name_idx @@ plainto_tsquery('simple', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.name_idx@@plainto_tsquery:simple:value",
+      );
     });
 
     test("phraseto_tsquery string", () => {
@@ -1030,6 +1370,24 @@ describe("postgres", () => {
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual(
         "name_idx@@phraseto_tsquery:english:value",
+      );
+
+      const cls2 = clause.PhraseToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "t2.name_idx @@ phraseto_tsquery('english', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.name_idx @@ phraseto_tsquery('english', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.name_idx@@phraseto_tsquery:english:value",
       );
     });
 
@@ -1048,6 +1406,27 @@ describe("postgres", () => {
       expect(cls.instanceKey()).toEqual(
         "name_idx@@phraseto_tsquery:simple:value",
       );
+
+      const cls2 = clause.PhraseToTsQuery<FullTextData>(
+        "name_idx",
+        {
+          language: "simple",
+          value: "value",
+        },
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "t2.name_idx @@ phraseto_tsquery('simple', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.name_idx @@ phraseto_tsquery('simple', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.name_idx@@phraseto_tsquery:simple:value",
+      );
     });
 
     test("websearch_to_tsquery string", () => {
@@ -1063,6 +1442,24 @@ describe("postgres", () => {
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual(
         "name_idx@@websearch_to_tsquery:english:value",
+      );
+
+      const cls2 = clause.WebsearchToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "t2.name_idx @@ websearch_to_tsquery('english', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.name_idx @@ websearch_to_tsquery('english', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.name_idx@@websearch_to_tsquery:english:value",
       );
     });
 
@@ -1083,6 +1480,27 @@ describe("postgres", () => {
       expect(cls.instanceKey()).toEqual(
         "name_idx@@websearch_to_tsquery:simple:value",
       );
+
+      const cls2 = clause.WebsearchToTsQuery<FullTextData>(
+        "name_idx",
+        {
+          language: "simple",
+          value: "value",
+        },
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "t2.name_idx @@ websearch_to_tsquery('simple', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.name_idx @@ websearch_to_tsquery('simple', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.name_idx@@websearch_to_tsquery:simple:value",
+      );
     });
 
     test("tsvectorcol_tsquery string", () => {
@@ -1098,6 +1516,24 @@ describe("postgres", () => {
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual(
         "to_tsvector(name_idx)@@to_tsquery:english:value",
+      );
+
+      const cls2 = clause.TsVectorColTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "to_tsvector(t2.name_idx) @@ to_tsquery('english', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "to_tsvector(t2.name_idx) @@ to_tsquery('english', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "to_tsvector(t2.name_idx)@@to_tsquery:english:value",
       );
     });
 
@@ -1118,6 +1554,27 @@ describe("postgres", () => {
       expect(cls.instanceKey()).toEqual(
         "to_tsvector(name_idx)@@to_tsquery:simple:value",
       );
+
+      const cls2 = clause.TsVectorColTsQuery<FullTextData>(
+        "name_idx",
+        {
+          language: "simple",
+          value: "value",
+        },
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "to_tsvector(t2.name_idx) @@ to_tsquery('simple', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "to_tsvector(t2.name_idx) @@ to_tsquery('simple', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "to_tsvector(t2.name_idx)@@to_tsquery:simple:value",
+      );
     });
 
     test("tsvectorcol_plainto_tsquery string", () => {
@@ -1136,6 +1593,24 @@ describe("postgres", () => {
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual(
         "to_tsvector(name_idx)@@plainto_tsquery:english:value",
+      );
+
+      const cls2 = clause.TsVectorPlainToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "to_tsvector(t2.name_idx) @@ plainto_tsquery('english', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "to_tsvector(t2.name_idx) @@ plainto_tsquery('english', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "to_tsvector(t2.name_idx)@@plainto_tsquery:english:value",
       );
     });
 
@@ -1156,6 +1631,27 @@ describe("postgres", () => {
       expect(cls.instanceKey()).toEqual(
         "to_tsvector(name_idx)@@plainto_tsquery:simple:value",
       );
+
+      const cls2 = clause.TsVectorPlainToTsQuery<FullTextData>(
+        "name_idx",
+        {
+          language: "simple",
+          value: "value",
+        },
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "to_tsvector(t2.name_idx) @@ plainto_tsquery('simple', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "to_tsvector(t2.name_idx) @@ plainto_tsquery('simple', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "to_tsvector(t2.name_idx)@@plainto_tsquery:simple:value",
+      );
     });
 
     test("tsvectorcol__phraseto_tsquery string", () => {
@@ -1174,6 +1670,24 @@ describe("postgres", () => {
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual(
         "to_tsvector(name_idx)@@phraseto_tsquery:english:value",
+      );
+
+      const cls2 = clause.TsVectorPhraseToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "to_tsvector(t2.name_idx) @@ phraseto_tsquery('english', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "to_tsvector(t2.name_idx) @@ phraseto_tsquery('english', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "to_tsvector(t2.name_idx)@@phraseto_tsquery:english:value",
       );
     });
 
@@ -1194,6 +1708,27 @@ describe("postgres", () => {
       expect(cls.instanceKey()).toEqual(
         "to_tsvector(name_idx)@@phraseto_tsquery:simple:value",
       );
+
+      const cls2 = clause.TsVectorPhraseToTsQuery(
+        "name_idx",
+        {
+          language: "simple",
+          value: "value",
+        },
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "to_tsvector(t2.name_idx) @@ phraseto_tsquery('simple', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "to_tsvector(t2.name_idx) @@ phraseto_tsquery('simple', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "to_tsvector(t2.name_idx)@@phraseto_tsquery:simple:value",
+      );
     });
 
     test("tsvectorcol_websearch_to_tsquery string", () => {
@@ -1213,6 +1748,24 @@ describe("postgres", () => {
       expect(cls.instanceKey()).toEqual(
         "to_tsvector(name_idx)@@websearch_to_tsquery:english:value",
       );
+
+      const cls2 = clause.TsVectorWebsearchToTsQuery<FullTextData>(
+        "name_idx",
+        "value",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "to_tsvector(t2.name_idx) @@ websearch_to_tsquery('english', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "to_tsvector(t2.name_idx) @@ websearch_to_tsquery('english', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "to_tsvector(t2.name_idx)@@websearch_to_tsquery:english:value",
+      );
     });
 
     test("websearch_to_tsquery complex", () => {
@@ -1231,6 +1784,27 @@ describe("postgres", () => {
       expect(cls.logValues()).toStrictEqual(["value"]);
       expect(cls.instanceKey()).toEqual(
         "to_tsvector(name_idx)@@websearch_to_tsquery:simple:value",
+      );
+
+      const cls2 = clause.TsVectorWebsearchToTsQuery<FullTextData>(
+        "name_idx",
+        {
+          language: "simple",
+          value: "value",
+        },
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "to_tsvector(t2.name_idx) @@ websearch_to_tsquery('simple', $1)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "to_tsvector(t2.name_idx) @@ websearch_to_tsquery('simple', $1)",
+      );
+      expect(cls2.columns()).toStrictEqual(["name_idx"]);
+      expect(cls2.values()).toStrictEqual(["value"]);
+      expect(cls2.logValues()).toStrictEqual(["value"]);
+      expect(cls2.instanceKey()).toEqual(
+        "to_tsvector(t2.name_idx)@@websearch_to_tsquery:simple:value",
       );
     });
   });
@@ -1254,6 +1828,25 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["fooo", "fooo", "fooo"]);
       expect(cls.logValues()).toStrictEqual(["fooo", "fooo", "fooo"]);
       expect(cls.instanceKey()).toEqual("start_time->-events-id-fooo");
+
+      const cls2 = clause.PaginationMultipleColsSubQuery<EventData>(
+        "start_time",
+        ">",
+        "events",
+        "id",
+        "fooo",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "(t2.start_time > (SELECT t2.start_time FROM events WHERE t2.id = $1) OR (t2.start_time = (SELECT t2.start_time FROM events WHERE t2.id = $2) AND t2.id > $3))",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "(t2.start_time > (SELECT t2.start_time FROM events WHERE t2.id = $1) OR (t2.start_time = (SELECT t2.start_time FROM events WHERE t2.id = $2) AND t2.id > $3))",
+      );
+      expect(cls2.columns()).toStrictEqual(["start_time"]);
+      expect(cls2.values()).toStrictEqual(["fooo", "fooo", "fooo"]);
+      expect(cls2.logValues()).toStrictEqual(["fooo", "fooo", "fooo"]);
+      expect(cls2.instanceKey()).toEqual("t2.start_time->-events-t2.id-fooo");
     });
 
     test("> clause 3", () => {
@@ -1274,6 +1867,25 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["fooo", "fooo", "fooo"]);
       expect(cls.logValues()).toStrictEqual(["fooo", "fooo", "fooo"]);
       expect(cls.instanceKey()).toEqual("start_time->-events-id-fooo");
+
+      const cls2 = clause.PaginationMultipleColsSubQuery<EventData>(
+        "start_time",
+        ">",
+        "events",
+        "id",
+        "fooo",
+        "t2",
+      );
+      expect(cls2.clause(3)).toBe(
+        "(t2.start_time > (SELECT t2.start_time FROM events WHERE t2.id = $3) OR (t2.start_time = (SELECT t2.start_time FROM events WHERE t2.id = $4) AND t2.id > $5))",
+      );
+      expect(cls2.clause(3, "t")).toBe(
+        "(t2.start_time > (SELECT t2.start_time FROM events WHERE t2.id = $3) OR (t2.start_time = (SELECT t2.start_time FROM events WHERE t2.id = $4) AND t2.id > $5))",
+      );
+      expect(cls2.columns()).toStrictEqual(["start_time"]);
+      expect(cls2.values()).toStrictEqual(["fooo", "fooo", "fooo"]);
+      expect(cls2.logValues()).toStrictEqual(["fooo", "fooo", "fooo"]);
+      expect(cls2.instanceKey()).toEqual("t2.start_time->-events-t2.id-fooo");
     });
 
     test("<", () => {
@@ -1294,6 +1906,25 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["fooo", "fooo", "fooo"]);
       expect(cls.logValues()).toStrictEqual(["fooo", "fooo", "fooo"]);
       expect(cls.instanceKey()).toEqual("start_time-<-events-id-fooo");
+
+      const cls2 = clause.PaginationMultipleColsSubQuery<EventData>(
+        "start_time",
+        "<",
+        "events",
+        "id",
+        "fooo",
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "(t2.start_time < (SELECT t2.start_time FROM events WHERE t2.id = $1) OR (t2.start_time = (SELECT t2.start_time FROM events WHERE t2.id = $2) AND t2.id < $3))",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "(t2.start_time < (SELECT t2.start_time FROM events WHERE t2.id = $1) OR (t2.start_time = (SELECT t2.start_time FROM events WHERE t2.id = $2) AND t2.id < $3))",
+      );
+      expect(cls2.columns()).toStrictEqual(["start_time"]);
+      expect(cls2.values()).toStrictEqual(["fooo", "fooo", "fooo"]);
+      expect(cls2.logValues()).toStrictEqual(["fooo", "fooo", "fooo"]);
+      expect(cls2.instanceKey()).toEqual("t2.start_time-<-events-t2.id-fooo");
     });
   });
 
@@ -1308,6 +1939,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual([4]);
       expect(cls.instanceKey()).toEqual("balance+4");
+
+      const cls2 = clause.Add<BalanceData>("balance", 4, "t2");
+      expect(cls2.clause(1)).toBe("t2.balance + $1");
+      expect(cls2.clause(2)).toBe("t2.balance + $2");
+      expect(cls2.clause(1, "t")).toBe("t2.balance + $1");
+      expect(cls2.clause(2, "t")).toBe("t2.balance + $2");
+      expect(cls2.columns()).toStrictEqual(["balance"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual([4]);
+      expect(cls2.instanceKey()).toEqual("t2.balance+4");
     });
 
     test("subtract", () => {
@@ -1320,6 +1961,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual([4]);
       expect(cls.instanceKey()).toEqual("balance-4");
+
+      const cls2 = clause.Subtract<BalanceData>("balance", 4, "t2");
+      expect(cls2.clause(1)).toBe("t2.balance - $1");
+      expect(cls2.clause(2)).toBe("t2.balance - $2");
+      expect(cls2.clause(1, "t")).toBe("t2.balance - $1");
+      expect(cls2.clause(2, "t")).toBe("t2.balance - $2");
+      expect(cls2.columns()).toStrictEqual(["balance"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual([4]);
+      expect(cls2.instanceKey()).toEqual("t2.balance-4");
     });
 
     test("divide", () => {
@@ -1332,6 +1983,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual([4]);
       expect(cls.instanceKey()).toEqual("balance/4");
+
+      const cls2 = clause.Divide<BalanceData>("balance", 4, "t2");
+      expect(cls2.clause(1)).toBe("t2.balance / $1");
+      expect(cls2.clause(2)).toBe("t2.balance / $2");
+      expect(cls2.clause(1, "t")).toBe("t2.balance / $1");
+      expect(cls2.clause(2, "t")).toBe("t2.balance / $2");
+      expect(cls2.columns()).toStrictEqual(["balance"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual([4]);
+      expect(cls2.instanceKey()).toEqual("t2.balance/4");
     });
 
     test("multiply", () => {
@@ -1344,6 +2005,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual([4]);
       expect(cls.instanceKey()).toEqual("balance*4");
+
+      const cls2 = clause.Multiply<BalanceData>("balance", 4, "t2");
+      expect(cls2.clause(1)).toBe("t2.balance * $1");
+      expect(cls2.clause(2)).toBe("t2.balance * $2");
+      expect(cls2.clause(1, "t")).toBe("t2.balance * $1");
+      expect(cls2.clause(2, "t")).toBe("t2.balance * $2");
+      expect(cls2.columns()).toStrictEqual(["balance"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual([4]);
+      expect(cls2.instanceKey()).toEqual("t2.balance*4");
     });
 
     test("modulo", () => {
@@ -1356,6 +2027,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual([4]);
       expect(cls.instanceKey()).toEqual("balance%4");
+
+      const cls2 = clause.Modulo<BalanceData>("balance", 4, "t2");
+      expect(cls2.clause(1)).toBe("t2.balance % $1");
+      expect(cls2.clause(2)).toBe("t2.balance % $2");
+      expect(cls2.clause(1, "t")).toBe("t2.balance % $1");
+      expect(cls2.clause(2, "t")).toBe("t2.balance % $2");
+      expect(cls2.columns()).toStrictEqual(["balance"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual([4]);
+      expect(cls2.instanceKey()).toEqual("t2.balance%4");
     });
   });
 
@@ -1370,6 +2051,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["%foo%"]);
       expect(cls.logValues()).toStrictEqual(["%foo%"]);
       expect(cls.instanceKey()).toEqual("barLIKE%foo%");
+
+      const cls2 = clause.Contains<ExampleData>("bar", "foo", "t2");
+      expect(cls2.clause(1)).toBe("t2.bar LIKE $1");
+      expect(cls2.clause(2)).toBe("t2.bar LIKE $2");
+      expect(cls2.clause(1, "t")).toBe("t2.bar LIKE $1");
+      expect(cls2.clause(2, "t")).toBe("t2.bar LIKE $2");
+      expect(cls2.columns()).toStrictEqual(["bar"]);
+      expect(cls2.values()).toStrictEqual(["%foo%"]);
+      expect(cls2.logValues()).toStrictEqual(["%foo%"]);
+      expect(cls2.instanceKey()).toEqual("t2.barLIKE%foo%");
     });
 
     test("contains ignore case", () => {
@@ -1382,6 +2073,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["%foo%"]);
       expect(cls.logValues()).toStrictEqual(["%foo%"]);
       expect(cls.instanceKey()).toEqual("barILIKE%foo%");
+
+      const cls2 = clause.ContainsIgnoreCase<ExampleData>("bar", "foo", "t2");
+      expect(cls2.clause(1)).toBe("t2.bar ILIKE $1");
+      expect(cls2.clause(2)).toBe("t2.bar ILIKE $2");
+      expect(cls2.clause(1, "t")).toBe("t2.bar ILIKE $1");
+      expect(cls2.clause(2, "t")).toBe("t2.bar ILIKE $2");
+      expect(cls2.columns()).toStrictEqual(["bar"]);
+      expect(cls2.values()).toStrictEqual(["%foo%"]);
+      expect(cls2.logValues()).toStrictEqual(["%foo%"]);
+      expect(cls2.instanceKey()).toEqual("t2.barILIKE%foo%");
     });
 
     test("starts_with", () => {
@@ -1394,6 +2095,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["foo%"]);
       expect(cls.logValues()).toStrictEqual(["foo%"]);
       expect(cls.instanceKey()).toEqual("barLIKEfoo%");
+
+      const cls2 = clause.StartsWith<ExampleData>("bar", "foo", "t2");
+      expect(cls2.clause(1)).toBe("t2.bar LIKE $1");
+      expect(cls2.clause(2)).toBe("t2.bar LIKE $2");
+      expect(cls2.clause(1, "t")).toBe("t2.bar LIKE $1");
+      expect(cls2.clause(2, "t")).toBe("t2.bar LIKE $2");
+      expect(cls2.columns()).toStrictEqual(["bar"]);
+      expect(cls2.values()).toStrictEqual(["foo%"]);
+      expect(cls2.logValues()).toStrictEqual(["foo%"]);
+      expect(cls2.instanceKey()).toEqual("t2.barLIKEfoo%");
     });
 
     test("starts_with ignore case", () => {
@@ -1406,6 +2117,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["foo%"]);
       expect(cls.logValues()).toStrictEqual(["foo%"]);
       expect(cls.instanceKey()).toEqual("barILIKEfoo%");
+
+      const cls2 = clause.StartsWithIgnoreCase<ExampleData>("bar", "foo", "t2");
+      expect(cls2.clause(1)).toBe("t2.bar ILIKE $1");
+      expect(cls2.clause(2)).toBe("t2.bar ILIKE $2");
+      expect(cls2.clause(1, "t")).toBe("t2.bar ILIKE $1");
+      expect(cls2.clause(2, "t")).toBe("t2.bar ILIKE $2");
+      expect(cls2.columns()).toStrictEqual(["bar"]);
+      expect(cls2.values()).toStrictEqual(["foo%"]);
+      expect(cls2.logValues()).toStrictEqual(["foo%"]);
+      expect(cls2.instanceKey()).toEqual("t2.barILIKEfoo%");
     });
 
     test("ends_with", () => {
@@ -1418,6 +2139,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["%foo"]);
       expect(cls.logValues()).toStrictEqual(["%foo"]);
       expect(cls.instanceKey()).toEqual("barLIKE%foo");
+
+      const cls2 = clause.EndsWith<ExampleData>("bar", "foo", "t2");
+      expect(cls2.clause(1)).toBe("t2.bar LIKE $1");
+      expect(cls2.clause(2)).toBe("t2.bar LIKE $2");
+      expect(cls2.clause(1, "t")).toBe("t2.bar LIKE $1");
+      expect(cls2.clause(2, "t")).toBe("t2.bar LIKE $2");
+      expect(cls2.columns()).toStrictEqual(["bar"]);
+      expect(cls2.values()).toStrictEqual(["%foo"]);
+      expect(cls2.logValues()).toStrictEqual(["%foo"]);
+      expect(cls2.instanceKey()).toEqual("t2.barLIKE%foo");
     });
 
     test("ends_with ignore_case", () => {
@@ -1430,6 +2161,16 @@ describe("postgres", () => {
       expect(cls.values()).toStrictEqual(["%foo"]);
       expect(cls.logValues()).toStrictEqual(["%foo"]);
       expect(cls.instanceKey()).toEqual("barILIKE%foo");
+
+      const cls2 = clause.EndsWithIgnoreCase<ExampleData>("bar", "foo", "t2");
+      expect(cls2.clause(1)).toBe("t2.bar ILIKE $1");
+      expect(cls2.clause(2)).toBe("t2.bar ILIKE $2");
+      expect(cls2.clause(1, "t")).toBe("t2.bar ILIKE $1");
+      expect(cls2.clause(2, "t")).toBe("t2.bar ILIKE $2");
+      expect(cls2.columns()).toStrictEqual(["bar"]);
+      expect(cls2.values()).toStrictEqual(["%foo"]);
+      expect(cls2.logValues()).toStrictEqual(["%foo"]);
+      expect(cls2.instanceKey()).toEqual("t2.barILIKE%foo");
     });
   });
 });
@@ -1452,6 +2193,16 @@ describe("sqlite", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual([4]);
       expect(cls.instanceKey()).toEqual("id=4");
+
+      const cls2 = clause.Eq<ExampleData>("id", 4, "t2");
+      expect(cls2.clause(1)).toBe("t2.id = ?");
+      expect(cls2.clause(2)).toBe("t2.id = ?");
+      expect(cls2.clause(1, "t")).toBe("t2.id = ?");
+      expect(cls2.clause(2, "t")).toBe("t2.id = ?");
+      expect(cls2.columns()).toStrictEqual(["id"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual([4]);
+      expect(cls2.instanceKey()).toEqual("t2.id=4");
     });
 
     test("sensitive value", () => {
@@ -1464,6 +2215,16 @@ describe("sqlite", () => {
       expect(cls.values()).toStrictEqual([4]);
       expect(cls.logValues()).toStrictEqual(["*"]);
       expect(cls.instanceKey()).toEqual("id=4");
+
+      const cls2 = clause.Eq<ExampleData>("id", clause.sensitiveValue(4), "t2");
+      expect(cls2.clause(1)).toBe("t2.id = ?");
+      expect(cls2.clause(2)).toBe("t2.id = ?");
+      expect(cls2.clause(1, "t")).toBe("t2.id = ?");
+      expect(cls2.clause(2, "t")).toBe("t2.id = ?");
+      expect(cls2.columns()).toStrictEqual(["id"]);
+      expect(cls2.values()).toStrictEqual([4]);
+      expect(cls2.logValues()).toStrictEqual(["*"]);
+      expect(cls2.instanceKey()).toEqual("t2.id=4");
     });
   });
 
@@ -1862,7 +2623,7 @@ describe("sqlite", () => {
   });
 
   describe("In", () => {
-    test("1 arg", () => {
+    test("In. deprecated. 1 arg", () => {
       const cls = clause.In<ExampleData>("id", 1);
       expect(cls.clause(1)).toBe("id = ?");
       expect(cls.clause(1, "t")).toBe("t.id = ?");
@@ -1870,6 +2631,24 @@ describe("sqlite", () => {
       expect(cls.values()).toStrictEqual([1]);
       expect(cls.logValues()).toStrictEqual([1]);
       expect(cls.instanceKey()).toEqual("in:id:1");
+    });
+
+    test("In. 1 arg", () => {
+      const cls = clause.DBTypeIn<ExampleData>("id", [1], "integer");
+      expect(cls.clause(1)).toBe("id = ?");
+      expect(cls.clause(1, "t")).toBe("t.id = ?");
+      expect(cls.columns()).toStrictEqual(["id"]);
+      expect(cls.values()).toStrictEqual([1]);
+      expect(cls.logValues()).toStrictEqual([1]);
+      expect(cls.instanceKey()).toEqual("in:id:1");
+
+      const cls2 = clause.DBTypeIn<ExampleData>("id", [1], "integer", "t2");
+      expect(cls2.clause(1)).toBe("t2.id = ?");
+      expect(cls2.clause(1, "t")).toBe("t2.id = ?");
+      expect(cls2.columns()).toStrictEqual(["id"]);
+      expect(cls2.values()).toStrictEqual([1]);
+      expect(cls2.logValues()).toStrictEqual([1]);
+      expect(cls2.instanceKey()).toEqual("in:t2.id:1");
     });
 
     test("not in. 1 arg", () => {
@@ -1880,6 +2659,14 @@ describe("sqlite", () => {
       expect(cls.values()).toStrictEqual([1]);
       expect(cls.logValues()).toStrictEqual([1]);
       expect(cls.instanceKey()).toEqual("not in:id:1");
+
+      const cls2 = clause.DBTypeNotIn<ExampleData>("id", [1], "integer", "t2");
+      expect(cls2.clause(1)).toBe("t2.id != ?");
+      expect(cls2.clause(1, "t")).toBe("t2.id != ?");
+      expect(cls2.columns()).toStrictEqual(["id"]);
+      expect(cls2.values()).toStrictEqual([1]);
+      expect(cls2.logValues()).toStrictEqual([1]);
+      expect(cls2.instanceKey()).toEqual("not in:t2.id:1");
     });
 
     test("spread args", () => {

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -603,7 +603,7 @@ class tsQueryClause<T extends Data, K = keyof T> implements Clause<T, K> {
     if (this.opts?.tsVectorCol) {
       return `${this.opts?.overrideAlias ?? ""}to_tsvector(${
         this.col
-      }):@@${this.getFunction()}:${language}:${value}`;
+      })@@${this.getFunction()}:${language}:${value}`;
     }
     return `${this.col}${
       this.opts?.overrideAlias ?? ""

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -117,9 +117,12 @@ class simpleClause<T extends Data, K = keyof T> implements Clause<T, K> {
     if (nullClause) {
       return nullClause.instanceKey();
     }
-    return `${this.col}${this.op}${this.opts?.overrideAlias ?? ""}${rawValue(
-      this.value,
-    )}`;
+    if (this.opts?.overrideAlias) {
+      return `${this.opts.overrideAlias}.${this.col}${this.op}${rawValue(
+        this.value,
+      )}`;
+    }
+    return `${this.col}${this.op}${rawValue(this.value)}`;
   }
 }
 
@@ -317,13 +320,21 @@ class postgresArrayOperator<T extends Data, K = keyof T>
 
   instanceKey(): string {
     if (this.opts?.not) {
+      if (this.opts.overrideAlias) {
+        return `NOT:${this.opts.overrideAlias}.${this.col}${this.op}${rawValue(
+          this.value,
+        )}`;
+      }
       return `NOT:${this.col}${this.opts?.overrideAlias ?? ""}${
         this.op
       }${rawValue(this.value)}`;
     }
-    return `${this.col}${this.opts?.overrideAlias ?? ""}${this.op}${rawValue(
-      this.value,
-    )}`;
+    if (this.opts?.overrideAlias) {
+      return `${this.opts.overrideAlias}.${this.col}${this.op}${rawValue(
+        this.value,
+      )}`;
+    }
+    return `${this.col}${this.op}${rawValue(this.value)}`;
   }
 }
 
@@ -459,9 +470,12 @@ export class inClause<T extends Data, K = keyof T> implements Clause<T, K> {
   }
 
   instanceKey(): string {
-    return `${this.op.toLowerCase()}:${this.col}${
-      this.overrideAlias ?? ""
-    }:${this.values().join(",")}`;
+    if (this.overrideAlias) {
+      return `${this.op.toLowerCase()}:${this.overrideAlias}.${
+        this.col
+      }:${this.values().join(",")}`;
+    }
+    return `${this.op.toLowerCase()}:${this.col}:${this.values().join(",")}`;
   }
 }
 
@@ -601,13 +615,21 @@ class tsQueryClause<T extends Data, K = keyof T> implements Clause<T, K> {
   instanceKey(): string {
     const { language, value } = this.getInfo();
     if (this.opts?.tsVectorCol) {
-      return `${this.opts?.overrideAlias ?? ""}to_tsvector(${
+      if (this.opts.overrideAlias) {
+        return `to_tsvector(${this.opts.overrideAlias}.${
+          this.col
+        })@@${this.getFunction()}:${language}:${value}`;
+      }
+      return `to_tsvector(${
         this.col
       })@@${this.getFunction()}:${language}:${value}`;
     }
-    return `${this.col}${
-      this.opts?.overrideAlias ?? ""
-    }@@${this.getFunction()}:${language}:${value}`;
+    if (this.opts?.overrideAlias) {
+      return `${this.opts.overrideAlias}.${
+        this.col
+      }@@${this.getFunction()}:${language}:${value}`;
+    }
+    return `${this.col}@@${this.getFunction()}:${language}:${value}`;
   }
 }
 
@@ -1189,9 +1211,12 @@ class jSONPathValuePredicateClause<T extends Data, K = keyof T>
   }
 
   instanceKey(): string {
-    return `${this.col}${this.overrideAlias ?? ""}${this.path}${rawValue(
-      this.value,
-    )}${this.pred}`;
+    if (this.overrideAlias) {
+      return `${this.overrideAlias}.${this.col}${this.path}${rawValue(
+        this.value,
+      )}${this.pred}`;
+    }
+    return `${this.col}${this.path}${rawValue(this.value)}${this.pred}`;
   }
 }
 
@@ -1327,9 +1352,10 @@ class paginationMultipleColumnsSubQueryClause<T extends Data, K = keyof T>
   }
 
   instanceKey(): string {
-    return `${this.col}${this.overrideAlias ?? ""}-${this.op}-${
-      this.tableName
-    }-${this.uniqueCol}-${this.val}`;
+    if (this.overrideAlias) {
+      return `${this.overrideAlias}.${this.col}-${this.op}-${this.tableName}-${this.overrideAlias}.${this.uniqueCol}-${this.val}`;
+    }
+    return `${this.col}-${this.op}-${this.tableName}-${this.uniqueCol}-${this.val}`;
   }
 }
 

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -37,11 +37,23 @@ function rawValue(val: any) {
   return val;
 }
 
-function renderCol<T extends Data, K = keyof T>(col: K, alias?: string) {
+function renderCol<T extends Data, K = keyof T>(
+  col: K,
+  overrideAlias?: string,
+  alias?: string,
+) {
+  if (overrideAlias) {
+    return `${overrideAlias}.${col}`;
+  }
   if (alias) {
     return `${alias}.${col}`;
   }
   return col;
+}
+
+interface simpleClauseOptions<T extends Data, K = keyof T> {
+  handleNull?: Clause<T, K>;
+  overrideAlias?: string;
 }
 
 class simpleClause<T extends Data, K = keyof T> implements Clause<T, K> {
@@ -49,7 +61,7 @@ class simpleClause<T extends Data, K = keyof T> implements Clause<T, K> {
     protected col: K,
     private value: any,
     private op: string,
-    private handleNull?: Clause<T, K>,
+    private opts?: simpleClauseOptions<T, K>,
   ) {}
 
   clause(idx: number, alias?: string): string {
@@ -58,16 +70,20 @@ class simpleClause<T extends Data, K = keyof T> implements Clause<T, K> {
       return nullClause.clause(idx, alias);
     }
     if (DB.getDialect() === Dialect.Postgres) {
-      return `${renderCol(this.col, alias)} ${this.op} $${idx}`;
+      return `${renderCol(this.col, this.opts?.overrideAlias, alias)} ${
+        this.op
+      } $${idx}`;
     }
-    return `${renderCol(this.col, alias)} ${this.op} ?`;
+    return `${renderCol(this.col, this.opts?.overrideAlias, alias)} ${
+      this.op
+    } ?`;
   }
 
   private nullClause() {
-    if (!this.handleNull || this.value !== null) {
+    if (!this.opts?.handleNull || this.value !== null) {
       return;
     }
-    return this.handleNull;
+    return this.opts.handleNull;
   }
 
   columns(): K[] {
@@ -101,7 +117,9 @@ class simpleClause<T extends Data, K = keyof T> implements Clause<T, K> {
     if (nullClause) {
       return nullClause.instanceKey();
     }
-    return `${this.col}${this.op}${rawValue(this.value)}`;
+    return `${this.col}${this.op}${this.opts?.overrideAlias ?? ""}${rawValue(
+      this.value,
+    )}`;
   }
 }
 
@@ -146,10 +164,13 @@ class existsQueryClause<T extends Data, K = keyof T> extends queryClause<T, K> {
 }
 
 class isNullClause<T extends Data, K = keyof T> implements Clause<T, K> {
-  constructor(protected col: K) {}
+  constructor(
+    protected col: K,
+    protected overrideAlias?: string,
+  ) {}
 
   clause(_idx: number, alias?: string): string {
-    return `${renderCol(this.col, alias)} IS NULL`;
+    return `${renderCol(this.col, this.overrideAlias, alias)} IS NULL`;
   }
 
   columns(): K[] {
@@ -165,31 +186,17 @@ class isNullClause<T extends Data, K = keyof T> implements Clause<T, K> {
   }
 
   instanceKey(): string {
-    return `${this.col} IS NULL`;
+    return `${this.col}${this.overrideAlias ?? ""} IS NULL`;
   }
 }
 
-class isNotNullClause<T extends Data, K = keyof T> implements Clause<T, K> {
-  constructor(protected col: K) {}
-
+class isNotNullClause<T extends Data, K = keyof T> extends isNullClause<T, K> {
   clause(idx: number, alias?: string): string {
-    return `${renderCol(this.col, alias)} IS NOT NULL`;
-  }
-
-  columns(): K[] {
-    return [];
-  }
-
-  values(): any[] {
-    return [];
-  }
-
-  logValues(): any[] {
-    return [];
+    return `${renderCol(this.col, this.overrideAlias, alias)} IS NOT NULL`;
   }
 
   instanceKey(): string {
-    return `${this.col} IS NOT NULL`;
+    return `${this.col}${this.overrideAlias ?? ""} IS NOT NULL`;
   }
 }
 
@@ -222,11 +229,16 @@ class arraySimpleClause<T extends Data, K = keyof T> implements Clause<T, K> {
     protected col: K,
     private value: any,
     private op: string,
+    private overrideAlias?: string,
   ) {}
 
   clause(idx: number, alias?: string): string {
     if (DB.getDialect() === Dialect.Postgres) {
-      return `$${idx} ${this.op} ANY(${renderCol(this.col, alias)})`;
+      return `$${idx} ${this.op} ANY(${renderCol(
+        this.col,
+        this.overrideAlias,
+        alias,
+      )})`;
     }
     return `${renderCol(this.col, alias)} ${this.op} ?`;
   }
@@ -250,8 +262,15 @@ class arraySimpleClause<T extends Data, K = keyof T> implements Clause<T, K> {
   }
 
   instanceKey(): string {
-    return `${this.col}${this.op}${rawValue(this.value)}`;
+    return `${this.col}${this.overrideAlias ?? ""}${this.op}${rawValue(
+      this.value,
+    )}`;
   }
+}
+
+interface postgresArrayOperatorOptions {
+  not?: boolean;
+  overrideAlias?: string;
 }
 
 class postgresArrayOperator<T extends Data, K = keyof T>
@@ -261,15 +280,19 @@ class postgresArrayOperator<T extends Data, K = keyof T>
     protected col: K,
     protected value: any,
     private op: string,
-    private not?: boolean,
+    private opts?: postgresArrayOperatorOptions,
   ) {}
 
   clause(idx: number, alias?: string): string {
     if (DB.getDialect() === Dialect.Postgres) {
-      if (this.not) {
-        return `NOT ${renderCol(this.col, alias)} ${this.op} $${idx}`;
+      if (this.opts?.not) {
+        return `NOT ${renderCol(this.col, this.opts.overrideAlias, alias)} ${
+          this.op
+        } $${idx}`;
       }
-      return `${renderCol(this.col, alias)} ${this.op} $${idx}`;
+      return `${renderCol(this.col, this.opts?.overrideAlias, alias)} ${
+        this.op
+      } $${idx}`;
     }
     throw new Error(`not supported`);
   }
@@ -293,10 +316,14 @@ class postgresArrayOperator<T extends Data, K = keyof T>
   }
 
   instanceKey(): string {
-    if (this.not) {
-      return `NOT:${this.col}${this.op}${rawValue(this.value)}`;
+    if (this.opts?.not) {
+      return `NOT:${this.col}${this.opts?.overrideAlias ?? ""}${
+        this.op
+      }${rawValue(this.value)}`;
     }
-    return `${this.col}${this.op}${rawValue(this.value)}`;
+    return `${this.col}${this.opts?.overrideAlias ?? ""}${this.op}${rawValue(
+      this.value,
+    )}`;
   }
 }
 
@@ -304,8 +331,13 @@ class postgresArrayOperatorList<
   T extends Data,
   K = keyof T,
 > extends postgresArrayOperator<T, K> {
-  constructor(col: K, value: any[], op: string, not?: boolean) {
-    super(col, value, op, not);
+  constructor(
+    col: K,
+    value: any[],
+    op: string,
+    opts?: postgresArrayOperatorOptions,
+  ) {
+    super(col, value, op, opts);
   }
 
   values(): any[] {
@@ -348,21 +380,20 @@ export class inClause<T extends Data, K = keyof T> implements Clause<T, K> {
     private col: K,
     private value: any[],
     private type = "uuid",
+    private overrideAlias?: string,
   ) {}
 
   clause(idx: number, alias?: string): string {
     // do a simple = when only one item
     if (this.value.length === 1) {
       if (this.op === "IN") {
-        return new simpleClause(this.col, this.value[0], "=").clause(
-          idx,
-          alias,
-        );
+        return new simpleClause(this.col, this.value[0], "=", {
+          overrideAlias: this.overrideAlias,
+        }).clause(idx, alias);
       } else {
-        return new simpleClause(this.col, this.value[0], "!=").clause(
-          idx,
-          alias,
-        );
+        return new simpleClause(this.col, this.value[0], "!=", {
+          overrideAlias: this.overrideAlias,
+        }).clause(idx, alias);
       }
     }
 
@@ -398,7 +429,9 @@ export class inClause<T extends Data, K = keyof T> implements Clause<T, K> {
       inValue = `VALUES${inValue}`;
     }
 
-    return `${renderCol(this.col, alias)} ${this.op} (${inValue})`;
+    return `${renderCol(this.col, this.overrideAlias, alias)} ${
+      this.op
+    } (${inValue})`;
     // TODO we need to return idx at end to query builder...
     // or anything that's doing a composite query so next clause knows where to start
     // or change to a sqlx.Rebind format
@@ -426,7 +459,9 @@ export class inClause<T extends Data, K = keyof T> implements Clause<T, K> {
   }
 
   instanceKey(): string {
-    return `${this.op.toLowerCase()}:${this.col}:${this.values().join(",")}`;
+    return `${this.op.toLowerCase()}:${this.col}${
+      this.overrideAlias ?? ""
+    }:${this.values().join(",")}`;
   }
 }
 
@@ -495,11 +530,16 @@ class compositeClause<T extends Data, K = keyof T> implements Clause<T, K> {
   }
 }
 
+interface tsQueryClauseOptions {
+  tsVectorCol?: boolean;
+  overrideAlias?: string;
+}
+
 class tsQueryClause<T extends Data, K = keyof T> implements Clause<T, K> {
   constructor(
     protected col: K,
     protected val: string | TsQuery,
-    private tsVectorCol?: boolean,
+    private opts?: tsQueryClauseOptions,
   ) {}
 
   private isTsQuery(val: string | TsQuery): val is TsQuery {
@@ -519,20 +559,23 @@ class tsQueryClause<T extends Data, K = keyof T> implements Clause<T, K> {
   clause(idx: number, alias?: string): string {
     const { language } = this.getInfo();
     if (Dialect.Postgres === DB.getDialect()) {
-      if (this.tsVectorCol) {
+      if (this.opts?.tsVectorCol) {
         return `to_tsvector(${renderCol(
           this.col,
+          this.opts.overrideAlias,
           alias,
         )}) @@ ${this.getFunction()}('${language}', $${idx})`;
       }
       return `${renderCol(
         this.col,
+        this.opts?.overrideAlias,
         alias,
       )} @@ ${this.getFunction()}('${language}', $${idx})`;
     }
     // FYI this doesn't actually work for sqlite since different
     return `${renderCol(
       this.col,
+      this.opts?.overrideAlias,
       alias,
     )} @@ ${this.getFunction()}('${language}', ?)`;
   }
@@ -557,12 +600,14 @@ class tsQueryClause<T extends Data, K = keyof T> implements Clause<T, K> {
 
   instanceKey(): string {
     const { language, value } = this.getInfo();
-    if (this.tsVectorCol) {
-      return `to_tsvector(${
+    if (this.opts?.tsVectorCol) {
+      return `${this.opts?.overrideAlias ?? ""}to_tsvector(${
         this.col
-      })@@${this.getFunction()}:${language}:${value}`;
+      }):@@${this.getFunction()}:${language}:${value}`;
     }
-    return `${this.col}@@${this.getFunction()}:${language}:${value}`;
+    return `${this.col}${
+      this.opts?.overrideAlias ?? ""
+    }@@${this.getFunction()}:${language}:${value}`;
   }
 }
 
@@ -604,8 +649,9 @@ class websearchTosQueryClause<
 export function PostgresArrayContainsValue<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new postgresArrayOperator(col, value, "@>");
+  return new postgresArrayOperator(col, value, "@>", { overrideAlias });
 }
 
 /**
@@ -616,8 +662,9 @@ export function PostgresArrayContainsValue<T extends Data, K = keyof T>(
 export function PostgresArrayContains<T extends Data, K = keyof T>(
   col: K,
   value: any[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new postgresArrayOperatorList(col, value, "@>");
+  return new postgresArrayOperatorList(col, value, "@>", { overrideAlias });
 }
 
 /**
@@ -628,8 +675,12 @@ export function PostgresArrayContains<T extends Data, K = keyof T>(
 export function PostgresArrayNotContainsValue<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new postgresArrayOperator(col, value, "@>", true);
+  return new postgresArrayOperator(col, value, "@>", {
+    not: true,
+    overrideAlias,
+  });
 }
 
 /**
@@ -640,8 +691,12 @@ export function PostgresArrayNotContainsValue<T extends Data, K = keyof T>(
 export function PostgresArrayNotContains<T extends Data, K = keyof T>(
   col: K,
   value: any[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new postgresArrayOperatorList(col, value, "@>", true);
+  return new postgresArrayOperatorList(col, value, "@>", {
+    not: true,
+    overrideAlias,
+  });
 }
 
 /**
@@ -652,8 +707,11 @@ export function PostgresArrayNotContains<T extends Data, K = keyof T>(
 export function PostgresArrayOverlaps<T extends Data, K = keyof T>(
   col: K,
   value: any[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new postgresArrayOperatorList(col, value, "&&");
+  return new postgresArrayOperatorList(col, value, "&&", {
+    overrideAlias,
+  });
 }
 
 /**
@@ -664,8 +722,12 @@ export function PostgresArrayOverlaps<T extends Data, K = keyof T>(
 export function PostgresArrayNotOverlaps<T extends Data, K = keyof T>(
   col: K,
   value: any[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new postgresArrayOperatorList(col, value, "&&", true);
+  return new postgresArrayOperatorList(col, value, "&&", {
+    not: true,
+    overrideAlias,
+  });
 }
 
 /**
@@ -691,85 +753,115 @@ export function ArrayNotEq<T extends Data, K = keyof T>(
 export function Eq<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, value, "=", new isNullClause(col));
+  return new simpleClause<T, K>(col, value, "=", {
+    handleNull: new isNullClause(col),
+    overrideAlias,
+  });
 }
 
 export function StartsWith<T extends Data, K = keyof T>(
   col: K,
   value: string,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, `${value}%`, "LIKE");
+  return new simpleClause<T, K>(col, `${value}%`, "LIKE", {
+    overrideAlias,
+  });
 }
 
 export function EndsWith<T extends Data, K = keyof T>(
   col: K,
   value: string,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, `%${value}`, "LIKE");
+  return new simpleClause<T, K>(col, `%${value}`, "LIKE", {
+    overrideAlias,
+  });
 }
 
 export function Contains<T extends Data, K = keyof T>(
   col: K,
   value: string,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, `%${value}%`, "LIKE");
+  return new simpleClause<T, K>(col, `%${value}%`, "LIKE", {
+    overrideAlias,
+  });
 }
 
 export function StartsWithIgnoreCase<T extends Data, K = keyof T>(
   col: K,
   value: string,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, `${value}%`, "ILIKE");
+  return new simpleClause<T, K>(col, `${value}%`, "ILIKE", {
+    overrideAlias,
+  });
 }
 
 export function EndsWithIgnoreCase<T extends Data, K = keyof T>(
   col: K,
   value: string,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, `%${value}`, "ILIKE");
+  return new simpleClause<T, K>(col, `%${value}`, "ILIKE", { overrideAlias });
 }
 
 export function ContainsIgnoreCase<T extends Data, K = keyof T>(
   col: K,
   value: string,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, `%${value}%`, "ILIKE");
+  return new simpleClause<T, K>(col, `%${value}%`, "ILIKE", {
+    overrideAlias,
+  });
 }
 
 export function NotEq<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, value, "!=", new isNotNullClause(col));
+  return new simpleClause<T, K>(col, value, "!=", {
+    handleNull: new isNotNullClause(col),
+    overrideAlias,
+  });
 }
 
 export function Greater<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, value, ">");
+  return new simpleClause<T, K>(col, value, ">", {
+    overrideAlias,
+  });
 }
 
 export function Less<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, value, "<");
+  return new simpleClause<T, K>(col, value, "<", { overrideAlias });
 }
 
 export function GreaterEq<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, value, ">=");
+  return new simpleClause<T, K>(col, value, ">=", { overrideAlias });
 }
 
 export function LessEq<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause<T, K>(col, value, "<=");
+  return new simpleClause<T, K>(col, value, "<=", { overrideAlias });
 }
 
 export function And<T extends Data, K = keyof T>(
@@ -837,22 +929,25 @@ export function In<T extends Data, K = keyof T>(...args: any[]): Clause<T, K> {
 export function UuidIn<T extends Data, K = keyof T>(
   col: K,
   values: ID[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new inClause(col, values, "uuid");
+  return new inClause(col, values, "uuid", overrideAlias);
 }
 
 export function IntegerIn<T extends Data, K = keyof T>(
   col: K,
   values: number[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new inClause(col, values, "integer");
+  return new inClause(col, values, "integer", overrideAlias);
 }
 
 export function TextIn<T extends Data, K = keyof T>(
   col: K,
   values: any[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new inClause(col, values, "text");
+  return new inClause(col, values, "text", overrideAlias);
 }
 
 /*
@@ -863,29 +958,33 @@ export function DBTypeIn<T extends Data, K = keyof T>(
   col: K,
   values: any[],
   typ: string,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new inClause(col, values, typ);
+  return new inClause(col, values, typ, overrideAlias);
 }
 
 export function UuidNotIn<T extends Data, K = keyof T>(
   col: K,
   values: ID[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new notInClause(col, values, "uuid");
+  return new notInClause(col, values, "uuid", overrideAlias);
 }
 
 export function IntegerNotIn<T extends Data, K = keyof T>(
   col: K,
   values: number[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new notInClause(col, values, "integer");
+  return new notInClause(col, values, "integer", overrideAlias);
 }
 
 export function TextNotIn<T extends Data, K = keyof T>(
   col: K,
   values: any[],
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new notInClause(col, values, "text");
+  return new notInClause(col, values, "text", overrideAlias);
 }
 
 /*
@@ -896,8 +995,9 @@ export function DBTypeNotIn<T extends Data, K = keyof T>(
   col: K,
   values: any[],
   typ: string,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new notInClause(col, values, typ);
+  return new notInClause(col, values, typ, overrideAlias);
 }
 
 interface TsQuery {
@@ -915,29 +1015,33 @@ interface TsQuery {
 export function TsQuery<T extends Data, K = keyof T>(
   col: K,
   val: string | TsQuery,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new tsQueryClause(col, val);
+  return new tsQueryClause(col, val, { overrideAlias });
 }
 
 export function PlainToTsQuery<T extends Data, K = keyof T>(
   col: K,
   val: string | TsQuery,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new plainToTsQueryClause(col, val);
+  return new plainToTsQueryClause(col, val, { overrideAlias });
 }
 
 export function PhraseToTsQuery<T extends Data, K = keyof T>(
   col: K,
   val: string | TsQuery,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new phraseToTsQueryClause(col, val);
+  return new phraseToTsQueryClause(col, val, { overrideAlias });
 }
 
 export function WebsearchToTsQuery<T extends Data, K = keyof T>(
   col: K,
   val: string | TsQuery,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new websearchTosQueryClause(col, val);
+  return new websearchTosQueryClause(col, val, { overrideAlias });
 }
 
 // TsVectorColTsQuery is used when the column is not a tsvector field e.g.
@@ -945,8 +1049,9 @@ export function WebsearchToTsQuery<T extends Data, K = keyof T>(
 export function TsVectorColTsQuery<T extends Data, K = keyof T>(
   col: K,
   val: string | TsQuery,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new tsQueryClause(col, val, true);
+  return new tsQueryClause(col, val, { tsVectorCol: true, overrideAlias });
 }
 
 // TsVectorPlainToTsQuery is used when the column is not a tsvector field e.g.
@@ -956,8 +1061,12 @@ export function TsVectorColTsQuery<T extends Data, K = keyof T>(
 export function TsVectorPlainToTsQuery<T extends Data, K = keyof T>(
   col: K,
   val: string | TsQuery,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new plainToTsQueryClause(col, val, true);
+  return new plainToTsQueryClause(col, val, {
+    tsVectorCol: true,
+    overrideAlias,
+  });
 }
 
 // TsVectorPhraseToTsQuery is used when the column is not a tsvector field e.g.
@@ -965,8 +1074,12 @@ export function TsVectorPlainToTsQuery<T extends Data, K = keyof T>(
 export function TsVectorPhraseToTsQuery<T extends Data, K = keyof T>(
   col: K,
   val: string | TsQuery,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new phraseToTsQueryClause(col, val, true);
+  return new phraseToTsQueryClause(col, val, {
+    tsVectorCol: true,
+    overrideAlias,
+  });
 }
 
 // TsVectorWebsearchToTsQuery is used when the column is not a tsvector field e.g.
@@ -974,8 +1087,12 @@ export function TsVectorPhraseToTsQuery<T extends Data, K = keyof T>(
 export function TsVectorWebsearchToTsQuery<T extends Data, K = keyof T>(
   col: K,
   val: string | TsQuery,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new websearchTosQueryClause(col, val, true);
+  return new websearchTosQueryClause(col, val, {
+    tsVectorCol: true,
+    overrideAlias,
+  });
 }
 
 // TODO would be nice to support this with building blocks but not supporting for now
@@ -1007,17 +1124,19 @@ export function sensitiveValue(val: any): SensitiveValue {
 export function JSONObjectFieldKeyASJSON<T extends Data, K = keyof T>(
   col: K,
   field: string,
+  overrideAlias?: string,
 ): keyof T {
   // type as keyof T to make it easier to use in other queries
-  return `${col}->'${field}'`;
+  return `${renderCol(col, overrideAlias)}->'${field}'`;
 }
 
 export function JSONObjectFieldKeyAsText<T extends Data, K = keyof T>(
   col: K,
   field: string,
+  overrideAlias?: string,
 ): keyof T {
   // type as keyof T to make it easier to use in other queries
-  return `${col}->>'${field}'`;
+  return `${renderCol(col, overrideAlias)}->>'${field}'`;
 }
 
 // can't get this to work...
@@ -1036,13 +1155,14 @@ class jSONPathValuePredicateClause<T extends Data, K = keyof T>
     protected path: string,
     protected value: any,
     private pred: predicate,
+    private overrideAlias?: string,
   ) {}
 
   clause(idx: number, alias?: string): string {
     if (DB.getDialect() !== Dialect.Postgres) {
       throw new Error(`not supported`);
     }
-    return `${renderCol(this.col, alias)} @@ $${idx}`;
+    return `${renderCol(this.col, this.overrideAlias, alias)} @@ $${idx}`;
   }
 
   columns(): K[] {
@@ -1069,7 +1189,9 @@ class jSONPathValuePredicateClause<T extends Data, K = keyof T>
   }
 
   instanceKey(): string {
-    return `${this.col}${this.path}${rawValue(this.value)}${this.pred}`;
+    return `${this.col}${this.overrideAlias ?? ""}${this.path}${rawValue(
+      this.value,
+    )}${this.pred}`;
   }
 }
 
@@ -1079,25 +1201,41 @@ export function JSONPathValuePredicate<T extends Data, K = keyof T>(
   path: string,
   val: any,
   pred: predicate,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new jSONPathValuePredicateClause(dbCol, path, val, pred);
+  return new jSONPathValuePredicateClause(
+    dbCol,
+    path,
+    val,
+    pred,
+    overrideAlias,
+  );
 }
 
 export function JSONKeyExists<T extends Data, K = keyof T>(
   dbCol: K,
   val: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause(dbCol, val, "?", new isNullClause(dbCol));
+  return new simpleClause(dbCol, val, "?", {
+    // TODO ola: does isNullClause make sense here???
+    handleNull: new isNullClause(dbCol),
+    overrideAlias,
+  });
 }
 
 export function JSONBKeyInList<T extends Data, K = keyof T>(
   dbCol: K,
   jsonCol: string,
   val: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
   const opts: QueryableDataOptions = {
     fields: ["1"],
-    tableName: `jsonb_array_elements(${dbCol}) AS json_element`,
+    tableName: `jsonb_array_elements(${renderCol(
+      dbCol,
+      overrideAlias,
+    )}) AS json_element`,
     // @ts-ignore
     clause: And(
       JSONKeyExists("json_element", jsonCol),
@@ -1112,10 +1250,14 @@ export function JSONKeyInList<T extends Data, K = keyof T>(
   dbCol: K,
   jsonCol: string,
   val: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
   const opts: QueryableDataOptions = {
     fields: ["1"],
-    tableName: `json_array_elements(${dbCol}) AS json_element`,
+    tableName: `json_array_elements(${renderCol(
+      dbCol,
+      overrideAlias,
+    )}) AS json_element`,
     // @ts-ignore
     clause: And(
       JSONKeyExists("json_element", jsonCol),
@@ -1137,29 +1279,36 @@ class paginationMultipleColumnsSubQueryClause<T extends Data, K = keyof T>
     private tableName: string,
     private uniqueCol: K,
     private val: any,
+    private overrideAlias?: string,
   ) {}
 
   private buildSimpleQuery(clause: Clause<T, K>, idx: number, alias?: string) {
-    return `SELECT ${renderCol(this.col, alias)} FROM ${
+    return `SELECT ${renderCol(this.col, this.overrideAlias, alias)} FROM ${
       this.tableName
     } WHERE ${clause.clause(idx, alias)}`;
   }
 
   clause(idx: number, alias?: string): string {
-    const eq1 = this.buildSimpleQuery(Eq(this.uniqueCol, this.val), idx, alias);
+    const eq1 = this.buildSimpleQuery(
+      Eq(this.uniqueCol, this.val, this.overrideAlias),
+      idx,
+      alias,
+    );
     const eq2 = this.buildSimpleQuery(
-      Eq(this.uniqueCol, this.val),
+      Eq(this.uniqueCol, this.val, this.overrideAlias),
       idx + 1,
       alias,
     );
-    const op = new simpleClause(this.uniqueCol, this.val, this.op).clause(
-      idx + 2,
-      alias,
-    );
+    const op = new simpleClause(this.uniqueCol, this.val, this.op, {
+      overrideAlias: this.overrideAlias,
+    }).clause(idx + 2, alias);
 
     // nest in () to make sure it's scoped correctly
-    return `(${renderCol(this.col, alias)} ${this.op} (${eq1}) OR (${renderCol(
+    return `(${renderCol(this.col, this.overrideAlias, alias)} ${
+      this.op
+    } (${eq1}) OR (${renderCol(
       this.col,
+      this.overrideAlias,
       alias,
     )} = (${eq2}) AND ${op}))`;
   }
@@ -1178,7 +1327,9 @@ class paginationMultipleColumnsSubQueryClause<T extends Data, K = keyof T>
   }
 
   instanceKey(): string {
-    return `${this.col}-${this.op}-${this.tableName}-${this.uniqueCol}-${this.val}`;
+    return `${this.col}${this.overrideAlias ?? ""}-${this.op}-${
+      this.tableName
+    }-${this.uniqueCol}-${this.val}`;
   }
 }
 
@@ -1188,6 +1339,7 @@ export function PaginationMultipleColsSubQuery<T extends Data, K = keyof T>(
   tableName: string,
   uniqueCol: K,
   val: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
   return new paginationMultipleColumnsSubQueryClause(
     col,
@@ -1195,6 +1347,7 @@ export function PaginationMultipleColsSubQuery<T extends Data, K = keyof T>(
     tableName,
     uniqueCol,
     val,
+    overrideAlias,
   );
 }
 
@@ -1202,36 +1355,56 @@ export function PaginationMultipleColsSubQuery<T extends Data, K = keyof T>(
 export function Add<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause(col, value, "+", new isNullClause(col));
+  return new simpleClause(col, value, "+", {
+    handleNull: new isNullClause(col),
+    overrideAlias,
+  });
 }
 
 export function Subtract<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause(col, value, "-", new isNullClause(col));
+  return new simpleClause(col, value, "-", {
+    handleNull: new isNullClause(col),
+    overrideAlias,
+  });
 }
 
 export function Multiply<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause(col, value, "*", new isNullClause(col));
+  return new simpleClause(col, value, "*", {
+    handleNull: new isNullClause(col),
+    overrideAlias,
+  });
 }
 
 export function Divide<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause(col, value, "/", new isNullClause(col));
+  return new simpleClause(col, value, "/", {
+    handleNull: new isNullClause(col),
+    overrideAlias,
+  });
 }
 
 export function Modulo<T extends Data, K = keyof T>(
   col: K,
   value: any,
+  overrideAlias?: string,
 ): Clause<T, K> {
-  return new simpleClause(col, value, "%", new isNullClause(col));
+  return new simpleClause(col, value, "%", {
+    handleNull: new isNullClause(col),
+    overrideAlias,
+  });
 }
 
 export function getCombinedClause<V extends Data = Data, K = keyof V>(


### PR DESCRIPTION
done at Clause creation time instead of at query construction time

goes along with https://github.com/lolopinto/ent/pull/1637

used when we know the alias for the Clause which may be different from the alias for other parts of query. usually used in a join. used in other PR coming. all part of testing new APIs