### PR TITLE
Fix transformWrite struct input shape regression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,50 @@
 This file documents behavior expectations for dev branch schema support.
 It is intended for contributors and automation working on this repo.
 
+## Local testing
+
+When changing code in `ts/`, validate in this order:
+
+1. Run targeted package tests in `ts/` first.
+2. If the change affects runtime behavior consumed by examples, rebuild `ts/dist`
+   via `cd ts && npm run compile`.
+3. Run only the relevant example tests while iterating.
+4. Before landing broader runtime changes, run the full example matrix below.
+
+Package-level commands:
+
+- `cd ts && npm test -- --runInBand`
+- `cd ts && npm test -- src/action/orchestrator.test.ts --runInBand`
+- `cd ts && npm test -- src/action/transformed_orchestrator.test.ts --runInBand`
+- `cd ts && npm run compile`
+
+Example test matrix:
+
+- `examples/simple`
+  `cd examples/simple && POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres npm test -- --runInBand`
+- `examples/ent-local-guide`
+  `cd examples/ent-local-guide && npm run db:up && POSTGRES_TEST_DB=ent-local-guide POSTGRES_PORT=54329 npm test -- --runInBand`
+- `examples/ent-semantic-notes`
+  `cd examples/ent-semantic-notes && npm run db:up && POSTGRES_TEST_DB=ent_semantic_notes POSTGRES_PORT=54330 npm test -- --runInBand`
+- `examples/todo-sqlite`
+  `cd examples/todo-sqlite && npm test -- --runInBand`
+
+How examples pick up local `@snowtop/ent` changes:
+
+- `examples/ent-local-guide` and `examples/ent-semantic-notes` already map
+  `@snowtop/ent` to local `../../ts/src` in Jest, so their tests exercise local
+  TS changes directly.
+- `examples/simple` and `examples/todo-sqlite` still use the installed package
+  by default. Their normal `npm test` runs do not prove local `ts/` changes.
+- When validating local `ts/` changes against `simple` or `todo-sqlite`, use a
+  temporary Jest override (or equivalent local-only config change) that maps:
+  - `^@snowtop/ent$` -> `<rootDir>/../../ts/src/index.ts`
+  - `^@snowtop/ent/(.*)$` -> `<rootDir>/../../ts/src/$1`
+- Do not rely on a published package version for local validation of runtime
+  fixes. If a temporary example-only test override is added for local
+  verification, revert it before finishing unless updating the example test
+  wiring is part of the intended change.
+
 ## Dev schema isolation (Postgres only)
 
 Default contract:

