### PR TITLE
Add codegen feature matrix smoke tests

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -7,6 +7,7 @@ on:
       - 'ent/**.go'
       - 'internal/**.go'
       - 'internal/**.tmpl'
+      - 'testdata/codegen_matrix/**'
       - 'ts/src/**'
       - .github/workflows/go_ci.yml
 

--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -50,9 +50,9 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v6
       with:
-        # auto_schema==0.0.34 pulls a SQLAlchemy stack that currently fails
-        # during import on Python 3.14 before codegen assertions can run.
-        python-version: '3.13'
+        # auto_schema==0.0.34 pins SQLAlchemy 2.0.18, which fails during
+        # import on Python 3.13+ before codegen assertions can run.
+        python-version: '3.11'
         cache: pip
         cache-dependency-path: python/Pipfile.lock
       

--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -50,7 +50,9 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.14'
+        # auto_schema==0.0.34 pulls a SQLAlchemy stack that currently fails
+        # during import on Python 3.14 before codegen assertions can run.
+        python-version: '3.13'
         cache: pip
         cache-dependency-path: python/Pipfile.lock
       

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,25 @@ Package-level commands:
 - `cd ts && npm test -- src/action/transformed_orchestrator.test.ts --runInBand`
 - `cd ts && npm run compile`
 
+Codegen feature matrix:
+
+- `go test ./internal/codegenmatrix -count=1`
+- See `testdata/codegen_matrix/README.md` before adding schema/codegen options
+  or generated-code regression coverage. New codegen inputs must be classified
+  in `testdata/codegen_matrix/features.yml` as covered, skipped with a focused
+  reason, delegated to an existing test, or non-codegen metadata. Prefer
+  representative cross-feature interactions over exhaustive low-value
+  combinations.
+- The matrix includes SQLite and Postgres DB-codegen smoke fixtures. Postgres
+  coverage runs when `DB_CONNECTION_STRING` or `ENT_CODEGEN_MATRIX_POSTGRES_URL`
+  points at Postgres; otherwise that fixture skips in local runs.
+- Core DB-rendered features should declare
+  `dialect_coverage: [sqlite, postgres]` in the matrix catalog so the test
+  enforces coverage in both DB fixtures. Dialect-specific behavior should
+  declare only the dialect it needs. Put shared core DB schema inputs in
+  `testdata/codegen_matrix/fixtures/_shared/core_db` so both SQLite and
+  Postgres fixtures exercise the same source.
+
 Example prerequisites:
 
 - Use Node 24 when validating the current example package locks and Docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ## [0.2.9]
 
