### PR TITLE
Fix action-only ID list GraphQL decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- decode GraphQL global IDs in action-only ID list inputs, including nested object-list inputs (#1988).
 - include the shared `parse_args` helper in the published package so CLI scripts can load without `MODULE_NOT_FOUND` (#1981).
 
 ## [0.2.8]

--- a/internal/codegenmatrix/codegen_matrix_test.go
+++ b/internal/codegenmatrix/codegen_matrix_test.go
@@ -60,6 +60,15 @@ type runtimeVariant struct {
 	PostgresDriver string `yaml:"postgresDriver"`
 }
 
+type fixtureAssertions struct {
+	Contains []fixtureContainsAssertion `yaml:"contains"`
+}
+
+type fixtureContainsAssertion struct {
+	Path string `yaml:"path"`
+	Text string `yaml:"text"`
+}
+
 const (
 	dirMode  os.FileMode = 0o755
 	fileMode os.FileMode = 0o644
@@ -530,11 +539,35 @@ func runCodegenFixture(t *testing.T, repo, appRoot string, fixture fixture) {
 	secondHash := hashGeneratedSnapshot(secondSnapshot)
 	require.Equal(t, firstHash, secondHash, "codegen fixture is not idempotent; changed files: %s\n%s", strings.Join(changedSnapshotFiles(firstSnapshot, secondSnapshot), ", "), snapshotChangeSummary(firstSnapshot, secondSnapshot))
 
+	runFixtureGeneratedAssertions(t, appRoot)
+
 	cmd := exec.Command(filepath.Join(repo, "ts", "node_modules", ".bin", "tsc"), "--noEmit", "--project", filepath.Join(appRoot, "tsconfig.generated.json"))
 	cmd.Dir = appRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("generated TypeScript did not compile:\n%s\n%v", string(out), err)
+	}
+}
+
+func runFixtureGeneratedAssertions(t *testing.T, appRoot string) {
+	t.Helper()
+	path := filepath.Join(appRoot, "codegen_matrix_assertions.yml")
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return
+	}
+	require.NoError(t, err)
+
+	var assertions fixtureAssertions
+	require.NoError(t, yaml.Unmarshal(b, &assertions))
+	for _, assertion := range assertions.Contains {
+		require.NotEmpty(t, assertion.Path, "generated assertion path is required")
+		require.NotEmpty(t, assertion.Text, "generated assertion text is required for %s", assertion.Path)
+
+		target := filepath.Join(appRoot, assertion.Path)
+		contents, err := os.ReadFile(target)
+		require.NoError(t, err, "read generated assertion target %s", assertion.Path)
+		require.Contains(t, string(contents), assertion.Text, "generated assertion failed for %s", assertion.Path)
 	}
 }
 

--- a/internal/enttype/type.go
+++ b/internal/enttype/type.go
@@ -1003,6 +1003,32 @@ func (t *ListWrapperType) GetTsTypeImports() []*tsimport.ImportPath {
 	return t2.GetTsTypeImports()
 }
 
+func (t *ListWrapperType) CustomGQLRender(cfg Config, v string) string {
+	t2, ok := t.Type.(CustomGQLRenderer)
+	if !ok {
+		return v
+	}
+
+	renderedItem := t2.CustomGQLRender(cfg, "i")
+	if renderedItem == "i" {
+		return v
+	}
+
+	renderedList := fmt.Sprintf("%s.map((i:any) => %s)", v, renderedItem)
+	if t.Nullable {
+		return fmt.Sprintf("%s ? %s : %s", v, renderedList, v)
+	}
+	return renderedList
+}
+
+func (t *ListWrapperType) ArgImports(cfg Config) []*tsimport.ImportPath {
+	t2, ok := t.Type.(CustomGQLRenderer)
+	if !ok {
+		return []*tsimport.ImportPath{}
+	}
+	return t2.ArgImports(cfg)
+}
+
 type enumType struct {
 }
 
@@ -2093,7 +2119,8 @@ func GetEnumType(t Type) (EnumeratedType, bool) {
 func IsListType(t Type) bool {
 	_, ok := t.(*ArrayListType)
 	_, ok2 := t.(*NullableArrayListType)
-	return ok || ok2
+	_, ok3 := t.(*ListWrapperType)
+	return ok || ok2 || ok3
 }
 
 func IsJSONBType(t Type) bool {

--- a/internal/graphql/can_viewer_do.go
+++ b/internal/graphql/can_viewer_do.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lolopinto/ent/internal/action"
 	"github.com/lolopinto/ent/internal/codegen"
+	"github.com/lolopinto/ent/internal/enttype"
 	"github.com/lolopinto/ent/internal/field"
 	"github.com/lolopinto/ent/internal/names"
 	"github.com/lolopinto/ent/internal/schema"
@@ -105,7 +106,7 @@ func getCanViewerDoObjectImpl(processor *codegen.Processor, ctx *canViewerDoCont
 
 			arg := &fieldConfigArg{
 				Name:    field.GetGraphQLName(),
-				Imports: field.GetTSGraphQLTypeForFieldImports(true),
+				Imports: getCanViewerDoFieldImports(action, field),
 			}
 
 			gqlField.Args = append(gqlField.Args, arg)
@@ -254,6 +255,31 @@ func getNewCanViewerDoClass(processor *codegen.Processor, ctx *canViewerDoContex
 		Contents:             classContents,
 		UnconditionalImports: imports,
 	}, nil
+}
+
+func getCanViewerDoFieldImports(a action.Action, f action.ActionField) []*tsimport.ImportPath {
+	imports := f.GetTSGraphQLTypeForFieldImports(true)
+	actionFields, ok := f.GetFieldType().(enttype.TSTypeWithActionFields)
+	if !ok || actionFields.GetActionFieldsInfo() == nil {
+		return imports
+	}
+	customType, ok := f.GetFieldType().(enttype.TSTypeWithCustomType)
+	if !ok || customType.GetCustomTypeInfo() == nil {
+		return imports
+	}
+
+	gqlType := customType.GetCustomTypeInfo().GraphQLInterface
+	ret := make([]*tsimport.ImportPath, 0, len(imports))
+	for _, imp := range imports {
+		if imp.Import == gqlType && imp.ImportPath == "" {
+			impCopy := *imp
+			impCopy.ImportPath = getImportPathForActionFromPackage(a.GetNodeInfo().PackageName, a)
+			ret = append(ret, &impCopy)
+			continue
+		}
+		ret = append(ret, imp)
+	}
+	return ret
 }
 
 func getActionCanViewerDoFields(a action.Action, actionCanViewerDo *input.CanViewerDo) ([]action.ActionField, error) {

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -3057,8 +3057,9 @@ func checkUnionType(cfg codegenapi.Config, nodeName string, f *field.Field, curr
 // returns (`foo: input.foo`, imports)
 func processActionField(processor *codegen.Processor, a action.Action, f action.ActionField, prefix string) (string, []*tsimport.ImportPath) {
 	typ := f.GetFieldType()
+	inputOptional := !action.IsRequiredField(a, f)
 	// get nullable version
-	if !action.IsRequiredField(a, f) {
+	if inputOptional {
 		nullable, ok := typ.(enttype.NullableType)
 		if ok {
 			typ = nullable.GetNullableType()
@@ -3083,10 +3084,16 @@ func processActionField(processor *codegen.Processor, a action.Action, f action.
 		cti := customType.GetCustomTypeInfo()
 		if cti != nil {
 
-			ci, ok := processor.Schema.CustomInterfaces[cti.TSInterface]
+			ci, ok := customInterfaceForActionField(processor, a, cti.TSInterface)
 			if ok {
-
+				var fields []action.ActionField
 				for _, f := range ci.Fields {
+					fields = append(fields, f)
+				}
+				for _, f := range ci.NonEntFields {
+					fields = append(fields, f)
+				}
+				for _, f := range fields {
 					nestedType := f.GetFieldType()
 
 					customRenderer, ok := nestedType.(enttype.CustomGQLRenderer)
@@ -3110,12 +3117,12 @@ func processActionField(processor *codegen.Processor, a action.Action, f action.
 
 					if f.Nullable() {
 						nestedInputField = fmt.Sprintf("%s: %s ? %s: undefined",
-							f.GetGraphQLName(),
+							f.TSPublicAPIName(),
 							nestedInputFieldPrefix,
 							nestedInputField,
 						)
 					} else {
-						nestedInputField = fmt.Sprintf("%s: %s", f.GetGraphQLName(), nestedInputField)
+						nestedInputField = fmt.Sprintf("%s: %s", f.TSPublicAPIName(), nestedInputField)
 					}
 
 					customList = append(customList, nestedInputField)
@@ -3136,7 +3143,11 @@ func processActionField(processor *codegen.Processor, a action.Action, f action.
 		}
 
 		if listType {
-			res = fmt.Sprintf("%s?.map((item: any) =>  ( %s ))", resPrefix, res)
+			if inputOptional {
+				res = fmt.Sprintf("%s ? %s.map((item: any) =>  ( %s )) : %s", resPrefix, resPrefix, res, resPrefix)
+			} else {
+				res = fmt.Sprintf("%s.map((item: any) =>  ( %s ))", resPrefix, res)
+			}
 		} else if f.Nullable() {
 			res = fmt.Sprintf("%s ? %s: undefined", resPrefix, res)
 		}
@@ -3148,6 +3159,19 @@ func processActionField(processor *codegen.Processor, a action.Action, f action.
 		f.TSPublicAPIName(),
 		inputField,
 	), argImports
+}
+
+func customInterfaceForActionField(processor *codegen.Processor, a action.Action, tsInterface string) (*customtype.CustomInterface, bool) {
+	ci, ok := processor.Schema.CustomInterfaces[tsInterface]
+	if ok {
+		return ci, true
+	}
+	for _, ci := range a.GetCustomInterfaces() {
+		if ci.TSType == tsInterface {
+			return ci, true
+		}
+	}
+	return nil, false
 }
 
 func buildActionFieldConfig(processor *codegen.Processor, nodeData *schema.NodeData, a action.Action) (*fieldConfig, error) {

--- a/internal/graphql/graphql_fields_test.go
+++ b/internal/graphql/graphql_fields_test.go
@@ -82,6 +82,143 @@ func TestActionWithFieldEdgeFieldConfig(t *testing.T) {
 	assert.Len(t, editNode.Fields, len(editAction.GetFields())+len(editAction.GetNonEntFields())+1)
 }
 
+func TestActionOnlyIDListFieldConfigDecodesGraphQLIDs(t *testing.T) {
+	schema := testhelper.ParseSchemaForTest(
+		t,
+		map[string]string{
+			"payment.ts": testhelper.GetCodeWithSchema(
+				`import {EntSchema, ActionOperation, IntegerType, StringType, UUIDType} from "{schema}";
+
+				const Payment = new EntSchema({
+					fields: {
+						externalID: StringType(),
+						amount: IntegerType(),
+						entID: UUIDType(),
+					},
+
+					actions: [
+						{
+							operation: ActionOperation.Create,
+							fields: ["externalID", "amount", "entID"],
+							actionOnlyFields: [
+								{
+									name: "studbooks",
+									type: "ID",
+									list: true,
+									nullable: true,
+								},
+								{
+									name: "nullableStudbooks",
+									type: "ID",
+									list: true,
+									nullable: "contents",
+								},
+							],
+						},
+					],
+				});
+				export default Payment;`),
+		},
+	)
+	processor, err := codegen.NewTestCodegenProcessor("src/schema", schema, &codegen.CodegenConfig{
+		DisableGraphQLRoot: true,
+	})
+	require.NoError(t, err)
+
+	paymentCfg := schema.Nodes["Payment"]
+	require.NotNil(t, paymentCfg)
+
+	createAction := paymentCfg.NodeData.ActionInfo.GetByName("CreatePaymentAction")
+	require.NotNil(t, createAction)
+
+	createActionCfg, err := buildActionFieldConfig(processor, paymentCfg.NodeData, createAction)
+	require.NoError(t, err)
+
+	contents := strings.Join(createActionCfg.FunctionContents, "\n")
+	assert.Contains(
+		t,
+		contents,
+		"studbooks: input.studbooks ? input.studbooks.map((i:any) => mustDecodeIDFromGQLID(i.toString())) : input.studbooks,",
+	)
+	assert.Contains(
+		t,
+		contents,
+		"nullableStudbooks: input.nullableStudbooks.map((i:any) => mustDecodeNullableIDFromGQLID(i?.toString() ?? i)),",
+	)
+	assert.Contains(t, actionConfigImportNames(createActionCfg), "mustDecodeIDFromGQLID")
+	assert.Contains(t, actionConfigImportNames(createActionCfg), "mustDecodeNullableIDFromGQLID")
+}
+
+func TestActionOnlyObjectListFieldConfigDecodesNestedGraphQLIDs(t *testing.T) {
+	schema := testhelper.ParseSchemaForTest(
+		t,
+		map[string]string{
+			"registration.ts": testhelper.GetCodeWithSchema(
+				`import {EntSchema, ActionOperation, IntegerType, UUIDType} from "{schema}";
+
+				const Registration = new EntSchema({
+					fields: {
+						registryID: UUIDType(),
+						position: IntegerType(),
+					},
+
+					actions: [
+						{
+							operation: ActionOperation.Create,
+							actionName: "AddRegistrationAction",
+						},
+					],
+				});
+				export default Registration;`),
+			"payment.ts": testhelper.GetCodeWithSchema(
+				`import {EntSchema, ActionOperation, StringType} from "{schema}";
+
+				const Payment = new EntSchema({
+					fields: {
+						externalID: StringType(),
+					},
+
+					actions: [
+						{
+							operation: ActionOperation.Create,
+							actionOnlyFields: [
+								{
+									name: "registrations",
+									type: "Object",
+									list: true,
+									nullable: true,
+									actionName: "AddRegistrationAction",
+								},
+							],
+						},
+					],
+				});
+				export default Payment;`),
+		},
+	)
+	processor, err := codegen.NewTestCodegenProcessor("src/schema", schema, &codegen.CodegenConfig{
+		DisableGraphQLRoot: true,
+	})
+	require.NoError(t, err)
+
+	paymentCfg := schema.Nodes["Payment"]
+	require.NotNil(t, paymentCfg)
+
+	createAction := paymentCfg.NodeData.ActionInfo.GetByName("CreatePaymentAction")
+	require.NotNil(t, createAction)
+
+	createActionCfg, err := buildActionFieldConfig(processor, paymentCfg.NodeData, createAction)
+	require.NoError(t, err)
+
+	contents := strings.Join(createActionCfg.FunctionContents, "\n")
+	assert.Contains(
+		t,
+		contents,
+		"registrations: input.registrations ? input.registrations.map((item: any) =>  ( {...item,  registryId: mustDecodeIDFromGQLID(item.registryId.toString())} )) : input.registrations,",
+	)
+	assert.Contains(t, actionConfigImportNames(createActionCfg), "mustDecodeIDFromGQLID")
+}
+
 func verifyFieldsOverlap(t *testing.T, action action.Action, cfg *fieldConfig) {
 	for _, f := range action.GetFields() {
 		found := false
@@ -94,4 +231,12 @@ func verifyFieldsOverlap(t *testing.T, action action.Action, cfg *fieldConfig) {
 		}
 		assert.True(t, found, "couldn't find field %s in FunctionContents", f.FieldName)
 	}
+}
+
+func actionConfigImportNames(cfg *fieldConfig) []string {
+	var imports []string
+	for _, imp := range cfg.ArgImports {
+		imports = append(imports, imp.Import)
+	}
+	return imports
 }

--- a/testdata/codegen_matrix/README.md
+++ b/testdata/codegen_matrix/README.md
@@ -53,7 +53,8 @@ The harness builds the current checked-out `tsent` and package-shaped
 `@snowtop/ent` `ts/dist`, copies fixtures to a temp app, links local
 `ts/node_modules` entries plus the freshly built `@snowtop/ent` package, runs
 real codegen steps, checks the generated tree is stable across repeated runs,
-and then runs `tsc --noEmit` against the generated app.
+checks any fixture-local `codegen_matrix_assertions.yml` generated-file
+snippets, and then runs `tsc --noEmit` against the generated app.
 It locates the repository from the Go test source path, so it does not require
 `git rev-parse` at runtime.
 
@@ -101,7 +102,9 @@ The bar is:
    runtime behavior. Omitted variants mean one Node/pg run; Bun SQL variants
    should use `runtime: bun` with `postgresDriver: bun`.
 4. Add or update feature entries so every active feature is covered.
-5. Run the fixture directly, then run the whole package.
+5. Add `codegen_matrix_assertions.yml` when a regression requires a specific
+   generated snippet that plain typechecking would not catch.
+6. Run the fixture directly, then run the whole package.
 
 Put core DB-rendered interactions in `fixtures/_shared/core_db` so the same
 schema source is exercised by both `db_schema_smoke` and

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -129,7 +129,9 @@ fixtures:
       - action.can_viewer_do
       - action.can_fail
       - action_field.scalar
+      - action_field.object
       - action_field.list
+      - action_field.id_list_graphql_decode
       - action_field.nullable_contents
       - action_field.optional
       - action_field.hide_from_graphql
@@ -769,12 +771,16 @@ features:
     rationale: Action-only scalar fields share render paths with representative scalar coverage.
   - id: action_field.object
     owns: [input.ActionField.Type.Object, input.ActionField.ActionName, input.ActionField.ExcludedFields]
-    mode: skipped
-    skip_reason: Generated action bases currently reference the lower-case embedded input interface without declaring/importing it; needs a focused action-only object fix.
+    mode: explicit
+    rationale: Action-only object fields generate embedded object inputs and nested action input conversion, including object lists with ID fields.
   - id: action_field.list
     owns: [input.ActionField.List]
     mode: representative
     rationale: List wrapping is a distinct generated input shape.
+  - id: action_field.id_list_graphql_decode
+    owns: []
+    mode: explicit
+    rationale: Action-only ID list fields must decode each GraphQL global ID before passing input to action builders.
   - id: action_field.nullable_contents
     owns: [input.ActionField.Nullable, input.NullableItem.Contents, input.NullableItem.ContentsAndList, input.NullableItem.True]
     mode: representative

--- a/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
+++ b/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
@@ -1,0 +1,5 @@
+contains:
+  - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts
+    text: "input.studbooks.map((i: any) => mustDecodeIDFromGQLID(i.toString()))"
+  - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts
+    text: "registryId: mustDecodeIDFromGQLID(item.registryId.toString())"

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/payment_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/payment_schema.ts
@@ -396,6 +396,19 @@ const PaymentSchema = new EntSchema({
           type: "JSON",
           nullable: true,
         },
+        {
+          name: "studbooks",
+          type: "ID",
+          list: true,
+          nullable: true,
+        },
+        {
+          name: "registrations",
+          type: "Object",
+          list: true,
+          nullable: true,
+          actionName: "AddRegistrationAction",
+        },
       ],
     },
     {

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/registration_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/registration_schema.ts
@@ -1,0 +1,21 @@
+import {
+  ActionOperation,
+  EntSchema,
+  IntegerType,
+  UUIDType,
+} from "@snowtop/ent/schema";
+
+const RegistrationSchema = new EntSchema({
+  fields: {
+    registryID: UUIDType(),
+    position: IntegerType(),
+  },
+  actions: [
+    {
+      operation: ActionOperation.Create,
+      actionName: "AddRegistrationAction",
+    },
+  ],
+});
+
+export default RegistrationSchema;


### PR DESCRIPTION
## Summary
- decode action-only ID list inputs from GraphQL global IDs before passing them to action builders
- decode nested ID fields inside action-only object list inputs
- add codegen matrix assertions for both regression cases

Fixes #1987

## Tests
- DB_CONNECTION_STRING=sqlite:////tmp/ent-graphql-test.sqlite LOCAL_SCRIPT_PATH=true go test ./internal/graphql -count=1
- go test ./internal/codegenmatrix -count=1