--- a/examples/simple/src/ent/tests/transform_write_struct_input.test.ts
+++ b/examples/simple/src/ent/tests/transform_write_struct_input.test.ts
@@ -1,0 +1,100 @@
+import type { Data } from "@snowtop/ent";
+import {
+  SQLStatementOperation,
+  type TransformedUpdateOperation,
+  type UpdateOperation,
+} from "@snowtop/ent/schema";
+import { User } from "..";
+import { NotifType } from "../generated/types";
+import CreateUserAction, {
+  type UserCreateInput,
+} from "../user/actions/create_user_action";
+import type { UserBuilder } from "../generated/user/actions/user_builder";
+import { LoggedOutExampleViewer } from "../../viewer/viewer";
+import { random, randomEmail, randomPhoneNumber } from "../../util/random";
+
+test.skip(
+  "transformWrite keeps generated struct list input in trigger shape",
+  async () => {
+    const viewer = new LoggedOutExampleViewer();
+    const existing = await CreateUserAction.create(viewer, {
+      firstName: "Existing",
+      lastName: "User",
+      emailAddress: randomEmail(),
+      phoneNumber: randomPhoneNumber(),
+      password: random(),
+    }).saveX();
+
+    const prefsList = [
+      {
+        finishedNux: true,
+        notifTypes: [NotifType.EMAIL],
+      },
+      {
+        finishedNux: false,
+        notifTypes: [NotifType.MOBILE],
+      },
+    ];
+
+    let triggerInput: UserCreateInput | undefined;
+    let builderInput: Data | undefined;
+    let builderGetter: UserCreateInput["prefsList"] | undefined;
+
+    class TransformingCreateUserAction extends CreateUserAction {
+      getTriggers() {
+        return [
+          {
+            changeset(
+              builder: UserBuilder<UserCreateInput>,
+              input: UserCreateInput,
+            ) {
+              triggerInput = input;
+              builderInput = builder.getInput();
+              builderGetter = builder.getNewPrefsListValue();
+            },
+          },
+        ];
+      }
+
+      transformWrite = (
+        stmt: UpdateOperation<User>,
+      ): TransformedUpdateOperation<User> | undefined => {
+        if (stmt.op !== SQLStatementOperation.Insert || !stmt.data) {
+          return;
+        }
+
+        const emailAddress = stmt.data.get("EmailAddress");
+        const transformedPrefsList = stmt.data.get("prefsList");
+
+        if (
+          emailAddress === existing.emailAddress &&
+          transformedPrefsList !== undefined
+        ) {
+          return {
+            op: SQLStatementOperation.Update,
+            existingEnt: existing,
+            data: {
+              prefsList: transformedPrefsList,
+            },
+          };
+        }
+      };
+    }
+
+    const action = TransformingCreateUserAction.create(viewer, {
+      firstName: "Replacement",
+      lastName: "User",
+      emailAddress: existing.emailAddress,
+      phoneNumber: randomPhoneNumber(),
+      password: random(),
+      prefsList,
+    });
+
+    await action.validX();
+
+    expect(triggerInput?.prefsList).toEqual(prefsList);
+    expect(builderInput?.prefsList).toEqual(prefsList);
+    expect(builderGetter).toEqual(prefsList);
+    expect(builderInput?.prefsList?.[0]).not.toHaveProperty("finished_nux");
+  },
+);

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -1011,19 +1011,20 @@ export class Orchestrator<
         for (const [k, field] of schemaFields) {
           const inputKey = this.getInputKey(k);
           const storageKey = this.getStorageKey(k);
-          let val = transformed.data[inputKey];
-          if (val === undefined) {
-            val = transformed.data[storageKey];
+          let inputVal = transformed.data[inputKey];
+          if (inputVal === undefined) {
+            inputVal = transformed.data[storageKey];
           }
-          if (val === undefined) {
+          if (inputVal === undefined) {
             continue;
           }
+          let dbVal = inputVal;
           if (field.format) {
-            val = field.format(transformed.data[k], true);
+            dbVal = field.format(inputVal, true);
           }
-          data[this.getStorageKey(k)] = val;
+          data[this.getStorageKey(k)] = dbVal;
           if (!field.immutable) {
-            this.defaultFieldsByTSName[this.getInputKey(k)] = val;
+            this.defaultFieldsByTSName[this.getInputKey(k)] = inputVal;
           }
           // hmm do we need this?
           // TODO how to do this for local tests?

--- a/ts/src/action/transformed_orchestrator.test.ts
+++ b/ts/src/action/transformed_orchestrator.test.ts
@@ -615,6 +615,84 @@ function commonTests() {
     expect(row3).toBe(null);
   });
 
+  test("transformWrite keeps struct input in trigger shape", async () => {
+    const loader = getAccountNewLoader();
+    const initialPrefs = {
+      notfisEnabled: true,
+      finishedNux: false,
+      locale: "en_US",
+    };
+    const action = getInsertAccountAction(
+      new Map<string, any>([
+        ["FirstName", "Jon"],
+        ["LastName", "Snow"],
+        ["prefs", initialPrefs],
+      ]),
+      loader.context,
+    );
+    const account = await action.saveX();
+
+    const transformedPrefs = {
+      notfisEnabled: false,
+      finishedNux: true,
+      locale: "en_US",
+    };
+
+    let triggerInput: Data | undefined;
+    let triggerBuilderInput: Data | undefined;
+
+    const action2 = getInsertAccountAction(
+      new Map<string, any>([
+        ["FirstName", "Aegon"],
+        ["LastName", "Targaryen"],
+        ["prefs", transformedPrefs],
+      ]),
+      loader.context,
+    );
+    action2.getTriggers = () => [
+      {
+        changeset(builder, input) {
+          triggerInput = input;
+          triggerBuilderInput = builder.getInput();
+        },
+      },
+    ];
+
+    const transformAegon = (
+      stmt: UpdateOperation<Account>,
+    ): TransformedUpdateOperation<Account> | undefined => {
+      if (stmt.op != SQLStatementOperation.Insert || !stmt.data) {
+        return;
+      }
+
+      const firstName = stmt.data.get("FirstName");
+      const lastName = stmt.data.get("LastName");
+      const prefs = stmt.data.get("prefs");
+
+      if (firstName === "Aegon" && lastName === "Targaryen") {
+        return {
+          op: SQLStatementOperation.Update,
+          existingEnt: account,
+          data: {
+            FirstName: "Aegon",
+            LastName: "Targaryen",
+            prefs,
+          },
+        };
+      }
+    };
+
+    // @ts-ignore
+    action2.transformWrite = transformAegon;
+
+    await action2.validX();
+
+    expect(triggerInput?.prefs).toEqual(transformedPrefs);
+    expect(triggerBuilderInput?.prefs).toEqual(transformedPrefs);
+    expect(triggerBuilderInput?.prefs).not.toHaveProperty("notfis_enabled");
+    expect(action2.builder.getInput().prefs).toEqual(transformedPrefs);
+  });
+
   test("insert -> update", async () => {
     const verifyRows = async (ct: number) => {
       // hmm, not sure why this is still needed...


### PR DESCRIPTION
## Summary
- keep transformWrite builder input in TS/input shape while still formatting DB writes
- add a transformed orchestrator regression for struct input seen from triggers
- add a skipped example-level repro in examples/simple and document local example test workflows in AGENTS.md

## Testing
- cd ts && npm test -- src/action/transformed_orchestrator.test.ts --runInBand
- cd ts && npm test -- src/action/orchestrator.test.ts --runInBand
- cd examples/simple && npm test -- src/ent/tests/transform_write_struct_input.test.ts --runInBand

Closes #1863