### PR TITLE
Fix Bun script stdout draining

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,14 @@ How examples pick up local `@snowtop/ent` changes:
   verification, revert it before finishing unless updating the example test
   wiring is part of the intended change.
 
+## Changelog
+
+- Put unreleased changes in a top-level `## [Unreleased]` section above the
+  latest released version.
+- Keep `### Added`, `### Changed`, and `### Fixed` subsections in that order
+  under `## [Unreleased]`, and add PR-specific entries under the matching
+  subsection instead of editing an already released version section.
+
 ## Dev schema isolation (Postgres only)
 
 Default contract:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- prevent Bun script stdout truncation when schema/codegen JSON exceeds pipe buffering (#1992).
+
 ## [0.2.10]
 
 ### Added
@@ -21,7 +31,6 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
-- prevent Bun script stdout truncation when schema/codegen JSON exceeds pipe buffering (#1992).
 - avoid bogus dev-schema autogen diffs for already-upgraded branch schemas (#1990).
 - decode GraphQL global IDs in action-only ID list inputs, including nested object-list inputs (#1988).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- prevent Bun script stdout truncation when schema/codegen JSON exceeds pipe buffering (#1992).
 - avoid bogus dev-schema autogen diffs for already-upgraded branch schemas (#1990).
 - decode GraphQL global IDs in action-only ID list inputs, including nested object-list inputs (#1988).
 

--- a/ts/src/scripts/custom_graphql.ts
+++ b/ts/src/scripts/custom_graphql.ts
@@ -28,6 +28,7 @@ import { exit } from "process";
 import { Data } from "../core/base";
 import { spawn } from "child_process";
 import { GRAPHQL_PATH } from "../core/const";
+import { writeJSONToStdout } from "./stdout";
 const { parseArgs } = require("./parse_args");
 
 // need to use the GQLCapture from the package so that when we call GQLCapture.enable()
@@ -564,21 +565,19 @@ async function main() {
     buildClasses(fields[k]);
   }
 
-  console.log(
-    JSON.stringify({
-      args,
-      inputs,
-      fields,
-      queries,
-      mutations,
-      classes,
-      objects,
-      interfaces,
-      unions,
-      files: allFiles,
-      customTypes,
-    }),
-  );
+  await writeJSONToStdout({
+    args,
+    inputs,
+    fields,
+    queries,
+    mutations,
+    classes,
+    objects,
+    interfaces,
+    unions,
+    files: allFiles,
+    customTypes,
+  });
 }
 
 main()

--- a/ts/src/scripts/read_schema.ts
+++ b/ts/src/scripts/read_schema.ts
@@ -5,8 +5,9 @@ import { parseSchema } from "../parse_schema/parse";
 import { getCustomInfo } from "../tsc/ast";
 import { GlobalSchema } from "../schema/schema";
 import { toClassName } from "../names/names";
+import { writeJSONToStdout } from "./stdout";
 
-function main() {
+async function main() {
   const options = parseArgs(process.argv.slice(2));
 
   if (!options.path) {
@@ -52,16 +53,11 @@ function main() {
   }
   //  console.log(potentialSchemas);
 
-  // NB: do not change this to async/await
-  // doing so runs it buffer limit on linux (65536 bytes) and we lose data reading in go
-  parseSchema(potentialSchemas, globalSchema).then((result) => {
-    console.log(JSON.stringify(result));
-  });
+  const result = await parseSchema(potentialSchemas, globalSchema);
+  await writeJSONToStdout(result);
 }
 
-try {
-  main();
-} catch (err) {
+main().catch((err) => {
   console.error(err);
   process.exit(1);
-}
+});

--- a/ts/src/scripts/stdout.test.ts
+++ b/ts/src/scripts/stdout.test.ts
@@ -1,0 +1,42 @@
+import { writeJSONToStdout } from "./stdout";
+
+describe("writeJSONToStdout", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("waits for stdout write callback before resolving", async () => {
+    let writeCallback: ((err?: Error | null) => void) | undefined;
+    const chunks: string[] = [];
+
+    jest.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: unknown,
+      encodingOrCallback?: unknown,
+      callback?: unknown,
+    ) => {
+      chunks.push(String(chunk));
+      writeCallback =
+        typeof encodingOrCallback === "function"
+          ? (encodingOrCallback as (err?: Error | null) => void)
+          : (callback as (err?: Error | null) => void);
+
+      return true;
+    }) as typeof process.stdout.write);
+
+    let resolved = false;
+    const promise = writeJSONToStdout({ ok: true }).then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+
+    expect(chunks).toEqual([JSON.stringify({ ok: true })]);
+    expect(writeCallback).toEqual(expect.any(Function));
+    expect(resolved).toBe(false);
+
+    writeCallback?.();
+    await promise;
+
+    expect(resolved).toBe(true);
+  });
+});

--- a/ts/src/scripts/stdout.ts
+++ b/ts/src/scripts/stdout.ts
@@ -1,0 +1,16 @@
+export async function writeJSONToStdout(value: unknown): Promise<void> {
+  await writeToStdout(JSON.stringify(value));
+}
+
+async function writeToStdout(payload: string): Promise<void> {
+  // Bun can exit before a large piped stdout write is fully consumed.
+  await new Promise<void>((resolve, reject) => {
+    process.stdout.write(payload, (err?: Error | null) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared stdout JSON writer that awaits the write callback before script exit
- use it in read_schema and custom_graphql so Bun subprocess output is not truncated
- add a regression test for the stdout drain contract

## Tests
- cd ts && npx biome check --diagnostic-level=error src/scripts/custom_graphql.ts src/scripts/read_schema.ts src/scripts/stdout.ts src/scripts/stdout.test.ts
- cd ts && npm run compile
- cd ts && npm test -- --runInBand
- ENT_CODEGEN_MATRIX_RUNTIME=bun go test ./internal/codegenmatrix -count=1