### PR TITLE
Prepare docker image release for v0.3.2

### DIFF
--- a/docker_CHANGELOG.md
+++ b/docker_CHANGELOG.md
@@ -7,17 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changelog for the npm version are [here](/CHANGELOG.md).
 
-## [Unreleased]
+## [0.3.2]
+
+### Added
+
+- support running auto_schema against non-public Postgres schemas (#1946)
+- add dev branch schema configuration and pruning commands (#1947, #1951)
+- add schema metadata and auto_schema operations for Postgres extensions (#1953, #1955)
+- add Postgres type metadata and computed query primitives to Go schema/codegen and auto_schema (#1956)
+
+### Changed
+
+- update auto_schema to the official Alembic package (#1923)
+- compare full-text index metadata through `pg_catalog` (#1966)
+- replace Go string-case and error helper dependencies with in-repo or standard-library code (#1964, #1965)
+- remove unused auto_schema date/datetime dependencies and add ty checks for auto_schema helpers (#1971, #1972, #1973)
 
 ### Fixed
 
 - fix types for struct list for on demand types (#1911)
+- validate generated edge-table primary key names against identifier length limits (#1916)
 - exclude action-only fields when embedding action inputs (#1914)
 - fix builder codegen for list inverse edges (#1915)
-- fix action custom inputs to use public field names when field privacy is enabled (#1874)
-- fix generation of union types to be deterministic (#1919)
-- fix bug which lead to union types to be missing sometimes (#1920)
-- dev schema config + pruning updates (#1946, #1947)
+- fix action custom inputs to use public field names when field privacy is enabled (#1918)
+- make generated union types deterministic (#1919)
+- fix missing generated union items (#1920)
+- tighten dev schema runtime and prune behavior (#1951)
 
 ## [0.3.0]
 

--- a/release_image/main.go
+++ b/release_image/main.go
@@ -17,11 +17,10 @@ import (
 )
 
 // next tag to use
-// testing changes. nothing to be used here...
-const TAG = "v0.3.2--test-test"
+const TAG = "v0.3.2"
 
 // current node gets latest tag...
-const CURRENT_NODE_VERSION = 22
+const CURRENT_NODE_VERSION = 24
 const REPO = "ghcr.io/lolopinto/ent"
 
 const UPDATE_LATEST = true
@@ -33,7 +32,7 @@ var NODE_VERSIONS = []int{
 }
 
 const AUTO_SCHEMA_VERSION = "0.0.34"
-const TSENT_VERSION = "v0.3.1"
+const TSENT_VERSION = "v0.3.2"
 
 // TODO release notes
 


### PR DESCRIPTION
## Summary
- point the docker release builder at the published v0.3.2 tag
- update the tsent install version to v0.3.2
- promote the docker changelog notes for v0.3.2

## Validation
- go test ./release_image

Expected image tags:
- ghcr.io/lolopinto/ent:v0.3.2-nodejs-24-dev
- ghcr.io/lolopinto/ent:v0.3.2-nodejs-24-slim
- ghcr.io/lolopinto/ent:latest