### PR TITLE
Adjust edge queries to support multiple sort columns

### DIFF
--- a/ts/src/core/clause.test.ts
+++ b/ts/src/core/clause.test.ts
@@ -1928,6 +1928,577 @@ describe("postgres", () => {
     });
   });
 
+  describe("pagination unbound cols query", () => {
+    test("All DESC", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls.clause(1)).toBe(
+        "(start_time < $1 AND start_time IS NOT NULL) OR (start_time = $2 AND id < $3 AND id IS NOT NULL)",
+      );
+      expect(cls.clause(1, "t")).toBe(
+        "(t.start_time < $1 AND t.start_time IS NOT NULL) OR (t.start_time = $2 AND t.id < $3 AND t.id IS NOT NULL)",
+      );
+      expect(cls.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls.values()).toStrictEqual(["timeValue", "timeValue", "idValue"]);
+      expect(cls.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls.instanceKey()).toEqual(
+        "(start_time<timeValue AND start_time IS NOT NULL) OR (start_time=timeValue AND id<idValue AND id IS NOT NULL)",
+      );
+
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          sortValue: "timeValue",
+          overrideAlias: "t2",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          sortValue: "idValue",
+          overrideAlias: "t2",
+        },
+      ])!;
+      expect(cls2.clause(1)).toBe(
+        "(t2.start_time < $1 AND t2.start_time IS NOT NULL) OR (t2.start_time = $2 AND t2.id < $3 AND t2.id IS NOT NULL)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "(t2.start_time < $1 AND t2.start_time IS NOT NULL) OR (t2.start_time = $2 AND t2.id < $3 AND t2.id IS NOT NULL)",
+      );
+      expect(cls2.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls2.values()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.instanceKey()).toEqual(
+        "(t2.start_time<timeValue AND start_timet2 IS NOT NULL) OR (t2.start_time=timeValue AND t2.id<idValue AND idt2 IS NOT NULL)",
+      );
+    });
+
+    test("All DESC clause 3", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls.clause(3)).toBe(
+        "(start_time < $3 AND start_time IS NOT NULL) OR (start_time = $4 AND id < $5 AND id IS NOT NULL)",
+      );
+      expect(cls.clause(3, "t")).toBe(
+        "(t.start_time < $3 AND t.start_time IS NOT NULL) OR (t.start_time = $4 AND t.id < $5 AND t.id IS NOT NULL)",
+      );
+      expect(cls.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls.values()).toStrictEqual(["timeValue", "timeValue", "idValue"]);
+      expect(cls.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls.instanceKey()).toEqual(
+        "(start_time<timeValue AND start_time IS NOT NULL) OR (start_time=timeValue AND id<idValue AND id IS NOT NULL)",
+      );
+
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          sortValue: "timeValue",
+          overrideAlias: "t2",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          sortValue: "idValue",
+          overrideAlias: "t2",
+        },
+      ])!;
+      expect(cls2.clause(3)).toBe(
+        "(t2.start_time < $3 AND t2.start_time IS NOT NULL) OR (t2.start_time = $4 AND t2.id < $5 AND t2.id IS NOT NULL)",
+      );
+      expect(cls2.clause(3, "t")).toBe(
+        "(t2.start_time < $3 AND t2.start_time IS NOT NULL) OR (t2.start_time = $4 AND t2.id < $5 AND t2.id IS NOT NULL)",
+      );
+      expect(cls2.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls2.values()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.instanceKey()).toEqual(
+        "(t2.start_time<timeValue AND start_timet2 IS NOT NULL) OR (t2.start_time=timeValue AND t2.id<idValue AND idt2 IS NOT NULL)",
+      );
+    });
+
+    test("All ASC", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls.clause(1)).toBe(
+        "start_time > $1 OR start_time IS NULL OR (start_time = $2 AND (id > $3 OR id IS NULL))",
+      );
+      expect(cls.clause(1, "t")).toBe(
+        "t.start_time > $1 OR t.start_time IS NULL OR (t.start_time = $2 AND (t.id > $3 OR t.id IS NULL))",
+      );
+      expect(cls.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls.values()).toStrictEqual(["timeValue", "timeValue", "idValue"]);
+      expect(cls.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls.instanceKey()).toEqual(
+        "start_time>timeValue OR start_time IS NULL OR (start_time=timeValue AND (id>idValue OR id IS NULL))",
+      );
+
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          sortValue: "timeValue",
+          overrideAlias: "t2",
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          sortValue: "idValue",
+          overrideAlias: "t2",
+        },
+      ])!;
+      expect(cls2.clause(1)).toBe(
+        "t2.start_time > $1 OR t2.start_time IS NULL OR (t2.start_time = $2 AND (t2.id > $3 OR t2.id IS NULL))",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.start_time > $1 OR t2.start_time IS NULL OR (t2.start_time = $2 AND (t2.id > $3 OR t2.id IS NULL))",
+      );
+      expect(cls2.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls2.values()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.start_time>timeValue OR start_timet2 IS NULL OR (t2.start_time=timeValue AND (t2.id>idValue OR idt2 IS NULL))",
+      );
+    });
+
+    test("DESC NULLS LAST", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          nullsPlacement: "last",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          nullsPlacement: "last",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls.clause(1)).toBe(
+        "start_time < $1 OR start_time IS NULL OR (start_time = $2 AND (id < $3 OR id IS NULL))",
+      );
+      expect(cls.clause(1, "t")).toBe(
+        "t.start_time < $1 OR t.start_time IS NULL OR (t.start_time = $2 AND (t.id < $3 OR t.id IS NULL))",
+      );
+      expect(cls.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls.values()).toStrictEqual(["timeValue", "timeValue", "idValue"]);
+      expect(cls.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls.instanceKey()).toEqual(
+        "start_time<timeValue OR start_time IS NULL OR (start_time=timeValue AND (id<idValue OR id IS NULL))",
+      );
+
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          nullsPlacement: "last",
+          sortValue: "timeValue",
+          overrideAlias: "t2",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          nullsPlacement: "last",
+          sortValue: "idValue",
+          overrideAlias: "t2",
+        },
+      ])!;
+      expect(cls2.clause(1)).toBe(
+        "t2.start_time < $1 OR t2.start_time IS NULL OR (t2.start_time = $2 AND (t2.id < $3 OR t2.id IS NULL))",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "t2.start_time < $1 OR t2.start_time IS NULL OR (t2.start_time = $2 AND (t2.id < $3 OR t2.id IS NULL))",
+      );
+      expect(cls2.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls2.values()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.instanceKey()).toEqual(
+        "t2.start_time<timeValue OR start_timet2 IS NULL OR (t2.start_time=timeValue AND (t2.id<idValue OR idt2 IS NULL))",
+      );
+    });
+
+    test("ASC NULLS FIRST", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          nullsPlacement: "first",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          nullsPlacement: "first",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls.clause(1)).toBe(
+        "(start_time > $1 AND start_time IS NOT NULL) OR (start_time = $2 AND id > $3 AND id IS NOT NULL)",
+      );
+      expect(cls.clause(1, "t")).toBe(
+        "(t.start_time > $1 AND t.start_time IS NOT NULL) OR (t.start_time = $2 AND t.id > $3 AND t.id IS NOT NULL)",
+      );
+      expect(cls.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls.values()).toStrictEqual(["timeValue", "timeValue", "idValue"]);
+      expect(cls.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls.instanceKey()).toEqual(
+        "(start_time>timeValue AND start_time IS NOT NULL) OR (start_time=timeValue AND id>idValue AND id IS NOT NULL)",
+      );
+
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          nullsPlacement: "first",
+          sortValue: "timeValue",
+          overrideAlias: "t2",
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          nullsPlacement: "first",
+          sortValue: "idValue",
+          overrideAlias: "t2",
+        },
+      ])!;
+      expect(cls2.clause(1)).toBe(
+        "(t2.start_time > $1 AND t2.start_time IS NOT NULL) OR (t2.start_time = $2 AND t2.id > $3 AND t2.id IS NOT NULL)",
+      );
+      expect(cls2.clause(1, "t")).toBe(
+        "(t2.start_time > $1 AND t2.start_time IS NOT NULL) OR (t2.start_time = $2 AND t2.id > $3 AND t2.id IS NOT NULL)",
+      );
+      expect(cls2.columns()).toStrictEqual([
+        "start_time",
+        "start_time",
+        "start_time",
+        "id",
+        "id",
+      ]);
+      expect(cls2.values()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.logValues()).toStrictEqual([
+        "timeValue",
+        "timeValue",
+        "idValue",
+      ]);
+      expect(cls2.instanceKey()).toEqual(
+        "(t2.start_time>timeValue AND start_timet2 IS NOT NULL) OR (t2.start_time=timeValue AND t2.id>idValue AND idt2 IS NOT NULL)",
+      );
+    });
+
+    test("DESC defaults to NULLS FIRST", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          sortValue: "idValue",
+        },
+      ])!;
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          nullsPlacement: "first",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          nullsPlacement: "first",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls.clause(1)).toEqual(cls2.clause(1));
+    });
+
+    test("ASC defaults to NULLS LAST", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          sortValue: "idValue",
+        },
+      ])!;
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          nullsPlacement: "last",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          nullsPlacement: "last",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls.clause(1)).toEqual(cls2.clause(1));
+    });
+
+    test("DESC with NULL", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          sortValue: null,
+        },
+      ])!;
+      expect(cls.clause(1)).toBe("start_time < $1 AND start_time IS NOT NULL");
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          sortValue: null,
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls2.clause(1)).toBe("id < $1 AND id IS NOT NULL");
+      const cls3 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "DESC",
+          sortValue: null,
+        },
+        {
+          sortCol: "id",
+          direction: "DESC",
+          sortValue: null,
+        },
+      ]);
+      expect(cls3).toBeUndefined();
+    });
+
+    test("ASC with NULL", () => {
+      const cls = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          sortValue: "timeValue",
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          sortValue: null,
+        },
+      ])!;
+      expect(cls.clause(1)).toBe(
+        "start_time > $1 OR start_time IS NULL OR (start_time = $2 AND id IS NULL)",
+      );
+      const cls2 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          sortValue: null,
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          sortValue: "idValue",
+        },
+      ])!;
+      expect(cls2.clause(1)).toBe(
+        "start_time IS NULL AND (id > $1 OR id IS NULL)",
+      );
+      const cls3 = clause.PaginationUnboundColsQuery<EventData>([
+        {
+          sortCol: "start_time",
+          direction: "ASC",
+          sortValue: null,
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          sortValue: null,
+        },
+      ])!;
+      expect(cls3.clause(1)).toBe("start_time IS NULL AND id IS NULL");
+    });
+
+    test("3 level multi-directional", () => {
+      const cls = clause.PaginationUnboundColsQuery<any>([
+        {
+          sortCol: "first_name",
+          direction: "ASC",
+          sortValue: "Stefan",
+        },
+        {
+          sortCol: "last_name",
+          direction: "DESC",
+          sortValue: "Parker",
+        },
+        {
+          sortCol: "id",
+          direction: "ASC",
+          sortValue: "24900783",
+        },
+      ])!;
+      expect(cls.clause(1)).toBe(
+        "first_name > $1 OR first_name IS NULL OR (first_name = $2 AND ((last_name < $3 AND last_name IS NOT NULL) OR (last_name = $4 AND (id > $5 OR id IS NULL))))",
+      );
+    });
+  });
+
   describe("rhs", () => {
     test("add", () => {
       const cls = clause.Add<BalanceData>("balance", 4);

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -1377,6 +1377,14 @@ export function PaginationMultipleColsSubQuery<T extends Data, K = keyof T>(
   );
 }
 
+export type PaginationUnboundColsQueryOrdering<T extends Data, K = keyof T> = {
+  sortCol: K;
+  direction: "ASC" | "DESC";
+  sortValue: string | number | null;
+  nullsPlacement?: "first" | "last";
+  overrideAlias?: string;
+};
+
 /**
  * When paginating over multiple ordered columns, we need to construct a nested
  * set of clauses to correctly filter. The resulting query will be structured as
@@ -1388,13 +1396,7 @@ export function PaginationMultipleColsSubQuery<T extends Data, K = keyof T>(
  * (col1 < $1 OR (col1 = $1 AND col2 > $2))
  */
 export function PaginationUnboundColsQuery<T extends Data, K = keyof T>(
-  ordering: {
-    sortCol: K;
-    direction: "ASC" | "DESC";
-    sortValue: string | number | null;
-    nullsPlacement?: "first" | "last";
-    overrideAlias?: string;
-  }[],
+  ordering: PaginationUnboundColsQueryOrdering<T, K>[],
 ): Clause<T, K> | undefined {
   if (ordering.length === 0) {
     throw new Error("Must provide at least one ordering.");

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -1405,7 +1405,7 @@ export function PaginationUnboundColsQuery<T extends Data, K = keyof T>(
     .forEach(
       ({ sortCol, direction, sortValue, nullsPlacement, overrideAlias }) => {
         const nullsOrder =
-          (nullsPlacement ?? direction === "DESC") ? "first" : "last";
+          nullsPlacement ?? (direction === "DESC" ? "first" : "last");
         const clauseFn = direction === "DESC" ? Less : Greater;
         const baseClause = clauseFn(sortCol, sortValue, overrideAlias);
         const withNullsClause =

--- a/ts/src/core/db.ts
+++ b/ts/src/core/db.ts
@@ -1,8 +1,8 @@
-import pg, { Pool, PoolClient, PoolConfig } from "pg";
 import * as fs from "fs";
 import { load } from "js-yaml";
-import { log } from "./logger";
 import { DateTime } from "luxon";
+import pg, { Pool, PoolClient, PoolConfig } from "pg";
+import { log } from "./logger";
 
 export interface Database extends PoolConfig {
   database?: string;
@@ -232,9 +232,8 @@ export default class DB {
   }
 }
 
-export const defaultTimestampParser = pg.types.getTypeParser(
-  pg.types.builtins.TIMESTAMP,
-);
+export const defaultTimestampParser: (value: string) => string =
+  pg.types.getTypeParser(pg.types.builtins.TIMESTAMP);
 
 // this is stored in the db without timezone but we want to make sure
 // it's parsed as UTC time as opposed to the local time
@@ -441,7 +440,7 @@ export class Postgres implements Connection {
     values?: any[],
   ): Promise<QueryResult<QueryResultRow>> {
     const r = await this.pool.query(query, values);
-    return r;
+    return r as QueryResult<QueryResultRow>;
   }
 
   async queryAll(
@@ -449,7 +448,7 @@ export class Postgres implements Connection {
     values?: any[],
   ): Promise<QueryResult<QueryResultRow>> {
     const r = await this.pool.query(query, values);
-    return r;
+    return r as QueryResult<QueryResultRow>;
   }
 
   async exec(query: string, values?: any[]): Promise<ExecResult> {
@@ -473,7 +472,7 @@ export class PostgresClient implements Client {
     values?: any[],
   ): Promise<QueryResult<QueryResultRow>> {
     const r = await this.client.query(query, values);
-    return r;
+    return r as QueryResult<QueryResultRow>;
   }
 
   async queryAll(
@@ -481,7 +480,7 @@ export class PostgresClient implements Client {
     values?: any[],
   ): Promise<QueryResult<QueryResultRow>> {
     const r = await this.client.query(query, values);
-    return r;
+    return r as QueryResult<QueryResultRow>;
   }
 
   async exec(query: string, values?: any[]): Promise<ExecResult> {

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -1284,7 +1284,7 @@ export function getCursor(opts: cursorOptions) {
   }
   const convert = (d: any) => {
     if (d instanceof Date) {
-      return d.getTime();
+      return d.toISOString();
     }
     return d;
   };

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -1294,9 +1294,9 @@ export function getCursor(opts: cursorOptions) {
 
   const parts: [string, string | number | null][] = [];
   for (let i = 0; i < cursorKeys.length; i++) {
-    const key = cursorKeys[i];
-    const cursorKey = rowKeys?.[i] || key;
-    parts.push([key, convert(row[cursorKey])]);
+    const cursorKey = cursorKeys[i];
+    const rowKey = rowKeys?.[i] || cursorKey;
+    parts.push([cursorKey, convert(row[rowKey])]);
   }
   return btoa(JSON.stringify(parts));
 }

--- a/ts/src/core/loaders/assoc_edge_loader.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.ts
@@ -1,28 +1,28 @@
 import DataLoader from "dataloader";
+import memoizee from "memoizee";
 import {
   Context,
-  ID,
   EdgeQueryableDataOptions,
+  ID,
   Loader,
   LoaderFactory,
 } from "../base";
+import * as clause from "../clause";
 import {
   AssocEdge,
-  loadCustomEdges,
   AssocEdgeConstructor,
-  loadEdgeData,
-  getDefaultLimit,
-  performRawQuery,
-  loadEdgeForID2,
-  buildGroupQuery,
   AssocEdgeData,
+  buildGroupQuery,
+  getDefaultLimit,
   getEdgeClauseAndFields,
+  loadCustomEdges,
+  loadEdgeData,
+  loadEdgeForID2,
   loadTwoWayEdges,
+  performRawQuery,
 } from "../ent";
-import * as clause from "../clause";
 import { logEnabled } from "../logger";
 import { CacheMap, getCustomLoader } from "./loader";
-import memoizee from "memoizee";
 
 function createLoader<T extends AssocEdge>(
   options: EdgeQueryableDataOptions,
@@ -263,7 +263,7 @@ export class AssocEdgeLoaderFactory<T extends AssocEdge>
     }
 
     // we create a loader which can combine first X queries in the same fetch
-    const key = `${this.name}:limit:${options.limit}:orderby:${options.orderby}:disableTransformations:${options.disableTransformations}`;
+    const key = `${this.name}:limit:${options.limit}:orderby:${options.orderby?.map((orderBy) => JSON.stringify(orderBy))}:disableTransformations:${options.disableTransformations}`;
     return getCustomLoader(
       key,
       () => new AssocEdgeLoader(this.edgeType, ctr, options, context),

--- a/ts/src/core/query/assoc_query.test.ts
+++ b/ts/src/core/query/assoc_query.test.ts
@@ -1,9 +1,9 @@
-import { Viewer } from "../base";
 import { FakeUser, UserToContactsQuery } from "../../testutils/fake_data/index";
-import { commonTests } from "./shared_test";
-import { assocTests } from "./shared_assoc_test";
 import { MockLogs } from "../../testutils/mock_log";
+import { Viewer } from "../base";
 import { And, Eq } from "../clause";
+import { assocTests } from "./shared_assoc_test";
+import { commonTests } from "./shared_test";
 
 // shared mock across tests
 // should this be global?
@@ -22,6 +22,10 @@ commonTests({
   orderby: [
     {
       column: "time",
+      direction: "DESC",
+    },
+    {
+      column: "id2",
       direction: "DESC",
     },
   ],

--- a/ts/src/core/query/assoc_query.ts
+++ b/ts/src/core/query/assoc_query.ts
@@ -1,16 +1,15 @@
 import {
-  ID,
-  Ent,
-  Viewer,
-  LoadEntOptions,
   EdgeQueryableDataOptions,
-  QueryableDataOptions,
+  Ent,
+  ID,
+  LoadEntOptions,
+  Viewer,
 } from "../base";
+import * as clause from "../clause";
 import { AssocEdge, loadEdgeData, loadEntsList } from "../ent";
 import { AssocEdgeCountLoaderFactory } from "../loaders/assoc_count_loader";
 import { AssocEdgeLoaderFactory } from "../loaders/assoc_edge_loader";
-import { EdgeQuery, BaseEdgeQuery, IDInfo, EdgeQueryFilter } from "./query";
-import * as clause from "../clause";
+import { BaseEdgeQuery, EdgeQuery, EdgeQueryFilter, IDInfo } from "./query";
 
 // TODO no more plurals for privacy reasons?
 export type EdgeQuerySource<
@@ -51,7 +50,15 @@ export abstract class AssocEdgeQueryBase<
       | LoadEntOptions<TDest, TViewer>
       | loaderOptionsFunc<TViewer>,
   ) {
-    super(viewer, "time", "id2");
+    super(viewer, {
+      cursorCol: "id2",
+      orderby: [
+        {
+          column: "time",
+          direction: "DESC",
+        },
+      ],
+    });
   }
 
   private isEdgeQuery(

--- a/ts/src/core/query/assoc_query.ts
+++ b/ts/src/core/query/assoc_query.ts
@@ -57,6 +57,10 @@ export abstract class AssocEdgeQueryBase<
           column: "time",
           direction: "DESC",
         },
+        {
+          column: "id2",
+          direction: "DESC",
+        },
       ],
     });
   }
@@ -306,11 +310,10 @@ export interface EdgeQueryCtr<
   TDest extends Ent,
   TEdge extends AssocEdge,
 > {
-  new (viewer: Viewer, src: EdgeQuerySource<TSource>): EdgeQuery<
-    TSource,
-    TDest,
-    TEdge
-  >;
+  new (
+    viewer: Viewer,
+    src: EdgeQuerySource<TSource>,
+  ): EdgeQuery<TSource, TDest, TEdge>;
 }
 
 class BeforeFilter implements EdgeQueryFilter<AssocEdge> {
@@ -338,7 +341,10 @@ class AfterFilter implements EdgeQueryFilter<AssocEdge> {
 }
 
 class WithinFilter implements EdgeQueryFilter<AssocEdge> {
-  constructor(private start: Date, private end: Date) {}
+  constructor(
+    private start: Date,
+    private end: Date,
+  ) {}
 
   query(options: EdgeQueryableDataOptions): EdgeQueryableDataOptions {
     const cls = clause.And(

--- a/ts/src/core/query/assoc_query_global.test.ts
+++ b/ts/src/core/query/assoc_query_global.test.ts
@@ -1,17 +1,17 @@
-import { Viewer } from "../base";
 import {
   EdgeType,
   FakeUser,
   UserToContactsQuery,
 } from "../../testutils/fake_data/index";
 import { inputs } from "../../testutils/fake_data/test_helpers";
-import { commonTests } from "./shared_test";
-import { assocTests } from "./shared_assoc_test";
-import { loadCustomEdges } from "../ent";
-import { EdgeWithDeletedAt } from "../../testutils/test_edge_global_schema";
-import { convertDate } from "../convert";
 import { MockLogs } from "../../testutils/mock_log";
+import { EdgeWithDeletedAt } from "../../testutils/test_edge_global_schema";
+import { Viewer } from "../base";
 import { And, Eq } from "../clause";
+import { convertDate } from "../convert";
+import { loadCustomEdges } from "../ent";
+import { assocTests } from "./shared_assoc_test";
+import { commonTests } from "./shared_test";
 
 const ml = new MockLogs();
 ml.mock();
@@ -53,6 +53,10 @@ commonTests({
   orderby: [
     {
       column: "time",
+      direction: "DESC",
+    },
+    {
+      column: "id2",
       direction: "DESC",
     },
   ],

--- a/ts/src/core/query/assoc_query_sqlite.test.ts
+++ b/ts/src/core/query/assoc_query_sqlite.test.ts
@@ -1,17 +1,17 @@
-import { Viewer } from "../base";
+import { setupSqlite } from "../../testutils/db/temp_db";
 import {
   EdgeType,
   FakeUser,
   UserToContactsQuery,
 } from "../../testutils/fake_data/index";
-import { commonTests } from "./shared_test";
-import { assocTests } from "./shared_assoc_test";
-import { loadCustomEdges } from "../ent";
-import { EdgeWithDeletedAt } from "../../testutils/test_edge_global_schema";
-import { MockLogs } from "../../testutils/mock_log";
-import { And, Eq } from "../clause";
-import { setupSqlite } from "../../testutils/db/temp_db";
 import { tempDBTables } from "../../testutils/fake_data/test_helpers";
+import { MockLogs } from "../../testutils/mock_log";
+import { EdgeWithDeletedAt } from "../../testutils/test_edge_global_schema";
+import { Viewer } from "../base";
+import { And, Eq } from "../clause";
+import { loadCustomEdges } from "../ent";
+import { assocTests } from "./shared_assoc_test";
+import { commonTests } from "./shared_test";
 
 const ml = new MockLogs();
 ml.mock();
@@ -49,6 +49,10 @@ describe("assoc query desc", () => {
     orderby: [
       {
         column: "time",
+        direction: "DESC",
+      },
+      {
+        column: "id2",
         direction: "DESC",
       },
     ],

--- a/ts/src/core/query/assoc_query_sqlite_global.test.ts
+++ b/ts/src/core/query/assoc_query_sqlite_global.test.ts
@@ -1,18 +1,18 @@
-import { Viewer } from "../base";
+import { convertDate } from "../../core/convert";
+import { setupSqlite } from "../../testutils/db/temp_db";
 import {
   EdgeType,
   FakeUser,
   UserToContactsQuery,
 } from "../../testutils/fake_data/index";
-import { commonTests } from "./shared_test";
-import { assocTests } from "./shared_assoc_test";
-import { loadCustomEdges } from "../ent";
-import { EdgeWithDeletedAt } from "../../testutils/test_edge_global_schema";
 import { inputs, tempDBTables } from "../../testutils/fake_data/test_helpers";
-import { convertDate } from "../../core/convert";
 import { MockLogs } from "../../testutils/mock_log";
+import { EdgeWithDeletedAt } from "../../testutils/test_edge_global_schema";
+import { Viewer } from "../base";
 import { And, Eq } from "../clause";
-import { setupSqlite } from "../../testutils/db/temp_db";
+import { loadCustomEdges } from "../ent";
+import { assocTests } from "./shared_assoc_test";
+import { commonTests } from "./shared_test";
 
 const ml = new MockLogs();
 ml.mock();
@@ -55,6 +55,10 @@ commonTests({
   orderby: [
     {
       column: "time",
+      direction: "DESC",
+    },
+    {
+      column: "id2",
       direction: "DESC",
     },
   ],

--- a/ts/src/core/query/complex_custom_query.test.ts
+++ b/ts/src/core/query/complex_custom_query.test.ts
@@ -1,15 +1,17 @@
-import { v1 } from "uuid";
 import { DateTime } from "luxon";
-import { MockLogs } from "../../testutils/mock_log";
+import { v1 } from "uuid";
+import { AnyEnt, SimpleBuilder } from "../../testutils/builder";
+import { TempDB, integer, table, text, uuid } from "../../testutils/db/temp_db";
+import { randomEmail } from "../../testutils/db/value";
 import {
-  FakeEvent,
-  FakeUser,
-  UserToEventsInNextWeekQuery,
   EdgeType,
-  FakeUserSchema,
-  getNextWeekClause,
+  FakeEvent,
   FakeEventSchema,
+  FakeUser,
+  FakeUserSchema,
+  UserToEventsInNextWeekQuery,
   ViewerWithAccessToken,
+  getNextWeekClause,
 } from "../../testutils/fake_data";
 import {
   addEdge,
@@ -18,20 +20,16 @@ import {
   inputs,
   setupTempDB,
 } from "../../testutils/fake_data/test_helpers";
-import { setLogLevels } from "../logger";
-import { TempDB, integer, table, text, uuid } from "../../testutils/db/temp_db";
-import { buildQuery, reverseOrderBy } from "../query_impl";
-import { loadCustomEnts } from "../ent";
-import * as clause from "../clause";
-import { Data, Ent, Viewer, WriteOperation } from "../base";
-import { CustomClauseQuery } from "./custom_clause_query";
-import { AnyEnt, SimpleBuilder } from "../../testutils/builder";
-import { OrderByOption } from "../query_impl";
+import { MockLogs } from "../../testutils/mock_log";
 import { createRowForTest } from "../../testutils/write";
-import { randomEmail } from "../../testutils/db/value";
+import { Data, Ent, Viewer, WriteOperation } from "../base";
+import * as clause from "../clause";
 import DB from "../db";
+import { loadCustomEnts } from "../ent";
+import { setLogLevels } from "../logger";
+import { OrderByOption, buildQuery, reverseOrderBy } from "../query_impl";
 import { LoggedOutViewer } from "../viewer";
-import { load } from "js-yaml";
+import { CustomClauseQuery } from "./custom_clause_query";
 
 const INTERVAL = 24 * 60 * 60 * 1000;
 
@@ -123,7 +121,11 @@ const getGlobalQuery = (viewer?: Viewer, opts?: Partial<OrderByOption>) => {
       {
         column: "start_time",
         direction: "DESC",
-        dateColumn: true,
+        ...opts,
+      },
+      {
+        column: "id",
+        direction: "DESC",
         ...opts,
       },
     ],
@@ -153,7 +155,11 @@ const getCreatorsOfGlobalEventsInNextWeek = (opts?: Partial<OrderByOption>) => {
       {
         column: "created_at",
         direction: "DESC",
-        dateColumn: true,
+        ...opts,
+      },
+      {
+        column: "id",
+        direction: "DESC",
         ...opts,
       },
     ],
@@ -180,6 +186,10 @@ const getEndTimeGlobalQuery = (
         column: "end_time",
         direction: "DESC",
         ...opts,
+      },
+      {
+        column: "id",
+        direction: opts?.direction ?? "DESC",
       },
     ],
   });
@@ -272,18 +282,23 @@ describe("query for user", () => {
         },
       ],
       limit: 3,
-      clause: clause.And(
+      clause: clause.AndOptional(
         clause.Eq("user_id", user.id),
         clause.GreaterEq("start_time", 1),
         clause.LessEq("start_time", 2),
         // the cursor check
-        clause.PaginationMultipleColsSubQuery(
-          "start_time",
-          "<",
-          FakeEvent.loaderOptions().tableName,
-          "id",
-          4,
-        ),
+        clause.PaginationUnboundColsQuery([
+          {
+            sortCol: "start_time",
+            direction: "DESC",
+            sortValue: 1,
+          },
+          {
+            sortCol: "id",
+            direction: "DESC",
+            sortValue: 4,
+          },
+        ]),
       ),
     });
     expect(query).toEqual(ml.logs[ml.logs.length - 1].query);
@@ -441,13 +456,18 @@ describe("global query", () => {
           clause.LessEq("start_time", 2),
           // the cursor check
           cursor
-            ? clause.PaginationMultipleColsSubQuery(
-                "start_time",
-                "<",
-                FakeEvent.loaderOptions().tableName,
-                "id",
-                4,
-              )
+            ? clause.PaginationUnboundColsQuery([
+                {
+                  sortCol: "start_time",
+                  direction: "DESC",
+                  sortValue: 1,
+                },
+                {
+                  sortCol: "id",
+                  direction: "DESC",
+                  sortValue: 4,
+                },
+              ])
             : undefined,
         ),
       });
@@ -537,13 +557,18 @@ describe("global query", () => {
           clause.LessEq("start_time", 2),
           // the cursor check
           cursor
-            ? clause.PaginationMultipleColsSubQuery(
-                "start_time",
-                ">",
-                FakeEvent.loaderOptions().tableName,
-                "id",
-                4,
-              )
+            ? clause.PaginationUnboundColsQuery([
+                {
+                  sortCol: "start_time",
+                  direction: "ASC",
+                  sortValue: 1,
+                },
+                {
+                  sortCol: "id",
+                  direction: "ASC",
+                  sortValue: 4,
+                },
+              ])
             : undefined,
         ),
       });
@@ -1151,13 +1176,13 @@ describe("joins - products", () => {
           SELECT
       p.id,
           COUNT(DISTINCT o.user_id) AS num_users
-      FROM 
+      FROM
           orders o
-      JOIN 
+      JOIN
           products p ON p.id = o.product_id
-      GROUP BY 
+      GROUP BY
           p.id
-      ORDER BY 
+      ORDER BY
           num_users DESC
       LIMIT 1;
 `);
@@ -1184,7 +1209,6 @@ describe("joins - products", () => {
         `,
         [productId],
       );
-
     expect(r2.rows.length).toEqual(expCount);
 
     // now let's do an ent query for it and the results should be the same
@@ -1197,6 +1221,10 @@ describe("joins - products", () => {
         orderby: [
           {
             column: "name",
+            direction: "DESC",
+          },
+          {
+            column: "id",
             direction: "DESC",
           },
         ],
@@ -1293,13 +1321,13 @@ describe("joins - products", () => {
           SELECT
       u.id,
           COUNT(DISTINCT o.product_id) AS num_products
-      FROM 
+      FROM
           users u
-      JOIN 
+      JOIN
           orders o ON u.id = o.user_id
-      GROUP BY 
+      GROUP BY
           u.id
-      ORDER BY 
+      ORDER BY
           num_products DESC
       LIMIT 1;
 `);
@@ -1372,6 +1400,10 @@ describe("joins - products", () => {
             column: "product_name",
             direction: "DESC",
           },
+          {
+            column: "id",
+            direction: "DESC",
+          },
         ],
         joinBETA: [
           {
@@ -1426,6 +1458,10 @@ describe("joins - products", () => {
             column: "product_name",
             direction: "DESC",
           },
+          {
+            column: "id",
+            direction: "DESC",
+          },
         ],
         joinBETA: [
           {
@@ -1464,29 +1500,29 @@ describe("joins - products", () => {
   test("query products for user in given category", async () => {
     const r = await DB.getInstance().getPool().query(`
 WITH UserCategoryOrders AS (
-    SELECT 
+    SELECT
         u.id as uid,
         c.id as cid,
         COUNT(DISTINCT o.product_id) AS num_products
-    FROM 
+    FROM
         users u
-    JOIN 
+    JOIN
         orders o ON u.id = o.user_id
-    JOIN 
+    JOIN
         products p ON o.product_id = p.id
-    JOIN 
+    JOIN
         categories c ON p.category_id = c.id
-    GROUP BY 
+    GROUP BY
         u.id, c.id
 )
 
-SELECT 
+SELECT
     uid,
     cid,
     num_products
-FROM 
+FROM
     UserCategoryOrders
-ORDER BY 
+ORDER BY
     num_products DESC
 LIMIT 1;
 `);
@@ -1535,6 +1571,10 @@ LIMIT 1;
           {
             // orderby will get the fields alias by default since ordering by column we're selecting from
             column: "product_name",
+            direction: "DESC",
+          },
+          {
+            column: "id",
             direction: "DESC",
           },
         ],
@@ -1592,25 +1632,26 @@ function getPaginationVerifyClauseWithJoin<T extends Ent>(
     const options = q2.__getOptions();
 
     const orderBy = options.orderby!;
-    expect(orderBy.length).toBe(1);
-    const less = orderBy[0].direction === "DESC";
-    orderBy.push({
-      column: "id",
-      direction: orderBy[0].direction,
+    orderBy.forEach((o) => {
+      o.alias =
+        o.alias ??
+        (options.loadEntOptions.disableFieldsAlias
+          ? undefined
+          : options.loadEntOptions.fieldsAlias);
     });
+    expect(orderBy.length).toBe(2);
     let cls = options.clause;
     if (cursor) {
       cls = clause.AndOptional(
         cls,
-        clause.PaginationMultipleColsQuery(
-          // same column from orderBy
-          orderBy[0].column,
-          "id",
-          less,
-          // these 2 values don't matter so just putting whatever
-          new Date().getTime(),
-          4,
-          options.loadEntOptions.fieldsAlias ?? options.loadEntOptions.alias,
+        clause.PaginationUnboundColsQuery(
+          orderBy.map((o) => ({
+            sortCol: o.column,
+            direction: o.direction,
+            // This value doesn't matter so just putting whatever
+            sortValue: "_",
+            overrideAlias: o.alias,
+          })),
         ),
       );
     }

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -17,7 +17,7 @@ import {
 } from "../ent";
 import { OrderBy } from "../query_impl";
 
-import { BaseEdgeQuery, EdgeQueryOptions, IDInfo } from "./query";
+import { BaseEdgeQuery, IDInfo } from "./query";
 
 export interface CustomClauseQueryOptions<
   TDest extends Ent<TViewer>,
@@ -120,11 +120,6 @@ export class CustomClauseQuery<
     return this.options.loadEntOptions.tableName;
   }
 
-  protected includeSortColInCursor(options: EdgeQueryOptions) {
-    // TODO maybe we should just always do this?
-    return options.joinBETA !== undefined && this.sortCol !== this.cursorCol;
-  }
-
   async queryRawCount(): Promise<number> {
     // sqlite needs as count otherwise it returns count(1)
     let fields: SelectBaseDataOptions["fields"] = ["count(1) as count"];
@@ -167,7 +162,7 @@ export class CustomClauseQuery<
     if (!options.orderby) {
       options.orderby = [
         {
-          column: this.getSortCol(),
+          column: this.getCursorCol(),
           direction: this.options.orderByDirection ?? "DESC",
           nullsPlacement: this.options.nullsPlacement,
         },

--- a/ts/src/core/query/custom_query.ts
+++ b/ts/src/core/query/custom_query.ts
@@ -1,12 +1,12 @@
 import {
+  ConfigurableLoaderFactory,
   Data,
+  EdgeQueryableDataOptions,
   Ent,
   ID,
-  EdgeQueryableDataOptions,
   LoadEntOptions,
-  Viewer,
   LoaderFactory,
-  ConfigurableLoaderFactory,
+  Viewer,
 } from "../base";
 import { Clause, getCombinedClause } from "../clause";
 import { applyPrivacyPolicyForRows, getDefaultLimit } from "../ent";
@@ -16,7 +16,7 @@ import {
   RawCountLoader,
 } from "../loaders";
 import { OrderBy } from "../query_impl";
-import { BaseEdgeQuery, IDInfo, EdgeQuery } from "./query";
+import { BaseEdgeQuery, EdgeQuery, IDInfo } from "./query";
 
 // TODO kill this. only used in graphql tests
 export interface CustomEdgeQueryOptionsDeprecated<
@@ -272,7 +272,7 @@ export abstract class CustomEdgeQueryBase<
     if (!options.orderby) {
       options.orderby = [
         {
-          column: this.getSortCol(),
+          column: this.getCursorCol(),
           direction: "DESC",
         },
       ];

--- a/ts/src/core/query/custom_query_live.test.ts
+++ b/ts/src/core/query/custom_query_live.test.ts
@@ -1,12 +1,12 @@
-import { Viewer } from "../base";
 import {
   FakeUser,
   UserToContactsFkeyQuery,
   UserToContactsFkeyQueryAsc,
 } from "../../testutils/fake_data/index";
-import { commonTests } from "./shared_test";
 import { MockLogs } from "../../testutils/mock_log";
+import { Viewer } from "../base";
 import { Eq } from "../clause";
+import { commonTests } from "./shared_test";
 
 const ml = new MockLogs();
 ml.mock();
@@ -23,6 +23,10 @@ describe("custom query", () => {
     orderby: [
       {
         column: "created_at",
+        direction: "DESC",
+      },
+      {
+        column: "id",
         direction: "DESC",
       },
     ],
@@ -42,6 +46,10 @@ describe("custom query ASC", () => {
     orderby: [
       {
         column: "created_at",
+        direction: "ASC",
+      },
+      {
+        column: "id",
         direction: "ASC",
       },
     ],

--- a/ts/src/core/query/custom_query_sqlite.test.ts
+++ b/ts/src/core/query/custom_query_sqlite.test.ts
@@ -1,12 +1,12 @@
-import { Viewer } from "../base";
 import {
   FakeUser,
   UserToContactsFkeyQuery,
   UserToContactsFkeyQueryAsc,
 } from "../../testutils/fake_data/index";
-import { commonTests } from "./shared_test";
 import { MockLogs } from "../../testutils/mock_log";
+import { Viewer } from "../base";
 import { Eq } from "../clause";
+import { commonTests } from "./shared_test";
 
 const ml = new MockLogs();
 ml.mock();
@@ -23,7 +23,10 @@ describe("custom query", () => {
     orderby: [
       {
         column: "created_at",
-        // dateColumn: true,
+        direction: "DESC",
+      },
+      {
+        column: "id",
         direction: "DESC",
       },
     ],
@@ -43,7 +46,10 @@ describe("custom query asc", () => {
     orderby: [
       {
         column: "created_at",
-        dateColumn: true,
+        direction: "ASC",
+      },
+      {
+        column: "id",
         direction: "ASC",
       },
     ],

--- a/ts/src/core/query/custom_query_sqlite_global.test.ts
+++ b/ts/src/core/query/custom_query_sqlite_global.test.ts
@@ -1,16 +1,14 @@
-import { Context, Viewer } from "../base";
 import {
   FakeContact,
   FakeContactSchemaWithDeletedAt,
   FakeUser,
-  UserToContactsFkeyQuery,
-  UserToContactsFkeyQueryAsc,
   UserToContactsFkeyQueryDeletedAt,
   UserToContactsFkeyQueryDeletedAtAsc,
 } from "../../testutils/fake_data/index";
-import { commonTests } from "./shared_test";
 import { MockLogs } from "../../testutils/mock_log";
+import { Context, Viewer } from "../base";
 import * as clause from "../clause";
+import { commonTests } from "./shared_test";
 
 const ml = new MockLogs();
 ml.mock();
@@ -28,6 +26,10 @@ describe("custom query", () => {
     orderby: [
       {
         column: "created_at",
+        direction: "DESC",
+      },
+      {
+        column: "id",
         direction: "DESC",
       },
     ],
@@ -52,6 +54,10 @@ describe("custom query ASC", () => {
     orderby: [
       {
         column: "created_at",
+        direction: "ASC",
+      },
+      {
+        column: "id",
         direction: "ASC",
       },
     ],

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -97,13 +97,15 @@ interface validCursorOptions {
   keys: string[];
 }
 
+export type CursorKeyValues = [key: string, value: string | number | null][];
+
 function translateCursorToKeyValues(
   cursor: string,
   opts: validCursorOptions,
-): [key: string, value: string | number | null][] {
+): CursorKeyValues {
   const { keys } = opts;
   const decoded = atob(cursor);
-  let cursorData: [string, string | number | null][] = [];
+  let cursorData: CursorKeyValues = [];
   try {
     cursorData = JSON.parse(decoded);
   } catch (error) {
@@ -145,7 +147,7 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
   private edgeQuery: BaseEdgeQuery<Ent, Ent, T>;
   private pageMap: Map<ID, PaginationInfo> = new Map();
   private usedQuery = false;
-  private cursorKeyValues: [key: string, value: string | number | null][] = [];
+  private cursorKeyValues: CursorKeyValues = [];
 
   constructor(private options: FirstFilterOptions<T>) {
     assertPositive(options.limit);
@@ -154,6 +156,7 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
       this.cursorKeyValues = translateCursorToKeyValues(options.after, {
         keys: options.cursorKeys,
       });
+      // The offset is the value of the last key in the cursor, which is the primary key for the table
       this.offset =
         this.cursorKeyValues[this.cursorKeyValues.length - 1][1] ?? undefined;
     }
@@ -267,7 +270,7 @@ class LastFilter<T extends Data> implements EdgeQueryFilter<T> {
   private offset: string | number | undefined;
   private pageMap: Map<ID, PaginationInfo> = new Map();
   private edgeQuery: BaseEdgeQuery<Ent, Ent, T>;
-  private cursorKeyValues: [key: string, value: string | number | null][] = [];
+  private cursorKeyValues: CursorKeyValues = [];
 
   constructor(private options: LastFilterOptions<T>) {
     assertPositive(options.limit);

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -143,6 +143,9 @@ interface LastFilterOptions<T extends Data> extends FilterOptions<T> {
 const orderbyRegex = new RegExp(/([0-9a-z_]+)[ ]?([0-9a-z_]+)?/i);
 
 class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
+  /**
+   * The offset is the value of the last key in the cursor, which is the primary key for the table
+   */
   private offset: string | number | undefined;
   private edgeQuery: BaseEdgeQuery<Ent, Ent, T>;
   private pageMap: Map<ID, PaginationInfo> = new Map();
@@ -156,7 +159,6 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
       this.cursorKeyValues = translateCursorToKeyValues(options.after, {
         keys: options.cursorKeys,
       });
-      // The offset is the value of the last key in the cursor, which is the primary key for the table
       this.offset =
         this.cursorKeyValues[this.cursorKeyValues.length - 1][1] ?? undefined;
     }
@@ -267,6 +269,9 @@ class FirstFilter<T extends Data> implements EdgeQueryFilter<T> {
 // TODO LastFilter same behavior as FirstFilter
 // TODO can we share so we don't keep needing to change in both
 class LastFilter<T extends Data> implements EdgeQueryFilter<T> {
+  /**
+   * The offset is the value of the last key in the cursor, which is the primary key for the table
+   */
   private offset: string | number | undefined;
   private pageMap: Map<ID, PaginationInfo> = new Map();
   private edgeQuery: BaseEdgeQuery<Ent, Ent, T>;

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -131,7 +131,7 @@ function translateCursorToKeyValues(
   const values: [key: string, value: string | number | null][] = [];
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    let keyPart = parts[i * 2];
+    const keyPart = parts[i * 2];
     if (key !== keyPart) {
       throw new Error(
         `invalid cursor ${cursor} passed. expected ${key}. got ${keyPart} as key of field`,
@@ -359,6 +359,7 @@ class LastFilter<T extends Data> implements EdgeQueryFilter<T> {
       column: this.options.cursorCol,
       direction: this.options.orderby[0].direction,
     });
+    this.options.orderby = reverseOrderBy(this.options.orderby);
 
     if (this.offset) {
       if (this.offset) {
@@ -369,7 +370,7 @@ class LastFilter<T extends Data> implements EdgeQueryFilter<T> {
         options.clause = clause.AndOptional(
           options.clause,
           clause.PaginationUnboundColsQuery(
-            reverseOrderBy(this.options.orderby).map((orderBy) => ({
+            this.options.orderby.map((orderBy) => ({
               sortCol: orderBy.column,
               sortValue: keyValuePairs[orderBy.column],
               direction: orderBy.direction,

--- a/ts/src/core/query/unique_col_query.test.ts
+++ b/ts/src/core/query/unique_col_query.test.ts
@@ -12,16 +12,7 @@ import {
 } from "../../testutils/fake_data/test_helpers";
 import { MockLogs } from "../../testutils/mock_log";
 import { Viewer } from "../base";
-import {
-  And,
-  AndOptional,
-  ClauseGroup,
-  Eq,
-  Greater,
-  Less,
-  NotEq,
-  Or,
-} from "../clause";
+import { And, AndOptional, Eq, Greater, Less, NotEq, Or } from "../clause";
 import { getDefaultLimit } from "../ent";
 import { setLogLevels } from "../logger";
 import { buildQuery } from "../query_impl";
@@ -114,11 +105,9 @@ function tests(
                   Less("canonical_name", canonicalName),
                   NotEq("canonical_name", null),
                 )
-              : ClauseGroup(
-                  Or(
-                    Greater("canonical_name", canonicalName),
-                    Eq("canonical_name", null),
-                  ),
+              : Or(
+                  Greater("canonical_name", canonicalName),
+                  Eq("canonical_name", null),
                 )
             : undefined,
         ),

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -5,12 +5,6 @@ export interface OrderByOption {
   direction: "ASC" | "DESC";
   alias?: string;
   nullsPlacement?: "first" | "last";
-  // is this column a date/time column?
-  // needed to know if we create a cursor based on this column to conver to timestamp and ISO string for
-  // comparison
-  // maybe eventually want a more generic version of this but for now this suffices
-  // @deprecated You no longer need to specify if a column is a date column
-  dateColumn?: boolean;
 }
 
 export type OrderBy = OrderByOption[];

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -9,6 +9,7 @@ export interface OrderByOption {
   // needed to know if we create a cursor based on this column to conver to timestamp and ISO string for
   // comparison
   // maybe eventually want a more generic version of this but for now this suffices
+  // @deprecated You no longer need to specify if a column is a date column
   dateColumn?: boolean;
 }
 

--- a/ts/src/graphql/query/shared_edge_connection.ts
+++ b/ts/src/graphql/query/shared_edge_connection.ts
@@ -121,15 +121,16 @@ export const commonTests = <TEdge extends Data>(
     if (isCustomQuery(q)) {
       opts = {
         row: contacts[idx],
-        keys: ["id"],
+        cursorKeys: ["created_at", "id"],
+        rowKeys: ["createdAt", "id"],
       };
     } else {
       // for assoc queries, we're getting the value from 'id' field but the edge
       // is from assoc_edge table id2 field and so cursor takes it from there
       opts = {
         row: contacts[idx],
-        keys: ["id2"],
-        cursorKeys: ["id"],
+        cursorKeys: ["time", "id2"],
+        rowKeys: ["createdAt", "id"],
       };
     }
     return getCursor(opts);

--- a/ts/src/testutils/db_mock.ts
+++ b/ts/src/testutils/db_mock.ts
@@ -1,11 +1,11 @@
-import { v4 as uuidv4 } from "uuid";
-import { Pool, PoolClient } from "pg";
 import { mocked } from "jest-mock";
-import { ID, Data } from "../core/base";
+import { Pool, PoolClient } from "pg";
+import { v4 as uuidv4 } from "uuid";
+import { Data, ID } from "../core/base";
 import { Clause } from "../core/clause";
 
-import { performQuery, queryResult, getDataToReturn } from "./parse_sql";
 import { MockLogs } from "./mock_log";
+import { getDataToReturn, performQuery, queryResult } from "./parse_sql";
 
 const eventEmitter = {
   on: jest.fn(),
@@ -320,6 +320,16 @@ export class QueryRecorder {
         totalCount: 1,
         idleCount: 1,
         waitingCount: 1,
+        expiredCount: 1,
+        ending: false,
+        ended: false,
+        options: {
+          max: 10,
+          maxUses: 10,
+          allowExitOnIdle: false,
+          maxLifetimeSeconds: 100,
+          idleTimeoutMillis: 100,
+        },
         connect: async (): Promise<PoolClient> => {
           return {
             connect: jest.fn(),
@@ -335,6 +345,8 @@ export class QueryRecorder {
             resumeDrain: jest.fn(),
             escapeIdentifier: jest.fn(),
             escapeLiteral: jest.fn(),
+            setTypeParser: jest.fn(),
+            getTypeParser: jest.fn(),
 
             // EventEmitter
             ...eventEmitter,

--- a/ts/src/testutils/db_mock.ts
+++ b/ts/src/testutils/db_mock.ts
@@ -320,16 +320,6 @@ export class QueryRecorder {
         totalCount: 1,
         idleCount: 1,
         waitingCount: 1,
-        expiredCount: 1,
-        ending: false,
-        ended: false,
-        options: {
-          max: 10,
-          maxUses: 10,
-          allowExitOnIdle: false,
-          maxLifetimeSeconds: 100,
-          idleTimeoutMillis: 100,
-        },
         connect: async (): Promise<PoolClient> => {
           return {
             connect: jest.fn(),
@@ -345,8 +335,6 @@ export class QueryRecorder {
             resumeDrain: jest.fn(),
             escapeIdentifier: jest.fn(),
             escapeLiteral: jest.fn(),
-            setTypeParser: jest.fn(),
-            getTypeParser: jest.fn(),
 
             // EventEmitter
             ...eventEmitter,

--- a/ts/src/testutils/ent-graphql-tests/index.ts
+++ b/ts/src/testutils/ent-graphql-tests/index.ts
@@ -1,30 +1,31 @@
 // NB: this is copied from ent-graphql-tests package until I have time to figure out how to share code here effectively
 // the circular dependencies btw this package and ent-graphql-tests seems to imply something needs to change
 import express, { Express, RequestHandler } from "express";
+import * as fs from "fs";
 import {
-  getGraphQLParameters,
-  processRequest,
-  ExecutionContext,
-  sendResult,
-} from "graphql-helix";
-import { Viewer } from "../../core/base";
-import {
-  GraphQLSchema,
+  GraphQLArgument,
+  GraphQLField,
+  GraphQLFieldMap,
+  GraphQLList,
   GraphQLObjectType,
   GraphQLScalarType,
-  isWrappingType,
-  GraphQLArgument,
-  GraphQLList,
-  isScalarType,
+  GraphQLSchema,
   GraphQLType,
-  GraphQLFieldMap,
-  GraphQLField,
   isEnumType,
+  isScalarType,
+  isWrappingType,
 } from "graphql";
-import { buildContext, registerAuthHandler } from "../../auth";
+import {
+  ExecutionContext,
+  getGraphQLParameters,
+  processRequest,
+  sendResult,
+} from "graphql-helix";
+import { IncomingHttpHeaders } from "http";
 import supertest from "supertest";
-import * as fs from "fs";
 import { inspect } from "util";
+import { buildContext, registerAuthHandler } from "../../auth";
+import { Viewer } from "../../core/base";
 
 function server(config: queryConfig): Express {
   const viewer = config.viewer;
@@ -127,7 +128,7 @@ function makeGraphQLRequest(
   if (files.size) {
     let ret = test
       .post(config.graphQLPath || "/graphql")
-      .set(config.headers || {});
+      .set((config.headers || {}) as IncomingHttpHeaders);
 
     ret.field(
       "operations",
@@ -161,7 +162,7 @@ function makeGraphQLRequest(
       test,
       test
         .post(config.graphQLPath || "/graphql")
-        .set(config.headers || {})
+        .set((config.headers || {}) as IncomingHttpHeaders)
         .send({
           query: query,
           variables: JSON.stringify(variables),

--- a/ts/src/testutils/fake_data/user_query.ts
+++ b/ts/src/testutils/fake_data/user_query.ts
@@ -1,5 +1,4 @@
 import { clear } from "jest-date-mock";
-import { Interval } from "luxon";
 import { getLoaderOptions } from ".";
 import { Data, Ent, ID, Viewer } from "../../core/base";
 import * as clause from "../../core/clause";
@@ -503,11 +502,11 @@ export const getNextWeekClause = (): clause.Clause => {
   clear();
   const start = MockDate.getDate();
   // 7 days
-  const end = Interval.after(start, 86400 * 1000 * 7)?.end?.toUTC();
+  const end = new Date(start.getTime() + 86400 * 1000 * 7);
 
   return clause.And(
     clause.GreaterEq("start_time", start.toISOString()),
-    clause.LessEq("start_time", end),
+    clause.LessEq("start_time", end.toISOString()),
   );
 };
 

--- a/ts/src/testutils/fake_data/user_query.ts
+++ b/ts/src/testutils/fake_data/user_query.ts
@@ -1,32 +1,32 @@
+import { clear } from "jest-date-mock";
+import { Interval } from "luxon";
+import { getLoaderOptions } from ".";
 import { Data, Ent, ID, Viewer } from "../../core/base";
-import { CustomEdgeQueryBase } from "../../core/query/custom_query";
-import { AssocEdge } from "../../core/ent";
 import * as clause from "../../core/clause";
+import { AssocEdge } from "../../core/ent";
+import { AssocEdgeCountLoaderFactory } from "../../core/loaders/assoc_count_loader";
+import { AssocEdgeLoaderFactory } from "../../core/loaders/assoc_edge_loader";
+import { QueryLoaderFactory } from "../../core/loaders/query_loader";
+import { RawCountLoaderFactory } from "../../core/loaders/raw_count_loader";
+import { AllowIfViewerPrivacyPolicy } from "../../core/privacy";
 import {
   AssocEdgeQueryBase,
   EdgeQuerySource,
 } from "../../core/query/assoc_query";
+import { CustomEdgeQueryBase } from "../../core/query/custom_query";
+import { MockDate } from "./../mock_date";
+import { contactLoader } from "./fake_contact";
 import {
   EdgeType,
-  FakeUser,
-  FakeEvent,
-  FakeContact,
   EventToAttendeesQuery,
   EventToDeclinedQuery,
   EventToHostsQuery,
   EventToInvitedQuery,
   EventToMaybeQuery,
+  FakeContact,
+  FakeEvent,
+  FakeUser,
 } from "./internal";
-import { RawCountLoaderFactory } from "../../core/loaders/raw_count_loader";
-import { AssocEdgeCountLoaderFactory } from "../../core/loaders/assoc_count_loader";
-import { AssocEdgeLoaderFactory } from "../../core/loaders/assoc_edge_loader";
-import { contactLoader } from "./fake_contact";
-import { clear } from "jest-date-mock";
-import { Interval } from "luxon";
-import { QueryLoaderFactory } from "../../core/loaders/query_loader";
-import { MockDate } from "./../mock_date";
-import { getLoaderOptions } from ".";
-import { AllowIfViewerPrivacyPolicy } from "../../core/privacy";
 
 export class UserToContactsQuery extends AssocEdgeQueryBase<
   FakeUser,
@@ -503,9 +503,7 @@ export const getNextWeekClause = (): clause.Clause => {
   clear();
   const start = MockDate.getDate();
   // 7 days
-  const end = Interval.after(start, 86400 * 1000 * 7)
-    .end.toUTC()
-    .toISO();
+  const end = Interval.after(start, 86400 * 1000 * 7)?.end?.toUTC();
 
   return clause.And(
     clause.GreaterEq("start_time", start.toISOString()),


### PR DESCRIPTION
When using `BaseEdgeQuery`, if you are sorting over multiple non-unique columns, the pagination was coming back incorrectly because the cursor was only storing a single sort column (plus the cursor key, usually the primary key uuid). This changes queries to allow for any number of sort columns and to run through the same SQL-generation despite the amount or type of sorting going on.

Fixes #1750 and #1751