### PR TITLE
Update auto_schema for Go CI

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -50,14 +50,15 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v6
       with:
-        # auto_schema==0.0.34 pins SQLAlchemy 2.0.18, which fails during
-        # import on Python 3.13+ before codegen assertions can run.
-        python-version: '3.11'
+        python-version: '3.14'
         cache: pip
         cache-dependency-path: python/Pipfile.lock
       
     - name: Install auto_schema
-      run: python3 -m pip install wheel auto_schema==0.0.34
+      # auto_schema==0.0.34 pins SQLAlchemy 2.0.18, which fails during
+      # import on Python 3.14. Keep python-dateutil in the published package:
+      # Alembic needs it when auto_schema generates timezone-aware revisions.
+      run: python3 -m pip install wheel auto_schema==0.0.35
 
     - name: Setup nodejs
       uses: actions/setup-node@v6

--- a/python/auto_schema/pyproject.toml
+++ b/python/auto_schema/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 # version = "0.0.36"
 # production https://pypi.org/project/auto-schema/
 name = "auto_schema"
-version = "0.0.34"
+version = "0.0.35"
 authors = [{ name = "Ola Okelola", email = "email@email.com" }]
 description = "auto schema for a db"
 readme = "README.md"
@@ -19,10 +19,13 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "sqlalchemy==2.0.18",
+  "sqlalchemy==2.0.45",
   "alembic==1.12.0",
-  "psycopg2==2.9.6",
+  "psycopg2==2.9.11",
   "ruff==0.0.285",
+  # Alembic requires python-dateutil when timezone is configured for generated
+  # revision timestamps. auto_schema sets timezone = "utc" in command.py.
+  "python-dateutil==2.8.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## What changed
- publish/use `auto_schema==0.0.35` for Go CI
- restore Go CI to Python 3.14 now that `auto_schema` no longer pins the Python 3.14-incompatible SQLAlchemy version
- bump `auto_schema` package deps to SQLAlchemy 2.0.45 and psycopg2 2.9.11
- keep `python-dateutil` documented in `pyproject.toml` because Alembic needs it when `timezone = "utc"` is configured for generated revision timestamps

## Validation
- Published `auto_schema` 0.0.35 to PyPI: https://pypi.org/project/auto-schema/0.0.35/
- Fresh venv install of `auto_schema==0.0.35` from PyPI imported successfully with SQLAlchemy 2.0.45, psycopg2 2.9.11, python-dateutil 2.8.2, and Alembic 1.12.0
- `ENT_CODEGEN_MATRIX_FIXTURE=db_schema_smoke go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v`
- `git diff --check`

## Notes
- Full `go test ./...` is still blocked locally by the existing parent `/Users/ola/code/package.json` `"type": "module"` issue causing temp TS schema fixtures to fail under CommonJS `require()` in `ts/src/scripts/read_schema.ts`; the codegen matrix passed in that same run.
