### PR TITLE
[codex] Replace dev schema underscore trim regex

### DIFF
--- a/ts/src/core/dev_schema.test.ts
+++ b/ts/src/core/dev_schema.test.ts
@@ -142,6 +142,27 @@ describe("dev schema resolution", () => {
     expect(res.schemaName).toBe("schema_123bad");
   });
 
+  test("collapses separators and trims boundary underscores", () => {
+    const repo = makeRepo("main");
+    process.chdir(repo);
+    process.env.NODE_ENV = "development";
+
+    const res = resolveDevSchema({
+      enabled: true,
+      schemaName: "---Feature___Branch---",
+    });
+    expect(res.schemaName).toBe("feature_branch");
+  });
+
+  test("falls back when explicit schemaName sanitizes to empty", () => {
+    const repo = makeRepo("main");
+    process.chdir(repo);
+    process.env.NODE_ENV = "development";
+
+    const res = resolveDevSchema({ enabled: true, schemaName: "---___---" });
+    expect(res.schemaName).toBe("schema");
+  });
+
   test("runtime config derives schema without state", () => {
     const repo = makeRepo("feature/add-dev-schema");
     process.chdir(repo);

--- a/ts/src/core/dev_schema.ts
+++ b/ts/src/core/dev_schema.ts
@@ -163,7 +163,21 @@ function slugify(input: string): string {
       lastUnderscore = true;
     }
   }
-  return out.replace(/^_+|_+$/g, "");
+  return trimBoundaryUnderscores(out);
+}
+
+function trimBoundaryUnderscores(input: string): string {
+  let start = 0;
+  let end = input.length;
+
+  while (start < end && input[start] === "_") {
+    start++;
+  }
+  while (end > start && input[end - 1] === "_") {
+    end--;
+  }
+
+  return input.slice(start, end);
 }
 
 function sanitizeIdentifier(input: string): string {


### PR DESCRIPTION
## Summary
- replace the trailing/leading underscore trim regex in `slugify` with a linear boundary-scan helper
- add dev-schema tests covering separator collapse, boundary trimming, and the empty-sanitization fallback

## Why
Code scanning flagged the previous regex as a potential polynomial-time ReDoS pattern. In practice, the current `slugify` logic already collapses repeated separators, so the alert was not exploitable through this code path. Replacing the regex still removes the warning and makes the behavior independent of that invariant.

## Impact
Dev schema identifier sanitization keeps the same externally visible behavior while avoiding the flagged regex entirely.

## Validation
- `cd ts && npm test -- --runInBand src/core/dev_schema.test.ts`
