### PR TITLE
Add ability to remove alias from order by clause

### DIFF
--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -165,6 +165,9 @@ export interface SelectBaseDataOptions extends DataOptions {
   // don't use either alias for this query.
   // possible reason in when doing aggregate queries and may have already aliased what we're querying
   disableFieldsAlias?: boolean;
+  // don't use the alias for the order by clause
+  // this is useful when doing a join and the order by clause is not on the main table
+  disableOrderByAlias?: boolean;
 }
 
 export interface SelectDataOptions extends SelectBaseDataOptions {

--- a/ts/src/core/base.ts
+++ b/ts/src/core/base.ts
@@ -167,7 +167,7 @@ export interface SelectBaseDataOptions extends DataOptions {
   disableFieldsAlias?: boolean;
   // don't use the alias for the order by clause
   // this is useful when doing a join and the order by clause is not on the main table
-  disableOrderByAlias?: boolean;
+  disableDefaultOrderByAlias?: boolean;
 }
 
 export interface SelectDataOptions extends SelectBaseDataOptions {

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -3,6 +3,7 @@ import { QueryableDataOptions } from "./base";
 export interface OrderByOption {
   column: string;
   direction: "ASC" | "DESC";
+  alias?: string;
   nullsPlacement?: "first" | "last";
   // is this column a date/time column?
   // needed to know if we create a cursor based on this column to conver to timestamp and ISO string for
@@ -25,7 +26,8 @@ export function getOrderByPhrase(orderby: OrderBy, alias?: string): string {
           nullsPlacement = " NULLS LAST";
           break;
       }
-      const col = alias ? `${alias}.${v.column}` : v.column;
+      const orderByAlias = v.alias ?? alias;
+      const col = orderByAlias ? `${orderByAlias}.${v.column}` : v.column;
       return `${col} ${v.direction}${nullsPlacement}`;
     })
     .join(", ");
@@ -97,7 +99,7 @@ export function buildQuery(options: QueryableDataOptions): string {
     parts.push(
       `ORDER BY ${getOrderByPhrase(
         options.orderby,
-        options.disableOrderByAlias ? undefined : fieldsAlias,
+        options.disableDefaultOrderByAlias ? undefined : fieldsAlias,
       )}`,
     );
   }

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -94,7 +94,12 @@ export function buildQuery(options: QueryableDataOptions): string {
     parts.push(`GROUP BY ${options.groupby}`);
   }
   if (options.orderby) {
-    parts.push(`ORDER BY ${getOrderByPhrase(options.orderby, fieldsAlias)}`);
+    parts.push(
+      `ORDER BY ${getOrderByPhrase(
+        options.orderby,
+        options.disableOrderByAlias ? undefined : fieldsAlias,
+      )}`,
+    );
   }
   if (options.limit) {
     parts.push(`LIMIT ${options.limit}`);


### PR DESCRIPTION
When running a query with a join, to order by a field not on the main table, we have to disable the alias prefixing of columns in the order by clause.