+### Added
+
+- add a codegen feature matrix smoke suite for generated TypeScript, GraphQL, DB schema, and idempotence coverage (#1984).
+
 ### Fixed
 
 - include the shared `parse_args` helper in the published package so CLI scripts can load without `MODULE_NOT_FOUND` (#1981).

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -308,7 +308,7 @@ func getNonEntFieldsFromAssocGroup(
 ) ([]*field.NonEntField, error) {
 	var fields []*field.NonEntField
 
-	inputName := getActionInputNameForEdgeActionType(cfg, typ, assocGroup, nodeName, "")
+	inputName := getActionInputNameForEdgeActionType(cfg, typ, assocGroup, nodeName, action.CustomInputName)
 
 	for _, f := range action.ActionOnlyFields {
 		// TODO we may want different names for graphql vs actions
@@ -349,7 +349,7 @@ func processEdgeActions(cfg codegenapi.Config, nodeName string, assocEdge *edge.
 			return nil, err
 		}
 
-		inputName := getActionInputNameForEdgeActionType(cfg, typ, assocEdge, nodeName, "")
+		inputName := getActionInputNameForEdgeActionType(cfg, typ, assocEdge, nodeName, edgeAction.CustomInputName)
 		nonEntFields, err := getNonEntFieldsFromActionOnlyFields(cfg, inputName, edgeAction.ActionOnlyFields)
 		if err != nil {
 			return nil, err
@@ -545,8 +545,8 @@ func getCommonInfoForEdgeAction(
 	return commonActionInfo{
 		ActionName:       getActionNameForEdgeActionType(cfg, typ, nodeName, assocEdge, edgeAction.CustomActionName, lang),
 		GraphQLName:      graphqlName,
-		ActionInputName:  typ.getDefaultActionInputName(cfg, nodeName, assocEdge),
-		GraphQLInputName: typ.getDefaultGraphQLInputName(cfg, nodeName, assocEdge),
+		ActionInputName:  getActionInputNameForEdgeActionType(cfg, typ, assocEdge, nodeName, edgeAction.CustomInputName),
+		GraphQLInputName: getGraphQLInputNameForEdgeActionType(cfg, typ, assocEdge, nodeName, edgeAction.CustomInputName),
 		ExposeToGraphQL:  edgeAction.ExposeToGraphQL,
 		Edges: []*edge.AssociationEdge{
 			assocEdge,
@@ -580,8 +580,8 @@ func getCommonInfoForGroupEdgeAction(
 	return commonActionInfo{
 		ActionName:       actionName,
 		GraphQLName:      graphqlName,
-		ActionInputName:  typ.getDefaultActionInputName(cfg, nodeName, assocEdgeGroup),
-		GraphQLInputName: typ.getDefaultGraphQLInputName(cfg, nodeName, assocEdgeGroup),
+		ActionInputName:  getActionInputNameForEdgeActionType(cfg, typ, assocEdgeGroup, nodeName, edgeAction.CustomInputName),
+		GraphQLInputName: getGraphQLInputNameForEdgeActionType(cfg, typ, assocEdgeGroup, nodeName, edgeAction.CustomInputName),
 		ExposeToGraphQL:  edgeAction.ExposeToGraphQL,
 		NonEntFields:     fields,
 		NodeInfo:         nodeinfo.GetNodeInfo(nodeName),

--- a/internal/action/compare_action_test.go
+++ b/internal/action/compare_action_test.go
@@ -238,6 +238,86 @@ func TestCompareRemoveEdgeAction(t *testing.T) {
 	require.True(t, ActionEqual(a1, a2))
 }
 
+func TestCompareEdgeActionInputName(t *testing.T) {
+	edge1, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
+		SchemaName: "User",
+		Name:       "createdEvents",
+	})
+	require.Nil(t, err)
+	edge2, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
+		SchemaName: "User",
+		Name:       "createdEvents",
+	})
+	require.Nil(t, err)
+
+	a1 := createEdgeActionWithOptions(
+		"User",
+		edge1,
+		&addEdgeActionType{},
+		&actionOptions{
+			edgeAction: &edge.EdgeAction{
+				Action:          "ent.AddEdgeAction",
+				CustomInputName: "AddCreatedEventInput",
+			},
+		},
+	)
+
+	a2 := createEdgeActionWithOptions(
+		"User",
+		edge2,
+		&addEdgeActionType{},
+		&actionOptions{
+			edgeAction: &edge.EdgeAction{
+				Action:          "ent.AddEdgeAction",
+				CustomInputName: "AddCreatedEventInput",
+			},
+		},
+	)
+
+	require.Equal(t, "AddCreatedEventInput", a1.GetActionInputName())
+	require.Equal(t, "AddCreatedEventInput", a1.GetGraphQLInputName())
+	require.True(t, ActionEqual(a1, a2))
+}
+
+func TestCompareUnequalEdgeActionInputName(t *testing.T) {
+	edge1, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
+		SchemaName: "User",
+		Name:       "createdEvents",
+	})
+	require.Nil(t, err)
+	edge2, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
+		SchemaName: "User",
+		Name:       "createdEvents",
+	})
+	require.Nil(t, err)
+
+	a1 := createEdgeActionWithOptions(
+		"User",
+		edge1,
+		&addEdgeActionType{},
+		&actionOptions{
+			edgeAction: &edge.EdgeAction{
+				Action:          "ent.AddEdgeAction",
+				CustomInputName: "AddCreatedEventInput",
+			},
+		},
+	)
+
+	a2 := createEdgeActionWithOptions(
+		"User",
+		edge2,
+		&addEdgeActionType{},
+		&actionOptions{
+			edgeAction: &edge.EdgeAction{
+				Action:          "ent.AddEdgeAction",
+				CustomInputName: "AddCreatedEventInput2",
+			},
+		},
+	)
+
+	require.False(t, ActionEqual(a1, a2))
+}
+
 func TestCompareActionName(t *testing.T) {
 	a1 := createNodeActionWithOptions(
 		"User",
@@ -847,6 +927,108 @@ func TestCompareEdgeGroupAction(t *testing.T) {
 	)
 
 	require.True(t, ActionEqual(a1, a2))
+}
+
+func TestCompareEdgeGroupActionInputName(t *testing.T) {
+	edge1, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
+		SchemaName: "User",
+		Name:       "Declined",
+	})
+	require.Nil(t, err)
+	edge2, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
+		SchemaName: "User",
+		Name:       "Attending",
+	})
+	require.Nil(t, err)
+	assocEdgeGroup := &edge.AssociationEdgeGroup{
+		GroupName:         "rsvps",
+		GroupStatusName:   "rsvpStatus",
+		TSGroupStatusName: "rsvpStatus",
+		ConstType:         "EventRsvpStatus",
+		NodeInfo:          nodeinfo.GetNodeInfo("event"),
+		DestNodeInfo:      nodeinfo.GetNodeInfo("user"),
+		Edges: map[string]*edge.AssociationEdge{
+			"attending": edge2,
+			"declined":  edge1,
+		},
+		StatusEnums: []string{"attending", "declined"},
+	}
+
+	a1 := createEdgeGroupActionWithOptions(
+		"User",
+		assocEdgeGroup,
+		&actionOptions{
+			edgeAction: &edge.EdgeAction{
+				Action:          "ent.EdgeGroupAction",
+				CustomInputName: "SetRsvpStatusInput",
+			},
+		},
+	)
+
+	a2 := createEdgeGroupActionWithOptions(
+		"User",
+		assocEdgeGroup,
+		&actionOptions{
+			edgeAction: &edge.EdgeAction{
+				Action:          "ent.EdgeGroupAction",
+				CustomInputName: "SetRsvpStatusInput",
+			},
+		},
+	)
+
+	require.Equal(t, "SetRsvpStatusInput", a1.GetActionInputName())
+	require.Equal(t, "SetRsvpStatusInput", a1.GetGraphQLInputName())
+	require.True(t, ActionEqual(a1, a2))
+}
+
+func TestCompareUnequalEdgeGroupActionInputName(t *testing.T) {
+	edge1, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
+		SchemaName: "User",
+		Name:       "Declined",
+	})
+	require.Nil(t, err)
+	edge2, err := edge.AssocEdgeFromInput(&codegenapi.DummyConfig{}, "user", &input.AssocEdge{
+		SchemaName: "User",
+		Name:       "Attending",
+	})
+	require.Nil(t, err)
+	assocEdgeGroup := &edge.AssociationEdgeGroup{
+		GroupName:         "rsvps",
+		GroupStatusName:   "rsvpStatus",
+		TSGroupStatusName: "rsvpStatus",
+		ConstType:         "EventRsvpStatus",
+		NodeInfo:          nodeinfo.GetNodeInfo("event"),
+		DestNodeInfo:      nodeinfo.GetNodeInfo("user"),
+		Edges: map[string]*edge.AssociationEdge{
+			"attending": edge2,
+			"declined":  edge1,
+		},
+		StatusEnums: []string{"attending", "declined"},
+	}
+
+	a1 := createEdgeGroupActionWithOptions(
+		"User",
+		assocEdgeGroup,
+		&actionOptions{
+			edgeAction: &edge.EdgeAction{
+				Action:          "ent.EdgeGroupAction",
+				CustomInputName: "SetRsvpStatusInput",
+			},
+		},
+	)
+
+	a2 := createEdgeGroupActionWithOptions(
+		"User",
+		assocEdgeGroup,
+		&actionOptions{
+			edgeAction: &edge.EdgeAction{
+				Action:          "ent.EdgeGroupAction",
+				CustomInputName: "SetRsvpStatusInput2",
+			},
+		},
+	)
+
+	require.False(t, ActionEqual(a1, a2))
 }
 
 func TestCompareUnequalEdgeGroupAction(t *testing.T) {

--- a/internal/codegen/codegen_processor.go
+++ b/internal/codegen/codegen_processor.go
@@ -212,7 +212,7 @@ func (p *Processor) FormatTS() error {
 func (p *Processor) formatWithBiome() error {
 	var nonGenerated []string
 	root := p.Config.GetAbsPathToRoot()
-	for _, f := range p.Config.changedTSFiles {
+	for _, f := range p.Config.GetChangedTSFiles() {
 		if !strings.Contains(f, "generated") {
 			if path.IsAbs(f) {
 				p, err := filepath.Rel(root, f)
@@ -327,20 +327,18 @@ func postProcess(p *Processor) error {
 		return nil
 	}
 
-	return fns.RunVarargs(
-		func() error {
-			return p.WriteSchema()
-		},
-		func() error {
-			return p.FormatTS()
-		},
-		func() error {
-			if p.buildInfo != nil {
-				return p.buildInfo.PostProcess(p.Config)
-			}
-			return nil
-		},
-	)
+	// RunVarargs is parallel; keep these final writes ordered so follow-up
+	// codegen passes observe a completed schema/format/build-info state.
+	if err := p.WriteSchema(); err != nil {
+		return err
+	}
+	if err := p.FormatTS(); err != nil {
+		return err
+	}
+	if p.buildInfo != nil {
+		return p.buildInfo.PostProcess(p.Config)
+	}
+	return nil
 }
 
 func runAndLog(p *Processor, fn func(p *Processor) error, logDiff func(d time.Duration)) error {

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/lolopinto/ent/internal/codegen/codegenapi"
 	"github.com/lolopinto/ent/internal/codepath"
@@ -38,7 +39,8 @@ type Config struct {
 	changes       change.ChangeMap
 	forcePrettier bool
 	// keep track of changed ts files to pass to the formatter
-	changedTSFiles []string
+	changedTSFilesMu sync.Mutex
+	changedTSFiles   []string
 }
 
 // Clone doesn't clone changes and changedTSFiles
@@ -288,12 +290,16 @@ func (cfg *Config) GetAbsPathToGraphQL() string {
 
 func (cfg *Config) AddChangedFile(filePath string) {
 	if strings.HasSuffix(filePath, ".ts") {
+		cfg.changedTSFilesMu.Lock()
+		defer cfg.changedTSFilesMu.Unlock()
 		cfg.changedTSFiles = append(cfg.changedTSFiles, filePath)
 	}
 }
 
 func (cfg *Config) GetChangedTSFiles() []string {
-	return cfg.changedTSFiles
+	cfg.changedTSFilesMu.Lock()
+	defer cfg.changedTSFilesMu.Unlock()
+	return append([]string(nil), cfg.changedTSFiles...)
 }
 
 func (cfg *Config) GetCustomGraphQLJSONPath() string {
@@ -559,8 +565,9 @@ var defaultArgs = []string{
 }
 
 func (cfg *Config) getPrettierArgs() [][]string {
+	changedTSFiles := cfg.GetChangedTSFiles()
 	// nothing to do here
-	if cfg.useChanges && len(cfg.changedTSFiles) == 0 {
+	if cfg.useChanges && len(changedTSFiles) == 0 {
 		return nil
 	}
 
@@ -595,7 +602,7 @@ func (cfg *Config) getPrettierArgs() [][]string {
 	// else break up into chunks and run each on its own
 
 	var ret [][]string
-	l := len(cfg.changedTSFiles)
+	l := len(changedTSFiles)
 	iters := l / PRETTIER_FILE_CHUNKS
 	if l%PRETTIER_FILE_CHUNKS > 0 {
 		iters++
@@ -605,9 +612,9 @@ func (cfg *Config) getPrettierArgs() [][]string {
 		var files []string
 		end := start + PRETTIER_FILE_CHUNKS
 		if end > l {
-			files = cfg.changedTSFiles[start:]
+			files = changedTSFiles[start:]
 		} else {
-			files = cfg.changedTSFiles[start:end]
+			files = changedTSFiles[start:end]
 		}
 		curr := append(args, "--write")
 		curr = append(curr, files...)

--- a/internal/codegenmatrix/codegen_matrix_test.go
+++ b/internal/codegenmatrix/codegen_matrix_test.go
@@ -1,0 +1,856 @@
+package codegenmatrix
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type catalog struct {
+	Version  int       `yaml:"version"`
+	Fixtures []fixture `yaml:"fixtures"`
+	Features []feature `yaml:"features"`
+}
+
+type fixture struct {
+	ID          string   `yaml:"id"`
+	Path        string   `yaml:"path"`
+	Includes    []string `yaml:"includes"`
+	Description string   `yaml:"description"`
+	Surfaces    []string `yaml:"surfaces"`
+	Dialect     string   `yaml:"dialect"`
+	Covers      []string `yaml:"covers"`
+	SkipReason  string   `yaml:"skip_reason"`
+}
+
+type feature struct {
+	ID              string   `yaml:"id"`
+	Owns            []string `yaml:"owns"`
+	Mode            string   `yaml:"mode"`
+	DialectCoverage []string `yaml:"dialect_coverage"`
+	Rationale       string   `yaml:"rationale"`
+	SkipReason      string   `yaml:"skip_reason"`
+	TestRefs        []string `yaml:"test_refs"`
+}
+
+const (
+	dirMode  os.FileMode = 0o755
+	fileMode os.FileMode = 0o644
+)
+
+var uuidLiteralPattern = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+func TestFeatureCatalogClassifiesCodegenInputs(t *testing.T) {
+	c := loadCatalog(t)
+	repo := repoRoot(t)
+	requiredOwners := map[string]bool{}
+	for _, owner := range requiredOwnersList() {
+		requiredOwners[owner] = true
+	}
+
+	featuresByID := map[string]feature{}
+	owners := map[string]string{}
+	for _, f := range c.Features {
+		require.NotEmpty(t, f.ID, "feature id is required")
+		require.NotEmpty(t, f.Mode, "feature %s must declare a mode", f.ID)
+		if f.Mode == "skipped" {
+			require.NotEmpty(t, f.SkipReason, "skipped feature %s must include skip_reason", f.ID)
+		} else {
+			require.NotEmpty(t, f.Rationale, "feature %s must explain why it is classified this way", f.ID)
+		}
+		if f.Mode == "existing_test" {
+			require.NotEmpty(t, f.TestRefs, "existing_test feature %s must point at existing tests", f.ID)
+		}
+		require.NotContains(t, featuresByID, f.ID, "duplicate feature id")
+		featuresByID[f.ID] = f
+		for _, owner := range f.Owns {
+			if !requiredOwners[owner] {
+				t.Fatalf("feature %s claims unknown owner %s", f.ID, owner)
+			}
+			if existing, ok := owners[owner]; ok {
+				t.Fatalf("owner %s is claimed by both %s and %s", owner, existing, f.ID)
+			}
+			owners[owner] = f.ID
+		}
+	}
+
+	var missingOwners []string
+	for _, owner := range requiredOwnersList() {
+		if _, ok := owners[owner]; !ok {
+			missingOwners = append(missingOwners, owner)
+		}
+	}
+	require.Empty(t, missingOwners, "codegen input owners missing from testdata/codegen_matrix/features.yml")
+
+	coveredFeatures := map[string]string{}
+	coveredDialects := map[string]map[string]string{}
+	for _, fixture := range c.Fixtures {
+		require.NotEmpty(t, fixture.ID, "fixture id is required")
+		require.NotEmpty(t, fixture.Path, "fixture %s must declare path", fixture.ID)
+		validateFixturePaths(t, repo, fixture)
+		validateFixtureDialect(t, fixture)
+		for _, covered := range fixture.Covers {
+			if _, ok := featuresByID[covered]; !ok {
+				t.Fatalf("fixture %s covers unknown feature %s", fixture.ID, covered)
+			}
+			coveredFeatures[covered] = fixture.ID
+			if fixture.Dialect != "" {
+				if coveredDialects[covered] == nil {
+					coveredDialects[covered] = map[string]string{}
+				}
+				coveredDialects[covered][fixture.Dialect] = fixture.ID
+			}
+		}
+	}
+
+	var uncovered []string
+	for _, f := range c.Features {
+		switch f.Mode {
+		case "non_codegen", "skipped", "existing_test":
+			continue
+		}
+		if _, ok := coveredFeatures[f.ID]; !ok {
+			uncovered = append(uncovered, f.ID)
+		}
+	}
+	sort.Strings(uncovered)
+	require.Empty(t, uncovered, "active features need fixture coverage")
+	require.Empty(t, missingDialectCoverage(c.Features, coveredDialects), "features covered by dialect fixtures must declare matching dialect_coverage")
+}
+
+func validateFixturePaths(t *testing.T, repo string, fixture fixture) {
+	t.Helper()
+	matrixRoot := filepath.Join(repo, "testdata/codegen_matrix")
+	require.DirExists(t, filepath.Join(matrixRoot, fixture.Path), "fixture %s path is missing", fixture.ID)
+	for _, include := range fixture.Includes {
+		require.DirExists(t, filepath.Join(matrixRoot, include), "fixture %s include %s is missing", fixture.ID, include)
+	}
+}
+
+func validateFixtureDialect(t *testing.T, fixture fixture) {
+	t.Helper()
+	if fixtureRunsDBCodegen(fixture) {
+		require.NotEmpty(t, fixture.Dialect, "DB fixture %s must declare dialect", fixture.ID)
+	}
+	if fixture.Dialect == "" {
+		return
+	}
+	require.Contains(t, validDialects(), fixture.Dialect, "fixture %s has unknown dialect", fixture.ID)
+}
+
+func missingDialectCoverage(features []feature, coveredDialects map[string]map[string]string) []string {
+	var missing []string
+	for _, f := range features {
+		switch f.Mode {
+		case "non_codegen", "skipped", "existing_test":
+			continue
+		}
+		actual := coveredDialects[f.ID]
+		if len(actual) == 0 && len(f.DialectCoverage) == 0 {
+			continue
+		}
+		declared := map[string]bool{}
+		for _, dialect := range f.DialectCoverage {
+			if !validDialects()[dialect] {
+				missing = append(missing, fmt.Sprintf("%s declares unknown dialect %s", f.ID, dialect))
+				continue
+			}
+			declared[dialect] = true
+			if actual[dialect] == "" {
+				missing = append(missing, fmt.Sprintf("%s missing %s fixture coverage", f.ID, dialect))
+			}
+		}
+		for dialect := range actual {
+			if !declared[dialect] {
+				missing = append(missing, fmt.Sprintf("%s covered by %s fixture but missing dialect_coverage entry", f.ID, dialect))
+			}
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func validDialects() map[string]bool {
+	return map[string]bool{
+		"sqlite":   true,
+		"postgres": true,
+	}
+}
+
+func TestCodegenMatrixFixtures(t *testing.T) {
+	c := loadCatalog(t)
+	repo := repoRoot(t)
+	entDist := buildEntDist(t, repo)
+	fixtureFilter := os.Getenv("ENT_CODEGEN_MATRIX_FIXTURE")
+
+	for _, fixture := range c.Fixtures {
+		fixture := fixture
+		if fixtureFilter != "" && fixtureFilter != fixture.ID {
+			continue
+		}
+		t.Run(fixture.ID, func(t *testing.T) {
+			if fixture.SkipReason != "" && os.Getenv("ENT_CODEGEN_MATRIX_RUN_SKIPPED") != "true" {
+				t.Skip(fixture.SkipReason)
+			}
+			appRoot := copyFixture(t, repo, fixture)
+			writeGeneratedHarnessFiles(t, repo, appRoot, entDist)
+			runCodegenFixture(t, repo, appRoot, fixture)
+		})
+	}
+}
+
+func loadCatalog(t *testing.T) catalog {
+	t.Helper()
+	repo := repoRoot(t)
+	path := filepath.Join(repo, "testdata/codegen_matrix/features.yml")
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var c catalog
+	require.NoError(t, yaml.Unmarshal(b, &c))
+	require.Equal(t, 1, c.Version)
+	require.NotEmpty(t, c.Features)
+	require.NotEmpty(t, c.Fixtures)
+	return c
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	return repoRootFromSource()
+}
+
+func repoRootFromSource() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("could not resolve codegenmatrix source path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func copyFixture(t *testing.T, repo string, fixture fixture) string {
+	t.Helper()
+	dst := filepath.Join(t.TempDir(), fixture.ID)
+	for _, include := range fixture.Includes {
+		require.NoError(t, copyDir(filepath.Join(repo, "testdata/codegen_matrix", include), dst), "copy include %s", include)
+	}
+	src := filepath.Join(repo, "testdata/codegen_matrix", fixture.Path)
+	require.NoError(t, copyDir(src, dst))
+	return dst
+}
+
+func writeGeneratedHarnessFiles(t *testing.T, repo, appRoot, entDist string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(appRoot, "node_modules"), dirMode))
+	nodeModules := filepath.Join(appRoot, "node_modules")
+	if _, err := os.Lstat(nodeModules); err == nil {
+		require.NoError(t, os.RemoveAll(nodeModules))
+	}
+	require.NoError(t, os.Symlink(filepath.Join(repo, "ts", "node_modules"), nodeModules))
+
+	writeHarnessTSConfig(t, filepath.Join(appRoot, "tsconfig.json"), entPathMapping{
+		packageRoot:     filepath.Join(repo, "ts", "src", "index.ts"),
+		packageWildcard: filepath.Join(repo, "ts", "src", "*"),
+	})
+	writeHarnessTSConfig(t, filepath.Join(appRoot, "tsconfig.generated.json"), entPathMapping{
+		packageRoot:     filepath.Join(entDist, "index.d.ts"),
+		packageWildcard: filepath.Join(entDist, "*"),
+	})
+	replaceHarnessPlaceholders(t, appRoot)
+}
+
+type entPathMapping struct {
+	packageRoot     string
+	packageWildcard string
+}
+
+func writeHarnessTSConfig(t *testing.T, path string, entPaths entPathMapping) {
+	t.Helper()
+	// tsconfig.json maps to source for schema loading; tsconfig.generated.json
+	// maps to dist declarations to typecheck generated code like a package user.
+	tsconfig := fmt.Sprintf(`{
+  "compilerOptions": {
+    "lib": ["es2018", "esnext.asynciterable"],
+    "target": "es2020",
+    "module": "commonjs",
+    "downlevelIteration": true,
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"],
+      "@snowtop/ent": [%q],
+      "@snowtop/ent/*": [%q]
+    },
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+`, entPaths.packageRoot, entPaths.packageWildcard)
+	require.NoError(t, os.WriteFile(path, []byte(tsconfig), fileMode))
+}
+
+func replaceHarnessPlaceholders(t *testing.T, appRoot string) {
+	t.Helper()
+	replacements := map[string]string{
+		"__APP_ROOT__": appRoot,
+	}
+	for _, relPath := range []string{"ent.yml", filepath.Join("src", "schema", "custom_graphql.json")} {
+		path := filepath.Join(appRoot, relPath)
+		b, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		updated := string(b)
+		for from, to := range replacements {
+			updated = strings.ReplaceAll(updated, from, to)
+		}
+		require.NoError(t, os.WriteFile(path, []byte(updated), fileMode))
+	}
+}
+
+func postgresDatabaseName(t *testing.T) string {
+	t.Helper()
+	hash := sha256.Sum256([]byte(t.Name()))
+	return fmt.Sprintf("codegen_matrix_%s", hex.EncodeToString(hash[:])[:16])
+}
+
+func buildEntDist(t *testing.T, repo string) string {
+	t.Helper()
+	cmd := exec.Command("npm", "run", "prepare-code")
+	cmd.Dir = filepath.Join(repo, "ts")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build @snowtop/ent dist:\n%s\n%v", string(out), err)
+	}
+	return filepath.Join(repo, "ts", "dist")
+}
+
+func runCodegenFixture(t *testing.T, repo, appRoot string, fixture fixture) {
+	t.Helper()
+	envPath := filepath.Join(repo, "ts", "node_modules", ".bin") + string(os.PathListSeparator) + os.Getenv("PATH")
+	t.Setenv("PATH", envPath)
+	t.Setenv("LOCAL_SCRIPT_PATH", "true")
+	t.Setenv("GRAPHQL_PATH", filepath.Join(repo, "ts", "src", "graphql"))
+	configureFixtureDatabase(t, fixture)
+	tsentBinary := buildTsentBinary(t, repo)
+
+	// The first pass bootstraps generated files and build metadata. The second
+	// pass gives codegen one clean stabilization pass before the idempotence
+	// snapshot, and the third pass is the actual no-churn assertion.
+	runCodegenCycle(t, tsentBinary, appRoot, fixture)
+	runCodegenCycle(t, tsentBinary, appRoot, fixture)
+	firstSnapshot := snapshotGeneratedTree(t, appRoot, fixture)
+	firstHash := hashGeneratedSnapshot(firstSnapshot)
+	runCodegenCycle(t, tsentBinary, appRoot, fixture)
+	secondSnapshot := snapshotGeneratedTree(t, appRoot, fixture)
+	secondHash := hashGeneratedSnapshot(secondSnapshot)
+	require.Equal(t, firstHash, secondHash, "codegen fixture is not idempotent; changed files: %s\n%s", strings.Join(changedSnapshotFiles(firstSnapshot, secondSnapshot), ", "), snapshotChangeSummary(firstSnapshot, secondSnapshot))
+
+	cmd := exec.Command(filepath.Join(repo, "ts", "node_modules", ".bin", "tsc"), "--noEmit", "--project", filepath.Join(appRoot, "tsconfig.generated.json"))
+	cmd.Dir = appRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated TypeScript did not compile:\n%s\n%v", string(out), err)
+	}
+}
+
+func configureFixtureDatabase(t *testing.T, fixture fixture) {
+	t.Helper()
+	if fixtureHasSurface(fixture, "postgres_db_codegen") {
+		dsn := os.Getenv("ENT_CODEGEN_MATRIX_POSTGRES_URL")
+		if dsn == "" {
+			dsn = os.Getenv("DB_CONNECTION_STRING")
+		}
+		if !isPostgresDSN(dsn) {
+			t.Skip("postgres fixture requires ENT_CODEGEN_MATRIX_POSTGRES_URL or a postgres DB_CONNECTION_STRING")
+		}
+		t.Setenv("DB_CONNECTION_STRING", createIsolatedPostgresDatabase(t, dsn))
+		return
+	}
+	t.Setenv("DB_CONNECTION_STRING", "sqlite:///"+filepath.Join(t.TempDir(), "codegen_matrix.sqlite"))
+}
+
+func isPostgresDSN(dsn string) bool {
+	return strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://")
+}
+
+func createIsolatedPostgresDatabase(t *testing.T, dsn string) string {
+	t.Helper()
+	adminURL, err := url.Parse(dsn)
+	require.NoError(t, err)
+	if adminURL.Path == "" || adminURL.Path == "/" {
+		adminURL.Path = "/postgres"
+	}
+	ensurePostgresSSLModeDisabled(adminURL)
+	dbName := postgresDatabaseName(t)
+	isolatedURL := *adminURL
+	isolatedURL.Path = "/" + dbName
+
+	adminDB, err := sql.Open("postgres", adminURL.String())
+	require.NoError(t, err)
+	defer adminDB.Close()
+	resetPostgresDatabase(t, adminDB, dbName)
+
+	t.Cleanup(func() {
+		cleanupDB, err := sql.Open("postgres", adminURL.String())
+		if err != nil {
+			return
+		}
+		defer cleanupDB.Close()
+		_, _ = cleanupDB.Exec("DROP DATABASE IF EXISTS " + pq.QuoteIdentifier(dbName) + " WITH (FORCE)")
+	})
+
+	return isolatedURL.String()
+}
+
+func ensurePostgresSSLModeDisabled(u *url.URL) {
+	q := u.Query()
+	if q.Get("sslmode") == "" {
+		q.Set("sslmode", "disable")
+		u.RawQuery = q.Encode()
+	}
+}
+
+func resetPostgresDatabase(t *testing.T, db *sql.DB, dbName string) {
+	t.Helper()
+	quoted := pq.QuoteIdentifier(dbName)
+	_, err := db.Exec("DROP DATABASE IF EXISTS " + quoted + " WITH (FORCE)")
+	require.NoError(t, err)
+	_, err = db.Exec("CREATE DATABASE " + quoted)
+	require.NoError(t, err)
+}
+
+func buildTsentBinary(t *testing.T, repo string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "tsent")
+	cmd := exec.Command("go", "build", "-o", bin, "./tsent")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build tsent:\n%s\n%v", string(out), err)
+	}
+	return bin
+}
+
+func runCodegenCycle(t *testing.T, tsentBinary, appRoot string, fixture fixture) {
+	t.Helper()
+	if fixtureRunsDBCodegen(fixture) {
+		runCodegenStep(t, tsentBinary, appRoot, "db")
+	}
+	runCodegenStep(t, tsentBinary, appRoot, "codegen")
+	runCodegenStep(t, tsentBinary, appRoot, "graphql")
+}
+
+func fixtureRunsDBCodegen(fixture fixture) bool {
+	return fixtureHasSurface(fixture, "db_codegen") || fixtureHasSurface(fixture, "postgres_db_codegen")
+}
+
+func fixtureHasSurface(fixture fixture, surface string) bool {
+	for _, candidate := range fixture.Surfaces {
+		if candidate == surface {
+			return true
+		}
+	}
+	return false
+}
+
+func runCodegenStep(t *testing.T, tsentBinary, appRoot, step string) {
+	t.Helper()
+	cmd := exec.Command(
+		tsentBinary,
+		"codegen",
+		"--disable_upgrade",
+		"--disable_prompts",
+		"--step",
+		step,
+	)
+	cmd.Dir = appRoot
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("codegen step %s failed:\n%s\n%v", step, string(out), err)
+	}
+}
+
+func snapshotGeneratedTree(t *testing.T, appRoot string, fixture fixture) map[string][]byte {
+	t.Helper()
+	var paths []string
+	roots := []string{
+		filepath.Join(appRoot, ".ent"),
+		filepath.Join(appRoot, "src", "ent"),
+		filepath.Join(appRoot, "src", "graphql"),
+	}
+	if fixtureRunsDBCodegen(fixture) {
+		roots = append(roots,
+			filepath.Join(appRoot, "src", "schema", "schema.py"),
+			filepath.Join(appRoot, "src", "schema", ".ent"),
+			filepath.Join(appRoot, "src", "schema", "versions"),
+		)
+	}
+	for _, root := range roots {
+		if _, err := os.Stat(root); err != nil {
+			continue
+		}
+		info, err := os.Stat(root)
+		require.NoError(t, err)
+		if !info.IsDir() {
+			paths = append(paths, root)
+			continue
+		}
+		require.NoError(t, filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() && d.Name() == "__pycache__" {
+				return filepath.SkipDir
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(path, ".pyc") {
+				return nil
+			}
+			paths = append(paths, path)
+			return nil
+		}))
+	}
+	sort.Strings(paths)
+	snapshot := map[string][]byte{}
+	for _, path := range paths {
+		rel, err := filepath.Rel(appRoot, path)
+		require.NoError(t, err)
+		if rel == ".ent/build_info.yaml" {
+			continue
+		}
+		b, err := os.ReadFile(path)
+		require.NoError(t, err)
+		// Generated migration metadata can contain UUID literals; normalize them
+		// so idempotence assertions focus on structural churn.
+		b = uuidLiteralPattern.ReplaceAll(b, []byte("<uuid>"))
+		b = bytes.TrimRight(b, "\r\n")
+		snapshot[rel] = b
+	}
+	return snapshot
+}
+
+func hashGeneratedSnapshot(snapshot map[string][]byte) string {
+	h := sha256.New()
+	var paths []string
+	for path := range snapshot {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		h.Write([]byte(path))
+		h.Write([]byte{0})
+		h.Write(snapshot[path])
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func changedSnapshotFiles(first, second map[string][]byte) []string {
+	files := map[string]bool{}
+	for path := range first {
+		files[path] = true
+	}
+	for path := range second {
+		files[path] = true
+	}
+	var changed []string
+	for path := range files {
+		firstContent, firstOK := first[path]
+		secondContent, secondOK := second[path]
+		if firstOK != secondOK || !bytes.Equal(firstContent, secondContent) {
+			changed = append(changed, path)
+		}
+	}
+	sort.Strings(changed)
+	return changed
+}
+
+func snapshotChangeSummary(first, second map[string][]byte) string {
+	var summaries []string
+	for _, path := range changedSnapshotFiles(first, second) {
+		firstLines := strings.Split(string(first[path]), "\n")
+		secondLines := strings.Split(string(second[path]), "\n")
+		max := len(firstLines)
+		if len(secondLines) > max {
+			max = len(secondLines)
+		}
+		for i := 0; i < max; i++ {
+			var a, b string
+			if i < len(firstLines) {
+				a = firstLines[i]
+			}
+			if i < len(secondLines) {
+				b = secondLines[i]
+			}
+			if a != b {
+				summaries = append(summaries, fmt.Sprintf("%s:%d\n- %s\n+ %s", path, i+1, a, b))
+				break
+			}
+		}
+	}
+	return strings.Join(summaries, "\n")
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, dirMode)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), dirMode); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fileMode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func requiredOwnersList() []string {
+	return mergeOwners(derivedOwnersList(), syntheticOwners())
+}
+
+func derivedOwnersList() []string {
+	return mergeOwners(reflectedInputOwners(), reflectedActionOperationOwners())
+}
+
+// Owners are coverage keys for generator inputs. Most are reflected from
+// internal/schema/input/input.go; synthetic owners should be limited to
+// non-reflectable codegen surfaces, not behavior/regression scenario names.
+func syntheticOwners() []string {
+	return []string{
+		"input.ActionField.List",
+		"custom_graphql.gqlField",
+		"custom_graphql.gqlObjectType",
+		"custom_graphql.gqlInputObjectType",
+		"custom_graphql.gqlQuery",
+		"custom_graphql.gqlMutation",
+		"custom_graphql.gqlConnection",
+		"custom_graphql.mutationReturnType",
+	}
+}
+
+func mergeOwners(ownerLists ...[]string) []string {
+	seen := map[string]bool{}
+	var owners []string
+	for _, ownerList := range ownerLists {
+		for _, owner := range ownerList {
+			if seen[owner] {
+				continue
+			}
+			seen[owner] = true
+			owners = append(owners, owner)
+		}
+	}
+	sort.Strings(owners)
+	return owners
+}
+
+func TestSyntheticOwnersDoNotDuplicateDerivedInputs(t *testing.T) {
+	derived := map[string]bool{}
+	for _, owner := range derivedOwnersList() {
+		derived[owner] = true
+	}
+
+	var duplicated []string
+	for _, owner := range syntheticOwners() {
+		if derived[owner] {
+			duplicated = append(duplicated, owner)
+		}
+	}
+	sort.Strings(duplicated)
+	require.Empty(t, duplicated, "derived input owners should be removed from syntheticOwners")
+}
+
+func reflectedInputOwners() []string {
+	var owners []string
+	src := filepath.Join(repoRootFromSource(), "internal", "schema", "input", "input.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, src, nil, 0)
+	if err != nil {
+		panic(err)
+	}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		switch gen.Tok {
+		case token.TYPE:
+			for _, spec := range gen.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok || !typeSpec.Name.IsExported() {
+					continue
+				}
+				structType, ok := typeSpec.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				for _, field := range structType.Fields.List {
+					for _, name := range field.Names {
+						if !name.IsExported() {
+							continue
+						}
+						owners = append(owners, "input."+typeSpec.Name.Name+"."+name.Name)
+					}
+				}
+			}
+		case token.CONST:
+			var currentType string
+			for _, spec := range gen.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				if ident, ok := valueSpec.Type.(*ast.Ident); ok {
+					currentType = ident.Name
+				}
+				if currentType == "" {
+					continue
+				}
+				for _, name := range valueSpec.Names {
+					if owner := reflectedInputEnumOwner(currentType, name.Name); owner != "" {
+						owners = append(owners, owner)
+					}
+				}
+			}
+		}
+	}
+	sort.Strings(owners)
+	return owners
+}
+
+func reflectedActionOperationOwners() []string {
+	src := filepath.Join(repoRootFromSource(), "internal", "schema", "input", "input.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, src, nil, 0)
+	if err != nil {
+		panic(err)
+	}
+
+	edgeActions := map[string]bool{
+		"AddEdge":    true,
+		"RemoveEdge": true,
+		"EdgeGroup":  true,
+	}
+	seen := map[string]bool{}
+	var owners []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "getTSStringOperation" {
+			return true
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			ret, ok := n.(*ast.ReturnStmt)
+			if !ok || len(ret.Results) != 1 {
+				return true
+			}
+			lit, ok := ret.Results[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			value, err := strconv.Unquote(lit.Value)
+			if err != nil || !strings.HasPrefix(value, "ActionOperation.") {
+				return true
+			}
+			operation := strings.TrimPrefix(value, "ActionOperation.")
+			ownerPrefix := "input.Action.Operation."
+			if edgeActions[operation] {
+				ownerPrefix = "input.EdgeAction.Operation."
+			}
+			owner := ownerPrefix + operation
+			if !seen[owner] {
+				seen[owner] = true
+				owners = append(owners, owner)
+			}
+			return true
+		})
+		return false
+	})
+	sort.Strings(owners)
+	return owners
+}
+
+func reflectedInputEnumOwner(typeName, constName string) string {
+	switch typeName {
+	case "DBType", "CustomType", "OnDeleteFkey", "IndexType":
+		return "input." + typeName + "." + constName
+	case "OrderByDirection":
+		return "input.OrderByDirection." + constName
+	case "NullsPlacement":
+		return "input.NullsPlacement." + constName
+	case "FullTextLanguage":
+		return "input.FullText.Language." + constName
+	case "NullableItem":
+		switch constName {
+		case "NullableContents":
+			return "input.NullableItem.Contents"
+		case "NullableContentsAndList":
+			return "input.NullableItem.ContentsAndList"
+		case "NullableTrue":
+			return "input.NullableItem.True"
+		}
+	case "ActionType":
+		if strings.HasPrefix(constName, "ActionType") {
+			return "input.ActionField.Type." + strings.TrimPrefix(constName, "ActionType")
+		}
+	case "ConstraintType":
+		switch constName {
+		case "PrimaryKeyConstraint":
+			return "input.Constraint.Type.PrimaryKey"
+		case "ForeignKeyConstraint":
+			return "input.Constraint.Type.ForeignKey"
+		case "UniqueConstraint":
+			return "input.Constraint.Type.Unique"
+		case "CheckConstraint":
+			return "input.Constraint.Type.Check"
+		}
+	}
+	return ""
+}

--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -1156,6 +1156,7 @@ type EdgeAction struct {
 	Action            string
 	CustomActionName  string
 	CustomGraphQLName string
+	CustomInputName   string
 	ExposeToGraphQL   bool
 	ActionOnlyFields  []*input.ActionField
 	CanViewerDo       *input.CanViewerDo
@@ -1335,6 +1336,7 @@ func edgeActionsFromInput(actions []*input.EdgeAction) ([]*EdgeAction, error) {
 			ExposeToGraphQL:   !action.HideFromGraphQL,
 			CustomActionName:  action.CustomActionName,
 			CustomGraphQLName: action.CustomGraphQLName,
+			CustomInputName:   action.CustomInputName,
 			Action:            a,
 			ActionOnlyFields:  action.ActionOnlyFields,
 			CanViewerDo:       action.CanViewerDo,

--- a/internal/graphql/custom_ts.go
+++ b/internal/graphql/custom_ts.go
@@ -361,7 +361,7 @@ func (mfcg *mutationFieldConfigBuilder) getReturnTypeHint() string {
 		if mfcg.cd.Objects[obj.Type] == nil {
 			return ""
 		}
-		typ := names.ToClassType(mfcg.field.GraphQLName, "Payload")
+		typ := obj.Type
 		return fmt.Sprintf("Promise<%s>", typ)
 	}
 	return ""
@@ -796,7 +796,7 @@ func processCustomFields(processor *codegen.Processor, cd *CustomData, s *gqlSch
 		for _, field := range fields {
 			if field.Connection {
 				customEdge := getGQLEdge(processor.Config, field, nodeName)
-				nodeInfo.connections = append(nodeInfo.connections, getGqlConnection(nodeData.PackageName, customEdge, processor))
+				nodeInfo.connections = appendGqlConnection(nodeInfo.connections, getGqlConnection(nodeData.PackageName, customEdge, processor))
 				if err := addConnection(processor, nodeData, customEdge, obj, &field, s); err != nil {
 					return err
 				}

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -1001,6 +1001,14 @@ func (obj *gqlobjectData) ForeignImport(name string) bool {
 			for _, class := range node.Classes {
 				obj.m[class.Name] = true
 			}
+
+			for _, field := range node.Fields {
+				for _, imp := range field.AllImports() {
+					if imp.ImportPath == "" {
+						obj.m[imp.Import] = true
+					}
+				}
+			}
 		}
 		for _, enum := range obj.Enums {
 			obj.m[enum.Type] = true
@@ -1338,6 +1346,31 @@ func getGqlConnection(packageName string, edge edge.ConnectionEdge, processor *c
 	}
 }
 
+func appendGqlConnection(conns []*gqlConnection, conn *gqlConnection) []*gqlConnection {
+	for idx, existing := range conns {
+		if existing.ConnType != conn.ConnType {
+			continue
+		}
+		if preferGqlConnection(conn, existing) {
+			conns[idx] = conn
+		}
+		return conns
+	}
+	return append(conns, conn)
+}
+
+func preferGqlConnection(candidate, existing *gqlConnection) bool {
+	candidateEdge := candidate.Edge.TsEdgeQueryEdgeName()
+	existingEdge := existing.Edge.TsEdgeQueryEdgeName()
+	if existingEdge == "Data" && candidateEdge != "Data" {
+		return true
+	}
+	if existingEdge != "Data" && candidateEdge == "Data" {
+		return false
+	}
+	return candidate.Edge.TsEdgeQueryName() < existing.Edge.TsEdgeQueryName()
+}
+
 type buildGQLSchemaResult struct {
 	schema *gqlSchema
 	error  error
@@ -1465,7 +1498,7 @@ func buildGQLSchema(processor *codegen.Processor) chan *buildGQLSchemaResult {
 						}
 						hasConnections = true
 						conn := getGqlConnection(nodeData.PackageName, edge, processor)
-						obj.connections = append(obj.connections, conn)
+						obj.connections = appendGqlConnection(obj.connections, conn)
 					}
 				}
 

--- a/internal/schema/node_data.go
+++ b/internal/schema/node_data.go
@@ -339,7 +339,7 @@ func (nodeData *NodeData) GetUpsertInfo(actionName string) *UpsertInfo {
 
 		lastType.Expression = buildType([]string{
 			buildExpression("update_cols?", "string[]"),
-			buildExpression(key, ret.Name),
+			buildExpression(key, typ.Name),
 		})
 	}
 

--- a/internal/tscode/base.tmpl
+++ b/internal/tscode/base.tmpl
@@ -466,6 +466,8 @@ implements {{useTypeImport "Ent"}}<{{$viewerType}}>
       {{ if $group.ViewerBased -}}
         // this should be overwritten by subclasses as needed. 
         protected async {{$group.NullStateFn}}() {
+          return {{$group.DefaultNullState}};
+        }
       {{ else -}}
         // this should be overwritten by subclasses as needed. 
         protected async {{$group.NullStateFn}}({{$group.DestNodeInfo.NodeInstance}}: {{useImport $group.DestNodeInfo.Node}}) {

--- a/internal/tscode/mixin.tmpl
+++ b/internal/tscode/mixin.tmpl
@@ -24,7 +24,7 @@ type Constructor<T extends {{$p.GetMixinInterfaceName}} = {{$p.GetMixinInterface
 
 export function {{$p.GetPatternMethod}}(ent: unknown): ent is {{$p.GetMixinInterfaceName}} {
   const o = ent as {{$p.GetMixinInterfaceName}};
-  return o.{{$p.GetPatternMethod}} && o.{{$p.GetPatternMethod}}() ?? false;
+  return (o.{{$p.GetPatternMethod}} && o.{{$p.GetPatternMethod}}()) ?? false;
 }
 
 {{ range $p.GetImportsForMixin $schema $cfg -}} 

--- a/internal/tscode/step.go
+++ b/internal/tscode/step.go
@@ -1080,6 +1080,8 @@ func getSortedInternalEntFileLines(s *schema.Schema) []string {
 	}
 
 	var baseQueryFiles []string
+	var indexedBaseQueryFiles []string
+	var indexedDerivedQueryFiles []string
 	var queryFiles []string
 	var mixins []string
 	// add patterns first  after const
@@ -1104,7 +1106,11 @@ func getSortedInternalEntFileLines(s *schema.Schema) []string {
 		}
 
 		for _, edge := range info.NodeData.EdgeInfo.GetEdgesForIndexLoader() {
-			append2(&queryFiles, getImportPathForCustomEdgeQueryFile(info.NodeData, edge))
+			if edge.GenerateBaseClass() {
+				append2(&indexedBaseQueryFiles, getImportPathForCustomEdgeQueryFile(info.NodeData, edge))
+			} else {
+				append2(&indexedDerivedQueryFiles, getImportPathForCustomEdgeQueryFile(info.NodeData, edge))
+			}
 		}
 
 		if info.NodeData.EdgeInfo.CreateEdgeBaseFile() {
@@ -1119,7 +1125,9 @@ func getSortedInternalEntFileLines(s *schema.Schema) []string {
 		baseFiles,
 		entFiles,
 		baseQueryFiles,
+		indexedBaseQueryFiles,
 		queryFiles,
+		indexedDerivedQueryFiles,
 	}
 	for _, l := range list {
 		sort.Strings(l)

--- a/internal/tsimport/import.go
+++ b/internal/tsimport/import.go
@@ -224,6 +224,9 @@ func (imps *Imports) reserve(input *importInfoInput) (string, error) {
 		if otherImportMap[ident] != nil && otherImportMap[ident].path == input.path && input.typeOnly {
 			continue
 		}
+		if !input.typeOnly && otherImportMap[ident] != nil && otherImportMap[ident].path == input.path {
+			imps.promoteTypeOnlyImportToValueImport(ident, otherImportMap[ident])
+		}
 		filteredImports = append(filteredImports, v)
 	}
 	input.imports = filteredImports
@@ -234,6 +237,9 @@ func (imps *Imports) reserve(input *importInfoInput) (string, error) {
 		}
 		if otherImportMap[ident] != nil && otherImportMap[ident].path == input.path && input.typeOnly {
 			input.defaultImport = ""
+		}
+		if !input.typeOnly && otherImportMap[ident] != nil && otherImportMap[ident].path == input.path {
+			imps.promoteTypeOnlyImportToValueImport(ident, otherImportMap[ident])
 		}
 	}
 
@@ -298,6 +304,27 @@ func (imps *Imports) reserve(input *importInfoInput) (string, error) {
 	return "", nil
 }
 
+func (imps *Imports) promoteTypeOnlyImportToValueImport(ident string, typeImport *importInfo) {
+	delete(imps.typeImportMap, ident)
+	if imps.usedTypeImports[ident] {
+		delete(imps.usedTypeImports, ident)
+		imps.usedImports[ident] = true
+	}
+
+	var imports []importedItem
+	for _, item := range typeImport.imports {
+		if item.getIdent() == ident {
+			continue
+		}
+		imports = append(imports, item)
+	}
+	typeImport.imports = imports
+
+	if typeImport.defaultExport == ident {
+		typeImport.defaultExport = ""
+	}
+}
+
 func (imps *Imports) ExportAll(path string) (string, error) {
 	return imps.export(path, "")
 }
@@ -341,23 +368,23 @@ func (imps *Imports) exportType(path string, as string, exports ...string) (stri
 // FuncMap returns the FuncMap to be passed to a template
 func (imps *Imports) FuncMap() template.FuncMap {
 	return template.FuncMap{
-		"reserveImport":                  imps.Reserve,
-		"reserveTypeImport":              imps.ReserveType,
-		"reserveDefaultImport":           imps.ReserveDefault,
-		"reserveAllImport":               imps.ReserveAll,
-		"reserveImportPath":              imps.ReserveImportPath,
-		"reserveTypeImportPath":          imps.ReserveTypeImportPath,
-		"conditionallyReserveImportPath": imps.ConditionallyReserveImportPath,
+		"reserveImport":                      imps.Reserve,
+		"reserveTypeImport":                  imps.ReserveType,
+		"reserveDefaultImport":               imps.ReserveDefault,
+		"reserveAllImport":                   imps.ReserveAll,
+		"reserveImportPath":                  imps.ReserveImportPath,
+		"reserveTypeImportPath":              imps.ReserveTypeImportPath,
+		"conditionallyReserveImportPath":     imps.ConditionallyReserveImportPath,
 		"conditionallyReserveTypeImportPath": imps.ConditionallyReserveTypeImportPath,
-		"useImport":                      imps.Use,
-		"useImportMaybe":                 imps.UseMaybe,
-		"useTypeImport":                  imps.UseType,
-		"useTypeImportMaybe":             imps.UseTypeMaybe,
-		"exportAll":                      imps.ExportAll,
-		"exportAllAs":                    imps.ExportAllAs,
-		"export":                         imps.Export,
-		"exportType":                     imps.ExportType,
-		"dict":                           dict,
+		"useImport":                          imps.Use,
+		"useImportMaybe":                     imps.UseMaybe,
+		"useTypeImport":                      imps.UseType,
+		"useTypeImportMaybe":                 imps.UseTypeMaybe,
+		"exportAll":                          imps.ExportAll,
+		"exportAllAs":                        imps.ExportAllAs,
+		"export":                             imps.Export,
+		"exportType":                         imps.ExportType,
+		"dict":                               dict,
 	}
 }
 

--- a/internal/tsimport/import_test.go
+++ b/internal/tsimport/import_test.go
@@ -146,6 +146,27 @@ func TestImports(t *testing.T) {
 				getLine("import {User} from {path};", "src/ent/user"),
 			},
 		},
+		"type + value import same path and same name": {
+			fn: func(imps *Imports) {
+				require.Nil(t, reserveTypeImport(imps, "src/ent/generated/types", "MatrixVisibility"))
+				require.Nil(t, useTypeImport(imps, "MatrixVisibility"))
+				require.Nil(t, reserveImport(imps, "src/ent/generated/types", "MatrixVisibility"))
+				require.Nil(t, useImport(imps, "MatrixVisibility"))
+			},
+			expectedLines: []string{
+				getLine("import {MatrixVisibility} from {path};", "src/ent/generated/types"),
+			},
+		},
+		"type usage promoted when value import is reserved later": {
+			fn: func(imps *Imports) {
+				require.Nil(t, reserveTypeImport(imps, "src/ent/generated/types", "MatrixVisibility"))
+				require.Nil(t, useTypeImport(imps, "MatrixVisibility"))
+				require.Nil(t, reserveImport(imps, "src/ent/generated/types", "MatrixVisibility"))
+			},
+			expectedLines: []string{
+				getLine("import {MatrixVisibility} from {path};", "src/ent/generated/types"),
+			},
+		},
 		"nothing used": {
 			fn: func(imps *Imports) {
 				require.Nil(t, reserveImport(imps, codepath.Package, "loadEnt", "loadEntX", "Viewer"))

--- a/testdata/codegen_matrix/README.md
+++ b/testdata/codegen_matrix/README.md
@@ -1,0 +1,121 @@
+# Ent Codegen Feature Matrix
+
+The codegen matrix is the broad smoke suite for Ent schema features. It exists
+to catch generated TypeScript, GraphQL, import-order, DB schema, and
+idempotence regressions before they reach downstream apps.
+
+Run it with:
+
+```sh
+go test ./internal/codegenmatrix -count=1
+```
+
+Run one fixture while iterating with:
+
+```sh
+ENT_CODEGEN_MATRIX_FIXTURE=feature_stress go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
+ENT_CODEGEN_MATRIX_FIXTURE=db_schema_smoke go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
+ENT_CODEGEN_MATRIX_POSTGRES_URL=postgres://postgres:postgres@localhost:5432/postgres ENT_CODEGEN_MATRIX_FIXTURE=postgres_schema_smoke go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
+```
+
+## What It Tests
+
+The matrix catalog lives in `features.yml`.
+
+- `feature_stress` runs TS schema parsing, `tsent codegen --step codegen`,
+  `tsent codegen --step graphql`, generated TypeScript typechecking, and
+  idempotence checks over a broad schema surface.
+- `db_schema_smoke` runs the same checks and also includes
+  `tsent codegen --step db` against SQLite-compatible schema features. Its
+  idempotence snapshot includes DB-generated schema and migration files. It
+  includes the shared core DB schema fixture.
+- `postgres_schema_smoke` runs the same full flow against core DB schema
+  rendering plus Postgres-only paths such as operator classes and index
+  parameters. It creates a generated temporary database for isolation and runs when
+  `ENT_CODEGEN_MATRIX_POSTGRES_URL` or a Postgres `DB_CONNECTION_STRING` is
+  present; otherwise it skips locally. Go CI already provides Postgres. It
+  includes the same shared core DB schema fixture as `db_schema_smoke`.
+- `TestFeatureCatalogClassifiesCodegenInputs` reflects exported fields,
+  selected enum constants from `internal/schema/input/input.go`, and action
+  operation mappings from `getTSStringOperation`; it verifies every active
+  feature in the catalog is either covered by a fixture, delegated to an
+  existing test, or skipped with an explicit reason.
+- `TestSyntheticOwnersDoNotDuplicateDerivedInputs` keeps the manual
+  supplemental owner list limited to non-reflectable inputs.
+
+The harness builds the current checked-out `tsent` and package-shaped
+`@snowtop/ent` `ts/dist`, copies fixtures to a temp app, symlinks local
+`ts/node_modules`, runs real codegen steps, checks the generated tree is stable
+across repeated runs, and then runs `tsc --noEmit` against the generated app.
+It locates the repository from the Go test source path, so it does not require
+`git rev-parse` at runtime.
+
+## Bar For Adding Coverage
+
+Add matrix coverage when a change affects generated files, schema parsing,
+GraphQL generation, DB schema rendering, generated imports, action/builder
+types, field-edge/query generation, or a customer-reported generated-code
+failure.
+
+The bar is:
+
+- Prefer one representative fixture interaction over a cartesian-product grid.
+  A nullable boolean is usually not interesting; an id field with a foreign key,
+  field edge, custom name, transform, or privacy policy often is.
+- Cover interactions that cross codegen boundaries: field type plus action,
+  pattern plus privacy, transform plus generated import, field edge plus indexed
+  query, custom GraphQL plus generated object, DB index plus schema output.
+- For customer-reported failures, add or extend a behavior-named feature and
+  make the fixture fail on the generated compile/idempotence path that would
+  have caught it. Keep issue or PR numbers in rationale only when they add
+  useful traceability.
+- If a feature is supported but cannot yet run in this matrix, mark it
+  `mode: skipped` with a focused reason. Do not leave it unclassified.
+- If a feature is already covered by a narrower unit/runtime/example test, use
+  `mode: existing_test` and list the test refs.
+- If a field in `internal/schema/input/input.go` is metadata rather than a
+  codegen selector, classify it as `mode: non_codegen` with a rationale.
+- Track known matrix gaps as behavior-named skipped features, even when they are
+  not tied to a reflected input owner.
+- For DB-rendered behavior, set `dialect_coverage` on the feature. Core DB
+  behavior should usually declare `dialect_coverage: [sqlite, postgres]`;
+  dialect-specific behavior should declare only the dialect it needs. The
+  catalog test fails when a declared dialect is not covered by a matching
+  fixture, or when a dialect fixture covers a feature that does not declare that
+  dialect.
+
+## Adding A Fixture
+
+1. Add files under `testdata/codegen_matrix/fixtures/<fixture_id>`.
+2. Add the fixture to `features.yml` with its `surfaces`, `covers`, and optional
+   `includes`. DB fixtures must also declare `dialect: sqlite` or
+   `dialect: postgres`.
+3. Add or update feature entries so every active feature is covered.
+4. Run the fixture directly, then run the whole package.
+
+Put core DB-rendered interactions in `fixtures/_shared/core_db` so the same
+schema source is exercised by both `db_schema_smoke` and
+`postgres_schema_smoke`. Use each dialect fixture directory only for behavior
+that is truly dialect-specific. Put PostGIS, pgvector, and extension-backed
+concrete field/index behavior in package-specific fixtures unless the CI image
+installs those extensions.
+
+## Interpreting Failures
+
+- Codegen step failures usually mean the fixture hit an unsupported combination
+  or exposed a generator bug.
+- TypeScript failures mean generated code did not compile and should usually be
+  fixed before adding a skip.
+- Idempotence failures include the changed generated files and a first-line diff
+  summary. The snapshot intentionally ignores build-info UUIDs and terminal
+  newline churn.
+- Catalog failures mean a new codegen input was added without a coverage
+  decision.
+
+## Tracked Gaps
+
+- `assoc_edge_config.stable_edge_type_ids`: idempotence snapshots normalize UUID
+  literals, but they do not yet prove DB-stored association edge type IDs remain
+  stable across generations.
+- `index.full_text`: Postgres full-text indexes currently generate a repeated
+  drop-index migration after apply.

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -1,0 +1,878 @@
+version: 1
+
+fixtures:
+  - id: feature_stress
+    path: fixtures/feature_stress
+    description: >
+      Broad compile-time smoke fixture for generated TS, GraphQL, imports,
+      patterns, struct fields, action inputs, field edges, indexed edges, and
+      historically fragile generated-code interactions.
+    surfaces:
+      - parse_ts_schema
+      - ts_codegen
+      - graphql_codegen
+      - generated_tsc
+      - idempotence
+    covers:
+      - schema.nodes
+      - schema.patterns
+      - schema.global_schema
+      - node.table_name
+      - node.field_overrides
+      - node.assoc_edges
+      - node.assoc_edge_groups
+      - node.actions
+      - node.constraints
+      - node.indices
+      - node.hide_from_graphql
+      - node.patterns
+      - node.support_upsert
+      - node.show_can_viewer_see
+      - node.show_can_viewer_edit
+      - node.default_action_privacy
+      - global.extra_edge_fields
+      - global.edge_indices
+      - global.db_extensions
+      - db_extension.metadata
+      - field.uuid
+      - field.boolean
+      - field.int
+      - field.bigint
+      - field.float
+      - field.string
+      - field.timestamp
+      - field.timestamptz
+      - field.time
+      - field.timetz
+      - field.date
+      - field.json
+      - field.jsonb
+      - field.string_enum
+      - field.int_enum
+      - field.list
+      - field.bytea
+      - field.string_byte
+      - field.nullable
+      - field.storage_key
+      - field.unique
+      - field.hide_from_graphql
+      - field.private
+      - field.graphql_name
+      - field.index
+      - field.index_concurrently
+      - field.index_where
+      - field.primary_key
+      - field.default_to_viewer_on_create
+      - field.foreign_key
+      - field.field_edge
+      - field.server_default
+      - field.disable_user_editable
+      - field.disable_user_graphql_editable
+      - field.default_value_on_create
+      - field.default_value_on_edit
+      - field.field_privacy
+      - field.edit_field_privacy
+      - field.polymorphic
+      - field.derived_when_embedded
+      - field.derived_fields
+      - field.convert
+      - field.fetch_on_demand
+      - field.db_only
+      - field.disable_base64_encode
+      - field.immutable
+      - field.struct_subfields
+      - field.union_fields
+      - field.foreign_key.ondelete
+      - field.field_edge.inverse
+      - field.field_edge.index_edge
+      - field.polymorphic.types
+      - field.polymorphic.hide_inverse_graphql
+      - field.polymorphic.disable_builder_type
+      - field.polymorphic.edge_const_name
+      - assoc_edge.basic
+      - assoc_edge.symmetric
+      - assoc_edge.unique
+      - assoc_edge.inverse
+      - assoc_edge.edge_actions
+      - assoc_edge.hide_from_graphql
+      - assoc_edge.edge_const_name
+      - assoc_edge_group.basic
+      - assoc_edge_group.viewer_based
+      - assoc_edge_group.status_enums
+      - assoc_edge_group.null_states
+      - assoc_edge_group.edge_action
+      - action.edge_add
+      - action.edge_remove
+      - action.edge_group
+      - action.create
+      - action.edit
+      - action.delete
+      - action.mutations
+      - action.fields
+      - action.excluded_fields
+      - action.optional_fields
+      - action.required_fields
+      - action.no_fields
+      - action.custom_names
+      - action.hide_from_graphql
+      - action.action_only_fields
+      - action.can_viewer_do
+      - action.can_fail
+      - action_field.scalar
+      - action_field.list
+      - action_field.nullable_contents
+      - action_field.optional
+      - action_field.hide_from_graphql
+      - constraint.primary
+      - constraint.foreign_key
+      - constraint.unique
+      - constraint.check
+      - constraint.columns
+      - index.basic
+      - index.unique
+      - index.concurrently
+      - index.where
+      - custom_graphql.custom_mutation_return
+      - pattern.struct_privacy_import
+      - polymorphic.struct_field_codegen
+      - field_edge.uuid_list_inverse
+      - polymorphic.indexed_query_import
+      - transform_read.enum_value_import
+  - id: db_schema_smoke
+    path: fixtures/db_schema_smoke
+    includes:
+      - fixtures/_shared/core_db
+    description: >
+      SQLite-compatible full-flow fixture that includes the DB schema step plus
+      generated TS, GraphQL, generated typecheck, and idempotence checks.
+    surfaces:
+      - parse_ts_schema
+      - db_codegen
+      - ts_codegen
+      - graphql_codegen
+      - generated_tsc
+      - idempotence
+    dialect: sqlite
+    covers:
+      - schema.nodes
+      - node.table_name
+      - node.actions
+      - field.uuid
+      - field.string
+      - field.int
+      - field.nullable
+      - field.index
+      - field.foreign_key
+      - field.foreign_key.ondelete
+      - field.server_default
+      - field.storage_key
+      - field.unique
+      - node.constraints
+      - node.indices
+      - constraint.unique
+      - constraint.check
+      - constraint.columns
+      - index.basic
+      - index.where
+      - action.create
+      - action.edit
+      - action.delete
+      - action.mutations
+  - id: postgres_schema_smoke
+    path: fixtures/postgres_schema_smoke
+    includes:
+      - fixtures/_shared/core_db
+    description: >
+      Postgres-backed DB schema fixture for core DB rendering plus
+      Postgres-only index rendering. Runs in CI when DB_CONNECTION_STRING
+      points at Postgres and skips locally when no Postgres DSN is configured.
+    surfaces:
+      - parse_ts_schema
+      - postgres_db_codegen
+      - ts_codegen
+      - graphql_codegen
+      - generated_tsc
+      - idempotence
+    dialect: postgres
+    covers:
+      - schema.nodes
+      - node.table_name
+      - node.actions
+      - field.uuid
+      - field.string
+      - field.int
+      - field.timestamptz
+      - field.nullable
+      - field.index
+      - field.foreign_key
+      - field.foreign_key.ondelete
+      - field.server_default
+      - field.storage_key
+      - field.unique
+      - node.constraints
+      - node.indices
+      - constraint.unique
+      - constraint.check
+      - constraint.columns
+      - index.basic
+      - index.index_type
+      - index.where
+      - index.ops
+      - index.params
+      - action.create
+      - action.edit
+      - action.delete
+      - action.mutations
+
+features:
+  - id: schema.nodes
+    owns: [input.Schema.Nodes, input.Node.Fields]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Top-level source for generated nodes, ent files, DB tables, and GraphQL objects.
+  - id: schema.patterns
+    owns: [input.Schema.Patterns, input.Pattern.Name, input.Pattern.Fields, input.Pattern.AssocEdges, input.Pattern.DisableMixin]
+    mode: explicit
+    rationale: Pattern fields and edges generate mixins, interfaces, imports, and inherited action fields.
+  - id: schema.global_schema
+    owns: [input.Schema.GlobalSchema]
+    mode: explicit
+    rationale: Global schema changes generated edge tables, global fields, and DB extension metadata.
+
+  - id: node.table_name
+    owns: [input.Node.TableName]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Table names affect DB schema and generated loader options.
+  - id: node.field_overrides
+    owns: [input.Node.FieldOverrides, input.FieldOverride.Nullable, input.FieldOverride.StorageKey, input.FieldOverride.Unique, input.FieldOverride.HideFromGraphQL, input.FieldOverride.GraphQLName, input.FieldOverride.Index, input.FieldOverride.IndexConcurrently, input.FieldOverride.IndexWhere, input.FieldOverride.ServerDefault]
+    mode: representative
+    rationale: Field override plumbing is shared; one representative field override covers the generated paths.
+  - id: node.assoc_edges
+    owns: [input.Node.AssocEdges]
+    mode: explicit
+    rationale: Association edges generate query classes, constants, action classes, GraphQL connections, and edge tables.
+  - id: node.assoc_edge_groups
+    owns: [input.Node.AssocEdgeGroups]
+    mode: explicit
+    rationale: Edge groups generate grouped action and query surfaces distinct from normal edges.
+  - id: node.actions
+    owns: [input.Node.Actions]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Actions generate builders, action bases, GraphQL mutation inputs, and operation-specific types.
+  - id: node.enum_table
+    owns: [input.Node.EnumTable, input.Node.DBRows]
+    mode: skipped
+    skip_reason: Lookup table enums need a small DB/render fixture; not part of compile-only smoke yet.
+  - id: node.constraints
+    owns: [input.Node.Constraints]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Constraints are DB-rendered codegen behavior and should stay in the matrix even without live DB.
+  - id: node.indices
+    owns: [input.Node.Indices]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Indices affect DB schema and can pull in extension/operator-class code paths.
+  - id: node.hide_from_graphql
+    owns: [input.Node.HideFromGraphQL]
+    mode: representative
+    rationale: Hiding one node exercises generated GraphQL deletion/omission behavior.
+  - id: node.edge_const_name
+    owns: [input.Node.EdgeConstName]
+    mode: skipped
+    skip_reason: Node-level edgeConstName exists in Go input but is not exposed by the current TS schema config type.
+  - id: node.transforms
+    owns: [input.Node.TransformsSelect, input.Node.TransformsDelete, input.Node.TransformsLoaderCodegen, input.TransformsLoaderCodegen.Code, input.TransformsLoaderCodegen.Imports]
+    mode: skipped
+    skip_reason: Transform read/delete needs a runtime loader smoke fixture; cataloged but not covered by compile-only fixture.
+  - id: node.patterns
+    owns: [input.Node.PatternName, input.Node.Patterns]
+    mode: explicit
+    rationale: Applying patterns to nodes is the common inherited-field regression surface.
+  - id: node.schema_path
+    owns: [input.Node.SchemaPath]
+    mode: non_codegen
+    rationale: SchemaPath records the source TS file for bookkeeping and incremental comparisons.
+  - id: node.custom_graphql_interfaces
+    owns: [input.Node.CustomGraphQLInterfaces]
+    mode: skipped
+    skip_reason: Custom GraphQL interfaces currently require decorator-scanned interface classes; skipped with decorator scanning until the local scanner is stable.
+  - id: node.support_upsert
+    owns: [input.Node.SupportUpsert]
+    mode: representative
+    rationale: Upsert toggles generated action APIs.
+  - id: node.show_can_viewer_see
+    owns: [input.Node.ShowCanViewerSee]
+    mode: representative
+    rationale: Generates field-privacy GraphQL surfaces.
+  - id: node.show_can_viewer_edit
+    owns: [input.Node.ShowCanViewerEdit]
+    mode: representative
+    rationale: Generates edit-privacy GraphQL surfaces.
+  - id: node.default_action_privacy
+    owns: [input.Node.HasDefaultActionPrivacy]
+    mode: representative
+    rationale: Default action privacy changes generated action imports.
+
+  - id: global.extra_edge_fields
+    owns: [input.GlobalSchema.ExtraEdgeFields]
+    mode: representative
+    rationale: Extra edge fields alter common edge table rendering and types.
+  - id: global.global_edges
+    owns: [input.GlobalSchema.GlobalEdges]
+    mode: skipped
+    skip_reason: Current TS codegen fails generated query processing for Global-owned edges; needs a focused fix before enabling.
+  - id: global.edge_indices
+    owns: [input.GlobalSchema.EdgeIndices]
+    mode: representative
+    rationale: Edge index DB rendering differs from node index rendering.
+  - id: global.init
+    owns: [input.GlobalSchema.Init]
+    mode: non_codegen
+    rationale: Init is carried in input metadata but does not currently select generated TS behavior.
+  - id: global.transforms_edges
+    owns: [input.GlobalSchema.TransformsEdges]
+    mode: skipped
+    skip_reason: Edge transform write/read needs runtime DB edge smoke coverage.
+  - id: global.global_fields
+    owns: [input.GlobalSchema.GlobalFields]
+    mode: skipped
+    skip_reason: Current global field parsing requires a primary key table shape; needs a focused fixture after clarifying intended support.
+  - id: global.db_extensions
+    owns: [input.GlobalSchema.DBExtensions]
+    mode: explicit
+    rationale: DB extensions affect generated schema metadata and runtime extension config.
+  - id: db_extension.metadata
+    owns: [input.DBExtension.Name, input.DBExtension.ProvisionedBy, input.DBExtension.Version, input.DBExtension.InstallSchema, input.DBExtension.RuntimeSchemas, input.DBExtension.DropCascade]
+    mode: representative
+    rationale: DB extension options share one metadata rendering path.
+
+  - id: field.uuid
+    owns: [input.FieldType.DBType, input.Field.Name, input.Field.Type, input.DBType.UUID]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: UUID is the id/edge/fkey workhorse and gets multiple explicit interactions.
+  - id: field.int64_id
+    owns: [input.DBType.Int64ID]
+    mode: skipped
+    skip_reason: The TS parser marks Int64ID unsupported today.
+  - id: field.boolean
+    owns: [input.DBType.Boolean]
+    mode: representative
+    rationale: Boolean scalar itself is covered once; nullable boolean is intentionally not a special interaction.
+  - id: field.int
+    owns: [input.DBType.Int]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Numeric scalar import and GraphQL mapping.
+  - id: field.bigint
+    owns: [input.DBType.BigInt]
+    mode: representative
+    rationale: BigInt has distinct generated TS/runtime type mapping.
+  - id: field.float
+    owns: [input.DBType.Float]
+    mode: representative
+    rationale: Float has distinct GraphQL scalar mapping.
+  - id: field.string
+    owns: [input.FieldType.CustomType, input.DBType.String, input.CustomType.EmailType, input.CustomType.PhoneType, input.CustomType.PasswordType]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: String and string-backed custom types share scalar generation; package custom types remain package-level tests.
+  - id: field.timestamp
+    owns: [input.DBType.Timestamp]
+    mode: representative
+    rationale: Timestamp has custom GraphQL scalar handling.
+  - id: field.timestamptz
+    owns: [input.DBType.Timestamptz]
+    mode: representative
+    dialect_coverage: [postgres]
+    rationale: Timestamptz uses a distinct DB type but shared TS shape.
+  - id: field.time
+    owns: [input.DBType.Time]
+    mode: representative
+    rationale: Time has custom GraphQL scalar handling.
+  - id: field.timetz
+    owns: [input.DBType.Timetz]
+    mode: representative
+    rationale: Timetz uses a distinct DB type but shared TS shape.
+  - id: field.date
+    owns: [input.DBType.Date]
+    mode: representative
+    rationale: Date has had nullable/runtime regressions and generated GraphQL scalar behavior.
+  - id: field.json
+    owns: [input.DBType.JSON]
+    mode: representative
+    rationale: JSON and JSONB diverge in DB rendering.
+  - id: field.jsonb
+    owns: [input.DBType.JSONB]
+    mode: representative
+    rationale: JSONB is the default struct/union storage path.
+  - id: field.string_enum
+    owns: [input.DBType.Enum, input.DBType.StringEnum, input.FieldType.Values, input.FieldType.EnumMap, input.FieldType.Type, input.FieldType.GraphQLType, input.FieldType.DisableUnknownType, input.FieldType.GlobalType]
+    mode: representative
+    rationale: String enum generation covers TS enum, GraphQL enum, global enum, and unknown handling.
+  - id: field.int_enum
+    owns: [input.DBType.IntEnum, input.FieldType.IntEnumMap, input.FieldType.DeprecatedIntEnumMap]
+    mode: representative
+    rationale: Integer enum generation has separate conversion and GraphQL paths.
+  - id: field.list
+    owns: [input.DBType.List, input.FieldType.ListElemType]
+    mode: representative
+    rationale: List wrapper generation is shared; interesting list+edge interactions are explicit.
+  - id: field.bytea
+    owns: [input.DBType.Bytea]
+    mode: representative
+    rationale: Binary DB storage has distinct type mapping.
+  - id: field.string_byte
+    owns: [input.DBType.StringByte]
+    mode: representative
+    rationale: Text-backed binary storage has distinct type mapping.
+  - id: field.postgres_type
+    owns: [input.FieldType.PostgresType]
+    mode: skipped
+    skip_reason: Postgres custom column types need a focused TS schema helper or JSON-schema fixture; the current Postgres smoke covers index rendering first.
+  - id: field.db_extension_type
+    owns: [input.FieldType.DBExtension]
+    mode: skipped
+    skip_reason: Extension-backed concrete fields need postgis/pgvector package fixtures.
+  - id: field.import_type
+    owns: [input.FieldType.ImportType]
+    mode: skipped
+    skip_reason: Custom import type should be covered with a focused custom scalar fixture.
+  - id: field.struct_subfields
+    owns: [input.FieldType.SubFields]
+    mode: explicit
+    rationale: Struct fields are frequent codegen/runtime regression sources.
+  - id: field.union_fields
+    owns: [input.FieldType.UnionFields]
+    mode: representative
+    rationale: Union fields generate shared types and GraphQL object/union wiring.
+
+  - id: field.nullable
+    owns: [input.Field.Nullable]
+    mode: once
+    dialect_coverage: [sqlite, postgres]
+    rationale: Nullability is a modifier; only explicit interactions get their own case.
+  - id: field.storage_key
+    owns: [input.Field.StorageKey]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Storage key changes DB columns and transformWrite input shape.
+  - id: field.unique
+    owns: [input.Field.Unique]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Unique fields alter DB constraints and generated loaders.
+  - id: field.hide_from_graphql
+    owns: [input.Field.HideFromGraphQL]
+    mode: representative
+    rationale: GraphQL omission is shared across scalar field types.
+  - id: field.private
+    owns: [input.Field.Private, input.PrivateOptions.ExposeToActions]
+    mode: representative
+    rationale: Private fields alter ent, action, and GraphQL generation.
+  - id: field.graphql_name
+    owns: [input.Field.GraphQLName]
+    mode: representative
+    rationale: Custom GraphQL field names affect generated object and mutation input names.
+  - id: field.index
+    owns: [input.Field.Index]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Scalar index generation is shared.
+  - id: field.index_concurrently
+    owns: [input.Field.IndexConcurrently]
+    mode: representative
+    rationale: Concurrent index DB rendering is separate from plain index rendering.
+  - id: field.index_where
+    owns: [input.Field.IndexWhere]
+    mode: representative
+    rationale: Partial index DB rendering is a separate code path.
+  - id: field.primary_key
+    owns: [input.Field.PrimaryKey]
+    mode: representative
+    rationale: Primary key selection affects base ent and DB schema.
+  - id: field.default_to_viewer_on_create
+    owns: [input.Field.DefaultToViewerOnCreate]
+    mode: representative
+    rationale: Viewer defaults alter action input/builder generation.
+  - id: field.foreign_key
+    owns: [input.Field.ForeignKey, input.ForeignKey.Schema, input.ForeignKey.Column, input.ForeignKey.Name, input.ForeignKey.DisableIndex, input.ForeignKey.DisableBuilderType]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Foreign keys interact with id fields, builder types, and DB constraints.
+  - id: field.foreign_key.ondelete
+    owns: [input.ForeignKey.OnDelete, input.OnDeleteFkey.Restrict, input.OnDeleteFkey.Cascade, input.OnDeleteFkey.SetNull, input.OnDeleteFkey.SetDefault, input.OnDeleteFkey.NoAction]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: ON DELETE variants share one DB-rendering path.
+  - id: field.field_edge
+    owns: [input.Field.FieldEdge, input.FieldEdge.Schema, input.FieldEdge.DisableBuilderType, input.FieldEdge.EdgeConstName]
+    mode: explicit
+    rationale: Field edges generate loaders, queries, connections, and action edge maintenance.
+  - id: field.field_edge.inverse
+    owns: [input.FieldEdge.InverseEdge, input.InverseFieldEdge.Name, input.InverseFieldEdge.TableName, input.InverseFieldEdge.HideFromGraphQL, input.InverseFieldEdge.EdgeConstName]
+    mode: explicit
+    rationale: Inverse field edges have distinct generated query and GraphQL paths.
+  - id: field.field_edge.index_edge
+    owns: [input.FieldEdge.IndexEdge, input.IndexEdgeOptions.Name, input.IndexEdgeOptions.OrderBy, input.OrderByOption.Column, input.OrderByOption.Direction, input.OrderByDirection.Ascending, input.OrderByDirection.Descending, input.OrderByOption.Alias, input.OrderByOption.NullsPlacement, input.NullsPlacement.First, input.NullsPlacement.Last]
+    mode: explicit
+    rationale: Indexed field edges produce generated query base files and import-stress failures.
+  - id: field.server_default
+    owns: [input.Field.ServerDefault]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Server defaults affect DB schema and action input optionality.
+  - id: field.disable_user_editable
+    owns: [input.Field.DisableUserEditable]
+    mode: representative
+    rationale: Removes generated setters/action inputs.
+  - id: field.disable_user_graphql_editable
+    owns: [input.Field.DisableUserGraphQLEditable]
+    mode: representative
+    rationale: Removes GraphQL mutation input fields while retaining TS action behavior.
+  - id: field.default_value_on_create
+    owns: [input.Field.HasDefaultValueOnCreate]
+    mode: representative
+    rationale: Default-on-create alters generated action required fields.
+  - id: field.default_value_on_edit
+    owns: [input.Field.HasDefaultValueOnEdit]
+    mode: representative
+    rationale: Default-on-edit alters generated edit action behavior.
+  - id: field.field_privacy
+    owns: [input.Field.HasFieldPrivacy]
+    mode: explicit
+    rationale: Field privacy generates async accessors and has import regressions with struct fields.
+  - id: field.edit_field_privacy
+    owns: [input.Field.HasEditFieldPrivacy]
+    mode: representative
+    rationale: Edit privacy affects action input and canViewerEdit generation.
+  - id: field.polymorphic
+    owns: [input.Field.Polymorphic, input.PolymorphicOptions.Name]
+    mode: explicit
+    rationale: Polymorphic id fields generate derived type fields, query classes, and GraphQL relationships.
+  - id: field.polymorphic.types
+    owns: [input.PolymorphicOptions.Types]
+    mode: explicit
+    rationale: Type restrictions affect generated imports and GraphQL unions.
+  - id: field.polymorphic.hide_inverse_graphql
+    owns: [input.PolymorphicOptions.HideFromInverseGraphQL]
+    mode: representative
+    rationale: GraphQL omission for inverse polymorphic edges.
+  - id: field.polymorphic.disable_builder_type
+    owns: [input.PolymorphicOptions.DisableBuilderType]
+    mode: representative
+    rationale: Builder type generation changes action inputs.
+  - id: field.polymorphic.edge_const_name
+    owns: [input.PolymorphicOptions.EdgeConstName]
+    mode: explicit
+    rationale: Custom polymorphic edge const names triggered generated query import bugs.
+  - id: field.derived_when_embedded
+    owns: [input.Field.DerivedWhenEmbedded]
+    mode: representative
+    rationale: Embedded action object generation uses this to omit derived fields.
+  - id: field.derived_fields
+    owns: [input.Field.DerivedFields]
+    mode: representative
+    rationale: Derived fields are added to generated field maps.
+  - id: field.convert
+    owns: [input.Field.UserConvert, input.UserConvertType.Path, input.UserConvertType.Function]
+    mode: representative
+    rationale: Convert functions alter generated imports and accessors.
+  - id: field.fetch_on_demand
+    owns: [input.Field.FetchOnDemand]
+    mode: representative
+    rationale: Fetch-on-demand changes base class accessors and privacy behavior.
+  - id: field.db_only
+    owns: [input.Field.DBOnly]
+    mode: representative
+    rationale: DB-only fields should render in DB but disappear from ent/GraphQL surfaces.
+  - id: field.disable_base64_encode
+    owns: [input.Field.DisableBase64Encode]
+    mode: representative
+    rationale: ID encoding behavior changes generated GraphQL field resolver behavior.
+  - id: field.immutable
+    owns: [input.Field.Immutable]
+    mode: representative
+    rationale: Immutable fields affect edit action generation.
+  - id: field.pattern_name
+    owns: [input.Field.PatternName]
+    mode: non_codegen
+    rationale: Internal metadata tracking inherited pattern ownership.
+  - id: field.import
+    owns: [input.Field.Import]
+    mode: non_codegen
+    rationale: Import is transient parser state and is intentionally not serialized into schema.json.
+
+  - id: assoc_edge.basic
+    owns: [input.AssocEdge.Name, input.AssocEdge.SchemaName, input.AssocEdge.TableName, input.AssocEdge.PatternName]
+    mode: explicit
+    rationale: Basic association edge generation.
+  - id: assoc_edge.symmetric
+    owns: [input.AssocEdge.Symmetric]
+    mode: representative
+    rationale: Symmetric edges alter edge config and inverse writes.
+  - id: assoc_edge.unique
+    owns: [input.AssocEdge.Unique]
+    mode: representative
+    rationale: Unique edges generate distinct loader/action shapes.
+  - id: assoc_edge.inverse
+    owns: [input.AssocEdge.InverseEdge, input.InverseAssocEdge.Name, input.InverseAssocEdge.EdgeConstName, input.InverseAssocEdge.HideFromGraphQL]
+    mode: explicit
+    rationale: Inverse association edges generate paired edge types and GraphQL fields.
+  - id: assoc_edge.edge_actions
+    owns: [input.AssocEdge.EdgeActions]
+    mode: explicit
+    rationale: Edge actions generate action classes and GraphQL mutations.
+  - id: assoc_edge.hide_from_graphql
+    owns: [input.AssocEdge.HideFromGraphQL]
+    mode: representative
+    rationale: Edge GraphQL omission is shared.
+  - id: assoc_edge.edge_const_name
+    owns: [input.AssocEdge.EdgeConstName]
+    mode: representative
+    rationale: Custom edge constants affect generated imports and names.
+  - id: assoc_edge_config.stable_edge_type_ids
+    owns: []
+    mode: skipped
+    skip_reason: Matrix snapshots normalize UUID literals but do not yet assert that assoc_edge_config edge type IDs stay stable across DB generations; needs a focused DB/runtime smoke.
+
+  - id: assoc_edge_group.basic
+    owns: [input.AssocEdgeGroup.Name, input.AssocEdgeGroup.GroupStatusName, input.AssocEdgeGroup.TableName, input.AssocEdgeGroup.AssocEdges]
+    mode: explicit
+    rationale: Edge groups have separate generated state and action code.
+  - id: assoc_edge_group.viewer_based
+    owns: [input.AssocEdgeGroup.ViewerBased]
+    mode: representative
+    rationale: Viewer-based groups generate viewer-specific helpers.
+  - id: assoc_edge_group.status_enums
+    owns: [input.AssocEdgeGroup.StatusEnums]
+    mode: representative
+    rationale: Restricted status enum generation.
+  - id: assoc_edge_group.null_states
+    owns: [input.AssocEdgeGroup.NullStateFn, input.AssocEdgeGroup.NullStates]
+    mode: representative
+    rationale: Null-state helpers alter generated edge group accessors.
+  - id: assoc_edge_group.edge_action
+    owns: [input.AssocEdgeGroup.EdgeAction, input.AssocEdgeGroup.EdgeActions]
+    mode: explicit
+    rationale: Edge group action generation is distinct from normal edge actions.
+  - id: assoc_edge_group.action_edges
+    owns: [input.AssocEdgeGroup.ActionEdges]
+    mode: non_codegen
+    rationale: ActionEdges is Go-only parsed state and not serialized through the TS schema input.
+
+  - id: action.create
+    owns: [input.Action.Operation, input.Action.Operation.Create]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Create action generation.
+  - id: action.edit
+    owns: [input.Action.Operation.Edit]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Edit action generation.
+  - id: action.delete
+    owns: [input.Action.Operation.Delete]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Delete action generation.
+  - id: action.mutations
+    owns: [input.Action.Operation.Mutations]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Mutations shortcut generation.
+  - id: action.edge_add
+    owns: [input.EdgeAction.Operation, input.EdgeAction.Operation.AddEdge]
+    mode: explicit
+    rationale: Add-edge action generation.
+  - id: action.edge_remove
+    owns: [input.EdgeAction.Operation.RemoveEdge]
+    mode: explicit
+    rationale: Remove-edge action generation.
+  - id: action.edge_group
+    owns: [input.EdgeAction.Operation.EdgeGroup]
+    mode: explicit
+    rationale: Edge-group action generation.
+  - id: action.fields
+    owns: [input.Action.Fields]
+    mode: representative
+    rationale: Field selection drives generated input type composition.
+  - id: action.excluded_fields
+    owns: [input.Action.ExcludedFields]
+    mode: representative
+    rationale: Exclusions have caused embedded object input bugs.
+  - id: action.optional_fields
+    owns: [input.Action.OptionalFields]
+    mode: representative
+    rationale: Optional field overrides affect generated action type requiredness.
+  - id: action.required_fields
+    owns: [input.Action.RequiredFields]
+    mode: representative
+    rationale: Required field overrides affect generated action type requiredness.
+  - id: action.no_fields
+    owns: [input.Action.NoFields]
+    mode: representative
+    rationale: No-field actions generate different constructor/input shapes.
+  - id: action.custom_names
+    owns: [input.Action.CustomActionName, input.Action.CustomGraphQLName, input.Action.CustomInputName, input.EdgeAction.CustomActionName, input.EdgeAction.CustomGraphQLName, input.EdgeAction.CustomInputName]
+    mode: representative
+    rationale: Custom names have import reservation and input rename regressions.
+  - id: action.hide_from_graphql
+    owns: [input.Action.HideFromGraphQL, input.EdgeAction.HideFromGraphQL]
+    mode: representative
+    rationale: GraphQL mutation omission is shared.
+  - id: action.action_only_fields
+    owns: [input.Action.ActionOnlyFields, input.EdgeAction.ActionOnlyFields, input.ActionField.Name]
+    mode: explicit
+    rationale: Action-only fields generate standalone input fields and embedded object inputs.
+  - id: action.can_viewer_do
+    owns: [input.Action.CanViewerDo, input.EdgeAction.CanViewerDo, input.CanViewerDo.AddAllFields, input.CanViewerDo.InputFields]
+    mode: representative
+    rationale: CanViewerDo adds GraphQL fields and action input plumbing.
+  - id: action.can_fail
+    owns: [input.Action.CanFail, input.EdgeAction.CanFail]
+    mode: representative
+    rationale: Can-fail changes generated save behavior.
+
+  - id: action_field.scalar
+    owns: [input.ActionField.Type, input.ActionField.Type.ID, input.ActionField.Type.Boolean, input.ActionField.Type.Int, input.ActionField.Type.Float, input.ActionField.Type.String, input.ActionField.Type.Time, input.ActionField.Type.JSON]
+    mode: representative
+    rationale: Action-only scalar fields share render paths with representative scalar coverage.
+  - id: action_field.object
+    owns: [input.ActionField.Type.Object, input.ActionField.ActionName, input.ActionField.ExcludedFields]
+    mode: skipped
+    skip_reason: Generated action bases currently reference the lower-case embedded input interface without declaring/importing it; needs a focused action-only object fix.
+  - id: action_field.list
+    owns: [input.ActionField.List]
+    mode: representative
+    rationale: List wrapping is a distinct generated input shape.
+  - id: action_field.nullable_contents
+    owns: [input.ActionField.Nullable, input.NullableItem.Contents, input.NullableItem.ContentsAndList, input.NullableItem.True]
+    mode: representative
+    rationale: Nullable list contents are an explicit action input encoding.
+  - id: action_field.optional
+    owns: [input.ActionField.Optional]
+    mode: representative
+    rationale: Optional action-only fields affect generated constructor typing.
+  - id: action_field.hide_from_graphql
+    owns: [input.ActionField.HideFromGraphQL]
+    mode: representative
+    rationale: Hides only the GraphQL input field.
+
+  - id: constraint.primary
+    owns: [input.Constraint.Type, input.Constraint.Type.PrimaryKey]
+    mode: representative
+    rationale: Primary key constraint DB rendering.
+  - id: constraint.foreign_key
+    owns: [input.Constraint.Type.ForeignKey, input.Constraint.ForeignKey, input.ForeignKeyInfo.TableName, input.ForeignKeyInfo.Columns, input.ForeignKeyInfo.OnDelete]
+    mode: representative
+    rationale: Multi-column foreign-key DB rendering.
+  - id: constraint.unique
+    owns: [input.Constraint.Type.Unique]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Unique constraint DB rendering.
+  - id: constraint.check
+    owns: [input.Constraint.Type.Check, input.Constraint.Condition]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Check constraint DB rendering.
+  - id: constraint.columns
+    owns: [input.Constraint.Name, input.Constraint.Columns]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Shared constraint naming/column plumbing.
+
+  - id: index.basic
+    owns: [input.Index.Name, input.Index.Columns]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Basic index DB rendering.
+  - id: index.unique
+    owns: [input.Index.Unique]
+    mode: representative
+    rationale: Unique index DB rendering.
+  - id: index.full_text
+    owns: [input.Index.FullText, input.FullText.GeneratedColumnName, input.FullText.Language, input.FullText.Language.English, input.FullText.Language.French, input.FullText.Language.German, input.FullText.Language.Simple, input.FullText.LanguageColumn, input.FullText.IndexType, input.FullText.Weights, input.FullTextWeight.A, input.FullTextWeight.B, input.FullTextWeight.C, input.FullTextWeight.D]
+    mode: skipped
+    skip_reason: Postgres full-text indexes currently generate a repeated drop-index migration after apply; enable once DB idempotence is fixed.
+  - id: index.index_type
+    owns: [input.Index.IndexType, input.IndexType.Gin, input.IndexType.Gist, input.IndexType.Btree, input.IndexType.Hash, input.IndexType.SpGist, input.IndexType.Brin, input.IndexType.HNSW, input.IndexType.IVFFlat]
+    mode: representative
+    dialect_coverage: [postgres]
+    rationale: Postgres access methods share DB rendering; the Postgres smoke exercises explicit access-method output.
+  - id: index.concurrently
+    owns: [input.Index.Concurrently]
+    mode: representative
+    rationale: Concurrent index rendering has separate DB options.
+  - id: index.where
+    owns: [input.Index.Where]
+    mode: representative
+    dialect_coverage: [sqlite, postgres]
+    rationale: Partial index rendering.
+  - id: index.ops
+    owns: [input.Index.Ops]
+    mode: representative
+    dialect_coverage: [postgres]
+    rationale: Operator classes are Postgres-only and are covered by the Postgres DB-render fixture.
+  - id: index.params
+    owns: [input.Index.IndexParams]
+    mode: representative
+    dialect_coverage: [postgres]
+    rationale: Index WITH params are Postgres-only and are covered by the Postgres DB-render fixture.
+  - id: index.db_extension
+    owns: [input.Index.DBExtension]
+    mode: skipped
+    skip_reason: Extension-backed indexes need postgis/pgvector package fixtures.
+
+  - id: custom_graphql.decorators
+    owns: [custom_graphql.gqlField, custom_graphql.gqlObjectType, custom_graphql.gqlInputObjectType, custom_graphql.gqlQuery, custom_graphql.gqlMutation, custom_graphql.gqlConnection]
+    mode: skipped
+    skip_reason: Local decorator scanning becomes unstable after generated ent files exist; JSON custom GraphQL keeps mutation codegen covered while decorator scanning gets a focused fix.
+  - id: custom_graphql.custom_mutation_return
+    owns: [custom_graphql.mutationReturnType]
+    mode: explicit
+    rationale: Custom mutation object returns must use the declared object type, not a generated payload type.
+
+  - id: transform_write.struct_input_runtime
+    owns: []
+    mode: existing_test
+    test_refs:
+      - ts/src/action/transformed_orchestrator.test.ts
+      - examples/simple/src/ent/tests/transform_write_struct_input.test.ts
+    rationale: Runtime transformWrite/input-shape behavior is covered outside compile-only codegen matrix.
+  - id: pattern.struct_privacy_import
+    owns: []
+    mode: explicit
+    rationale: Pattern struct field privacy must compile generated base accessors with imported struct types.
+  - id: polymorphic.struct_field_codegen
+    owns: []
+    mode: explicit
+    rationale: Polymorphic UUID fields inside struct/list fields must generate valid GraphQL/TS.
+  - id: polymorphic.struct_runtime_write
+    owns: []
+    mode: skipped
+    skip_reason: Needs generated runtime action smoke that writes struct polymorphic type fields to DB.
+  - id: field_edge.uuid_list_inverse
+    owns: []
+    mode: explicit
+    rationale: UUIDListType with inverse fieldEdge must codegen and compile.
+  - id: polymorphic.indexed_query_import
+    owns: []
+    mode: explicit
+    rationale: Polymorphic indexed edge query imports must reserve source-node imports.
+  - id: field_edge.inverse_index_name_collision
+    owns: []
+    mode: skipped
+    skip_reason: An indexed field edge and inverse field edge can generate duplicate query/connection names when they share one edge const; the matrix fixture keeps inverse and index-edge coverage separate until aliasing is fixed.
+  - id: node_name.reserved_ent_import
+    owns: []
+    mode: skipped
+    skip_reason: A schema named Ent collides with the framework Ent import in generated query bases; this needs an import aliasing strategy before it can be enabled.
+  - id: transform_read.enum_value_import
+    owns: []
+    mode: explicit
+    rationale: transformReadCodegen_BETA can import an enum value already reserved as a generated type-only field import in loaders.ts; value imports should reconcile the prior type-only import.

--- a/testdata/codegen_matrix/fixtures/_shared/core_db/src/schema/account_schema.ts
+++ b/testdata/codegen_matrix/fixtures/_shared/core_db/src/schema/account_schema.ts
@@ -1,0 +1,67 @@
+import {
+  ActionOperation,
+  ConstraintType,
+  EntSchema,
+  IntegerType,
+  StringType,
+  UUIDType,
+} from "@snowtop/ent/schema";
+
+const AccountSchema = new EntSchema({
+  tableName: "matrix_core_accounts",
+  fields: {
+    ownerID: UUIDType({
+      index: true,
+      foreignKey: {
+        schema: "User",
+        column: "id",
+        ondelete: "CASCADE",
+      },
+    }),
+    accountNumber: StringType({
+      unique: true,
+      storageKey: "account_number",
+    }),
+    balance: IntegerType({
+      serverDefault: "0",
+    }),
+    memo: StringType({
+      nullable: true,
+    }),
+  },
+  constraints: [
+    {
+      name: "matrix_core_accounts_owner_number_unique",
+      type: ConstraintType.Unique,
+      columns: ["ownerID", "accountNumber"],
+    },
+    {
+      name: "matrix_core_accounts_balance_non_negative",
+      type: ConstraintType.Check,
+      columns: [],
+      condition: "balance >= 0",
+    },
+  ],
+  indices: [
+    {
+      name: "matrix_core_accounts_owner_positive_balance_idx",
+      columns: ["ownerID", "balance"],
+      where: "balance > 0",
+    },
+  ],
+  actions: [
+    {
+      operation: ActionOperation.Create,
+      fields: ["ownerID", "accountNumber", "balance", "memo"],
+    },
+    {
+      operation: ActionOperation.Edit,
+      fields: ["balance", "memo"],
+    },
+    {
+      operation: ActionOperation.Delete,
+    },
+  ],
+});
+
+export default AccountSchema;

--- a/testdata/codegen_matrix/fixtures/_shared/core_db/src/schema/user_schema.ts
+++ b/testdata/codegen_matrix/fixtures/_shared/core_db/src/schema/user_schema.ts
@@ -1,0 +1,21 @@
+import { ActionOperation, EntSchema, StringType } from "@snowtop/ent/schema";
+
+const UserSchema = new EntSchema({
+  tableName: "matrix_core_users",
+  fields: {
+    emailAddress: StringType({
+      unique: true,
+      storageKey: "email_address",
+    }),
+    displayName: StringType({
+      nullable: true,
+    }),
+  },
+  actions: [
+    {
+      operation: ActionOperation.Mutations,
+    },
+  ],
+});
+
+export default UserSchema;

--- a/testdata/codegen_matrix/fixtures/db_schema_smoke/ent.yml
+++ b/testdata/codegen_matrix/fixtures/db_schema_smoke/ent.yml
@@ -1,0 +1,4 @@
+codegen:
+  relativeImports: true
+  generatedHeader: "Codegen matrix DB fixture"
+  fieldPrivacyEvaluated: on_demand

--- a/testdata/codegen_matrix/fixtures/feature_stress/ent.yml
+++ b/testdata/codegen_matrix/fixtures/feature_stress/ent.yml
@@ -1,0 +1,5 @@
+codegen:
+  relativeImports: true
+  generatedHeader: "Codegen matrix fixture"
+  fieldPrivacyEvaluated: on_demand
+customGraphQLJSONPath: src/schema/custom_graphql.json

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/edge_action_input_name_assertions.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/edge_action_input_name_assertions.ts
@@ -1,0 +1,18 @@
+import type { AddPaymentWatcherInput } from "./ent/generated/payment/actions/add_payment_watcher_action_base";
+import {
+  PaymentPaymentReviewStatusInput,
+  type SetPaymentReviewStatusInput,
+} from "./ent/generated/payment/actions/set_payment_review_status_action_base";
+
+const addPaymentWatcherInput: AddPaymentWatcherInput = {
+  reason: "watching for review",
+};
+
+const setPaymentReviewStatusInput: SetPaymentReviewStatusInput = {
+  paymentReviewStatus: PaymentPaymentReviewStatusInput.Reviewed,
+  userId: "viewer",
+  note: "reviewed",
+};
+
+void addPaymentWatcherInput;
+void setPaymentReviewStatusInput;

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/graphql/mutations/auth.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/graphql/mutations/auth.ts
@@ -1,0 +1,28 @@
+import { RequestContext } from "@snowtop/ent";
+
+export class NamedNode {
+  name: string;
+}
+
+export class ThirdPartyLogin {
+  constructor(token: string, newAccount: boolean) {
+    this.token = token;
+    this.newAccount = newAccount;
+  }
+
+  token: string;
+  newAccount: boolean;
+}
+
+export class LoginInput {
+  identityToken: string;
+}
+
+export class RootResolver {
+  async loginWithApple(
+    _context: RequestContext,
+    input: LoginInput,
+  ): Promise<ThirdPartyLogin> {
+    return new ThirdPartyLogin(input.identityToken, false);
+  }
+}

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/__global__schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/__global__schema.ts
@@ -1,0 +1,24 @@
+import { GlobalSchema, StringType } from "@snowtop/ent/schema";
+
+const globalSchema: GlobalSchema = {
+  extraEdgeFields: {
+    metadata: StringType({ nullable: true }),
+  },
+  edgeIndices: [
+    {
+      columns: ["time"],
+      name: "time_lookup",
+      where: "time IS NOT NULL",
+    },
+  ],
+  dbExtensions: [
+    {
+      name: "pg_trgm",
+      provisionedBy: "ent",
+      installSchema: "public",
+      runtimeSchemas: ["public"],
+    },
+  ],
+};
+
+export default globalSchema;

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/competition_event_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/competition_event_schema.ts
@@ -1,0 +1,11 @@
+import { EntSchema, StringType } from "@snowtop/ent/schema";
+import { BadgeRecipient } from "src/schema/patterns/badge_recipient";
+
+const CompetitionEventSchema = new EntSchema({
+  patterns: [BadgeRecipient],
+  fields: {
+    name: StringType(),
+  },
+});
+
+export default CompetitionEventSchema;

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/custom_graphql.json
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/custom_graphql.json
@@ -1,0 +1,44 @@
+{
+  "inputs": [
+    {
+      "name": "LoginInput",
+      "graphQLName": "RenamedLoginInput",
+      "fields": [
+        {
+          "name": "identityToken",
+          "fieldType": "FIELD",
+          "resultType": "String"
+        }
+      ]
+    }
+  ],
+  "objects": [
+    {
+      "name": "ThirdPartyLogin",
+      "fields": [
+        {
+          "name": "token",
+          "fieldType": "FIELD",
+          "resultType": "String"
+        },
+        {
+          "name": "newAccount",
+          "fieldType": "FIELD",
+          "resultType": "Boolean"
+        }
+      ]
+    }
+  ],
+  "mutations": [
+    {
+      "class": "RootResolver",
+      "name": "loginWithApple",
+      "fieldType": "ASYNC_FUNCTION",
+      "args": [
+        { "name": "context", "type": "Context", "isContextArg": true },
+        { "name": "input", "type": "LoginInput" }
+      ],
+      "resultType": "ThirdPartyLogin"
+    }
+  ]
+}

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/horse_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/horse_schema.ts
@@ -1,0 +1,14 @@
+import { ActionOperation, EntSchema, StringType } from "@snowtop/ent/schema";
+
+const HorseSchema = new EntSchema({
+  fields: {
+    name: StringType(),
+  },
+  actions: [
+    {
+      operation: ActionOperation.Mutations,
+    },
+  ],
+});
+
+export default HorseSchema;

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/internal_note_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/internal_note_schema.ts
@@ -1,0 +1,10 @@
+import { EntSchema, StringType } from "@snowtop/ent/schema";
+
+const InternalNoteSchema = new EntSchema({
+  hideFromGraphQL: true,
+  fields: {
+    note: StringType(),
+  },
+});
+
+export default InternalNoteSchema;

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/matrix_ent_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/matrix_ent_schema.ts
@@ -1,0 +1,34 @@
+import {
+  ActionOperation,
+  BooleanType,
+  EntSchema,
+  IntegerType,
+  StringType,
+} from "@snowtop/ent/schema";
+import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
+
+const MatrixEntSchema = new EntSchema({
+  tableName: "matrix_ents",
+  fields: {
+    name: StringType({
+      unique: true,
+      graphqlName: "displayName",
+      privacyPolicy: AlwaysAllowPrivacyPolicy,
+    }),
+    active: BooleanType({
+      serverDefault: true,
+      defaultValueOnCreate: () => true,
+    }),
+    rank: IntegerType({
+      nullable: true,
+      index: true,
+    }),
+  },
+  actions: [
+    {
+      operation: ActionOperation.Mutations,
+    },
+  ],
+});
+
+export default MatrixEntSchema;

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/patterns/badge_recipient.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/patterns/badge_recipient.ts
@@ -1,0 +1,119 @@
+import {
+  BooleanType,
+  DateType,
+  EnumType,
+  IntegerEnumType,
+  IntegerType,
+  Pattern,
+  StringType,
+  StructType,
+  StructTypeAsList,
+  UUIDType,
+} from "@snowtop/ent/schema";
+import {
+  AlwaysAllowPrivacyPolicy,
+  AlwaysDenyPrivacyPolicy,
+  query,
+} from "@snowtop/ent";
+
+enum MatrixVisibility {
+  VISIBLE = 0,
+  DELETED = 1,
+  DEACTIVATED = 2,
+}
+
+export const BadgeRecipient: Pattern = {
+  name: "BadgeRecipient",
+  fields: {
+    badgeProgress: StructType({
+      tsType: "BadgeProgress",
+      graphQLType: "BadgeProgress",
+      nullable: true,
+      privacyPolicy: AlwaysAllowPrivacyPolicy,
+      fields: {
+        competitionsWon: IntegerType({
+          nullable: true,
+        }),
+      },
+    }),
+    badges: StructTypeAsList({
+      tsType: "Badge",
+      graphQLType: "Badge",
+      nullable: true,
+      privacyPolicy: AlwaysDenyPrivacyPolicy,
+      fields: {
+        typeOfBadge: EnumType({
+          tsType: "TypeOfBadge",
+          graphQLType: "TypeOfBadge",
+          values: ["GOLD", "SILVER"],
+        }),
+        awardedOn: DateType({
+          immutable: true,
+        }),
+        referenceEntID: UUIDType({
+          polymorphic: {
+            types: ["CompetitionEvent"],
+          },
+          immutable: true,
+        }),
+        currency: EnumType({
+          tsType: "Currency",
+          graphQLType: "Currency",
+          values: ["USD", "EUR"],
+          nullable: true,
+        }),
+        level: EnumType({
+          tsType: "BadgeLevel",
+          graphQLType: "BadgeLevel",
+          values: ["LOCAL", "GLOBAL"],
+        }),
+        publicNote: StringType({
+          nullable: true,
+        }),
+        hidden: BooleanType({
+          nullable: true,
+        }),
+      },
+    }),
+    status: IntegerEnumType({
+      map: {
+        VISIBLE: MatrixVisibility.VISIBLE,
+        DELETED: MatrixVisibility.DELETED,
+        DEACTIVATED: MatrixVisibility.DEACTIVATED,
+      },
+      tsType: "MatrixVisibility",
+      defaultValueOnCreate: () => MatrixVisibility.VISIBLE,
+      disableUserGraphQLEditable: true,
+      hideFromGraphQL: true,
+      disableUnknownType: true,
+    }),
+  },
+  edges: [
+    {
+      name: "badgeRecipients",
+      schemaName: "User",
+      inverseEdge: {
+        name: "badgeSources",
+        hideFromGraphQL: true,
+      },
+    },
+  ],
+  transformRead() {
+    return query.Eq("status", MatrixVisibility.VISIBLE);
+  },
+  transformReadCodegen_BETA() {
+    return {
+      code: "query.Eq('status', MatrixVisibility.VISIBLE)",
+      imports: [
+        {
+          importPath: "@snowtop/ent",
+          import: "query",
+        },
+        {
+          importPath: "src/ent/generated/types",
+          import: "MatrixVisibility",
+        },
+      ],
+    };
+  },
+};

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/payment_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/payment_schema.ts
@@ -1,0 +1,428 @@
+import {
+  ActionOperation,
+  BigIntegerType,
+  BinaryTextType,
+  BooleanType,
+  ByteaType,
+  ConstraintType,
+  DateType,
+  EntSchema,
+  EnumListType,
+  EnumType,
+  FloatListType,
+  FloatType,
+  IntegerEnumListType,
+  IntegerEnumType,
+  IntegerListType,
+  IntegerType,
+  JSONBType,
+  JSONType,
+  NoFields,
+  StringListType,
+  StringType,
+  StructType,
+  StructTypeAsList,
+  TimeType,
+  TimestampType,
+  TimestamptzType,
+  TimetzType,
+  UnionType,
+  UUIDListType,
+  UUIDType,
+  requiredField,
+  optionalField,
+} from "@snowtop/ent/schema";
+import { AlwaysAllowPrivacyPolicy, AlwaysDenyPrivacyPolicy } from "@snowtop/ent";
+
+const PaymentSchema = new EntSchema({
+  tableName: "matrix_payments",
+  patterns: [],
+  supportUpsert: true,
+  showCanViewerSee: true,
+  showCanViewerEdit: true,
+  defaultActionPrivacy: AlwaysAllowPrivacyPolicy,
+  fields: {
+    externalID: StringType({
+      storageKey: "external_id",
+    }),
+    amount: IntegerType({
+      index: true,
+      indexConcurrently: true,
+      indexWhere: "amount > 0",
+    }),
+    settled: BooleanType({
+      nullable: true,
+    }),
+    ratio: FloatType({
+      nullable: true,
+    }),
+    bigintAmount: BigIntegerType({
+      nullable: true,
+    }),
+    description: StringType({
+      nullable: true,
+      private: {
+        exposeToActions: true,
+      },
+    }),
+    visibleCode: StringType({
+      hideFromGraphQL: true,
+      disableUserGraphQLEditable: true,
+      defaultValueOnCreate: () => "hidden",
+    }),
+    createdAtOverride: TimestampType({
+      disableUserEditable: true,
+      defaultValueOnCreate: () => new Date(),
+    }),
+    editedAt: TimestamptzType({
+      nullable: true,
+      defaultValueOnEdit: () => new Date(),
+    }),
+    paidAt: DateType({
+      nullable: true,
+      immutable: true,
+    }),
+    localTime: TimeType({ nullable: true }),
+    localTimetz: TimetzType({ nullable: true }),
+    payload: JSONType({
+      nullable: true,
+    }),
+    metadata: JSONBType({
+      nullable: true,
+      tsType: "PaymentMetadata",
+      graphQLType: "PaymentMetadata",
+      fields: {
+        attempt: IntegerType(),
+        source: StringType(),
+      },
+    }),
+    tags: StringListType({
+      nullable: true,
+    }),
+    scores: IntegerListType({
+      nullable: true,
+    }),
+    ratios: FloatListType({
+      nullable: true,
+    }),
+    receiptBytes: ByteaType({
+      nullable: true,
+      hideFromGraphQL: true,
+    }),
+    receiptText: BinaryTextType({
+      nullable: true,
+      hideFromGraphQL: true,
+    }),
+    status: EnumType({
+      values: ["PENDING", "SETTLED", "FAILED"],
+      disableUnknownType: true,
+      defaultValueOnCreate: () => "PENDING",
+    }),
+    statusHistory: EnumListType({
+      values: ["PENDING", "SETTLED", "FAILED"],
+      nullable: true,
+    }),
+    priority: IntegerEnumType({
+      map: {
+        LOW: 1,
+        HIGH: 2,
+      },
+      deprecated: {
+        LEGACY: 0,
+      },
+    }),
+    priorityHistory: IntegerEnumListType({
+      map: {
+        LOW: 1,
+        HIGH: 2,
+      },
+      nullable: true,
+    }),
+    threadID: UUIDType({
+      nullable: true,
+      fieldEdge: {
+        schema: "Thread",
+        inverseEdge: {
+          name: "payments",
+          edgeConstName: "ThreadToPayments",
+        },
+      },
+    }),
+    indexedThreadID: UUIDType({
+      nullable: true,
+      index: true,
+      fieldEdge: {
+        schema: "Thread",
+        edgeConstName: "IndexedThreadToPayments",
+        indexEdge: {
+          name: "payments_for_indexed_thread",
+          orderby: [
+            {
+              column: "created_at",
+              direction: "DESC",
+            },
+          ],
+        },
+      },
+    }),
+    entID: UUIDType({
+      index: true,
+      fieldEdge: {
+        schema: "MatrixEnt",
+        edgeConstName: "EntToPayments",
+        indexEdge: {
+          name: "payments_for_ent",
+        },
+      },
+    }),
+    createdByID: UUIDType({
+      foreignKey: {
+        schema: "User",
+        column: "id",
+        name: "payment_created_by",
+        disableBuilderType: true,
+        ondelete: "SET NULL",
+      },
+      nullable: true,
+    }),
+    ownerID: UUIDType({
+      index: true,
+      polymorphic: {
+        name: "owner",
+        types: ["User", "MatrixEnt"],
+        hideFromInverseGraphQL: true,
+        disableBuilderType: true,
+        edgeConstName: "OwnerToPayments",
+      },
+    }),
+    horseIDs: UUIDListType({
+      nullable: true,
+      fieldEdge: {
+        schema: "Horse",
+        inverseEdge: {
+          name: "payments",
+        },
+      },
+    }),
+    auditEntries: StructTypeAsList({
+      tsType: "PaymentAuditEntry",
+      graphQLType: "PaymentAuditEntry",
+      nullable: true,
+      privacyPolicy: AlwaysDenyPrivacyPolicy,
+      fields: {
+        changedByID: UUIDType({
+          nullable: true,
+          foreignKey: {
+            schema: "User",
+            column: "id",
+          },
+        }),
+        changedByType: StringType({
+          nullable: true,
+        }),
+        comment: StringType({
+          storageKey: "comment_text",
+          nullable: true,
+        }),
+        relatedIDs: UUIDListType({
+          nullable: true,
+        }),
+      },
+    }),
+    nestedObject: StructType({
+      tsType: "PaymentNestedObject",
+      nullable: true,
+      fetchOnDemand: true,
+      fields: {
+        uuid: UUIDType({
+          disableBase64Encode: true,
+        }),
+        unionValue: UnionType({
+          tsType: "PaymentUnionValue",
+          nullable: true,
+          fields: {
+            card: StructType({
+              tsType: "PaymentCard",
+              fields: {
+                lastFour: StringType(),
+              },
+            }),
+            bank: StructType({
+              tsType: "PaymentBank",
+              fields: {
+                routingNumber: StringType(),
+              },
+            }),
+          },
+        }),
+      },
+    }),
+    dbOnlyNote: StringType({
+      nullable: true,
+      dbOnly: true,
+    }),
+  },
+  fieldOverrides: {
+    createdAt: {
+      index: true,
+      indexConcurrently: true,
+    },
+    updatedAt: {
+      storageKey: "updated_time",
+      graphqlName: "updatedTime",
+    },
+  },
+  constraints: [
+    {
+      name: "payments_external_amount_unique",
+      type: ConstraintType.Unique,
+      columns: ["externalID", "amount"],
+    },
+    {
+      name: "payments_amount_positive",
+      type: ConstraintType.Check,
+      columns: [],
+      condition: "amount >= 0",
+    },
+    {
+      name: "payments_thread_fk",
+      type: ConstraintType.ForeignKey,
+      columns: ["threadID"],
+      fkey: {
+        tableName: "threads",
+        columns: ["id"],
+        ondelete: "SET NULL",
+      },
+    },
+  ],
+  indices: [
+    {
+      name: "payments_amount_idx",
+      columns: ["amount"],
+      unique: true,
+      where: "amount > 0",
+    },
+  ],
+  edges: [
+    {
+      name: "watchers",
+      schemaName: "User",
+      symmetric: true,
+      edgeConstName: "PaymentWatchers",
+      edgeActions: [
+        {
+          operation: ActionOperation.AddEdge,
+          actionName: "AddPaymentWatcherAction",
+          inputName: "AddPaymentWatcherInput",
+          graphQLName: "addPaymentWatcher",
+          __canFailBETA: true,
+          actionOnlyFields: [
+            {
+              name: "reason",
+              type: "String",
+              nullable: true,
+            },
+          ],
+        },
+        {
+          operation: ActionOperation.RemoveEdge,
+          hideFromGraphQL: true,
+        },
+      ],
+    },
+    {
+      name: "approver",
+      schemaName: "User",
+      unique: true,
+      inverseEdge: {
+        name: "approvedPayments",
+        edgeConstName: "UserToApprovedPayments",
+      },
+      hideFromGraphQL: true,
+    },
+  ],
+  edgeGroups: [
+    {
+      name: "PaymentReview",
+      groupStatusName: "PaymentReviewStatus",
+      tableName: "payment_review_edges",
+      assocEdges: [
+        {
+          name: "needsReview",
+          schemaName: "User",
+        },
+        {
+          name: "reviewed",
+          schemaName: "User",
+        },
+      ],
+      viewerBased: true,
+      statusEnums: ["needsReview", "reviewed"],
+      nullStates: ["none"],
+      nullStateFn: "getNullPaymentReviewStatus",
+      edgeAction: {
+        operation: ActionOperation.EdgeGroup,
+        actionName: "SetPaymentReviewStatusAction",
+        inputName: "SetPaymentReviewStatusInput",
+        graphQLName: "setPaymentReviewStatus",
+        actionOnlyFields: [
+          {
+            name: "note",
+            type: "String",
+            optional: true,
+          },
+        ],
+      },
+    },
+  ],
+  actions: [
+    {
+      operation: ActionOperation.Create,
+      fields: [
+        "externalID",
+        "amount",
+        requiredField("entID"),
+        optionalField("description"),
+      ],
+      actionName: "CreateMatrixPaymentAction",
+      inputName: "CreateMatrixPaymentInput",
+      graphQLName: "createMatrixPayment",
+      canViewerDo: {
+        addAllFields: true,
+      },
+      actionOnlyFields: [
+        {
+          name: "metadataPatch",
+          type: "JSON",
+          nullable: true,
+        },
+      ],
+    },
+    {
+      operation: ActionOperation.Edit,
+      fields: ["description", "settled"],
+      optionalFields: ["description"],
+      requiredFields: ["settled"],
+      actionOnlyFields: [
+        {
+          name: "reviewItems",
+          type: "String",
+          list: true,
+          nullable: "contentsAndList",
+        },
+      ],
+      __canFailBETA: true,
+    },
+    {
+      operation: ActionOperation.Edit,
+      actionName: "TouchMatrixPaymentAction",
+      fields: [NoFields],
+      hideFromGraphQL: true,
+    },
+    {
+      operation: ActionOperation.Delete,
+    },
+  ],
+});
+
+export default PaymentSchema;

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/thread_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/thread_schema.ts
@@ -1,0 +1,36 @@
+import {
+  ActionOperation,
+  EntSchema,
+  StringType,
+  UUIDType,
+} from "@snowtop/ent/schema";
+
+const ThreadSchema = new EntSchema({
+  fields: {
+    title: StringType(),
+    entID: UUIDType({
+      index: true,
+      fieldEdge: {
+        schema: "MatrixEnt",
+        edgeConstName: "EntToThreads",
+        indexEdge: {
+          name: "threads_for_ent",
+          orderby: [
+            {
+              column: "created_at",
+              direction: "DESC",
+              nullsPlacement: "last",
+            },
+          ],
+        },
+      },
+    }),
+  },
+  actions: [
+    {
+      operation: ActionOperation.Mutations,
+    },
+  ],
+});
+
+export default ThreadSchema;

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/user_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/user_schema.ts
@@ -1,0 +1,33 @@
+import {
+  ActionOperation,
+  EntSchema,
+  StringType,
+  UUIDType,
+} from "@snowtop/ent/schema";
+import { AlwaysAllowPrivacyPolicy } from "@snowtop/ent";
+
+const UserSchema = new EntSchema({
+  fields: {
+    name: StringType({
+      privacyPolicy: AlwaysAllowPrivacyPolicy,
+      editPrivacyPolicy: AlwaysAllowPrivacyPolicy,
+    }),
+    primaryPaymentID: UUIDType({
+      nullable: true,
+      foreignKey: {
+        schema: "Payment",
+        column: "id",
+        name: "user_primary_payment",
+        disableIndex: true,
+        ondelete: "RESTRICT",
+      },
+    }),
+  },
+  actions: [
+    {
+      operation: ActionOperation.Mutations,
+    },
+  ],
+});
+
+export default UserSchema;

--- a/testdata/codegen_matrix/fixtures/postgres_schema_smoke/ent.yml
+++ b/testdata/codegen_matrix/fixtures/postgres_schema_smoke/ent.yml
@@ -1,0 +1,4 @@
+codegen:
+  relativeImports: true
+  generatedHeader: "Codegen matrix Postgres fixture"
+  fieldPrivacyEvaluated: on_demand

--- a/testdata/codegen_matrix/fixtures/postgres_schema_smoke/src/schema/search_document_schema.ts
+++ b/testdata/codegen_matrix/fixtures/postgres_schema_smoke/src/schema/search_document_schema.ts
@@ -1,0 +1,41 @@
+import {
+  ActionOperation,
+  EntSchema,
+  StringType,
+  TimestamptzType,
+} from "@snowtop/ent/schema";
+
+const SearchDocumentSchema = new EntSchema({
+  tableName: "matrix_pg_search_documents",
+  fields: {
+    title: StringType(),
+    body: StringType({
+      nullable: true,
+    }),
+    category: StringType({
+      serverDefault: "general",
+    }),
+    publishedAt: TimestamptzType(),
+  },
+  indices: [
+    {
+      name: "matrix_pg_search_documents_title_pattern_idx",
+      columns: ["title"],
+      indexType: "btree",
+      ops: {
+        title: "text_pattern_ops",
+      },
+      indexParams: {
+        fillfactor: 70,
+      },
+      where: "title IS NOT NULL",
+    },
+  ],
+  actions: [
+    {
+      operation: ActionOperation.Mutations,
+    },
+  ],
+});
+
+export default SearchDocumentSchema;

--- a/ts/src/schema/schema.ts
+++ b/ts/src/schema/schema.ts
@@ -177,6 +177,7 @@ export interface EdgeAction {
   //   ActionOperation.AddEdge | ActionOperation.RemoveEdge
   // >;
   actionName?: string;
+  inputName?: string;
   hideFromGraphQL?: boolean;
   graphQLName?: string;
   actionOnlyFields?: ActionField[];
@@ -207,6 +208,7 @@ export interface EdgeGroupAction {
   //   ActionOperation.AddEdge | ActionOperation.RemoveEdge
   // >;
   actionName?: string;
+  inputName?: string;
   hideFromGraphQL?: boolean;
   graphQLName?: string;
   actionOnlyFields?: ActionField[];

--- a/ts/src/scripts/custom_graphql.ts
+++ b/ts/src/scripts/custom_graphql.ts
@@ -416,6 +416,7 @@ async function main() {
   if (process.env.LOCAL_SCRIPT_PATH) {
     const r = require("../graphql/graphql");
     gqlCapture = r.GQLCapture;
+    gqlCapture.enable(true);
   } else {
     const r = require(gqlPath);
     if (!r.GQLCapture) {


### PR DESCRIPTION
## Summary

- add an end-to-end codegen feature matrix with fixture catalog checks, idempotence snapshots, generated TypeScript typechecking, and SQLite/Postgres DB-codegen smoke fixtures
- add representative fixtures for schema/codegen features, custom GraphQL, generated import regressions, edge-action custom input names, and shared DB-rendered core coverage
- harden generated code paths found by the matrix, including import promotion, custom GraphQL return hints, indexed query export ordering, edge-action `inputName`, and ordered post-processing
- document the matrix bar in `testdata/codegen_matrix/README.md` and link it from `AGENTS.md`
- pin Go CI's Python runtime to 3.11 for the codegen matrix until `auto_schema==0.0.34`'s pinned SQLAlchemy dependency stack is compatible with Python 3.13+

## Validation

- `go test ./internal/tsimport -count=1`
- `DB_CONNECTION_STRING=sqlite:////tmp/ent-action-review.sqlite go test ./internal/action -run 'TestCompare(EdgeActionInputName|UnequalEdgeActionInputName|EdgeGroupActionInputName|UnequalEdgeGroupActionInputName)$' -count=1`
- `go test ./internal/codegenmatrix -count=1`
- `cd ts && npm run compile`
- `cd ts && npm test -- src/graphql/tests/file_upload.test.ts --runInBand` on local Node 22.22.1
- `cd ts && npx -p node@20 -c 'node ./node_modules/jest/bin/jest.js src/graphql/tests/file_upload.test.ts --runInBand'`
- local Python 3.11 temp venv: `pip install wheel auto_schema==0.0.34` then `import auto_schema.cli`
- Go CI `build` passed on commit `e329ead1`
- `git diff --check`

## Notes

- Go CI was failing before codegen assertions because `auto_schema==0.0.34` exactly pins `sqlalchemy==2.0.18`, and that SQLAlchemy version hits its `TypingOnly` assertion during import on Python 3.13+. This PR keeps Go CI on Python 3.11 for now; upgrading `auto_schema`/SQLAlchemy can be handled separately.
- Node.js CI has shown unrelated flakes while this PR was rerun: `src/graphql/tests/file_upload.test.ts` (`file upload multiple` returning `invalid file sent`) and Node 20 `src/core/ent_custom_data.test.ts` failing with `Connection terminated`. I did not change those tests or Node CI in this PR; targeted file-upload reruns pass locally under Node 20.20.2 and Node 22.22.1.
- Local `postgres_schema_smoke` skips unless `ENT_CODEGEN_MATRIX_POSTGRES_URL` or a Postgres `DB_CONNECTION_STRING` is set; Go CI provides Postgres.
- Full `go test ./internal/action` is blocked in this local checkout by the parent `/Users/ola/code/package.json` declaring `"type": "module"`, which causes temporary `.ts` schemas under the repo to be treated as ESM while `read_schema.ts` loads them with CommonJS `require(...)`.