### PR TITLE
Fix invalid generated TS "float" type

### DIFF
--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -67,7 +67,7 @@ var knownTsTypes = map[string]string{
 	"String":  "string",
 	"Date":    "Date",
 	"Int":     "number",
-	"Float":   "float",
+	"Float":   "number",
 	"Boolean": "boolean",
 	// "ID":         "ID",
 	"BigInt": "bigint",


### PR DESCRIPTION
`float` is not a valid TS type. It needs to be `number`.

Per the comment on line 65 above, in the `graphql.ts` file `knownAllowedNames` is already correctly defined as such:
```ts
export const knownAllowedNames: Map<string, string> = new Map([
  ["Date", "Date"],
  ["Boolean", "boolean"],
  ["Number", "number"],
  ["String", "string"],
  // TODO not right to have this and Number
  ["Int", "number"],
  ["Float", "number"],
  ["ID", "ID"],
  ["JSON", "any"],
  ["Node", "Ent"],
]);
```

Fixes #1826