### PR TITLE
CustomClauseQuery support for joins

### DIFF
--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -162,6 +162,9 @@ export interface SelectBaseDataOptions extends DataOptions {
   // use this alias to alias the fields instead of the table name or table alias
   // takes precedence over tableName and alias
   fieldsAlias?: string;
+  // don't use either alias for this query.
+  // possible reason in when doing aggregate queries and may have already aliased what we're querying
+  disableFieldsAlias?: boolean;
 }
 
 export interface SelectDataOptions extends SelectBaseDataOptions {

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -205,7 +205,7 @@ export interface LoadRowOptions extends QueryableDataOptions {}
 export interface LoadRowsOptions extends QueryableDataOptions {}
 
 interface OnConflictOptions {
-  // TODO these should change to fields instead of columns
+  // TODO should these change to fields instead of columns?
   onConflictCols: string[];
 
   // onConflictConstraint doesn't work with do nothing since ent always reloads the

--- a/ts/src/core/clause.test.ts
+++ b/ts/src/core/clause.test.ts
@@ -2713,7 +2713,7 @@ describe("sqlite", () => {
     });
   });
 
-  describe("pagination multiple cols query", () => {
+  describe("pagination multiple cols sub query", () => {
     test(">", () => {
       const cls = clause.PaginationMultipleColsSubQuery<EventData>(
         "start_time",
@@ -2772,6 +2772,108 @@ describe("sqlite", () => {
       expect(cls.values()).toStrictEqual(["fooo", "fooo", "fooo"]);
       expect(cls.logValues()).toStrictEqual(["fooo", "fooo", "fooo"]);
       expect(cls.instanceKey()).toEqual("start_time-<-events-id-fooo");
+    });
+  });
+
+  describe("pagination multiple cols query", () => {
+    test("less", () => {
+      const d = new Date();
+      const cls = clause.PaginationMultipleColsQuery<EventData>(
+        "start_time",
+        "id",
+        true,
+        d.toISOString(),
+        4,
+      );
+      expect(cls.clause(1)).toBe(
+        "(start_time < ? OR (start_time = ? AND id < ?))",
+      );
+      expect(cls.clause(1, "t")).toBe(
+        "(t.start_time < ? OR (t.start_time = ? AND t.id < ?))",
+      );
+      expect(cls.columns()).toStrictEqual(["start_time", "start_time", "id"]);
+      expect(cls.values()).toStrictEqual([d.toISOString(), d.toISOString(), 4]);
+      expect(cls.logValues()).toStrictEqual([
+        d.toISOString(),
+        d.toISOString(),
+        4,
+      ]);
+
+      const cls2 = clause.PaginationMultipleColsQuery<EventData>(
+        "start_time",
+        "id",
+        true,
+        d.toISOString(),
+        4,
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "(t2.start_time < ? OR (t2.start_time = ? AND t2.id < ?))",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "(t2.start_time < ? OR (t2.start_time = ? AND t2.id < ?))",
+      );
+      expect(cls2.columns()).toStrictEqual(["start_time", "start_time", "id"]);
+      expect(cls2.values()).toStrictEqual([
+        d.toISOString(),
+        d.toISOString(),
+        4,
+      ]);
+      expect(cls2.logValues()).toStrictEqual([
+        d.toISOString(),
+        d.toISOString(),
+        4,
+      ]);
+    });
+
+    test("greater", () => {
+      const d = new Date();
+      const cls = clause.PaginationMultipleColsQuery<EventData>(
+        "start_time",
+        "id",
+        false,
+        d.toISOString(),
+        4,
+      );
+      expect(cls.clause(1)).toBe(
+        "(start_time > ? OR (start_time = ? AND id > ?))",
+      );
+      expect(cls.clause(1, "t")).toBe(
+        "(t.start_time > ? OR (t.start_time = ? AND t.id > ?))",
+      );
+      expect(cls.columns()).toStrictEqual(["start_time", "start_time", "id"]);
+      expect(cls.values()).toStrictEqual([d.toISOString(), d.toISOString(), 4]);
+      expect(cls.logValues()).toStrictEqual([
+        d.toISOString(),
+        d.toISOString(),
+        4,
+      ]);
+
+      const cls2 = clause.PaginationMultipleColsQuery<EventData>(
+        "start_time",
+        "id",
+        false,
+        d.toISOString(),
+        4,
+        "t2",
+      );
+      expect(cls2.clause(1)).toBe(
+        "(t2.start_time > ? OR (t2.start_time = ? AND t2.id > ?))",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "(t2.start_time > ? OR (t2.start_time = ? AND t2.id > ?))",
+      );
+      expect(cls2.columns()).toStrictEqual(["start_time", "start_time", "id"]);
+      expect(cls2.values()).toStrictEqual([
+        d.toISOString(),
+        d.toISOString(),
+        4,
+      ]);
+      expect(cls2.logValues()).toStrictEqual([
+        d.toISOString(),
+        d.toISOString(),
+        4,
+      ]);
     });
   });
 

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -1205,13 +1205,11 @@ export function PaginationMultipleColsQuery<T extends Data, K = keyof T>(
   sortValue: any,
   cursorValue: any,
 ): Clause<T, K> {
+  const clauseFn = less ? Less : Greater;
   return And(
     Or(
-      less ? Less(sortCol, sortValue) : Greater(sortCol, sortValue),
-      And(
-        Eq(sortCol, sortValue),
-        less ? Less(cursorCol, cursorValue) : Greater(cursorCol, cursorValue),
-      ),
+      clauseFn(sortCol, sortValue),
+      And(Eq(sortCol, sortValue), clauseFn(cursorCol, cursorValue)),
     ),
   );
 }

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -603,7 +603,7 @@ class tsQueryClause<T extends Data, K = keyof T> implements Clause<T, K> {
     if (this.opts?.tsVectorCol) {
       return `${this.opts?.overrideAlias ?? ""}to_tsvector(${
         this.col
-      }):@@${this.getFunction()}:${language}:${value}`;
+      })@@${this.getFunction()}:${language}:${value}`;
     }
     return `${this.col}${
       this.opts?.overrideAlias ?? ""

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -1198,6 +1198,24 @@ export function PaginationMultipleColsSubQuery<T extends Data, K = keyof T>(
   );
 }
 
+export function PaginationMultipleColsQuery<T extends Data, K = keyof T>(
+  sortCol: K,
+  cursorCol: K,
+  less: boolean, // if true, <, if false, >
+  sortValue: any,
+  cursorValue: any,
+): Clause<T, K> {
+  return And(
+    Or(
+      less ? Less(sortCol, sortValue) : Greater(sortCol, sortValue),
+      And(
+        Eq(sortCol, sortValue),
+        less ? Less(cursorCol, cursorValue) : Greater(cursorCol, cursorValue),
+      ),
+    ),
+  );
+}
+
 // These 5 are used on the RHS of an expression
 export function Add<T extends Data, K = keyof T>(
   col: K,

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -334,9 +334,7 @@ class postgresArrayOperator<T extends Data, K = keyof T>
         this.value,
       )}`;
     }
-    return `${this.col}${this.opts?.overrideAlias ?? ""}${this.op}${rawValue(
-      this.value,
-    )}`;
+    return `${this.col}${this.op}${rawValue(this.value)}`;
   }
 }
 

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -1237,49 +1237,51 @@ export class AssocEdge {
   getCursor(): string {
     return getCursor({
       row: this,
-      col: "id2",
+      keys: ["id2"],
     });
   }
 }
 
 export interface cursorOptions {
   row: Data;
-  col: string;
-  cursorKey?: string; // used by tests. if cursor is from one column but the key in the name is different e.g. time for assocs and created_at when taken from the object
+  keys: string[];
+  // col: string;
+  // cursorKey?: string; // used by tests. if cursor is from one column but the key in the name is different e.g. time for assocs and created_at when taken from the object
   // used rarely, indicates that the cursor will be more than 2 parts and will have more fields
-  extraParts?: string[];
-  conv?: (any: any) => any;
+  // extraParts?: string[];
+  // conv?: (any: any) => any;
 }
 
 // TODO eventually update this for sortCol time unique keys
 export function getCursor(opts: cursorOptions) {
-  const { row, col, conv } = opts;
+  const { row, keys } = opts;
   //  row: Data, col: string, conv?: (any) => any) {
   if (!row) {
     throw new Error(`no row passed to getCursor`);
   }
-  const convert = (d: any, convFn?: any) => {
-    if (convFn) {
-      return convFn(d);
-    }
+  const convert = (d: any) => {
+    // if (convFn) {
+    //   return convFn(d);
+    // }
     if (d instanceof Date) {
-      return d.toISOString();
+      return d.getTime();
     }
     return d;
   };
 
-  let datum = convert(row[col], conv);
-  if (!datum) {
-    return "";
-  }
+  // let datum = convert(row[col], conv);
+  // if (!datum) {
+  //   return "";
+  // }
 
-  const cursorKey = opts.cursorKey || col;
-  const parts: string[] = [cursorKey, datum];
-  if (opts.extraParts) {
-    for (const p of opts.extraParts) {
-      parts.push(p);
-      parts.push(convert(row[p]));
-    }
+  // const cursorKey = opts.cursorKey || col;
+  const parts: string[] = [];
+  for (const key of keys) {
+    // if (opts.extraParts) {
+    // for (const p of opts.extraParts) {
+    parts.push(key);
+    parts.push(convert(row[key]));
+    // }
   }
   const str = parts.join(":");
   return Buffer.from(str, "ascii").toString("base64");

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -1246,10 +1246,6 @@ export interface cursorOptions {
   row: Data;
   keys: string[];
   cursorKeys?: string[]; // used by tests. if cursor is from one column but the key in the name is different e.g. time for assocs and created_at when taken from the object
-  // col: string;
-  // used rarely, indicates that the cursor will be more than 2 parts and will have more fields
-  // extraParts?: string[];
-  // conv?: (any: any) => any;
 }
 
 // TODO eventually update this for sortCol time unique keys
@@ -1263,19 +1259,11 @@ export function getCursor(opts: cursorOptions) {
     throw new Error("length of cursorKeys should match keys");
   }
   const convert = (d: any) => {
-    // if (convFn) {
-    //   return convFn(d);
-    // }
     if (d instanceof Date) {
       return d.getTime();
     }
     return d;
   };
-
-  // let datum = convert(row[col], conv);
-  // if (!datum) {
-  //   return "";
-  // }
 
   const parts: string[] = [];
   for (let i = 0; i < keys.length; i++) {

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -7,6 +7,7 @@ import {
   FakeUserSchema,
   getNextWeekClause,
   FakeEventSchema,
+  ViewerWithAccessToken,
 } from "../../testutils/fake_data";
 import {
   addEdge,
@@ -115,6 +116,45 @@ const getGlobalQuery = (viewer?: Viewer, opts?: Partial<OrderByOption>) => {
         column: "start_time",
         direction: "DESC",
         ...opts,
+      },
+    ],
+  });
+};
+
+// get creators of users in next week
+const getCreatorsOfGlobalEventsInNextWeek = (
+  // viewer?: Viewer,
+  opts?: Partial<OrderByOption>,
+) => {
+  const loaderOptions = FakeUser.loaderOptions();
+  const tableName = loaderOptions.tableName;
+  loaderOptions.tableName = "fake_events";
+  loaderOptions.alias = "e";
+  loaderOptions.fieldsAlias = "u";
+
+  const viewer = new ViewerWithAccessToken(user.id, {
+    tokens: {
+      always_allow_user: true,
+    },
+  });
+
+  return new CustomClauseQuery<FakeUser>(viewer, {
+    // can do the clause on the events table as long as it's aliased
+    clause: getNextWeekClause(),
+    loadEntOptions: loaderOptions,
+    name: "global_creators_for_events_in_next_week",
+    orderby: [
+      {
+        column: "created_at",
+        direction: "DESC",
+        ...opts,
+      },
+    ],
+    join: [
+      {
+        tableName,
+        alias: "u",
+        clause: clause.Expression("u.id = e.user_id"),
       },
     ],
   });
@@ -558,7 +598,7 @@ describe("global query", () => {
   });
 });
 
-describe("global query", () => {
+describe("global query - end time", () => {
   test("rawCount", async () => {
     const q = getEndTimeGlobalQuery();
 
@@ -833,5 +873,290 @@ describe("global query. id. cursor and sort_column the same", () => {
 
     const edges = await q.queryEdges();
     expect(edges.length).toBe(7 * infos.length);
+  });
+});
+
+describe.only("global query - with joins", () => {
+  test("rawCount", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek();
+
+    const count = await q.queryRawCount();
+    // console.debug("result", count);
+    expect(count).toBe(infos.length);
+  });
+
+  test("ents", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek();
+
+    const ents = await q.queryEnts();
+    // console.debug(ml.logs);
+    // console.debug(new Set(ents.map((ent) => ent.id)));
+    // console.debug(ents.length);
+    expect(ents.length).toBe(infos.length);
+  });
+
+  test("first N", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek();
+
+    const ents = await q.first(2).queryEnts();
+    expect(ents.length).toBe(2);
+  });
+
+  test("first N. nulls first on non-nullable does nothing", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek({
+      nullsPlacement: "first",
+    });
+
+    const ents = await q.first(2).queryEnts();
+    expect(ents.length).toBe(2);
+  });
+
+  test("first N. nulls last on non-nullable does nothing", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek({
+      nullsPlacement: "last",
+    });
+
+    const ents = await q.first(2).queryEnts();
+    expect(ents.length).toBe(2);
+  });
+
+  test("ids", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek();
+
+    const ids = await q.queryIDs();
+    expect(ids.length).toBe(infos.length);
+  });
+
+  test("count", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek();
+
+    const count = await q.queryCount();
+    expect(count).toBe(infos.length);
+  });
+
+  test("edges", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek();
+
+    const edges = await q.queryEdges();
+    expect(edges.length).toBe(infos.length);
+  });
+
+  // need different pagination logic for joins
+  // may need a different example so that we have enough ids to test pagination
+  test.only("first N. after each cursor", async () => {
+    const q = getCreatorsOfGlobalEventsInNextWeek();
+
+    const edges = await q.queryEdges();
+    expect(edges.length).toBe(infos.length);
+
+    ml.clear();
+    const PAGE = 2;
+
+    async function verify(
+      idx: number,
+      hasEdge: boolean,
+      hasNextPage: boolean,
+      cursor?: string,
+    ) {
+      const q2 = getCreatorsOfGlobalEventsInNextWeek().first(PAGE, cursor);
+
+      const ents = await q2.queryEnts();
+      const newEdges = await q2.queryEdges();
+      console.debug(ents.length, newEdges.length);
+
+      const query = buildQuery({
+        ...FakeUser.loaderOptions(),
+        distinct: true,
+        orderby: [
+          {
+            column: "created_at",
+            direction: "DESC",
+          },
+          {
+            column: "id",
+            direction: "DESC",
+          },
+        ],
+        limit: PAGE + 1,
+        clause: clause.AndOptional(
+          clause.GreaterEq("start_time", 1),
+          clause.LessEq("start_time", 2),
+          // the cursor check
+          cursor
+            ? clause.PaginationMultipleColsSubQuery(
+                "created_at",
+                "<",
+                FakeEvent.loaderOptions().tableName,
+                "id",
+                4,
+              )
+            : undefined,
+        ),
+        tableName: "fake_events",
+        fieldsAlias: "u",
+        alias: "e",
+        join: [
+          {
+            tableName: "fake_users",
+            alias: "u",
+            clause: clause.Expression("u.id = e.user_id"),
+          },
+        ],
+      });
+      console.debug(query);
+      expect(query, idx.toString()).toEqual(ml.logs[ml.logs.length - 1].query);
+
+      // 1 is a hack...
+      const pagination = q2.paginationInfo().get(1);
+      if (hasEdge) {
+        expect(ents.length, idx.toString()).toBeGreaterThan(0);
+        expect(ents.length, idx.toString()).toBeLessThanOrEqual(PAGE);
+        // console.debug(page, ents[0].id, edges[PAGE * page]);
+        expect(ents[0].id, idx.toString()).toBe(edges[idx].id);
+      } else {
+        expect(ents.length, idx.toString()).toBe(0);
+        expect(newEdges.length, idx.toString()).toBe(0);
+      }
+
+      if (hasNextPage) {
+        // has exact if next page
+        expect(ents.length, idx.toString()).toBe(PAGE);
+
+        expect(pagination?.hasNextPage, idx.toString()).toBe(true);
+        expect(pagination?.hasPreviousPage, idx.toString()).toBe(false);
+      } else {
+        expect(pagination?.hasNextPage, idx.toString()).toBe(undefined);
+        expect(pagination?.hasNextPage, idx.toString()).toBe(undefined);
+      }
+    }
+
+    await verify(0, true, true); // 0-1
+    const cursor = q.getCursor(edges[PAGE - 1]);
+    console.debug(cursor, Buffer.from(cursor, "base64").toString("ascii"));
+
+    // await verify(1 * PAGE, true, false, q.getCursor(edges[PAGE - 1])); // 2-
+    // await verify(2 * PAGE, true, true, q.getCursor(edges[2 * PAGE - 1])); // 10-14
+    // await verify(3 * PAGE, true, true, q.getCursor(edges[3 * PAGE - 1])); //15-19
+    // await verify(4 * PAGE, true, true, q.getCursor(edges[4 * PAGE - 1])); //20-24
+    // await verify(5 * PAGE, true, false, q.getCursor(edges[5 * PAGE - 1])); //25-28
+
+    // // do a few around transitions to make sure we handle it correctly
+    // // 0-4, 5-8, 9-12, 13-16 etc have duplicate timestamps
+    // await verify(1, true, true, q.getCursor(edges[0]));
+    // await verify(2, true, true, q.getCursor(edges[1]));
+    // await verify(3, true, true, q.getCursor(edges[2]));
+    // await verify(4, true, true, q.getCursor(edges[3]));
+
+    // await verify(8, true, true, q.getCursor(edges[7]));
+    // await verify(14, true, true, q.getCursor(edges[13]));
+    // await verify(19, true, true, q.getCursor(edges[18]));
+  });
+
+  test("first N. after each cursor. asc", async () => {
+    const q = getGlobalQuery(user.viewer, { direction: "ASC" });
+
+    const edges = await q.queryEdges();
+    expect(edges.length).toBe(7 * infos.length);
+
+    ml.clear();
+    const PAGE = 5;
+
+    async function verify(
+      idx: number,
+      hasEdge: boolean,
+      hasNextPage: boolean,
+      cursor?: string,
+    ) {
+      const q2 = getGlobalQuery(user.viewer, { direction: "ASC" }).first(
+        PAGE,
+        cursor,
+      );
+
+      const ents = await q2.queryEnts();
+      const newEdges = await q2.queryEdges();
+
+      const query = buildQuery({
+        ...FakeEvent.loaderOptions(),
+        orderby: [
+          {
+            column: "start_time",
+            direction: "ASC",
+          },
+          {
+            column: "id",
+            direction: "ASC",
+          },
+        ],
+        limit: PAGE + 1,
+        clause: clause.AndOptional(
+          clause.GreaterEq("start_time", 1),
+          clause.LessEq("start_time", 2),
+          // the cursor check
+          cursor
+            ? clause.PaginationMultipleColsSubQuery(
+                "start_time",
+                ">",
+                FakeEvent.loaderOptions().tableName,
+                "id",
+                4,
+              )
+            : undefined,
+        ),
+      });
+      expect(query, idx.toString()).toEqual(ml.logs[ml.logs.length - 1].query);
+
+      // 1 is a hack...
+      const pagination = q2.paginationInfo().get(1);
+      if (hasEdge) {
+        expect(ents.length, idx.toString()).toBeGreaterThan(0);
+        expect(ents.length, idx.toString()).toBeLessThanOrEqual(PAGE);
+        // console.debug(page, ents[0].id, edges[PAGE * page]);
+        expect(ents[0].id, idx.toString()).toBe(edges[idx].id);
+      } else {
+        expect(ents.length, idx.toString()).toBe(0);
+        expect(newEdges.length, idx.toString()).toBe(0);
+      }
+
+      if (hasNextPage) {
+        // has exact if next page
+        expect(ents.length, idx.toString()).toBe(PAGE);
+
+        expect(pagination?.hasNextPage, idx.toString()).toBe(true);
+        expect(pagination?.hasPreviousPage, idx.toString()).toBe(false);
+      } else {
+        expect(pagination?.hasNextPage, idx.toString()).toBe(undefined);
+        expect(pagination?.hasNextPage, idx.toString()).toBe(undefined);
+      }
+    }
+
+    await verify(0, true, true); // 0-4
+    await verify(1 * PAGE, true, true, q.getCursor(edges[PAGE - 1])); // 5-9
+    await verify(2 * PAGE, true, true, q.getCursor(edges[2 * PAGE - 1])); // 10-14
+    await verify(3 * PAGE, true, true, q.getCursor(edges[3 * PAGE - 1])); //15-19
+    await verify(4 * PAGE, true, true, q.getCursor(edges[4 * PAGE - 1])); //20-24
+    await verify(5 * PAGE, true, false, q.getCursor(edges[5 * PAGE - 1])); //25-28
+
+    // do a few around transitions to make sure we handle it correctly
+    // 0-4, 5-8, 9-12, 13-16 etc have duplicate timestamps
+    await verify(1, true, true, q.getCursor(edges[0]));
+    await verify(2, true, true, q.getCursor(edges[1]));
+    await verify(3, true, true, q.getCursor(edges[2]));
+    await verify(4, true, true, q.getCursor(edges[3]));
+
+    await verify(8, true, true, q.getCursor(edges[7]));
+    await verify(14, true, true, q.getCursor(edges[13]));
+    await verify(19, true, true, q.getCursor(edges[18]));
+  });
+
+  test("first N. after each cursor. asc + desc compared", async () => {
+    const q = getGlobalQuery(user.viewer);
+    const q2 = getGlobalQuery(user.viewer, { direction: "ASC" });
+
+    const edges = await q.queryEdges();
+    expect(edges.length).toBe(7 * infos.length);
+
+    const edges2 = await q2.queryEdges();
+    expect(edges2.length).toBe(edges.length);
+    expect(edges.reverse()).toStrictEqual(edges2);
   });
 });

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -1308,7 +1308,6 @@ describe.only("joins - products", () => {
     const max = min * 4;
     // increased these numbers so that we can have enough numbers
     // when querying for the most ordered product by a given user in a category
-    // console.debug(min, max);
     for (const user of users) {
       for (let i = 0; i < getRandomNumber(min, max); i++) {
         const product = products[i % products.length];
@@ -1330,7 +1329,6 @@ describe.only("joins - products", () => {
         orders.push(order!);
       }
     }
-    // console.debug(orders.length);
   });
 
   function getPaginationVerify(
@@ -1383,7 +1381,6 @@ describe.only("joins - products", () => {
         clause: cls,
         join: options.join,
       });
-      // console.debug(query, ml.logs);
       expect(query, idx.toString()).toEqual(ml.logs[ml.logs.length - 1].query);
 
       // 1 is a hack...
@@ -1391,7 +1388,6 @@ describe.only("joins - products", () => {
       if (hasEdge) {
         expect(ents.length, idx.toString()).toBeGreaterThan(0);
         expect(ents.length, idx.toString()).toBeLessThanOrEqual(perPage);
-        // console.debug(page, ents[0].id, edges[PAGE * page]);
         expect(ents[0].id, idx.toString()).toBe(edges[idx].id);
       } else {
         expect(ents.length, idx.toString()).toBe(0);
@@ -1436,7 +1432,6 @@ describe.only("joins - products", () => {
       last = edges[i * perPage + perPage - 1];
       // hasMorePages | last issues | cursor
       let hasMorePages = edges[(i + 1) * perPage] !== undefined;
-      console.debug(i, perPage, edges.length, hasEdge, hasMorePages, cursor);
       await verify(i * perPage, hasEdge, hasMorePages, cursor);
       if (!hasMorePages) {
         break;
@@ -1554,11 +1549,8 @@ describe.only("joins - products", () => {
           num_products DESC
       LIMIT 1;
 `);
-    // console.debug(r.rows);
 
     const expCount = parseInt(r.rows[0].num_products, 10);
-
-    console.debug(expCount);
 
     const userId = r.rows[0].id;
     // query for the products ordered by that user
@@ -1720,7 +1712,7 @@ describe.only("joins - products", () => {
   });
 
   // ~15
-  test.only("query products for user in given category", async () => {
+  test("query products for user in given category", async () => {
     // TODO sc6193ba6874ed
     const r = await DB.getInstance().getPool().query(`
 WITH UserCategoryOrders AS (
@@ -1753,8 +1745,6 @@ LIMIT 1;
     const expCount = parseInt(r.rows[0].num_products, 10);
     const userId = r.rows[0].uid;
     const categoryId = r.rows[0].cid;
-
-    console.debug(expCount);
 
     const r2 = await DB.getInstance()
       .getPool()

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -993,14 +993,6 @@ describe.only("global query - with joins", () => {
                 4,
               )
             : undefined,
-          // ? clause.PaginationMultipleColsSubQuery(
-          //     "created_at",
-          //     "<",
-          //     FakeEvent.loaderOptions().tableName,
-          //     "id",
-          //     4,
-          //   )
-          // : undefined,
         ),
         tableName: "fake_events",
         fieldsAlias: "u",

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -1377,39 +1377,13 @@ describe.only("joins - products", () => {
       const query = buildQuery({
         // tableName, fieldsAlias, alias all from here
         ...options.loadEntOptions,
-        // ...FakeEvent.loaderOptions(),
         distinct: true,
-
         orderby: orderBy,
-        // orderby: [
-        //   {
-        //     column: "start_time",
-        //     direction: "DESC",
-        //   },
-        //   {
-        //     column: "id",
-        //     direction: "DESC",
-        //   },
-        // ],
         limit: perPage + 1,
         clause: cls,
         join: options.join,
-        // clause: clause.AndOptional(
-        //   clause.GreaterEq("start_time", 1),
-        //   clause.LessEq("start_time", 2),
-        //   // the cursor check
-        //   cursor
-        //     ? clause.PaginationMultipleColsSubQuery(
-        //         "start_time",
-        //         "<",
-        //         FakeEvent.loaderOptions().tableName,
-        //         "id",
-        //         4,
-        //       )
-        //     : undefined,
-        // ),
       });
-      console.debug(query, ml.logs);
+      // console.debug(query, ml.logs);
       expect(query, idx.toString()).toEqual(ml.logs[ml.logs.length - 1].query);
 
       // 1 is a hack...
@@ -1457,16 +1431,17 @@ describe.only("joins - products", () => {
       if (last) {
         cursor = q.getCursor(last);
       }
-      let hasEdge = i * perPage < edges.length;
+      // let hasEdge = edges[i * perPage] !== undefined;
+      const hasEdge = i * perPage < edges.length;
       last = edges[i * perPage + perPage - 1];
       // hasMorePages | last issues | cursor
-      let hasMorePages = edges[i * perPage + perPage] !== undefined;
-      // console.debug(i, hasEdge, hasMorePages, cursor);
+      let hasMorePages = edges[(i + 1) * perPage] !== undefined;
+      console.debug(i, perPage, edges.length, hasEdge, hasMorePages, cursor);
       await verify(i * perPage, hasEdge, hasMorePages, cursor);
-      if (!hasEdge) {
+      if (!hasMorePages) {
         break;
       }
-      last = edges[i * perPage + perPage - 1];
+      last = edges[(i + 1) * perPage - 1];
     }
   }
   // psql tb826ca1e5d3a6
@@ -1563,7 +1538,7 @@ describe.only("joins - products", () => {
   });
 
   // ~147
-  test.only("query products for user", async () => {
+  test("query products for user", async () => {
     // find the user who ordered the most products
     const r = await DB.getInstance().getPool().query(`
           SELECT
@@ -1739,16 +1714,13 @@ describe.only("joins - products", () => {
       r2.rows.map((row) => row.id),
     );
 
-    // TODO paginate both...
     await paginateAndVerify(getQuery, edges);
 
-    // await paginateAndVerify(getQuery2, edges2);
-
-    // TODO generic pagination tests??
+    await paginateAndVerify(getQuery2, edges2);
   });
 
   // ~15
-  test("query products for user in given category", async () => {
+  test.only("query products for user in given category", async () => {
     // TODO sc6193ba6874ed
     const r = await DB.getInstance().getPool().query(`
 WITH UserCategoryOrders AS (
@@ -1855,7 +1827,7 @@ LIMIT 1;
     expect(ents.map((ent) => ent.id)).toStrictEqual(
       r2.rows.map((row) => row.id),
     );
-  });
 
-  // TODO generic pagination tests
+    await paginateAndVerify(getQuery, edges);
+  });
 });

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -155,7 +155,7 @@ const getCreatorsOfGlobalEventsInNextWeek = (opts?: Partial<OrderByOption>) => {
         ...opts,
       },
     ],
-    join: [
+    joinBETA: [
       {
         tableName,
         alias: "u",
@@ -1198,7 +1198,7 @@ describe("joins - products", () => {
             direction: "DESC",
           },
         ],
-        join: [
+        joinBETA: [
           {
             tableName: "orders",
             alias: "o",
@@ -1321,7 +1321,7 @@ describe("joins - products", () => {
             direction: "DESC",
           },
         ],
-        join: [
+        joinBETA: [
           {
             tableName: "orders",
             alias: "o",
@@ -1375,7 +1375,7 @@ describe("joins - products", () => {
             direction: "DESC",
           },
         ],
-        join: [
+        joinBETA: [
           {
             tableName: "products",
             alias: "p",
@@ -1486,7 +1486,7 @@ LIMIT 1;
             direction: "DESC",
           },
         ],
-        join: [
+        joinBETA: [
           {
             tableName: "products",
             alias: "p",
@@ -1572,7 +1572,7 @@ function getPaginationVerifyClauseWithJoin<T extends Ent>(
       orderby: orderBy,
       limit: perPage + 1,
       clause: cls,
-      join: options.join,
+      join: options.joinBETA,
     });
     expect(query, idx.toString()).toEqual(ml.logs[ml.logs.length - 1].query);
 

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -991,6 +991,8 @@ describe.only("global query - with joins", () => {
                 // these 2 values don't matter
                 new Date().getTime(),
                 4,
+                // fake_users alias will be used here
+                "u",
               )
             : undefined,
         ),
@@ -1038,7 +1040,7 @@ describe.only("global query - with joins", () => {
 
     // this should fail, we need to change the pagination logic to take the second id
     // and instead of using a subquery changes the and clause to handle this
-    await verify(1 * PAGE, true, false, q.getCursor(edges[PAGE - 1])); // 2-
+    await verify(1 * PAGE, true, false, q.getCursor(edges[PAGE - 1])); // 2-3
 
     // await verify(2 * PAGE, true, true, q.getCursor(edges[2 * PAGE - 1])); // 10-14
     // await verify(3 * PAGE, true, true, q.getCursor(edges[3 * PAGE - 1])); //15-19

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -128,7 +128,7 @@ const getGlobalQuery = (viewer?: Viewer, opts?: Partial<OrderByOption>) => {
   });
 };
 
-// get creators of users in next week
+// get creators of events (users) in next week
 const getCreatorsOfGlobalEventsInNextWeek = (opts?: Partial<OrderByOption>) => {
   const loaderOptions = FakeUser.loaderOptions();
   const tableName = loaderOptions.tableName;
@@ -883,7 +883,7 @@ describe("global query. id. cursor and sort_column the same", () => {
 
 describe("global query - with joins", () => {
   // this only has 4 ids returned so not the best example which is
-  // why we have what's below
+  // why we have what's below (joins - products)
   test("rawCount", async () => {
     const q = getCreatorsOfGlobalEventsInNextWeek();
 
@@ -1609,7 +1609,7 @@ function getPaginationVerifyClauseWithJoin<T extends Ent>(
 
 // this paginates forwards and backwards and verifies that it returns
 // values in the list
-// TODO: get this logic somewhere else and use it in all these places that dos pagination tests?
+// TODO: get this logic somewhere else and use it in all these places that does pagination tests?
 async function paginateAndVerifyClauseWithJoin<T extends Ent>(
   toQuery: () => CustomClauseQuery<T>,
   edges: Data[],

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -983,14 +983,24 @@ describe.only("global query - with joins", () => {
           clause.LessEq("start_time", 2),
           // the cursor check
           cursor
-            ? clause.PaginationMultipleColsSubQuery(
+            ? // this clause needs to be u not e...
+              clause.PaginationMultipleColsQuery(
                 "created_at",
-                "<",
-                FakeEvent.loaderOptions().tableName,
                 "id",
+                true,
+                // these 2 values don't matter
+                new Date().getTime(),
                 4,
               )
             : undefined,
+          // ? clause.PaginationMultipleColsSubQuery(
+          //     "created_at",
+          //     "<",
+          //     FakeEvent.loaderOptions().tableName,
+          //     "id",
+          //     4,
+          //   )
+          // : undefined,
         ),
         tableName: "fake_events",
         fieldsAlias: "u",
@@ -1034,7 +1044,10 @@ describe.only("global query - with joins", () => {
     const cursor = q.getCursor(edges[PAGE - 1]);
     console.debug(cursor, Buffer.from(cursor, "base64").toString("ascii"));
 
-    // await verify(1 * PAGE, true, false, q.getCursor(edges[PAGE - 1])); // 2-
+    // this should fail, we need to change the pagination logic to take the second id
+    // and instead of using a subquery changes the and clause to handle this
+    await verify(1 * PAGE, true, false, q.getCursor(edges[PAGE - 1])); // 2-
+
     // await verify(2 * PAGE, true, true, q.getCursor(edges[2 * PAGE - 1])); // 10-14
     // await verify(3 * PAGE, true, true, q.getCursor(edges[3 * PAGE - 1])); //15-19
     // await verify(4 * PAGE, true, true, q.getCursor(edges[4 * PAGE - 1])); //20-24

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -882,6 +882,8 @@ describe("global query. id. cursor and sort_column the same", () => {
 });
 
 describe("global query - with joins", () => {
+  // this only has 4 ids returned so not the best example which is
+  // why we have what's below
   test("rawCount", async () => {
     const q = getCreatorsOfGlobalEventsInNextWeek();
 
@@ -942,8 +944,6 @@ describe("global query - with joins", () => {
     expect(edges.length).toBe(infos.length);
   });
 
-  // need different pagination logic for joins
-  // may need a different example so that we have enough ids to test pagination
   test("first N. after each cursor", async () => {
     const q = getCreatorsOfGlobalEventsInNextWeek();
 
@@ -989,7 +989,6 @@ describe("global query - with joins", () => {
 });
 
 describe("joins - products", () => {
-  // TODO more
   const usersTable = table(
     "users",
     uuid("id", {
@@ -1005,7 +1004,6 @@ describe("joins - products", () => {
     }),
     text("name"),
   );
-
   const productsTable = table(
     "products",
     uuid("id", { primaryKey: true }),
@@ -1018,7 +1016,6 @@ describe("joins - products", () => {
     integer("price"),
     text("product_name"),
   );
-
   const ordersTable = table(
     "orders",
     uuid("id", { primaryKey: true }),
@@ -1075,7 +1072,7 @@ describe("joins - products", () => {
         },
         "RETURNING *",
       );
-      console.assert(user, `couldn't create user`);
+      expect(user).not.toBeUndefined();
       users.push(user!);
     }
 
@@ -1090,7 +1087,7 @@ describe("joins - products", () => {
         },
         "RETURNING *",
       );
-      console.assert(category, `couldn't create category`);
+      expect(category).not.toBeUndefined();
       categories.push(category!);
     }
 
@@ -1111,7 +1108,7 @@ describe("joins - products", () => {
         },
         "RETURNING *",
       );
-      console.assert(product, `couldn't create product`);
+      expect(product).not.toBeUndefined();
       products.push(product!);
     }
     function getRandomNumber(min: number, max: number) {
@@ -1145,7 +1142,6 @@ describe("joins - products", () => {
     }
   });
 
-  // psql tb826ca1e5d3a6
   // ~20
   test("query users for product", async () => {
     // find the most ordered product
@@ -1380,11 +1376,6 @@ describe("joins - products", () => {
           },
         ],
         join: [
-          // {
-          //   tableName: "orders",
-          //   alias: "o",
-          //   clause: clause.Expression("u.id = o.user_id"),
-          // },
           {
             tableName: "products",
             alias: "p",
@@ -1419,7 +1410,6 @@ describe("joins - products", () => {
 
   // ~15
   test("query products for user in given category", async () => {
-    // TODO sc6193ba6874ed
     const r = await DB.getInstance().getPool().query(`
 WITH UserCategoryOrders AS (
     SELECT 
@@ -1524,7 +1514,6 @@ LIMIT 1;
       r2.rows.map((row) => row.id),
     );
 
-    // need a last version of this to work..
     await paginateAndVerifyClauseWithJoin(getQuery, edges);
   });
 });
@@ -1551,11 +1540,7 @@ function getPaginationVerifyClauseWithJoin<T extends Ent>(
     const options = q2.__getOptions();
 
     const orderBy = options.orderby!;
-    console.assert(orderBy.length === 1);
-    // flip the order by
-    if (!first) {
-      // orderBy[0].direction = orderBy[0].direction === "DESC" ? "ASC" : "DESC";
-    }
+    expect(orderBy.length).toBe(1);
     const less = orderBy[0].direction === "DESC";
     orderBy.push({
       column: "id",
@@ -1622,6 +1607,9 @@ function getPaginationVerifyClauseWithJoin<T extends Ent>(
   return verify;
 }
 
+// this paginates forwards and backwards and verifies that it returns
+// values in the list
+// TODO: get this logic somewhere else and use it in all these places that dos pagination tests?
 async function paginateAndVerifyClauseWithJoin<T extends Ent>(
   toQuery: () => CustomClauseQuery<T>,
   edges: Data[],

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -44,7 +44,7 @@ export interface CustomClauseQueryOptions<
 
   disableTransformations?: boolean;
 
-  join?: QueryDataOptions["join"];
+  joinBETA?: QueryDataOptions["join"];
 }
 
 function getClause<TDest extends Ent<TViewer>, TViewer extends Viewer = Viewer>(
@@ -105,7 +105,7 @@ export class CustomClauseQuery<
     super(viewer, {
       orderby,
       cursorCol,
-      join: options.join,
+      join: options.joinBETA,
       fieldOptions: options.loadEntOptions,
     });
     this.clause = getClause(options);
@@ -127,7 +127,7 @@ export class CustomClauseQuery<
   async queryRawCount(): Promise<number> {
     // sqlite needs as count otherwise it returns count(1)
     let fields = ["count(1) as count"];
-    if (this.options.join) {
+    if (this.options.joinBETA) {
       const requestedFields = this.options.loadEntOptions.fields;
       const alias =
         this.options.loadEntOptions.fieldsAlias ??
@@ -144,7 +144,7 @@ export class CustomClauseQuery<
       fields,
       clause: this.clause,
       context: this.viewer.context,
-      join: this.options.join,
+      join: this.options.joinBETA,
       disableFieldsAlias: true,
     });
     return parseInt(row?.count, 10) || 0;
@@ -180,9 +180,9 @@ export class CustomClauseQuery<
       orderby: options.orderby,
       limit: options?.limit || getDefaultLimit(),
       context: this.viewer.context,
-      join: this.options.join,
+      join: this.options.joinBETA,
       // if doing a join, select distinct rows
-      distinct: this.options.join !== undefined,
+      distinct: this.options.joinBETA !== undefined,
     });
 
     this.edges.set(1, rows);

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -69,10 +69,6 @@ export class CustomClauseQuery<
   TViewer extends Viewer = Viewer,
 > extends BaseEdgeQuery<any, TDest, Data> {
   private clause: Clause;
-  // store this here because we want the value in this class
-  // separate from this.options
-  // private join: QueryDataOptions["join"] | undefined;
-  // private options: CustomClauseQueryOptions<TDest, TViewer>;
 
   constructor(
     public viewer: TViewer,
@@ -106,7 +102,6 @@ export class CustomClauseQuery<
       ? primarySortCol
       : options.loadEntOptions.loaderFactory.options?.key || "id";
 
-    // this.options = options;
     super(viewer, {
       orderby,
       cursorCol,
@@ -130,12 +125,6 @@ export class CustomClauseQuery<
   }
 
   async queryRawCount(): Promise<number> {
-    // if (this.options.join) {
-    //   throw new Error(
-    //     `queryRawCount doesn't support join. use queryAllRawCount`,
-    //   );
-    // }
-
     // sqlite needs as count otherwise it returns count(1)
     let fields = ["count(1) as count"];
     if (this.options.join) {

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -117,14 +117,10 @@ export class CustomClauseQuery<
     return this.options.loadEntOptions.tableName;
   }
 
-  protected getCursorParts(row: Data) {
-    // TODO we're going to do this differently
-    const ret = super.getCursorParts(row);
-    if (this.sortCol !== this.cursorCol) {
-      // add the sortCol to the generated cursor so we can use it
-      ret.extraParts = [this.sortCol];
-    }
-    return ret;
+  protected includeSortColInCursor() {
+    // TODO maybe we should just always do this?
+    // return this.options.join !== undefined &&
+    return this.sortCol !== this.cursorCol;
   }
 
   async queryRawCount(): Promise<number> {

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -105,7 +105,7 @@ export class CustomClauseQuery<
     super(viewer, {
       orderby,
       cursorCol,
-      join: options.joinBETA,
+      joinBETA: options.joinBETA,
       fieldOptions: options.loadEntOptions,
     });
     this.clause = getClause(options);
@@ -121,7 +121,7 @@ export class CustomClauseQuery<
 
   protected includeSortColInCursor(options: EdgeQueryOptions) {
     // TODO maybe we should just always do this?
-    return options.join !== undefined && this.sortCol !== this.cursorCol;
+    return options.joinBETA !== undefined && this.sortCol !== this.cursorCol;
   }
 
   async queryRawCount(): Promise<number> {

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -101,7 +101,6 @@ export class CustomClauseQuery<
       ? primarySortCol
       : options.loadEntOptions.loaderFactory.options?.key || "id";
 
-    console.debug("fieldOptions", options.loadEntOptions);
     super(viewer, {
       orderby,
       cursorCol,
@@ -181,7 +180,6 @@ export class CustomClauseQuery<
       options.limit = getDefaultLimit();
     }
 
-    // console.debug(this.options.loadEntOptions, this.options.join);
     const rows = await loadRows({
       ...this.options.loadEntOptions,
       clause: AndOptional(this.clause, options.clause),
@@ -192,7 +190,6 @@ export class CustomClauseQuery<
       // if doing a join, select distinct rows
       distinct: this.options.join !== undefined,
     });
-    // console.debug(rows);
 
     this.edges.set(1, rows);
   }

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -101,10 +101,12 @@ export class CustomClauseQuery<
       ? primarySortCol
       : options.loadEntOptions.loaderFactory.options?.key || "id";
 
+    console.debug("fieldOptions", options.loadEntOptions);
     super(viewer, {
       orderby,
       cursorCol,
       join: options.join,
+      fieldOptions: options.loadEntOptions,
     });
     this.clause = getClause(options);
   }

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -16,7 +16,7 @@ import {
 } from "../ent";
 import { OrderBy } from "../query_impl";
 
-import { BaseEdgeQuery, IDInfo } from "./query";
+import { BaseEdgeQuery, EdgeQueryOptions, IDInfo } from "./query";
 
 export interface CustomClauseQueryOptions<
   TDest extends Ent<TViewer>,
@@ -69,6 +69,11 @@ export class CustomClauseQuery<
   TViewer extends Viewer = Viewer,
 > extends BaseEdgeQuery<any, TDest, Data> {
   private clause: Clause;
+  // store this here because we want the value in this class
+  // separate from this.options
+  // private join: QueryDataOptions["join"] | undefined;
+  // private options: CustomClauseQueryOptions<TDest, TViewer>;
+
   constructor(
     public viewer: TViewer,
     private options: CustomClauseQueryOptions<TDest, TViewer>,
@@ -101,6 +106,7 @@ export class CustomClauseQuery<
       ? primarySortCol
       : options.loadEntOptions.loaderFactory.options?.key || "id";
 
+    // this.options = options;
     super(viewer, {
       orderby,
       cursorCol,
@@ -118,10 +124,9 @@ export class CustomClauseQuery<
     return this.options.loadEntOptions.tableName;
   }
 
-  protected includeSortColInCursor() {
+  protected includeSortColInCursor(options: EdgeQueryOptions) {
     // TODO maybe we should just always do this?
-    // return this.options.join !== undefined &&
-    return this.sortCol !== this.cursorCol;
+    return options.join !== undefined && this.sortCol !== this.cursorCol;
   }
 
   async queryRawCount(): Promise<number> {

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -208,4 +208,8 @@ export class CustomClauseQuery<
       this.options.loadEntOptions,
     );
   }
+
+  __getOptions() {
+    return this.options;
+  }
 }

--- a/ts/src/core/query/custom_query.ts
+++ b/ts/src/core/query/custom_query.ts
@@ -193,6 +193,7 @@ export abstract class CustomEdgeQueryBase<
     super(viewer, {
       cursorCol: uniqueCol,
       orderby,
+      fieldOptions: opts.loaderFactory.options,
     });
     if (typeof options.src === "object") {
       this.id = options.src.id;

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -124,7 +124,6 @@ function assertValidCursor(cursor: string, opts: validCursorOptions): any {
   // invalid or unknown cursor. nothing to do here.
   // we should have the same number of parts as keys * 2
   // ISO string has...
-  // console.debug(decoded, parts, keys);
   if (parts.length !== keys.length * 2) {
     throw new Error(`invalid cursor ${cursor} passed`);
   }
@@ -189,7 +188,6 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
     assertPositive(options.limit);
 
     this.sortCol = options.sortCol;
-    console.debug(options.after, options.cursorKeys);
     if (options.after) {
       this.cursorValues = assertValidCursor(options.after, {
         keys: options.cursorKeys,
@@ -276,7 +274,6 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
     const less = this.options.orderby[0].direction === "DESC";
     const orderby = this.options.orderby;
 
-    // console.debug(this.options);
     if (this.options.cursorCol !== this.sortCol) {
       // we also sort cursor col in same direction. (direction doesn't matter)
       orderby.push({
@@ -311,12 +308,6 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
           this.cursorValues.length === 2 &&
           this.options.cursorKeys.length === 2
         ) {
-          console.debug(
-            this.sortCol,
-            this.options.cursorCol,
-            this.cursorValues,
-          );
-
           options.clause = clause.AndOptional(
             options.clause,
             // this clause needs to be u not e...
@@ -566,7 +557,6 @@ export abstract class BaseEdgeQuery<
   abstract sourceEnt(id: ID): Promise<Ent | null>;
 
   first(n: number, after?: string): this {
-    console.debug("first", n, after);
     this.limitAdded = true;
     this.assertQueryNotDispatched("first");
     this.filters.push(

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -317,7 +317,9 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
               this.options.cursorCol,
               less,
               // TODO we need a way to know if this is a time column or not
-              new Date(this.cursorValues[1]).toISOString(),
+              // not time column for products|users|categories
+              this.cursorValues[1],
+              // new Date(this.cursorValues[1]).toISOString(),
               this.offset,
               this.options.fieldOptions?.fieldsAlias ??
                 this.options.fieldOptions?.alias,

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -7,6 +7,7 @@ import {
   PrivacyPolicy,
   EdgeQueryableDataOptionsConfigureLoader,
   QueryableDataOptions,
+  SelectBaseDataOptions,
 } from "../base";
 import { getDefaultLimit, getCursor, cursorOptions } from "../ent";
 import * as clause from "../clause";
@@ -151,6 +152,10 @@ interface FilterOptions<T extends Data> {
 
   // TODO probably don't need this long term
   join?: NonNullable<QueryableDataOptions["join"]>;
+
+  // fieldOptions used to query field values
+  // used for alias
+  fieldOptions?: SelectBaseDataOptions;
 }
 
 interface FirstFilterOptions<T extends Data> extends FilterOptions<T> {
@@ -314,6 +319,8 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
               // TODO we need a way to know if this is a time column or not
               new Date(this.cursorValues[1]).toISOString(),
               this.offset,
+              this.options.fieldOptions?.fieldsAlias ??
+                this.options.fieldOptions?.alias,
             ),
           );
         } else {
@@ -455,7 +462,10 @@ class LastFilter<T extends Data> implements EdgeQueryFilter<T> {
 interface EdgeQueryOptions {
   cursorCol: string;
   orderby: OrderBy;
+  // TODO kill?
   join?: NonNullable<QueryableDataOptions["join"]>;
+  // field options used to query field values
+  fieldOptions?: SelectBaseDataOptions;
 }
 
 export abstract class BaseEdgeQuery<
@@ -556,6 +566,7 @@ export abstract class BaseEdgeQuery<
         cursorKeys: this.cursorKeys,
         orderby: this.edgeQueryOptions.orderby,
         query: this,
+        fieldOptions: this.edgeQueryOptions.fieldOptions,
         join: this.edgeQueryOptions.join,
       }),
     );
@@ -586,6 +597,7 @@ export abstract class BaseEdgeQuery<
         cursorKeys: this.cursorKeys,
         orderby: this.edgeQueryOptions.orderby,
         query: this,
+        fieldOptions: this.edgeQueryOptions.fieldOptions,
         join: this.edgeQueryOptions.join,
       }),
     );

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -305,6 +305,8 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
           options.clause = clause.AndOptional(
             options.clause,
             // this clause needs to be u not e...
+            // use aliases and we know we need aliases since
+            // they must match...
             clause.PaginationMultipleColsQuery(
               this.sortCol,
               this.options.cursorCol,
@@ -313,26 +315,6 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
               new Date(this.cursorValues[1]).toISOString(),
               this.offset,
             ),
-            // clause.And(
-            //   clause.Or(
-            //     less
-            //       ? clause.Less(this.options.cursorCol, this.offset)
-            //       : clause.Greater(this.options.cursorCol, this.offset),
-            //     clause.And(
-            //       clause.Eq(this.options.cursorCol, this.offset),
-            //       less
-            //         ? // TODO we need a way to know if this is a time column or not
-            //           clause.Less(
-            //             this.sortCol,
-            //             new Date(this.cursorValues[1]).toISOString(),
-            //           )
-            //         : clause.Greater(
-            //             this.sortCol,
-            //             new Date(this.cursorValues[1]).toISOString(),
-            //           ),
-            //     ),
-            //   ),
-            // ),
           );
         } else {
           options.clause = clause.AndOptional(

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -99,6 +99,23 @@ interface validCursorOptions {
   // timeIsNumber?: boolean;
 }
 
+function convertToIntMaybe(val: string) {
+  // TODO handle both cases... (time vs not) better
+  // TODO change this to only do the parseInt part if time...
+  // pass flag indicating if time?
+
+  // handle non-integers for which the first part is an int
+  // @ts-ignore
+  if (isNaN(val)) {
+    return val;
+  }
+  const time = parseInt(val, 10);
+  if (isNaN(time)) {
+    return val;
+  }
+  return time;
+}
+
 function assertValidCursor(cursor: string, opts: validCursorOptions): any {
   let decoded = Buffer.from(cursor, "base64").toString("ascii");
   let parts = decoded.split(":");
@@ -125,15 +142,7 @@ function assertValidCursor(cursor: string, opts: validCursorOptions): any {
       continue;
     }
 
-    // TODO handle both cases... (time vs not) better
-    // TODO change this to only do the parseInt part if time...
-    // pass flag indicating if time?
-    const time = parseInt(val, 10);
-    if (isNaN(time)) {
-      values.push(val);
-    } else {
-      values.push(time);
-    }
+    values.push(convertToIntMaybe(val));
   }
   return values;
 }
@@ -302,11 +311,12 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
           this.cursorValues.length === 2 &&
           this.options.cursorKeys.length === 2
         ) {
-          // console.debug(
-          //   this.sortCol,
-          //   this.options.cursorCol,
-          //   this.cursorValues,
-          // );
+          console.debug(
+            this.sortCol,
+            this.options.cursorCol,
+            this.cursorValues,
+          );
+
           options.clause = clause.AndOptional(
             options.clause,
             // this clause needs to be u not e...

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -96,7 +96,6 @@ function assertPositive(n: number) {
 
 interface validCursorOptions {
   keys: string[];
-  // timeIsNumber?: boolean;
 }
 
 function convertToIntMaybe(val: string) {
@@ -284,22 +283,6 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
       if (this.offset) {
         const res = this.edgeQuery.getTableName();
         let tableName = isPromise(res) ? await res : res;
-        if (this.options.join) {
-          // console.debug(this.options);
-          // TODO good way to always derive this somehow
-          // use fields alias/regular alias to map?
-          // console.debug("changing tableName");
-          // tableName = "fake_users";
-        }
-        // inner col time
-
-        // TODO if join, use a different clause instead of PaginationMultipleColsSubQuery
-
-        // TODO: do we need a subclause here or can we just and with the existing clause?
-        // we need a subclause when
-        // if (this.options.join) {
-
-        // } else {
 
         // using a join, we already know sortCol and cursorCol are different
         // we have encoded both values in the cursor
@@ -310,9 +293,6 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
         ) {
           options.clause = clause.AndOptional(
             options.clause,
-            // this clause needs to be u not e...
-            // use aliases and we know we need aliases since
-            // they must match...
             clause.PaginationMultipleColsQuery(
               this.sortCol,
               this.options.cursorCol,
@@ -328,6 +308,8 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
             ),
           );
         } else {
+          // inner col time
+
           // TODO audit values for cursorColIsDate and sortColIsDate...
           options.clause = clause.AndOptional(
             options.clause,

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -9,7 +9,7 @@ import {
   QueryableDataOptions,
   SelectBaseDataOptions,
 } from "../base";
-import { getDefaultLimit, getCursor, cursorOptions } from "../ent";
+import { getDefaultLimit, getCursor } from "../ent";
 import * as clause from "../clause";
 import memoize from "memoizee";
 import { AlwaysAllowPrivacyPolicy, applyPrivacyPolicy } from "../privacy";
@@ -156,9 +156,6 @@ interface FilterOptions<T extends Data> {
   cursorColIsDate?: boolean;
 
   cursorKeys: string[];
-
-  // TODO probably don't need this long term
-  join?: NonNullable<QueryableDataOptions["join"]>;
 
   // fieldOptions used to query field values
   // used for alias
@@ -597,7 +594,6 @@ export abstract class BaseEdgeQuery<
         orderby: this.edgeQueryOptions.orderby,
         query: this,
         fieldOptions: this.edgeQueryOptions.fieldOptions,
-        join: this.edgeQueryOptions.join,
       }),
     );
     return this;
@@ -630,7 +626,6 @@ export abstract class BaseEdgeQuery<
         orderby: this.edgeQueryOptions.orderby,
         query: this,
         fieldOptions: this.edgeQueryOptions.fieldOptions,
-        join: this.edgeQueryOptions.join,
       }),
     );
     return this;

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -481,7 +481,7 @@ export interface EdgeQueryOptions {
   cursorCol: string;
   cursorColIsDate?: boolean;
   orderby: OrderBy;
-  join?: NonNullable<QueryableDataOptions["join"]>;
+  joinBETA?: NonNullable<QueryableDataOptions["join"]>;
   // field options used to query field values
   fieldOptions?: SelectBaseDataOptions;
 }

--- a/ts/src/core/query/shared_test.ts
+++ b/ts/src/core/query/shared_test.ts
@@ -338,7 +338,7 @@ export const commonTests = <TData extends Data>(opts: options<TData>) => {
   function getCursorFrom(contacts: FakeContact[], idx: number) {
     return getCursor({
       row: contacts[idx],
-      col: "id",
+      keys: ["id"],
     });
   }
 

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -94,5 +94,6 @@ export function buildQuery(options: QueryableDataOptions): string {
   if (options.limit) {
     parts.push(`LIMIT ${options.limit}`);
   }
+  // console.debug("buildQuery", parts.join(" "));
   return parts.join(" ");
 }

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -99,6 +99,5 @@ export function buildQuery(options: QueryableDataOptions): string {
   if (options.limit) {
     parts.push(`LIMIT ${options.limit}`);
   }
-  // console.debug("buildQuery", parts.join(" "));
   return parts.join(" ");
 }

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -61,16 +61,21 @@ export function getJoinInfo(
 
 export function buildQuery(options: QueryableDataOptions): string {
   const fieldsAlias = options.fieldsAlias ?? options.alias;
-  const fields = fieldsAlias
-    ? options.fields.map((f) => `${fieldsAlias}.${f}`).join(", ")
-    : options.fields.join(", ");
+  const fields =
+    fieldsAlias && !options.disableFieldsAlias
+      ? options.fields.map((f) => `${fieldsAlias}.${f}`).join(", ")
+      : options.fields.join(", ");
 
   // always start at 1
   const parts: string[] = [];
   const tableName = options.alias
     ? `${options.tableName} AS ${options.alias}`
     : options.tableName;
-  parts.push(`SELECT ${fields} FROM ${tableName}`);
+  if (options.distinct) {
+    parts.push(`SELECT DISTINCT ${fields} FROM ${tableName}`);
+  } else {
+    parts.push(`SELECT ${fields} FROM ${tableName}`);
+  }
 
   let whereStart = 1;
   if (options.join) {
@@ -84,7 +89,7 @@ export function buildQuery(options: QueryableDataOptions): string {
     parts.push(`GROUP BY ${options.groupby}`);
   }
   if (options.orderby) {
-    parts.push(`ORDER BY ${getOrderByPhrase(options.orderby, options.alias)}`);
+    parts.push(`ORDER BY ${getOrderByPhrase(options.orderby, fieldsAlias)}`);
   }
   if (options.limit) {
     parts.push(`LIMIT ${options.limit}`);

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -4,6 +4,11 @@ export interface OrderByOption {
   column: string;
   direction: "ASC" | "DESC";
   nullsPlacement?: "first" | "last";
+  // is this column a date/time column?
+  // needed to know if we create a cursor based on this column to conver to timestamp and ISO string for
+  // comparison
+  // maybe eventually want a more generic version of this but for now this suffices
+  dateColumn?: boolean;
 }
 
 export type OrderBy = OrderByOption[];

--- a/ts/src/graphql/query/shared_edge_connection.ts
+++ b/ts/src/graphql/query/shared_edge_connection.ts
@@ -80,7 +80,7 @@ export const commonTests = <TEdge extends Data>(
   function getCursorFrom(contacts: FakeContact[], idx: number) {
     return getCursor({
       row: contacts[idx],
-      col: "id",
+      keys: ["id"],
     });
   }
 

--- a/ts/src/graphql/query/shared_edge_connection.ts
+++ b/ts/src/graphql/query/shared_edge_connection.ts
@@ -1,8 +1,14 @@
 import { IDViewer } from "../../core/viewer";
 import { Viewer, Data, Ent } from "../../core/base";
-import { getCursor } from "../../core/ent";
+import { cursorOptions, getCursor } from "../../core/ent";
 import { GraphQLEdgeConnection } from "./edge_connection";
-import { FakeUser, FakeContact } from "../../testutils/fake_data/index";
+import {
+  FakeUser,
+  FakeContact,
+  UserToContactsFkeyQuery,
+  UserToContactsFkeyQueryDeprecated,
+  UserToContactsFkeyQueryAsc,
+} from "../../testutils/fake_data/index";
 import {
   inputs,
   createAllContacts,
@@ -77,11 +83,36 @@ interface options<TEnt extends Ent, TEdge extends Data> {
 export const commonTests = <TEdge extends Data>(
   opts: options<FakeContact, TEdge>,
 ) => {
-  function getCursorFrom(contacts: FakeContact[], idx: number) {
-    return getCursor({
-      row: contacts[idx],
-      keys: ["id"],
-    });
+  function isCustomQuery(q: EdgeQuery<Ent, Ent, any>): boolean {
+    // TODO sad not generic enough
+    return (
+      q instanceof UserToContactsFkeyQuery ||
+      q instanceof UserToContactsFkeyQueryDeprecated ||
+      q instanceof UserToContactsFkeyQueryAsc
+    );
+  }
+
+  function getCursorFrom(
+    q: EdgeQuery<Ent, Ent, any>,
+    contacts: FakeContact[],
+    idx: number,
+  ) {
+    let opts: cursorOptions;
+    if (isCustomQuery(q)) {
+      opts = {
+        row: contacts[idx],
+        keys: ["id"],
+      };
+    } else {
+      // for assoc queries, we're getting the value from 'id' field but the edge
+      // is from assoc_edge table id2 field and so cursor takes it from there
+      opts = {
+        row: contacts[idx],
+        keys: ["id2"],
+        cursorKeys: ["id"],
+      };
+    }
+    return getCursor(opts);
   }
 
   describe("no filters", () => {
@@ -163,7 +194,7 @@ export const commonTests = <TEdge extends Data>(
         user: FakeUser,
         contacts: FakeContact[],
       ) => {
-        const cursor = getCursorFrom(contacts, idx);
+        const cursor = getCursorFrom(conn.query, contacts, idx);
         conn.first(2, cursor);
       },
     );
@@ -207,7 +238,7 @@ export const commonTests = <TEdge extends Data>(
         contacts: FakeContact[],
       ) => {
         // get the 2 before it
-        const cursor = getCursorFrom(contacts, 4);
+        const cursor = getCursorFrom(conn.query, contacts, 4);
 
         conn.last(2, cursor);
       },

--- a/ts/src/testutils/db/temp_db.ts
+++ b/ts/src/testutils/db/temp_db.ts
@@ -606,7 +606,7 @@ export class TempDB {
 
     // drop db
     await this.client.query(`DROP DATABASE ${this.db}`);
-    // console.log(this.db);
+    // console.debug(this.db);
 
     await this.client.end();
   }


### PR DESCRIPTION
builds on top of https://github.com/lolopinto/ent/pull/1672

depends on https://github.com/lolopinto/ent/pull/1672

addresses https://github.com/lolopinto/ent/issues/1660

`joinBETA` instead of `join` because I don't like the API and may end up changing it e.g. maybe it's own query class that has better ways of handling things instead of what we currently do with fieldsAlias and alias