### PR TITLE
port .swcrc logic into central location and reuse

### DIFF
--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -789,34 +789,8 @@ func ParseRawCustomData(processor *codegen.Processor, fromTest bool) ([]byte, er
 	cmdInfo := cmd.GetCommandInfo(processor.Config.GetAbsPathToRoot(), fromTest)
 
 	if cmdInfo.UseSwc {
-		swcPath := filepath.Join(processor.Config.GetAbsPathToRoot(), ".swcrc")
-		_, err := os.Stat(swcPath)
-		if err != nil && os.IsNotExist(err) {
-			// temp .swcrc file to be used
-			// probably need this for parse_ts too
-			err = os.WriteFile(swcPath, []byte(`{
-		"$schema": "http://json.schemastore.org/swcrc",
-    "jsc": {
-        "parser": {
-            "syntax": "typescript",
-            "decorators": true
-        },
-        "target": "es2020",
-        "keepClassNames":true,
-        "transform": {
-            "decoratorVersion": "2022-03"
-        }
-    },
-		"module": {
-			"type": "commonjs",
-		}
-}
-				`), os.ModePerm)
-
-			if err == nil {
-				defer os.Remove(".swcrc")
-			}
-		}
+		cleanup := cmdInfo.MaybeSetupSwcrc(processor.Config.GetAbsPathToRoot())
+		defer cleanup()
 	}
 
 	if fromTest {

--- a/internal/schema/input/parse_ts.go
+++ b/internal/schema/input/parse_ts.go
@@ -50,9 +50,14 @@ func GetRawSchema(dirPath string, fromTest bool) ([]byte, error) {
 	execCmd.Stderr = os.Stderr
 	execCmd.Env = cmdInfo.Env
 
+	if cmdInfo.UseSwc {
+		cleanup := cmdInfo.MaybeSetupSwcrc(dirPath)
+		defer cleanup()
+	}
+
 	// flags not showing up in command but my guess is it's function of what's passed to process.argv
 	if err := execCmd.Run(); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error getting raw schema")
 	}
 
 	return out.Bytes(), nil


### PR DESCRIPTION
pulled from https://github.com/lolopinto/ent/pull/1858/files

was missing in parse_schema path 