### PR TITLE
Optimize Docker image workflow cache

### DIFF
--- a/.github/workflows/new_docker_image.yml
+++ b/.github/workflows/new_docker_image.yml
@@ -33,6 +33,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
+    # Use the GitHub Actions cache for Docker layers to avoid repeatedly
+    # pushing/pulling cache data from the registry during CI runs.
+    - name: Configure Build Cache
+      env:
+        CACHE_TYPE: gha
+      run: echo "CACHE_TYPE=${CACHE_TYPE}" >> $GITHUB_ENV
+
     - name: docker login
       env:
         DOCKER_TOKEN: ${{secrets.DOCKER_TOKEN}}

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -53,6 +53,17 @@ func do(version int) error {
 	wg.Add(len(SUFFIXES))
 	var serr syncerr.Error
 
+	builder, err := createBuilder()
+	if err != nil {
+		return errors.Wrap(err, "error creating docker builder")
+	}
+
+	defer func() {
+		if err := removeBuilder(builder); err != nil {
+			log.Println(err, "error cleaning up docker builder instance")
+		}
+	}()
+
 	for j := range SUFFIXES {
 		go func(j int) {
 			suffix := SUFFIXES[j]
@@ -62,7 +73,7 @@ func do(version int) error {
 				Suffix:            suffix,
 				TsentVersion:      TSENT_VERSION,
 				AutoSchemaVersion: AUTO_SCHEMA_VERSION,
-			}, &wg)
+			}, builder, &wg)
 			serr.Append(err)
 		}(j)
 	}
@@ -93,6 +104,25 @@ func (d *dockerfileData) Development() bool {
 	return d.Suffix == "dev"
 }
 
+func createBuilder() (string, error) {
+	var out bytes.Buffer
+	buildCommand := exec.Command("docker", "buildx", "create", "--use")
+	buildCommand.Stderr = os.Stderr
+	buildCommand.Stdout = &out
+	if err := buildCommand.Run(); err != nil {
+		return "", errors.Wrap(err, "error creating builder")
+	}
+
+	return strings.TrimSpace(out.String()), nil
+}
+
+func removeBuilder(builder string) error {
+	cleanupCmd := exec.Command("docker", "buildx", "rm", builder)
+	cleanupCmd.Stdout = os.Stdout
+	cleanupCmd.Stderr = os.Stderr
+	return cleanupCmd.Run()
+}
+
 func createDockerfile(path string, d dockerfileData) error {
 	cfg, err := codegen.NewConfig("src/schema", "")
 	if err != nil {
@@ -118,8 +148,37 @@ func getTags(d dockerfileData) []string {
 	return ret
 }
 
-func getCommandArgs(d dockerfileData, builder string) []string {
+func getCacheType() string {
+	cacheType := os.Getenv("CACHE_TYPE")
+	if cacheType == "gha" {
+		return cacheType
+	}
+
+	return "registry"
+}
+
+func getCacheArgs(d dockerfileData, cacheType string) []string {
 	cacheTag := fmt.Sprintf("%s:cache-nodejs%d", REPO, d.NodeVersion)
+	scope := fmt.Sprintf("cache-nodejs-%d", d.NodeVersion)
+	if cacheType == "gha" {
+		return []string{
+			"--cache-from",
+			fmt.Sprintf("type=gha,scope=%s", scope),
+			"--cache-to",
+			fmt.Sprintf("type=gha,mode=max,scope=%s", scope),
+		}
+	}
+
+	return []string{
+		"--cache-from",
+		fmt.Sprintf("type=registry,ref=%s", cacheTag),
+		"--cache-to",
+		fmt.Sprintf("type=registry,mode=max,ref=%s", cacheTag),
+	}
+}
+
+func getCommandArgs(d dockerfileData, builder string) []string {
+	cacheType := getCacheType()
 	tags := getTags(d)
 	ret := []string{
 		"buildx",
@@ -128,12 +187,10 @@ func getCommandArgs(d dockerfileData, builder string) []string {
 		builder,
 		"--platform",
 		strings.Join(PLATFORMS, ","),
-		"--cache-from",
-		fmt.Sprintf("type=registry,ref=%s", cacheTag),
-		"--cache-to",
-		fmt.Sprintf("type=registry,mode=max,ref=%s", cacheTag),
-		"--push",
 	}
+
+	ret = append(ret, getCacheArgs(d, cacheType)...)
+	ret = append(ret, "--push")
 
 	for _, tag := range tags {
 		ret = append(ret, "--tag")
@@ -144,7 +201,7 @@ func getCommandArgs(d dockerfileData, builder string) []string {
 	return ret
 }
 
-func run(d dockerfileData, wg *sync.WaitGroup) error {
+func run(d dockerfileData, builder string, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	dir := fmt.Sprintf("node_%d_%s", d.NodeVersion, d.Suffix)
 	info, err := os.Stat(dir)
@@ -170,27 +227,6 @@ func run(d dockerfileData, wg *sync.WaitGroup) error {
 	if err != nil {
 		return errors.Wrap(err, "error creating docker file")
 	}
-
-	// create new builder to user here
-	var out bytes.Buffer
-	buildCommand := exec.Command("docker", "buildx", "create", "--use")
-	buildCommand.Stderr = os.Stderr
-	buildCommand.Stdout = &out
-	if err := buildCommand.Run(); err != nil {
-		return errors.Wrap(err, "error creating builder")
-	}
-	builder := strings.TrimSpace(out.String())
-
-	defer func() {
-		// remove builder
-		cleanupCmd := exec.Command("docker", "buildx", "rm", builder)
-		cleanupCmd.Stdout = os.Stdout
-		cleanupCmd.Stderr = os.Stderr
-		err = cleanupCmd.Run()
-		if err != nil {
-			log.Println(err, "error cleaning up docker builder instance")
-		}
-	}()
 
 	// build image
 	cmd := exec.Command("docker", getCommandArgs(d, builder)...)


### PR DESCRIPTION
## Summary
- configure the Docker image workflow to use GitHub Actions cache settings
- reuse a single buildx builder per run and allow build cache type selection for faster Docker builds

## Testing
- go test ./release_image -run TestNonexistent -count=0 (hangs locally; interrupted)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927af6cdf9483258fca16842a6590d2)