### PR TITLE
fix disableBuilderType missing in field.Clone()

### DIFF
--- a/internal/field/field.go
+++ b/internal/field/field.go
@@ -939,6 +939,7 @@ func (f *Field) Clone(opts ...Option) (*Field, error) {
 		exposeToActionsByDefault:   f.exposeToActionsByDefault,
 		singleFieldPrimaryKey:      f.singleFieldPrimaryKey,
 		disableUserEditable:        f.disableUserEditable,
+		disableBuilderType:         f.disableBuilderType,
 		disableUserGraphQLEditable: f.disableUserGraphQLEditable,
 		hasDefaultValueOnCreate:    f.hasDefaultValueOnCreate,
 		hasDefaultValueOnEdit:      f.hasDefaultValueOnEdit,


### PR DESCRIPTION
led to disableBuilderType in UUIDType not being respected when defaultValueOnCreate is true and disableUserGraphQLEditable is true 