### PR TITLE
ability to configure exports for actions not to be default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ## [Unreleased]
 
+## [0.1.21] - 2023-10-14
+
+### Added
+
+- ability to configure exports for actions not to be default export (#1689)
+
 ## [0.1.20] - 2023-10-08
 
 ### Added

--- a/examples/todo-sqlite/develop.Dockerfile
+++ b/examples/todo-sqlite/develop.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:v0.1.10-nodejs-18-dev
+FROM ghcr.io/lolopinto/ent:v0.1.11-test1-nodejs-18-dev
 
 WORKDIR /app
 

--- a/examples/todo-sqlite/ent.yml
+++ b/examples/todo-sqlite/ent.yml
@@ -11,3 +11,4 @@ codegen:
   schemaSQLFilePath: 'src/schema/schema.sql'
   transformDeleteMethod: "hardDelete"
   transformLoadMethod: "loadSoftDeleted"
+  disableDefaultExportForActions: true

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "^0.1.20",
+        "@snowtop/ent": "^0.1.21-test1",
         "@snowtop/ent-phonenumber": "^0.1.0-rc1",
         "@snowtop/ent-soft-delete": "^0.1.0-rc1",
         "@types/node": "^15.0.3",
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.20.tgz",
-      "integrity": "sha512-30IbiI97gZSIxw7jln/iqfsP/l7yDrHm/RoptDBeqn5tI9j0+VNLRgV/smue2lCJjWfnzaw1oTNMzFIxvaGcXQ==",
+      "version": "0.1.21-test1",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.21-test1.tgz",
+      "integrity": "sha512-sn9WW2wl8VZE6ob8nyLlzcmadBsPbGzNGeldGyprcCFWVqhRbMTyFB0pjXWY+8JtE+vrFBnNC6RYJBuw3Q9E3Q==",
       "dependencies": {
         "@types/node": "^20.2.5",
         "camel-case": "^4.1.2",
@@ -6945,9 +6945,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.20.tgz",
-      "integrity": "sha512-30IbiI97gZSIxw7jln/iqfsP/l7yDrHm/RoptDBeqn5tI9j0+VNLRgV/smue2lCJjWfnzaw1oTNMzFIxvaGcXQ==",
+      "version": "0.1.21-test1",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.1.21-test1.tgz",
+      "integrity": "sha512-sn9WW2wl8VZE6ob8nyLlzcmadBsPbGzNGeldGyprcCFWVqhRbMTyFB0pjXWY+8JtE+vrFBnNC6RYJBuw3Q9E3Q==",
       "requires": {
         "@types/node": "^20.2.5",
         "camel-case": "^4.1.2",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -37,7 +37,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "^0.1.20",
+    "@snowtop/ent": "^0.1.21-test1",
     "@snowtop/ent-phonenumber": "^0.1.0-rc1",
     "@snowtop/ent-soft-delete": "^0.1.0-rc1",
     "@types/node": "^15.0.3",

--- a/examples/todo-sqlite/src/ent/account/actions/account_transfer_credits_action.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/account_transfer_credits_action.ts
@@ -11,7 +11,7 @@ import {
   AccountTransferCreditsInput,
 } from "src/ent/generated/account/actions/account_transfer_credits_action_base";
 import { Account } from "src/ent/internal";
-import AccountUpdateBalanceAction from "./account_update_balance_action";
+import { AccountUpdateBalanceAction } from "./account_update_balance_action";
 
 export { AccountTransferCreditsInput };
 

--- a/examples/todo-sqlite/src/ent/account/actions/account_transfer_credits_action.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/account_transfer_credits_action.ts
@@ -15,7 +15,7 @@ import AccountUpdateBalanceAction from "./account_update_balance_action";
 
 export { AccountTransferCreditsInput };
 
-export default class AccountTransferCreditsAction extends AccountTransferCreditsActionBase {
+export class AccountTransferCreditsAction extends AccountTransferCreditsActionBase {
   getPrivacyPolicy(): PrivacyPolicy<
     Account,
     Viewer<Ent<any> | null, ID | null>

--- a/examples/todo-sqlite/src/ent/account/actions/account_update_balance_action.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/account_update_balance_action.ts
@@ -7,7 +7,7 @@ import {
 
 export { AccountUpdateBalanceInput };
 
-export default class AccountUpdateBalanceAction extends AccountUpdateBalanceActionBase {
+export class AccountUpdateBalanceAction extends AccountUpdateBalanceActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/account/actions/create_account_action.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/create_account_action.ts
@@ -6,7 +6,7 @@ import {
 
 export { AccountCreateInput };
 
-export default class CreateAccountAction extends CreateAccountActionBase {
+export class CreateAccountAction extends CreateAccountActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/account/actions/delete_account_action.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/delete_account_action.ts
@@ -1,7 +1,7 @@
 import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
 import { DeleteAccountActionBase } from "src/ent/generated/account/actions/delete_account_action_base";
 
-export default class DeleteAccountAction extends DeleteAccountActionBase {
+export class DeleteAccountAction extends DeleteAccountActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/account/actions/edit_account_action.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/edit_account_action.ts
@@ -6,7 +6,7 @@ import {
 
 export { AccountEditInput };
 
-export default class EditAccountAction extends EditAccountActionBase {
+export class EditAccountAction extends EditAccountActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/account/actions/edit_account_todo_status_action.ts
+++ b/examples/todo-sqlite/src/ent/account/actions/edit_account_todo_status_action.ts
@@ -7,7 +7,7 @@ import {
 
 export { EditAccountTodoStatusInput };
 
-export default class EditAccountTodoStatusAction extends EditAccountTodoStatusActionBase {
+export class EditAccountTodoStatusAction extends EditAccountTodoStatusActionBase {
   getPrivacyPolicy(): PrivacyPolicy {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/tag/actions/create_tag_action.ts
+++ b/examples/todo-sqlite/src/ent/tag/actions/create_tag_action.ts
@@ -7,7 +7,7 @@ import {
 
 export { TagCreateInput };
 
-export default class CreateTagAction extends CreateTagActionBase {
+export class CreateTagAction extends CreateTagActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/tests/account.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/account.test.ts
@@ -1,10 +1,10 @@
-import EditAccountAction from "../account/actions/edit_account_action";
-import DeleteAccountAction from "../account/actions/delete_account_action";
+import { EditAccountAction } from "../account/actions/edit_account_action";
+import { DeleteAccountAction } from "../account/actions/delete_account_action";
 import { Account } from "../internal";
 import { createAccount } from "../testutils/util";
 import { advanceTo } from "jest-date-mock";
-import AccountUpdateBalanceAction from "../account/actions/account_update_balance_action";
-import AccountTransferCreditsAction from "../account/actions/account_transfer_credits_action";
+import { AccountUpdateBalanceAction } from "../account/actions/account_update_balance_action";
+import { AccountTransferCreditsAction } from "../account/actions/account_transfer_credits_action";
 import { Transaction } from "@snowtop/ent/action";
 
 test("create", async () => {

--- a/examples/todo-sqlite/src/ent/tests/tag.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/tag.test.ts
@@ -1,7 +1,7 @@
 import { createAccount, createTodoForSelf, createTag } from "../testutils/util";
 import { AccountToTagsQuery } from "../account/query/account_to_tags_query";
-import TodoAddTagAction from "../todo/actions/todo_add_tag_action";
-import TodoRemoveTagAction from "../todo/actions/todo_remove_tag_action";
+import { TodoAddTagAction } from "../todo/actions/todo_add_tag_action";
+import { TodoRemoveTagAction } from "../todo/actions/todo_remove_tag_action";
 
 test("create", async () => {
   await createTag("SPORTS");

--- a/examples/todo-sqlite/src/ent/tests/todo.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/todo.test.ts
@@ -1,6 +1,6 @@
-import ChangeTodoStatusAction from "src/ent/todo/actions/change_todo_status_action";
-import RenameTodoStatusAction from "src/ent/todo/actions/rename_todo_status_action";
-import DeleteTodoAction from "src/ent/todo/actions/delete_todo_action";
+import { ChangeTodoStatusAction } from "src/ent/todo/actions/change_todo_status_action";
+import { RenameTodoStatusAction } from "src/ent/todo/actions/rename_todo_status_action";
+import { DeleteTodoAction } from "src/ent/todo/actions/delete_todo_action";
 import { Account, Todo } from "src/ent/";
 import { AccountTodoStatus, NodeType } from "src/ent/generated/types";
 import {
@@ -12,10 +12,10 @@ import {
 } from "../testutils/util";
 import { IDViewer, query } from "@snowtop/ent";
 import { advanceTo } from "jest-date-mock";
-import TodoAddTagAction from "../todo/actions/todo_add_tag_action";
-import TodoRemoveTagAction from "../todo/actions/todo_remove_tag_action";
-import CreateTodoAction from "../todo/actions/create_todo_action";
-import ChangeTodoBountyAction from "../todo/actions/change_todo_bounty_action";
+import { TodoAddTagAction } from "../todo/actions/todo_add_tag_action";
+import { TodoRemoveTagAction } from "../todo/actions/todo_remove_tag_action";
+import { CreateTodoAction } from "../todo/actions/create_todo_action";
+import { ChangeTodoBountyAction } from "../todo/actions/change_todo_bounty_action";
 import { Transaction } from "@snowtop/ent/action";
 
 test("create for self", async () => {

--- a/examples/todo-sqlite/src/ent/tests/workspace.test.ts
+++ b/examples/todo-sqlite/src/ent/tests/workspace.test.ts
@@ -1,7 +1,7 @@
 import { createAccount, createWorkspace } from "../testutils/util";
 import { Workspace } from "../workspace";
-import DeleteWorkspaceAction from "../workspace/actions/delete_workspace_action";
-import EditWorkspaceAction from "../workspace/actions/edit_workspace_action";
+import { DeleteWorkspaceAction } from "../workspace/actions/delete_workspace_action";
+import { EditWorkspaceAction } from "../workspace/actions/edit_workspace_action";
 
 test("create", async () => {
   await createWorkspace();

--- a/examples/todo-sqlite/src/ent/testutils/util.ts
+++ b/examples/todo-sqlite/src/ent/testutils/util.ts
@@ -1,15 +1,17 @@
 import { LoggedOutViewer, ID, IDViewer, Viewer } from "@snowtop/ent";
-import CreateAccountAction, {
+import {
+  CreateAccountAction,
   AccountCreateInput,
 } from "src/ent/account/actions/create_account_action";
 import { parsePhoneNumberFromString } from "libphonenumber-js";
 import { validate } from "uuid";
-import CreateTodoAction, {
+import {
+  CreateTodoAction,
   TodoCreateInput,
 } from "src/ent/todo/actions/create_todo_action";
-import CreateTagAction from "../tag/actions/create_tag_action";
+import { CreateTagAction } from "../tag/actions/create_tag_action";
 import { Account } from "src/ent";
-import CreateWorkspaceAction from "../workspace/actions/create_workspace_action";
+import { CreateWorkspaceAction } from "../workspace/actions/create_workspace_action";
 import { randomInt } from "crypto";
 import { NodeType } from "../generated/types";
 

--- a/examples/todo-sqlite/src/ent/todo/actions/change_todo_bounty_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/change_todo_bounty_action.ts
@@ -15,7 +15,7 @@ import { Account } from "src/ent/internal";
 
 export { ChangeTodoBountyInput };
 
-export default class ChangeTodoBountyAction extends ChangeTodoBountyActionBase {
+export class ChangeTodoBountyAction extends ChangeTodoBountyActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/todo/actions/change_todo_status_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/change_todo_status_action.ts
@@ -10,7 +10,7 @@ import {
 } from "src/ent/generated/todo/actions/change_todo_status_action_base";
 export { ChangeTodoStatusInput };
 
-export default class ChangeTodoStatusAction extends ChangeTodoStatusActionBase {
+export class ChangeTodoStatusAction extends ChangeTodoStatusActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/todo/actions/change_todo_status_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/change_todo_status_action.ts
@@ -1,7 +1,6 @@
 import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
-import { access } from "fs";
-import AccountTransferCreditsAction from "src/ent/account/actions/account_transfer_credits_action";
-import EditAccountTodoStatusAction from "src/ent/account/actions/edit_account_todo_status_action";
+import { AccountTransferCreditsAction } from "src/ent/account/actions/account_transfer_credits_action";
+import { EditAccountTodoStatusAction } from "src/ent/account/actions/edit_account_todo_status_action";
 import { AccountTodoStatusInput } from "src/ent/generated/account/actions/edit_account_todo_status_action_base";
 import {
   ChangeTodoStatusActionBase,

--- a/examples/todo-sqlite/src/ent/todo/actions/create_todo_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/create_todo_action.ts
@@ -8,7 +8,7 @@ import { NodeType } from "src/ent/generated/types";
 
 export { TodoCreateInput };
 
-export default class CreateTodoAction extends CreateTodoActionBase {
+export class CreateTodoAction extends CreateTodoActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/todo/actions/delete_todo_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/delete_todo_action.ts
@@ -1,7 +1,7 @@
 import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
 import { DeleteTodoActionBase } from "src/ent/generated/todo/actions/delete_todo_action_base";
 
-export default class DeleteTodoAction extends DeleteTodoActionBase {
+export class DeleteTodoAction extends DeleteTodoActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/todo/actions/rename_todo_status_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/rename_todo_status_action.ts
@@ -6,7 +6,7 @@ import {
 
 export { RenameTodoInput };
 
-export default class RenameTodoStatusAction extends RenameTodoStatusActionBase {
+export class RenameTodoStatusAction extends RenameTodoStatusActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/todo/actions/todo_add_tag_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/todo_add_tag_action.ts
@@ -1,7 +1,7 @@
 import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
 import { TodoAddTagActionBase } from "src/ent/generated/todo/actions/todo_add_tag_action_base";
 
-export default class TodoAddTagAction extends TodoAddTagActionBase {
+export class TodoAddTagAction extends TodoAddTagActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/todo/actions/todo_remove_tag_action.ts
+++ b/examples/todo-sqlite/src/ent/todo/actions/todo_remove_tag_action.ts
@@ -1,7 +1,7 @@
 import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
 import { TodoRemoveTagActionBase } from "src/ent/generated/todo/actions/todo_remove_tag_action_base";
 
-export default class TodoRemoveTagAction extends TodoRemoveTagActionBase {
+export class TodoRemoveTagAction extends TodoRemoveTagActionBase {
   getPrivacyPolicy() {
     return AlwaysAllowPrivacyPolicy;
   }

--- a/examples/todo-sqlite/src/ent/workspace/actions/create_workspace_action.ts
+++ b/examples/todo-sqlite/src/ent/workspace/actions/create_workspace_action.ts
@@ -13,7 +13,7 @@ import { Workspace } from "src/ent/workspace";
 
 export { WorkspaceCreateInput };
 
-export default class CreateWorkspaceAction extends CreateWorkspaceActionBase {
+export class CreateWorkspaceAction extends CreateWorkspaceActionBase {
   getPrivacyPolicy(): PrivacyPolicy<
     Workspace,
     Viewer<Ent<any> | null, ID | null>

--- a/examples/todo-sqlite/src/ent/workspace/actions/delete_workspace_action.ts
+++ b/examples/todo-sqlite/src/ent/workspace/actions/delete_workspace_action.ts
@@ -9,7 +9,7 @@ import {
 import { DeleteWorkspaceActionBase } from "src/ent/generated/workspace/actions/delete_workspace_action_base";
 import { Workspace } from "src/ent/workspace";
 
-export default class DeleteWorkspaceAction extends DeleteWorkspaceActionBase {
+export class DeleteWorkspaceAction extends DeleteWorkspaceActionBase {
   getPrivacyPolicy(): PrivacyPolicy<
     Workspace,
     Viewer<Ent<any> | null, ID | null>

--- a/examples/todo-sqlite/src/ent/workspace/actions/edit_workspace_action.ts
+++ b/examples/todo-sqlite/src/ent/workspace/actions/edit_workspace_action.ts
@@ -14,7 +14,7 @@ import { Workspace } from "src/ent/workspace";
 
 export { WorkspaceEditInput };
 
-export default class EditWorkspaceAction extends EditWorkspaceActionBase {
+export class EditWorkspaceAction extends EditWorkspaceActionBase {
   getPrivacyPolicy(): PrivacyPolicy<
     Workspace,
     Viewer<Ent<any> | null, ID | null>

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/account_transfer_credits_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/account_transfer_credits_type.ts
@@ -13,7 +13,8 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Account } from "src/ent/";
-import AccountTransferCreditsAction, {
+import {
+  AccountTransferCreditsAction,
   AccountTransferCreditsInput,
 } from "src/ent/account/actions/account_transfer_credits_action";
 import { AccountType } from "src/graphql/resolvers/";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/account_update_balance_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/account_update_balance_type.ts
@@ -13,7 +13,8 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Account } from "src/ent/";
-import AccountUpdateBalanceAction, {
+import {
+  AccountUpdateBalanceAction,
   AccountUpdateBalanceInput,
 } from "src/ent/account/actions/account_update_balance_action";
 import { AccountType } from "src/graphql/resolvers/";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/create_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/create_account_type.ts
@@ -14,8 +14,9 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Account } from "src/ent/";
-import CreateAccountAction, {
+import {
   AccountCreateInput,
+  CreateAccountAction,
 } from "src/ent/account/actions/create_account_action";
 import { AccountPrefs, CountryInfo } from "src/ent/generated/types";
 import { AccountPrefsInputType } from "src/graphql/generated/mutations/input/account_prefs_input_type";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/delete_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/delete_account_type.ts
@@ -11,7 +11,7 @@ import {
   GraphQLResolveInfo,
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
-import DeleteAccountAction from "src/ent/account/actions/delete_account_action";
+import { DeleteAccountAction } from "src/ent/account/actions/delete_account_action";
 
 interface customDeleteAccountInput {
   id: string;

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/edit_account_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/edit_account_type.ts
@@ -14,8 +14,9 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Account } from "src/ent/";
-import EditAccountAction, {
+import {
   AccountEditInput,
+  EditAccountAction,
 } from "src/ent/account/actions/edit_account_action";
 import { AccountPrefs, CountryInfo } from "src/ent/generated/types";
 import { AccountPrefsInputType } from "src/graphql/generated/mutations/input/account_prefs_input_type";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/account/todo_status_account_edit_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/account/todo_status_account_edit_type.ts
@@ -12,7 +12,8 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Account } from "src/ent/";
-import EditAccountTodoStatusAction, {
+import {
+  EditAccountTodoStatusAction,
   EditAccountTodoStatusInput,
 } from "src/ent/account/actions/edit_account_todo_status_action";
 import { AccountTodoStatusInput } from "src/ent/generated/account/actions/edit_account_todo_status_action_base";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/tag/create_tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/tag/create_tag_type.ts
@@ -14,7 +14,8 @@ import {
 } from "graphql";
 import { ID, RequestContext, Viewer } from "@snowtop/ent";
 import { Tag } from "src/ent/";
-import CreateTagAction, {
+import {
+  CreateTagAction,
   TagCreateInput,
 } from "src/ent/tag/actions/create_tag_action";
 import { TagType } from "src/graphql/resolvers/";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/add_todo_tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/add_todo_tag_type.ts
@@ -12,7 +12,7 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Todo } from "src/ent/";
-import TodoAddTagAction from "src/ent/todo/actions/todo_add_tag_action";
+import { TodoAddTagAction } from "src/ent/todo/actions/todo_add_tag_action";
 import { TodoType } from "src/graphql/resolvers/";
 
 interface customAddTodoTagInput {

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/change_todo_bounty_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/change_todo_bounty_type.ts
@@ -13,7 +13,8 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Todo } from "src/ent/";
-import ChangeTodoBountyAction, {
+import {
+  ChangeTodoBountyAction,
   ChangeTodoBountyInput,
 } from "src/ent/todo/actions/change_todo_bounty_action";
 import { TodoType } from "src/graphql/resolvers/";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/change_todo_status_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/change_todo_status_type.ts
@@ -13,7 +13,8 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Todo } from "src/ent/";
-import ChangeTodoStatusAction, {
+import {
+  ChangeTodoStatusAction,
   ChangeTodoStatusInput,
 } from "src/ent/todo/actions/change_todo_status_action";
 import { TodoType } from "src/graphql/resolvers/";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/create_todo_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/create_todo_type.ts
@@ -14,7 +14,8 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Todo } from "src/ent/";
-import CreateTodoAction, {
+import {
+  CreateTodoAction,
   TodoCreateInput,
 } from "src/ent/todo/actions/create_todo_action";
 import { TodoType } from "src/graphql/resolvers/";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/delete_todo_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/delete_todo_type.ts
@@ -11,7 +11,7 @@ import {
   GraphQLResolveInfo,
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
-import DeleteTodoAction from "src/ent/todo/actions/delete_todo_action";
+import { DeleteTodoAction } from "src/ent/todo/actions/delete_todo_action";
 
 interface customDeleteTodoInput {
   id: string;

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/remove_todo_tag_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/remove_todo_tag_type.ts
@@ -12,7 +12,7 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Todo } from "src/ent/";
-import TodoRemoveTagAction from "src/ent/todo/actions/todo_remove_tag_action";
+import { TodoRemoveTagAction } from "src/ent/todo/actions/todo_remove_tag_action";
 import { TodoType } from "src/graphql/resolvers/";
 
 interface customRemoveTodoTagInput {

--- a/examples/todo-sqlite/src/graphql/generated/mutations/todo/rename_todo_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/todo/rename_todo_type.ts
@@ -13,8 +13,9 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Todo } from "src/ent/";
-import RenameTodoStatusAction, {
+import {
   RenameTodoInput,
+  RenameTodoStatusAction,
 } from "src/ent/todo/actions/rename_todo_status_action";
 import { TodoType } from "src/graphql/resolvers/";
 

--- a/examples/todo-sqlite/src/graphql/generated/mutations/workspace/create_workspace_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/workspace/create_workspace_type.ts
@@ -12,7 +12,8 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Workspace } from "src/ent/";
-import CreateWorkspaceAction, {
+import {
+  CreateWorkspaceAction,
   WorkspaceCreateInput,
 } from "src/ent/workspace/actions/create_workspace_action";
 import { WorkspaceType } from "src/graphql/resolvers/";

--- a/examples/todo-sqlite/src/graphql/generated/mutations/workspace/delete_workspace_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/workspace/delete_workspace_type.ts
@@ -11,7 +11,7 @@ import {
   GraphQLResolveInfo,
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
-import DeleteWorkspaceAction from "src/ent/workspace/actions/delete_workspace_action";
+import { DeleteWorkspaceAction } from "src/ent/workspace/actions/delete_workspace_action";
 
 interface customDeleteWorkspaceInput {
   id: string;

--- a/examples/todo-sqlite/src/graphql/generated/mutations/workspace/edit_workspace_type.ts
+++ b/examples/todo-sqlite/src/graphql/generated/mutations/workspace/edit_workspace_type.ts
@@ -13,7 +13,8 @@ import {
 } from "graphql";
 import { RequestContext, Viewer } from "@snowtop/ent";
 import { Workspace } from "src/ent/";
-import EditWorkspaceAction, {
+import {
+  EditWorkspaceAction,
   WorkspaceEditInput,
 } from "src/ent/workspace/actions/edit_workspace_action";
 import { WorkspaceType } from "src/graphql/resolvers/";

--- a/examples/todo-sqlite/src/graphql/mutations/todo/todo_resolver.ts
+++ b/examples/todo-sqlite/src/graphql/mutations/todo/todo_resolver.ts
@@ -3,9 +3,9 @@ import { gqlMutation } from "@snowtop/ent/graphql";
 import { Account, AccountToTodosQuery } from "src/ent";
 import { BaseAction } from "@snowtop/ent/action/experimental_action";
 import { AccountBuilder } from "src/ent/generated/account/actions/account_builder";
-import ChangeTodoStatusAction from "src/ent/todo/actions/change_todo_status_action";
+import { ChangeTodoStatusAction } from "src/ent/todo/actions/change_todo_status_action";
 import { GraphQLBoolean, GraphQLID } from "graphql";
-import DeleteTodoAction from "src/ent/todo/actions/delete_todo_action";
+import { DeleteTodoAction } from "src/ent/todo/actions/delete_todo_action";
 
 export class TodosResolver {
   @gqlMutation({

--- a/examples/todo-sqlite/src/graphql/tests/closed_todos.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/closed_todos.test.ts
@@ -1,7 +1,7 @@
 import { Account, Todo } from "src/ent";
 import { expectQueryFromRoot } from "@snowtop/ent-graphql-tests";
 import schema from "src/graphql/generated/schema";
-import ChangeTodoStatusAction from "src/ent/todo/actions/change_todo_status_action";
+import { ChangeTodoStatusAction } from "src/ent/todo/actions/change_todo_status_action";
 import { createAccount, createTodoForSelf } from "src/ent/testutils/util";
 import { advanceBy } from "jest-date-mock";
 import { DB, loadConfig } from "@snowtop/ent";

--- a/examples/todo-sqlite/src/graphql/tests/todo.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/todo.test.ts
@@ -4,7 +4,7 @@ import {
   expectQueryFromRoot,
 } from "@snowtop/ent-graphql-tests";
 import schema from "src/graphql/generated/schema";
-import ChangeTodoStatusAction from "src/ent/todo/actions/change_todo_status_action";
+import { ChangeTodoStatusAction } from "src/ent/todo/actions/change_todo_status_action";
 import {
   createAccount,
   createTodoForSelf,
@@ -13,7 +13,7 @@ import {
   createTodoOtherInWorksapce,
 } from "src/ent/testutils/util";
 import { advanceBy } from "jest-date-mock";
-import DeleteTodoAction from "src/ent/todo/actions/delete_todo_action";
+import { DeleteTodoAction } from "src/ent/todo/actions/delete_todo_action";
 
 async function createTodos(): Promise<[Account, Todo[]]> {
   const account = await createAccount();

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -497,6 +497,13 @@ func (cfg *Config) CustomSQLExclude() []string {
 	return nil
 }
 
+func (cfg *Config) DisableDefaultExportForActions() bool {
+	if codegen := cfg.getCodegenConfig(); codegen != nil {
+		return codegen.DisableDefaultExportForActions
+	}
+	return false
+}
+
 const DEFAULT_PRETTIER_GLOB = "src/**/*.ts"
 const PRETTIER_FILE_CHUNKS = 20
 
@@ -649,27 +656,28 @@ func cloneConfig(cfg *ConfigurableConfig) *ConfigurableConfig {
 }
 
 type CodegenConfig struct {
-	DefaultEntPolicy           *PrivacyConfig                   `yaml:"defaultEntPolicy"`
-	DefaultActionPolicy        *PrivacyConfig                   `yaml:"defaultActionPolicy"`
-	Prettier                   *PrettierConfig                  `yaml:"prettier"`
-	RelativeImports            bool                             `yaml:"relativeImports"`
-	DisableGraphQLRoot         bool                             `yaml:"disableGraphQLRoot"`
-	GeneratedHeader            string                           `yaml:"generatedHeader"`
-	DisableBase64Encoding      bool                             `yaml:"disableBase64Encoding"`
-	GenerateRootResolvers      bool                             `yaml:"generateRootResolvers"`
-	DefaultGraphQLMutationName codegenapi.GraphQLMutationName   `yaml:"defaultGraphQLMutationName"`
-	DefaultGraphQLFieldFormat  codegenapi.GraphQLFieldFormat    `yaml:"defaultGraphQLFieldFormat"`
-	SchemaSQLFilePath          string                           `yaml:"schemaSQLFilePath"`
-	SubscriptionType           *codegenapi.ImportedObject       `yaml:"subscriptionType"`
-	DatabaseToCompareTo        string                           `yaml:"databaseToCompareTo"`
-	FieldPrivacyEvaluated      codegenapi.FieldPrivacyEvaluated `yaml:"fieldPrivacyEvaluated"`
-	TemplatizedViewer          *codegenapi.ImportedObject       `yaml:"templatizedViewer"`
-	CustomAssocEdgePath        *codegenapi.ImportedObject       `yaml:"customAssocEdgePath"`
-	GlobalImportPath           string                           `yaml:"globalImportPath"`
-	UserOverridenFiles         []string                         `yaml:"userOverridenFiles"`
-	userOverridenFiles         map[string]bool
-	TransformDeleteMethod      string `yaml:"transformDeleteMethod"`
-	TransformLoadMethod        string `yaml:"transformLoadMethod"`
+	DefaultEntPolicy               *PrivacyConfig                   `yaml:"defaultEntPolicy"`
+	DefaultActionPolicy            *PrivacyConfig                   `yaml:"defaultActionPolicy"`
+	Prettier                       *PrettierConfig                  `yaml:"prettier"`
+	RelativeImports                bool                             `yaml:"relativeImports"`
+	DisableGraphQLRoot             bool                             `yaml:"disableGraphQLRoot"`
+	GeneratedHeader                string                           `yaml:"generatedHeader"`
+	DisableBase64Encoding          bool                             `yaml:"disableBase64Encoding"`
+	GenerateRootResolvers          bool                             `yaml:"generateRootResolvers"`
+	DefaultGraphQLMutationName     codegenapi.GraphQLMutationName   `yaml:"defaultGraphQLMutationName"`
+	DefaultGraphQLFieldFormat      codegenapi.GraphQLFieldFormat    `yaml:"defaultGraphQLFieldFormat"`
+	SchemaSQLFilePath              string                           `yaml:"schemaSQLFilePath"`
+	SubscriptionType               *codegenapi.ImportedObject       `yaml:"subscriptionType"`
+	DatabaseToCompareTo            string                           `yaml:"databaseToCompareTo"`
+	FieldPrivacyEvaluated          codegenapi.FieldPrivacyEvaluated `yaml:"fieldPrivacyEvaluated"`
+	TemplatizedViewer              *codegenapi.ImportedObject       `yaml:"templatizedViewer"`
+	CustomAssocEdgePath            *codegenapi.ImportedObject       `yaml:"customAssocEdgePath"`
+	GlobalImportPath               string                           `yaml:"globalImportPath"`
+	UserOverridenFiles             []string                         `yaml:"userOverridenFiles"`
+	userOverridenFiles             map[string]bool
+	TransformDeleteMethod          string `yaml:"transformDeleteMethod"`
+	TransformLoadMethod            string `yaml:"transformLoadMethod"`
+	DisableDefaultExportForActions bool   `yaml:"disableDefaultExportForActions"`
 }
 
 func cloneCodegen(cfg *CodegenConfig) *CodegenConfig {
@@ -688,27 +696,28 @@ func cloneDatabaseMigration(cfg *DatabaseMigrationConfig) *DatabaseMigrationConf
 
 func (cfg *CodegenConfig) Clone() *CodegenConfig {
 	return &CodegenConfig{
-		DefaultEntPolicy:           clonePrivacyConfig(cfg.DefaultEntPolicy),
-		DefaultActionPolicy:        clonePrivacyConfig(cfg.DefaultActionPolicy),
-		Prettier:                   clonePrettierConfig(cfg.Prettier),
-		RelativeImports:            cfg.RelativeImports,
-		DisableGraphQLRoot:         cfg.DisableGraphQLRoot,
-		GeneratedHeader:            cfg.GeneratedHeader,
-		DisableBase64Encoding:      cfg.DisableBase64Encoding,
-		GenerateRootResolvers:      cfg.GenerateRootResolvers,
-		DefaultGraphQLMutationName: cfg.DefaultGraphQLMutationName,
-		DefaultGraphQLFieldFormat:  cfg.DefaultGraphQLFieldFormat,
-		SchemaSQLFilePath:          cfg.SchemaSQLFilePath,
-		SubscriptionType:           cfg.SubscriptionType,
-		DatabaseToCompareTo:        cfg.DatabaseToCompareTo,
-		FieldPrivacyEvaluated:      cfg.FieldPrivacyEvaluated,
-		TemplatizedViewer:          cloneImportedObject(cfg.TemplatizedViewer),
-		CustomAssocEdgePath:        cloneImportedObject(cfg.CustomAssocEdgePath),
-		GlobalImportPath:           cfg.GlobalImportPath,
-		UserOverridenFiles:         cfg.UserOverridenFiles,
-		userOverridenFiles:         cfg.userOverridenFiles,
-		TransformDeleteMethod:      cfg.TransformDeleteMethod,
-		TransformLoadMethod:        cfg.TransformLoadMethod,
+		DefaultEntPolicy:               clonePrivacyConfig(cfg.DefaultEntPolicy),
+		DefaultActionPolicy:            clonePrivacyConfig(cfg.DefaultActionPolicy),
+		Prettier:                       clonePrettierConfig(cfg.Prettier),
+		RelativeImports:                cfg.RelativeImports,
+		DisableGraphQLRoot:             cfg.DisableGraphQLRoot,
+		GeneratedHeader:                cfg.GeneratedHeader,
+		DisableBase64Encoding:          cfg.DisableBase64Encoding,
+		GenerateRootResolvers:          cfg.GenerateRootResolvers,
+		DefaultGraphQLMutationName:     cfg.DefaultGraphQLMutationName,
+		DefaultGraphQLFieldFormat:      cfg.DefaultGraphQLFieldFormat,
+		SchemaSQLFilePath:              cfg.SchemaSQLFilePath,
+		SubscriptionType:               cfg.SubscriptionType,
+		DatabaseToCompareTo:            cfg.DatabaseToCompareTo,
+		FieldPrivacyEvaluated:          cfg.FieldPrivacyEvaluated,
+		TemplatizedViewer:              cloneImportedObject(cfg.TemplatizedViewer),
+		CustomAssocEdgePath:            cloneImportedObject(cfg.CustomAssocEdgePath),
+		GlobalImportPath:               cfg.GlobalImportPath,
+		UserOverridenFiles:             cfg.UserOverridenFiles,
+		userOverridenFiles:             cfg.userOverridenFiles,
+		TransformDeleteMethod:          cfg.TransformDeleteMethod,
+		TransformLoadMethod:            cfg.TransformLoadMethod,
+		DisableDefaultExportForActions: cfg.DisableDefaultExportForActions,
 	}
 }
 

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -2626,12 +2626,6 @@ func buildActionPayloadNode(processor *codegen.Processor, nodeData *schema.NodeD
 		TSType:   payload,
 		Exported: true,
 		GQLType:  "GraphQLObjectType",
-		DefaultImports: []*tsimport.ImportPath{
-			{
-				ImportPath: getActionPath(nodeData, a),
-				Import:     a.GetActionName(),
-			},
-		},
 		Imports: []*tsimport.ImportPath{
 			{
 				ImportPath: codepath.GetExternalImportPath(),
@@ -2647,6 +2641,17 @@ func buildActionPayloadNode(processor *codegen.Processor, nodeData *schema.NodeD
 			},
 		},
 	})
+	if processor.Config.DisableDefaultExportForActions() {
+		result.Imports = append(result.Imports, &tsimport.ImportPath{
+			ImportPath: getActionPath(nodeData, a),
+			Import:     a.GetActionName(),
+		})
+	} else {
+		result.DefaultImports = append(result.Imports, &tsimport.ImportPath{
+			ImportPath: getActionPath(nodeData, a),
+			Import:     a.GetActionName(),
+		})
+	}
 
 	// this is here but it's probably better in buildActionFieldConfig
 	if action.HasInput(a) {

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -2647,7 +2647,7 @@ func buildActionPayloadNode(processor *codegen.Processor, nodeData *schema.NodeD
 			Import:     a.GetActionName(),
 		})
 	} else {
-		result.DefaultImports = append(result.Imports, &tsimport.ImportPath{
+		result.DefaultImports = append(result.DefaultImports, &tsimport.ImportPath{
 			ImportPath: getActionPath(nodeData, a),
 			Import:     a.GetActionName(),
 		})

--- a/internal/tscode/action.tmpl
+++ b/internal/tscode/action.tmpl
@@ -1,5 +1,6 @@
 {{$action := .Action }}
 {{ $actionName := $action.GetActionName -}}
+{{ $cfg := .CodePath }}
 {{ $baseName := printf "%sBase" $actionName -}}
 
 {{ $hasInput := hasInput $action -}}
@@ -14,6 +15,12 @@
   export { {{useImport $inputName}} };
 {{end}}
 
+{{if  $cfg.DisableDefaultExportForActions }} 
+export class {{$actionName}} extends {{useImport $baseName}} {
+
+}
+{{else}}
 export default class {{$actionName}} extends {{useImport $baseName}} {
 
 }
+{{end}}

--- a/internal/tscode/write_action.go
+++ b/internal/tscode/write_action.go
@@ -62,6 +62,8 @@ func writeActionFile(nodeData *schema.NodeData, processor *codegen.Processor, ac
 		Config: processor.Config,
 		Data: actionTemplate{
 			NodeData: nodeData,
+			// TODO more places where s/CodePath/Config
+			CodePath: processor.Config,
 			Action:   action,
 			BasePath: getImportPathForActionBaseFile(nodeData, action),
 			Package:  cfg.GetImportPackage(),

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.20",
+  "version": "0.1.21-test1",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.1.21-test1",
+  "version": "0.1.21",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/src/core/config.ts
+++ b/ts/src/core/config.ts
@@ -150,6 +150,8 @@ interface CodegenConfig {
 
   // if set, overrides the saveWithoutTransform(X) methods to be this instead of the default saveWithoutTransform(X)
   transformDeleteMethod?: string;
+
+  disableDefaultExportForActions?: boolean;
 }
 
 interface PrettierConfig {

--- a/ts/src/scripts/fix_action_exports.ts
+++ b/ts/src/scripts/fix_action_exports.ts
@@ -1,0 +1,69 @@
+import { getClassInfo } from "../tsc/ast";
+import { TransformFile, transform } from "../tsc/transform";
+import ts, { SourceFile, Node, isClassDeclaration } from "typescript";
+
+class FixActionExports implements TransformFile {
+  glob = "src/ent/**/actions/*_action.ts";
+
+  prettierGlob = "src/ent/**/actions/*_action.ts";
+
+  traverseChild(
+    sourceFile: SourceFile,
+    contents: string,
+    file: string,
+    node: Node,
+  ) {
+    if (!isClassDeclaration(node)) {
+      return { node };
+    }
+    // only Action classes
+    if (!node.name?.text.endsWith("Action")) {
+      return { node };
+    }
+
+    const modifiers = ts.canHaveModifiers(node)
+      ? ts.getModifiers(node)
+      : undefined;
+
+    const exported = modifiers?.filter(
+      (mod) => mod.getText(sourceFile) === "export",
+    );
+    const defaultExport = modifiers?.filter(
+      (mod) => mod.getText(sourceFile) === "default",
+    );
+
+    // for now, we're only supporting changing from default -> non-default
+    // trivial to support the other way around but don't need it yet
+    if (!exported?.length || !defaultExport?.length) {
+      return { node };
+    }
+
+    let classInfo = getClassInfo(contents, sourceFile, node, {
+      hasExport: true,
+      hasDefault: false,
+    });
+
+    if (!classInfo) {
+      // somehow don't have classInfo, bye
+      return { node };
+    }
+
+    let klassContents = "";
+    for (const mm of node.members) {
+      klassContents += mm.getFullText(sourceFile);
+    }
+
+    return {
+      traversed: true,
+      rawString: classInfo.wrapClassContents(klassContents),
+    };
+  }
+}
+
+// ts-node-script --swc --project ./tsconfig.json -r tsconfig-paths/register ../../ts/src/scripts/fix_action_exports.ts
+function main() {
+  const f = new FixActionExports();
+  transform(f);
+}
+
+main();

--- a/ts/src/tsc/ast.ts
+++ b/ts/src/tsc/ast.ts
@@ -29,6 +29,10 @@ export function getClassInfo(
   fileContents: string,
   sourceFile: ts.SourceFile,
   node: ts.ClassDeclaration,
+  override?: {
+    hasExport: boolean;
+    hasDefault: boolean;
+  },
 ): ClassInfo | undefined {
   let className = node.name?.text;
 
@@ -83,7 +87,10 @@ export function getClassInfo(
     }`;
   };
 
-  if (node.modifiers) {
+  if (override) {
+    hasExport = override.hasExport;
+    hasDefault = override.hasDefault;
+  } else if (node.modifiers) {
     for (const mod of node.modifiers) {
       const text = mod.getText(sourceFile);
       if (text === "export") {

--- a/ts/src/tsc/transform.ts
+++ b/ts/src/tsc/transform.ts
@@ -1,6 +1,6 @@
 import * as glob from "glob";
 import ts from "typescript";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import * as fs from "fs";
 import { getImportInfo, transformImport } from "./ast";
 import { createSourceFile, getTargetFromCurrentDir } from "./compilerOptions";
@@ -212,7 +212,7 @@ export function transform(transform: TransformFile) {
   });
 
   if (transform.prettierGlob) {
-    execSync(`prettier ${transform.prettierGlob} --write`);
+    spawnSync(`prettier`, [transform.prettierGlob, "--write"]);
   }
 }
 

--- a/tsent/cmd/run_script.go
+++ b/tsent/cmd/run_script.go
@@ -28,6 +28,7 @@ var runScriptCmd = &cobra.Command{
 			cmd2.GetArgsForTsNodeScript(cfg.GetAbsPathToRoot()),
 			// "--swc",
 			scriptPath,
+			// TODO extra args...
 		)
 
 		command := exec.Command("ts-node-script", cmdArgs...)

--- a/tsent/cmd/run_script.go
+++ b/tsent/cmd/run_script.go
@@ -15,6 +15,7 @@ var runScriptCmd = &cobra.Command{
 	Short: "run script",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// usually a path like scripts/fix_action_exports.ts
 		script := args[0]
 
 		cfg, err := codegen.NewConfig("src/schema", "")

--- a/tsent/cmd/run_script.go
+++ b/tsent/cmd/run_script.go
@@ -28,7 +28,6 @@ var runScriptCmd = &cobra.Command{
 			cmd2.GetArgsForTsNodeScript(cfg.GetAbsPathToRoot()),
 			// "--swc",
 			scriptPath,
-			// TODO extra args...
 		)
 
 		command := exec.Command("ts-node-script", cmdArgs...)


### PR DESCRIPTION
fixes https://github.com/lolopinto/ent/issues/1686

how to use it:

* get new image
* update ent.yml and add this line under codegen: https://github.com/lolopinto/ent/blob/configure-imports/examples/todo-sqlite/ent.yml#L14
* npm run rebuild-image && npm run codegen
* docker-compose -f docker-compose.dev.yml run --rm app tsent run_script  scripts/fix_action_exports.ts to fix the export for the actions themselves