### PR TITLE
Update example Docker images to v0.3.2

### DIFF
--- a/docs/docs/migration-v01/migration-guide.md
+++ b/docs/docs/migration-v01/migration-guide.md
@@ -70,7 +70,7 @@ rm -rf .ent
 * pull latest version of docker image
 
 ```shell
-docker pull ghcr.io/lolopinto/ent:0.1.0-alpha.5-nodejs-17-dev
+docker pull ghcr.io/lolopinto/ent:v0.3.2-nodejs-17-dev
 ```
 
 * Update `develop.Dockerfile` and/or `Dockerfile` to get the latest docker image.

--- a/examples/ent-rsvp/backend/Dockerfile
+++ b/examples/ent-rsvp/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:v0.1.17-nodejs-18-dev
+FROM ghcr.io/lolopinto/ent:v0.3.2-nodejs-18-dev
 
 WORKDIR /app
 

--- a/examples/ent-rsvp/backend/develop.Dockerfile
+++ b/examples/ent-rsvp/backend/develop.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:v0.1.17-nodejs-18-dev
+FROM ghcr.io/lolopinto/ent:v0.3.2-nodejs-18-dev
 
 WORKDIR /app
 

--- a/examples/simple/Dockerfile
+++ b/examples/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:v0.1.17-nodejs-18-slim
+FROM ghcr.io/lolopinto/ent:v0.3.2-nodejs-18-slim
 
 # TODO this needs to be tested for "production"
 # works locally when run here but needs to be tested in hostile environments

--- a/examples/simple/develop.Dockerfile
+++ b/examples/simple/develop.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:v0.2.0-alpha.11-nodejs-22-dev
+FROM ghcr.io/lolopinto/ent:v0.3.2-nodejs-22-dev
 
 WORKDIR /app
 

--- a/examples/todo-sqlite/Dockerfile
+++ b/examples/todo-sqlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:v0.1.17-nodejs-18-dev
+FROM ghcr.io/lolopinto/ent:v0.3.2-nodejs-18-dev
 
 WORKDIR /app
 

--- a/examples/todo-sqlite/develop.Dockerfile
+++ b/examples/todo-sqlite/develop.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lolopinto/ent:v0.1.17-nodejs-18-dev
+FROM ghcr.io/lolopinto/ent:v0.3.2-nodejs-18-dev
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- bump example Docker image tags to ghcr.io/lolopinto/ent:v0.3.2 while preserving Node major and image flavor
- update the migration guide docker pull example to v0.3.2

## Tests
- not run; image tag/docs-only update