### PR TITLE
indicate list of fields to return in orchestrator instead of returning *

### DIFF
--- a/ts/src/action/action.test.ts
+++ b/ts/src/action/action.test.ts
@@ -1,4 +1,9 @@
-import { User, BuilderSchema, SimpleBuilder } from "../testutils/builder";
+import {
+  User,
+  BuilderSchema,
+  SimpleBuilder,
+  getDbFields,
+} from "../testutils/builder";
 import { IDViewer, LoggedOutViewer } from "../core/viewer";
 import { StringType, UUIDType, FieldMap } from "../schema";
 import { createRowForTest } from "../testutils/write";
@@ -187,7 +192,7 @@ function getInsertQuery(id: ID) {
         foo: "bar",
       },
     },
-    "RETURNING *",
+    "RETURNING id,foo",
   );
   return { query, values: logValues };
 }
@@ -204,7 +209,7 @@ function getUpdateQuery(ent: User) {
       },
       whereClause: clause.Eq("id", ent.id),
     },
-    "RETURNING *",
+    "RETURNING id,foo",
   );
   return { query, values: logValues };
 }
@@ -251,7 +256,7 @@ function getSelectQuery(id: ID): Data | undefined {
     return {
       query: buildQuery({
         tableName: "users",
-        fields: ["*"],
+        fields: ["id", "foo"],
         clause: clause.Eq("id", id),
       }),
       values: [id],

--- a/ts/src/action/operations.ts
+++ b/ts/src/action/operations.ts
@@ -243,7 +243,7 @@ export class EditNodeOperation<
       if (this.hasData(options.fields)) {
         // even this with returning * may not always work if transformed...
         // we can have a transformed flag to see if it should be returned?
-        this.row = await editRow(queryer, options, "RETURNING *");
+        this.row = await editRow(queryer, options, this.getReturning());
       } else {
         // @ts-ignore
         this.row = this.existingEnt["data"];
@@ -252,7 +252,7 @@ export class EditNodeOperation<
       // TODO: eventually, when we officially support auto-increment ids. need to make sure/test that this works
       // https://github.com/lolopinto/ent/issues/1431
 
-      this.row = await createRow(queryer, options, "RETURNING *");
+      this.row = await createRow(queryer, options, this.getReturning());
       const key = this.options.key;
 
       if (this.row && this.row[key] !== this.options.fields[key]) {
@@ -327,6 +327,13 @@ export class EditNodeOperation<
     }
   }
 
+  private getReturning() {
+    if (this.options.loadEntOptions.fields.length) {
+      return `RETURNING ${this.options.loadEntOptions.fields.join(",")}`;
+    }
+    return `RETURNING *`;
+  }
+
   performWriteSync(queryer: SyncQueryer, context?: Context): void {
     let options = {
       ...this.options,
@@ -335,14 +342,14 @@ export class EditNodeOperation<
 
     if (this.existingEnt) {
       if (this.hasData(this.options.fields)) {
-        editRowSync(queryer, options, "RETURNING *");
+        editRowSync(queryer, options, this.getReturning());
         this.reloadRow(queryer, this.existingEnt.id, options);
       } else {
         // @ts-ignore
         this.row = this.existingEnt["data"];
       }
     } else {
-      createRowSync(queryer, options, "RETURNING *");
+      createRowSync(queryer, options, this.getReturning());
       const id = options.fields[options.key];
       this.reloadRow(queryer, id, options);
       const key = this.options.key;

--- a/ts/src/action/orchestrator_upsert.test.ts
+++ b/ts/src/action/orchestrator_upsert.test.ts
@@ -13,6 +13,7 @@ import {
   getBuilderSchemaFromFields,
   BuilderSchema,
   getTableName,
+  getDbFields,
 } from "../testutils/builder";
 import { FakeComms, Mode } from "../testutils/fake_comms";
 import { createRowForTest } from "../testutils/write";
@@ -29,7 +30,7 @@ import {
   setupSqlite,
   Table,
 } from "../testutils/db/temp_db";
-import { ConstraintType } from "../schema";
+import { ConstraintType, getStorageKey } from "../schema";
 import { randomEmail } from "../testutils/db/value";
 import DB, { Dialect } from "../core/db";
 
@@ -341,7 +342,7 @@ function commonTests() {
     expect(select).toContainEqual({
       query: buildQuery({
         tableName: "user_extendeds",
-        fields: ["*"],
+        fields: getDbFields(UserSchemaExtended),
         clause: clause.Eq("email_address", email),
       }),
       values: [email],
@@ -422,7 +423,7 @@ function commonTests() {
     expect(select).toContainEqual({
       query: buildQuery({
         tableName: "user_extendeds",
-        fields: ["*"],
+        fields: getDbFields(UserSchemaExtended),
         clause: clause.Eq("email_address", email),
       }),
       values: [email],
@@ -470,7 +471,7 @@ function commonTests() {
     expect(select).toContainEqual({
       query: buildQuery({
         tableName: "user_extendeds",
-        fields: ["*"],
+        fields: getDbFields(UserSchemaExtended),
         clause: clause.Eq("email_address", email),
       }),
       values: [email],
@@ -519,7 +520,7 @@ function commonTests() {
       expect(select).toContainEqual({
         query: buildQuery({
           tableName: "user_extendeds",
-          fields: ["*"],
+          fields: getDbFields(UserSchemaExtended),
           clause: clause.Eq("email_address", email),
         }),
         values: [email],
@@ -595,7 +596,7 @@ function commonTests() {
       expect(select).not.toContainEqual({
         query: buildQuery({
           tableName: "user_extendeds",
-          fields: ["*"],
+          fields: getDbFields(UserSchemaExtended),
           clause: clause.Eq("email_address", email),
         }),
         values: [email],
@@ -605,7 +606,7 @@ function commonTests() {
       expect(select).toContainEqual({
         query: buildQuery({
           tableName: "user_extendeds",
-          fields: ["*"],
+          fields: getDbFields(UserSchemaExtended),
           clause: clause.Eq("email_address", email),
         }),
         values: [email],
@@ -658,7 +659,7 @@ function commonTests() {
       expect(select).toContainEqual({
         query: buildQuery({
           tableName: "user_extendeds",
-          fields: ["*"],
+          fields: getDbFields(UserSchemaExtended),
           clause: clause.Eq("email_address", email),
         }),
         values: [email],
@@ -700,7 +701,7 @@ function commonTests() {
     expect(select).toContainEqual({
       query: buildQuery({
         tableName: "user_multiple_uniques",
-        fields: ["*"],
+        fields: getDbFields(UserSchemaMultipleUnique),
         clause: clause.And(
           clause.Eq("email_address", email),
           clause.Eq("account_status", "UNVERIFIED"),
@@ -741,7 +742,7 @@ function commonTests() {
       expect(select).toContainEqual({
         query: buildQuery({
           tableName: "user_multiple_uniques",
-          fields: ["*"],
+          fields: getDbFields(UserSchemaMultipleUnique),
           clause: clause.And(
             clause.Eq("email_address", email),
             clause.Eq("account_status", "UNVERIFIED"),
@@ -807,7 +808,7 @@ function commonTests() {
       expect(select).toContainEqual({
         query: buildQuery({
           tableName: "user_multiple_uniques",
-          fields: ["*"],
+          fields: getDbFields(UserSchemaMultipleUnique),
           clause: clause.And(
             clause.Eq("email_address", email),
             clause.Eq("account_status", "UNVERIFIED"),
@@ -851,7 +852,7 @@ function commonTests() {
     expect(select).toContainEqual({
       query: buildQuery({
         tableName: "user_extendeds",
-        fields: ["*"],
+        fields: getDbFields(UserSchemaExtended),
         clause: clause.Eq("email_address", email),
       }),
       values: [email],
@@ -997,7 +998,7 @@ function commonTests() {
     // and the conditional flows through in an upsert
     const event_row = await loadRow({
       tableName: "events",
-      fields: ["*"],
+      fields: getDbFields(EventSchema),
       clause: clause.Eq("owner_id", u1.id),
     });
     if (!event_row) {
@@ -1006,7 +1007,7 @@ function commonTests() {
 
     const address_row = await loadRow({
       tableName: getTableName(AddressSchema),
-      fields: ["*"],
+      fields: getDbFields(AddressSchema),
       clause: clause.Eq("owner_id", event_row.id),
     });
 
@@ -1103,7 +1104,7 @@ function commonTests() {
     // and the conditional flows through in an upsert
     const event_row = await loadRow({
       tableName: "events",
-      fields: ["*"],
+      fields: getDbFields(EventSchema),
       clause: clause.Eq("owner_id", u1.id),
     });
     if (!event_row) {
@@ -1112,7 +1113,7 @@ function commonTests() {
 
     const address_row = await loadRow({
       tableName: getTableName(AddressSchema),
-      fields: ["*"],
+      fields: getDbFields(AddressSchema),
       clause: clause.Eq("owner_id", event_row.id),
     });
 

--- a/ts/src/testutils/builder.ts
+++ b/ts/src/testutils/builder.ts
@@ -199,6 +199,15 @@ export function getTableName(value: BuilderSchema<Ent>) {
   return pluralize(snakeCase(value.ent.name)).toLowerCase();
 }
 
+export const getDbFields = (schema: BuilderSchema<Ent>) => {
+  const fields = getFields(schema);
+  const dbFields: string[] = [];
+  for (const [fieldName, field] of fields) {
+    dbFields.push(getStorageKey(field, fieldName));
+  }
+  return dbFields;
+};
+
 function randomNum(): string {
   return Math.random().toString(10).substring(2);
 }
@@ -260,6 +269,10 @@ export class SimpleBuilder<
 
     const schemaFields = getFields(schema);
     let key = "id";
+    const dbFields: string[] = [];
+    for (const [name, f] of schemaFields) {
+      dbFields.push(getStorageKey(f, name));
+    }
     if (!schemaFields.has("id") && !schemaFields.has("ID")) {
       if (schemaFields.size !== 1) {
         throw new Error(
@@ -283,12 +296,12 @@ export class SimpleBuilder<
       loaderOptions: {
         loaderFactory: new ObjectLoaderFactory({
           tableName: tableName,
-          fields: [],
+          fields: dbFields,
           key,
         }),
         ent: schema.ent,
         tableName: tableName,
-        fields: [],
+        fields: dbFields,
         fieldPrivacy: getFieldsWithPrivacy(schema, fieldInfo),
       },
       builder: this,


### PR DESCRIPTION
needed for test in https://github.com/lolopinto/ent/pull/1676 where the list of fields needs to change depending on the test and "returning *" returns extra fields we don't need in that case

we don't do select * when querying so this is consistent