### PR TITLE
Fix edge connection pagination

### DIFF
--- a/ts/src/graphql/query/edge_connection.ts
+++ b/ts/src/graphql/query/edge_connection.ts
@@ -76,14 +76,17 @@ export class GraphQLEdgeConnection<
       if (this.args.before && !this.args.before) {
         throw new Error("cannot process before without last");
       }
-      const argFirst = this.args.first;
-      const argLast = this.args.last;
-      const argCursor = this.args.cursor;
       if (this.args.first) {
-        this.query = this.query.then((query) => query.first(argFirst, argLast));
+        const argFirst = this.args.first;
+        const argAfter = this.args.after;
+        this.query = this.query.then((query) =>
+          query.first(argFirst, argAfter),
+        );
       }
       if (this.args.last) {
-        this.query = this.query.then((query) => query.last(argLast, argCursor));
+        const argLast = this.args.last;
+        const argBefore = this.args.before;
+        this.query = this.query.then((query) => query.last(argLast, argBefore));
       }
       // TODO custom args
       // how to proceed


### PR DESCRIPTION
The edge connection work I previously did to enable async custom connections highlighted an existing bug and also introduced a new one.

The existing bug: `args.cursor` should have been `args.before`.
The new bug: `args.last` was and should be `args.after`.