### PR TITLE
Add ty checks for auto_schema helpers

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -63,6 +63,14 @@ jobs:
       run: |
         pipenv install --deploy --dev
 
+    - name: Install ty
+      run: |
+        python -m pip install ty==0.0.28
+
+    - name: Run ty
+      run: |
+        ty check --python "$(pipenv --py)"
+
     - name: run test suite
       run: |
         pipenv run pytest -svv

--- a/python/auto_schema/CONTRIBUTING.MD
+++ b/python/auto_schema/CONTRIBUTING.MD
@@ -5,6 +5,8 @@ make changes to code and then run as following:
 * `pipenv shell` to get into virtual environment.
 * run a test: `python -m pytest -k test_enum_type`
 * run all tests: `python -m pytest`
+* install the incremental type checker once: `python -m pip install ty==0.0.28`
+* run the incremental type check: `ty check --python "$(pipenv --py)"`
 
 * `pip3 install pipenv` to install `pipenv`
 * `pipenv install --dev` to install dependencies from `Pipfile`

--- a/python/auto_schema/auto_schema/change.py
+++ b/python/auto_schema/auto_schema/change.py
@@ -2,10 +2,9 @@ from typing import TypedDict
 from .change_type import ChangeType
 
 
-class Change(TypedDict):
+class Change(TypedDict, total=False):
     change: ChangeType
     desc: str
-    # optional
     col: str
     index: str
     edge_type: str

--- a/python/auto_schema/auto_schema/clearable_string_io.py
+++ b/python/auto_schema/auto_schema/clearable_string_io.py
@@ -1,24 +1,26 @@
 import io
 
-class ClearableStringIO(io.StringIO):
-    
-    def __init__(self, initial_value: str | None = None, newline: str | None = None) -> None:
-        super().__init__(initial_value, newline)
-        self.chunks = []
-        if initial_value is not None:
-            self.chunks.append(initial_value)
-    
-    def write(self, s):
-        super().write(s)
-        self.chunks.append(s)
 
-    def clear(self):
+class ClearableStringIO(io.StringIO):
+    def __init__(self, initial_value: str | None = None, newline: str | None = None) -> None:
+        normalized_initial_value = initial_value or ""
+        super().__init__(normalized_initial_value, newline)
+        self.chunks: list[str] = []
+        if normalized_initial_value:
+            self.chunks.append(normalized_initial_value)
+
+    def write(self, s: str) -> int:
+        written = super().write(s)
+        self.chunks.append(s)
+        return written
+
+    def clear(self) -> None:
         self.seek(0)
-        self.truncate(0) 
+        self.truncate(0)
         self.chunks = []
-        
-    def chunk_len(self):
+
+    def chunk_len(self) -> int:
         return len(self.chunks)
-    
-    def get_chunk(self, i):
+
+    def get_chunk(self, i: int) -> str:
         return self.chunks[i]

--- a/python/auto_schema/auto_schema/config.py
+++ b/python/auto_schema/auto_schema/config.py
@@ -1,8 +1,10 @@
+from typing import Any, TextIO
+
 # set in runner.Runner.__init__
-metadata = None
-connection = None
+metadata: Any | None = None
+connection: Any | None = None
 # set in Runner.progressive_sql
-output_buffer = None
+output_buffer: TextIO | None = None
 # dev branch schema support (set in Runner.__init__)
-schema_name = None
-include_public = None
+schema_name: str | None = None
+include_public: bool | None = None

--- a/python/auto_schema/auto_schema/csv.py
+++ b/python/auto_schema/auto_schema/csv.py
@@ -1,8 +1,11 @@
-def render_list_csv(l):
-    str_l = [f"'{v}'" for v in l]
+from collections.abc import Iterable
+
+
+def render_list_csv(values: Iterable[object]) -> str:
+    str_l = [f"'{v}'" for v in values]
     return ", ".join(str_l)
 
 
-def render_list_csv_as_list(l):
-    str_l = [f"'{v}'" for v in l]
+def render_list_csv_as_list(values: Iterable[object]) -> str:
+    str_l = [f"'{v}'" for v in values]
     return f"[{', '.join(str_l)}]"

--- a/python/auto_schema/auto_schema/util/os.py
+++ b/python/auto_schema/auto_schema/util/os.py
@@ -1,24 +1,26 @@
 import os
+from collections.abc import AsyncGenerator
 
-async def async_walk(dir):
-  dirs, nondirs = [], []
-  for entry in os.scandir(dir):
-      if entry.is_dir():
-          dirs.append(entry.name)
-      else:
-          nondirs.append(entry.name)
 
-  yield dir, dirs, nondirs
+async def async_walk(root_dir: str) -> AsyncGenerator[tuple[str, list[str], list[str]], None]:
+    dirs: list[str] = []
+    nondirs: list[str] = []
+    for entry in os.scandir(root_dir):
+        if entry.is_dir():
+            dirs.append(entry.name)
+        else:
+            nondirs.append(entry.name)
 
-  for d in dirs:
-      path = os.path.join(dir, d)
-      async for x in async_walk(path):
-          yield x
-            
-            
-            
-async def delete_py_files(dir):
-    async for root, dirs, files in async_walk(dir):
+    yield root_dir, dirs, nondirs
+
+    for dir_name in dirs:
+        path = os.path.join(root_dir, dir_name)
+        async for child in async_walk(path):
+            yield child
+
+
+async def delete_py_files(root_dir: str) -> None:
+    async for root, _, files in async_walk(root_dir):
         for file in files:
             if file.endswith('.py'):
                 file_path = os.path.join(root, file)

--- a/python/auto_schema/ty.toml
+++ b/python/auto_schema/ty.toml
@@ -1,0 +1,12 @@
+[environment]
+python-version = "3.11"
+
+[src]
+include = [
+  "auto_schema/change.py",
+  "auto_schema/change_type.py",
+  "auto_schema/clearable_string_io.py",
+  "auto_schema/config.py",
+  "auto_schema/csv.py",
+  "auto_schema/util/os.py",
+]


### PR DESCRIPTION
## Summary
- add an incremental `ty` type-check step to the Python auto_schema CI workflow
- add scoped `ty` configuration for low-coupling auto_schema helper modules
- tighten helper annotations so the new check passes cleanly

## Testing
- `/tmp/ent-ty/bin/ty check --python "$(pipenv --py)"`
- `cd python/auto_schema && pipenv run pytest -q tests/renderers_test.py tests/ops_sql_test.py`