### PR TITLE
Add Bun runtime variants to codegen matrix

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -66,6 +66,10 @@ jobs:
         node-version: 24.x
         cache: npm
         cache-dependency-path: ts/package-lock.json
+    - name: Setup bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.3.6
     - run: npm install -g ts-node@11.0.0-beta.1 typescript@5.3.2 @swc/core@1.3.100 @swc/cli@0.1.63 @biomejs/biome@2.4.7
     - run: |
         cd ts 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,11 @@ Codegen feature matrix:
   combinations.
 - The matrix includes SQLite and Postgres DB-codegen smoke fixtures. Postgres
   coverage runs when `DB_CONNECTION_STRING` or `ENT_CODEGEN_MATRIX_POSTGRES_URL`
-  points at Postgres; otherwise that fixture skips in local runs.
+  points at Postgres; otherwise that fixture skips in local runs. The Postgres
+  smoke fixture runs both Node/pg and Bun/Bun SQL runtime variants.
+- The matrix includes Bun runtime coverage via fixture runtime variants. Install
+  Bun locally before running the full matrix, or use
+  `ENT_CODEGEN_MATRIX_RUNTIME=node` while iterating on Node-only changes.
 - Core DB-rendered features should declare
   `dialect_coverage: [sqlite, postgres]` in the matrix catalog so the test
   enforces coverage in both DB fixtures. Dialect-specific behavior should

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 - add a codegen feature matrix smoke suite for generated TypeScript, GraphQL, DB schema, and idempotence coverage (#1984).
 - add optional Bun runtime and Bun native Postgres driver support (#1976).
+- add Bun runtime coverage to the codegen feature matrix (#1986).
 
 ### Fixed
 

--- a/internal/codegenmatrix/codegen_matrix_test.go
+++ b/internal/codegenmatrix/codegen_matrix_test.go
@@ -33,14 +33,15 @@ type catalog struct {
 }
 
 type fixture struct {
-	ID          string   `yaml:"id"`
-	Path        string   `yaml:"path"`
-	Includes    []string `yaml:"includes"`
-	Description string   `yaml:"description"`
-	Surfaces    []string `yaml:"surfaces"`
-	Dialect     string   `yaml:"dialect"`
-	Covers      []string `yaml:"covers"`
-	SkipReason  string   `yaml:"skip_reason"`
+	ID              string           `yaml:"id"`
+	Path            string           `yaml:"path"`
+	Includes        []string         `yaml:"includes"`
+	Description     string           `yaml:"description"`
+	Surfaces        []string         `yaml:"surfaces"`
+	Dialect         string           `yaml:"dialect"`
+	RuntimeVariants []runtimeVariant `yaml:"runtime_variants"`
+	Covers          []string         `yaml:"covers"`
+	SkipReason      string           `yaml:"skip_reason"`
 }
 
 type feature struct {
@@ -51,6 +52,12 @@ type feature struct {
 	Rationale       string   `yaml:"rationale"`
 	SkipReason      string   `yaml:"skip_reason"`
 	TestRefs        []string `yaml:"test_refs"`
+}
+
+type runtimeVariant struct {
+	ID             string `yaml:"id"`
+	Runtime        string `yaml:"runtime"`
+	PostgresDriver string `yaml:"postgresDriver"`
 }
 
 const (
@@ -109,6 +116,8 @@ func TestFeatureCatalogClassifiesCodegenInputs(t *testing.T) {
 		require.NotEmpty(t, fixture.Path, "fixture %s must declare path", fixture.ID)
 		validateFixturePaths(t, repo, fixture)
 		validateFixtureDialect(t, fixture)
+		validateFixtureRuntimeVariants(t, fixture)
+		validateFixtureRuntimeCoverage(t, fixture)
 		for _, covered := range fixture.Covers {
 			if _, ok := featuresByID[covered]; !ok {
 				t.Fatalf("fixture %s covers unknown feature %s", fixture.ID, covered)
@@ -145,6 +154,45 @@ func validateFixturePaths(t *testing.T, repo string, fixture fixture) {
 	for _, include := range fixture.Includes {
 		require.DirExists(t, filepath.Join(matrixRoot, include), "fixture %s include %s is missing", fixture.ID, include)
 	}
+}
+
+func validateFixtureRuntimeVariants(t *testing.T, fixture fixture) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, variant := range runtimeVariantsForFixture(fixture) {
+		require.NotEmpty(t, variant.ID, "runtime variant id is required for fixture %s", fixture.ID)
+		require.False(t, seen[variant.ID], "duplicate runtime variant %s for fixture %s", variant.ID, fixture.ID)
+		seen[variant.ID] = true
+		require.Contains(t, validRuntimes(), variant.Runtime, "fixture %s runtime variant %s has unknown runtime", fixture.ID, variant.ID)
+		require.Contains(t, validPostgresDrivers(), variant.PostgresDriver, "fixture %s runtime variant %s has unknown postgres driver", fixture.ID, variant.ID)
+		if variant.PostgresDriver == "bun" {
+			require.Equal(t, "bun", variant.Runtime, "fixture %s runtime variant %s cannot use Bun postgres driver outside Bun runtime", fixture.ID, variant.ID)
+		}
+	}
+}
+
+func validateFixtureRuntimeCoverage(t *testing.T, fixture fixture) {
+	t.Helper()
+	var hasBunRuntime, hasBunPostgresDriver bool
+	for _, variant := range runtimeVariantsForFixture(fixture) {
+		hasBunRuntime = hasBunRuntime || variant.Runtime == "bun"
+		hasBunPostgresDriver = hasBunPostgresDriver || variant.PostgresDriver == "bun"
+	}
+	if fixtureCovers(fixture, "runtime.bun") {
+		require.True(t, hasBunRuntime, "fixture %s claims runtime.bun coverage without a Bun runtime variant", fixture.ID)
+	}
+	if fixtureCovers(fixture, "postgres_driver.bun") {
+		require.True(t, hasBunPostgresDriver, "fixture %s claims postgres_driver.bun coverage without a Bun postgres driver variant", fixture.ID)
+	}
+}
+
+func fixtureCovers(fixture fixture, featureID string) bool {
+	for _, covered := range fixture.Covers {
+		if covered == featureID {
+			return true
+		}
+	}
+	return false
 }
 
 func validateFixtureDialect(t *testing.T, fixture fixture) {
@@ -197,11 +245,26 @@ func validDialects() map[string]bool {
 	}
 }
 
+func validRuntimes() map[string]bool {
+	return map[string]bool{
+		"node": true,
+		"bun":  true,
+	}
+}
+
+func validPostgresDrivers() map[string]bool {
+	return map[string]bool{
+		"pg":  true,
+		"bun": true,
+	}
+}
+
 func TestCodegenMatrixFixtures(t *testing.T) {
 	c := loadCatalog(t)
 	repo := repoRoot(t)
 	entDist := buildEntDist(t, repo)
 	fixtureFilter := os.Getenv("ENT_CODEGEN_MATRIX_FIXTURE")
+	runtimeFilter := os.Getenv("ENT_CODEGEN_MATRIX_RUNTIME")
 
 	for _, fixture := range c.Fixtures {
 		fixture := fixture
@@ -212,9 +275,18 @@ func TestCodegenMatrixFixtures(t *testing.T) {
 			if fixture.SkipReason != "" && os.Getenv("ENT_CODEGEN_MATRIX_RUN_SKIPPED") != "true" {
 				t.Skip(fixture.SkipReason)
 			}
-			appRoot := copyFixture(t, repo, fixture)
-			writeGeneratedHarnessFiles(t, repo, appRoot, entDist)
-			runCodegenFixture(t, repo, appRoot, fixture)
+			for _, variant := range runtimeVariantsForFixture(fixture) {
+				variant := variant
+				if runtimeFilter != "" && runtimeFilter != variant.ID && runtimeFilter != variant.Runtime {
+					continue
+				}
+				t.Run(variant.ID, func(t *testing.T) {
+					appRoot := copyFixture(t, repo, fixture)
+					writeGeneratedHarnessFiles(t, repo, appRoot, entDist)
+					applyRuntimeVariantConfig(t, appRoot, variant)
+					runCodegenFixture(t, repo, appRoot, fixture)
+				})
+			}
 		})
 	}
 }
@@ -258,14 +330,58 @@ func copyFixture(t *testing.T, repo string, fixture fixture) string {
 	return dst
 }
 
+func runtimeVariantsForFixture(fixture fixture) []runtimeVariant {
+	if len(fixture.RuntimeVariants) > 0 {
+		var variants []runtimeVariant
+		for _, variant := range fixture.RuntimeVariants {
+			variants = append(variants, normalizeRuntimeVariant(variant))
+		}
+		return variants
+	}
+	return []runtimeVariant{defaultRuntimeVariant()}
+}
+
+func normalizeRuntimeVariant(variant runtimeVariant) runtimeVariant {
+	if variant.Runtime == "" {
+		variant.Runtime = "node"
+	}
+	if variant.PostgresDriver == "" {
+		variant.PostgresDriver = "pg"
+	}
+	return variant
+}
+
+func defaultRuntimeVariant() runtimeVariant {
+	return runtimeVariant{
+		ID:             "node_pg",
+		Runtime:        "node",
+		PostgresDriver: "pg",
+	}
+}
+
+func applyRuntimeVariantConfig(t *testing.T, appRoot string, variant runtimeVariant) {
+	t.Helper()
+	path := filepath.Join(appRoot, "ent.yml")
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	cfg := map[string]any{}
+	if len(bytes.TrimSpace(b)) > 0 {
+		require.NoError(t, yaml.Unmarshal(b, &cfg))
+	}
+	cfg["runtime"] = variant.Runtime
+	cfg["postgresDriver"] = variant.PostgresDriver
+	out, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, out, fileMode))
+}
+
 func writeGeneratedHarnessFiles(t *testing.T, repo, appRoot, entDist string) {
 	t.Helper()
-	require.NoError(t, os.MkdirAll(filepath.Join(appRoot, "node_modules"), dirMode))
 	nodeModules := filepath.Join(appRoot, "node_modules")
 	if _, err := os.Lstat(nodeModules); err == nil {
 		require.NoError(t, os.RemoveAll(nodeModules))
 	}
-	require.NoError(t, os.Symlink(filepath.Join(repo, "ts", "node_modules"), nodeModules))
+	linkHarnessNodeModules(t, filepath.Join(repo, "ts", "node_modules"), nodeModules, entDist)
 
 	writeHarnessTSConfig(t, filepath.Join(appRoot, "tsconfig.json"), entPathMapping{
 		packageRoot:     filepath.Join(repo, "ts", "src", "index.ts"),
@@ -276,6 +392,52 @@ func writeGeneratedHarnessFiles(t *testing.T, repo, appRoot, entDist string) {
 		packageWildcard: filepath.Join(entDist, "*"),
 	})
 	replaceHarnessPlaceholders(t, appRoot)
+}
+
+func linkHarnessNodeModules(t *testing.T, sourceNodeModules, targetNodeModules, entDist string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(targetNodeModules, dirMode))
+	entries, err := os.ReadDir(sourceNodeModules)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if entry.Name() == "@snowtop" {
+			linkHarnessSnowtopModules(t, filepath.Join(sourceNodeModules, entry.Name()), filepath.Join(targetNodeModules, entry.Name()), entDist)
+			continue
+		}
+		require.NoError(t, os.Symlink(
+			filepath.Join(sourceNodeModules, entry.Name()),
+			filepath.Join(targetNodeModules, entry.Name()),
+		))
+	}
+	snowtopDir := filepath.Join(targetNodeModules, "@snowtop")
+	require.NoError(t, os.MkdirAll(snowtopDir, dirMode))
+	ensureSnowtopEntLink(t, snowtopDir, entDist)
+}
+
+func linkHarnessSnowtopModules(t *testing.T, sourceSnowtop, targetSnowtop, entDist string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(targetSnowtop, dirMode))
+	entries, err := os.ReadDir(sourceSnowtop)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if entry.Name() == "ent" {
+			continue
+		}
+		require.NoError(t, os.Symlink(
+			filepath.Join(sourceSnowtop, entry.Name()),
+			filepath.Join(targetSnowtop, entry.Name()),
+		))
+	}
+	ensureSnowtopEntLink(t, targetSnowtop, entDist)
+}
+
+func ensureSnowtopEntLink(t *testing.T, snowtopDir, entDist string) {
+	t.Helper()
+	entLink := filepath.Join(snowtopDir, "ent")
+	if _, err := os.Lstat(entLink); err == nil {
+		require.NoError(t, os.RemoveAll(entLink))
+	}
+	require.NoError(t, os.Symlink(entDist, entLink))
 }
 
 type entPathMapping struct {

--- a/testdata/codegen_matrix/README.md
+++ b/testdata/codegen_matrix/README.md
@@ -14,8 +14,10 @@ Run one fixture while iterating with:
 
 ```sh
 ENT_CODEGEN_MATRIX_FIXTURE=feature_stress go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
+ENT_CODEGEN_MATRIX_FIXTURE=feature_stress ENT_CODEGEN_MATRIX_RUNTIME=bun go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
 ENT_CODEGEN_MATRIX_FIXTURE=db_schema_smoke go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
 ENT_CODEGEN_MATRIX_POSTGRES_URL=postgres://postgres:postgres@localhost:5432/postgres ENT_CODEGEN_MATRIX_FIXTURE=postgres_schema_smoke go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
+ENT_CODEGEN_MATRIX_POSTGRES_URL=postgres://postgres:postgres@localhost:5432/postgres ENT_CODEGEN_MATRIX_FIXTURE=postgres_schema_smoke ENT_CODEGEN_MATRIX_RUNTIME=bun go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
 ```
 
 ## What It Tests
@@ -25,6 +27,9 @@ The matrix catalog lives in `features.yml`.
 - `feature_stress` runs TS schema parsing, `tsent codegen --step codegen`,
   `tsent codegen --step graphql`, generated TypeScript typechecking, and
   idempotence checks over a broad schema surface.
+  It runs once with the default Node/pg launcher settings and once with
+  Bun/Bun SQL settings, so generated Bun-specific resolver exports and
+  Postgres value conversion helpers stay covered by the same broad fixture.
 - `db_schema_smoke` runs the same checks and also includes
   `tsent codegen --step db` against SQLite-compatible schema features. Its
   idempotence snapshot includes DB-generated schema and migration files. It
@@ -33,8 +38,9 @@ The matrix catalog lives in `features.yml`.
   rendering plus Postgres-only paths such as operator classes and index
   parameters. It creates a generated temporary database for isolation and runs when
   `ENT_CODEGEN_MATRIX_POSTGRES_URL` or a Postgres `DB_CONNECTION_STRING` is
-  present; otherwise it skips locally. Go CI already provides Postgres. It
-  includes the same shared core DB schema fixture as `db_schema_smoke`.
+  present; otherwise it skips locally. Go CI already provides Postgres. It runs
+  both the default Node/pg path and the Bun/Bun SQL path, and includes the same
+  shared core DB schema fixture as `db_schema_smoke`.
 - `TestFeatureCatalogClassifiesCodegenInputs` reflects exported fields,
   selected enum constants from `internal/schema/input/input.go`, and action
   operation mappings from `getTSStringOperation`; it verifies every active
@@ -44,9 +50,10 @@ The matrix catalog lives in `features.yml`.
   supplemental owner list limited to non-reflectable inputs.
 
 The harness builds the current checked-out `tsent` and package-shaped
-`@snowtop/ent` `ts/dist`, copies fixtures to a temp app, symlinks local
-`ts/node_modules`, runs real codegen steps, checks the generated tree is stable
-across repeated runs, and then runs `tsc --noEmit` against the generated app.
+`@snowtop/ent` `ts/dist`, copies fixtures to a temp app, links local
+`ts/node_modules` entries plus the freshly built `@snowtop/ent` package, runs
+real codegen steps, checks the generated tree is stable across repeated runs,
+and then runs `tsc --noEmit` against the generated app.
 It locates the repository from the Go test source path, so it does not require
 `git rev-parse` at runtime.
 
@@ -90,8 +97,11 @@ The bar is:
 2. Add the fixture to `features.yml` with its `surfaces`, `covers`, and optional
    `includes`. DB fixtures must also declare `dialect: sqlite` or
    `dialect: postgres`.
-3. Add or update feature entries so every active feature is covered.
-4. Run the fixture directly, then run the whole package.
+3. Add `runtime_variants` only when the fixture should exercise non-default
+   runtime behavior. Omitted variants mean one Node/pg run; Bun SQL variants
+   should use `runtime: bun` with `postgresDriver: bun`.
+4. Add or update feature entries so every active feature is covered.
+5. Run the fixture directly, then run the whole package.
 
 Put core DB-rendered interactions in `fixtures/_shared/core_db` so the same
 schema source is exercised by both `db_schema_smoke` and

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -9,14 +9,24 @@ fixtures:
       historically fragile generated-code interactions.
     surfaces:
       - parse_ts_schema
+      - bun_runtime
       - ts_codegen
       - graphql_codegen
       - generated_tsc
       - idempotence
+    runtime_variants:
+      - id: node_pg
+        runtime: node
+        postgresDriver: pg
+      - id: bun_bun
+        runtime: bun
+        postgresDriver: bun
     covers:
       - schema.nodes
       - schema.patterns
       - schema.global_schema
+      - runtime.bun
+      - postgres_driver.bun
       - node.table_name
       - node.field_overrides
       - node.assoc_edges
@@ -189,11 +199,19 @@ fixtures:
     surfaces:
       - parse_ts_schema
       - postgres_db_codegen
+      - bun_runtime
       - ts_codegen
       - graphql_codegen
       - generated_tsc
       - idempotence
     dialect: postgres
+    runtime_variants:
+      - id: node_pg
+        runtime: node
+        postgresDriver: pg
+      - id: bun_bun
+        runtime: bun
+        postgresDriver: bun
     covers:
       - schema.nodes
       - node.table_name
@@ -238,6 +256,14 @@ features:
     owns: [input.Schema.GlobalSchema]
     mode: explicit
     rationale: Global schema changes generated edge tables, global fields, and DB extension metadata.
+  - id: runtime.bun
+    owns: []
+    mode: explicit
+    rationale: Bun runtime changes TS schema/custom GraphQL launchers and generated GraphQL resolver export shape, so the matrix runs a full codegen fixture under Bun.
+  - id: postgres_driver.bun
+    owns: []
+    mode: explicit
+    rationale: Bun's native Postgres driver changes generated value/result conversion helpers for enum, list, and custom field types.
 
   - id: node.table_name
     owns: [input.Node.TableName]


### PR DESCRIPTION
## Summary
- add runtime variants to the codegen matrix harness so fixtures can run under Node/pg or Bun/Bun SQL
- run feature_stress and postgres_schema_smoke with Bun while keeping SQLite DB smoke on the default Node path
- install Bun in Go CI and document the new matrix runtime filters

## Validation
- go test ./internal/codegenmatrix -run TestFeatureCatalogClassifiesCodegenInputs -count=1
- ENT_CODEGEN_MATRIX_FIXTURE=feature_stress ENT_CODEGEN_MATRIX_RUNTIME=bun go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
- ENT_CODEGEN_MATRIX_FIXTURE=postgres_schema_smoke ENT_CODEGEN_MATRIX_RUNTIME=bun go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v (skips locally without Postgres DSN)
- go test ./internal/codegenmatrix -count=1
- git diff --check