### PR TITLE
Load custom GraphQL decorators with JSON config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,14 @@ How examples pick up local `@snowtop/ent` changes:
   verification, revert it before finishing unless updating the example test
   wiring is part of the intended change.
 
+## Changelog
+
+- Put unreleased changes in a top-level `## [Unreleased]` section above the
+  latest released version.
+- Keep `### Added`, `### Changed`, and `### Fixed` subsections in that order
+  under `## [Unreleased]`, and add PR-specific entries under the matching
+  subsection instead of editing an already released version section.
+
 ## Dev schema isolation (Postgres only)
 
 Default contract:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- load decorator-discovered custom GraphQL definitions when `customGraphQLJSONPath` is configured (#1993).
+
 ## [0.2.10]
 
 ### Added
@@ -21,7 +31,6 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
-- load decorator-discovered custom GraphQL definitions when `customGraphQLJSONPath` is configured (#1993).
 - avoid bogus dev-schema autogen diffs for already-upgraded branch schemas (#1990).
 - decode GraphQL global IDs in action-only ID list inputs, including nested object-list inputs (#1988).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- load decorator-discovered custom GraphQL definitions when `customGraphQLJSONPath` is configured (#1993).
 - avoid bogus dev-schema autogen diffs for already-upgraded branch schemas (#1990).
 - decode GraphQL global IDs in action-only ID list inputs, including nested object-list inputs (#1988).
 

--- a/internal/graphql/custom_ts_test.go
+++ b/internal/graphql/custom_ts_test.go
@@ -492,6 +492,111 @@ func TestCustomQuery(t *testing.T) {
 	})
 }
 
+func TestCustomGraphQLJSONPathAlsoLoadsDecorators(t *testing.T) {
+	m := map[string]string{
+		"contact_schema.ts": testhelper.GetCodeWithSchema(`
+			import {EntSchema, StringType} from "{schema}";
+
+			const ContactSchema = new EntSchema({
+				fields: {
+					firstName: StringType(),
+					lastName: StringType(),
+				},
+			});
+			export default ContactSchema;
+		`),
+	}
+
+	absPath, err := filepath.Abs(".")
+	require.NoError(t, err)
+	dirPath, err := os.MkdirTemp(absPath, "project")
+	defer os.RemoveAll(dirPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dirPath, "package.json"), []byte(`{"type":"commonjs"}`), os.ModePerm))
+	snowtopDir := filepath.Join(dirPath, "node_modules", "@snowtop")
+	require.NoError(t, os.MkdirAll(snowtopDir, os.ModePerm))
+	require.NoError(t, os.Symlink(input.GetAbsoluteRootPathForTest(), filepath.Join(snowtopDir, "ent")))
+
+	schema := testhelper.ParseSchemaForTest(t, m, testhelper.TempDir(dirPath))
+	tmpCfg := getConfig(t, dirPath)
+
+	enumMap := map[string]string{
+		"NODE": "node",
+		"BUN":  "bun",
+	}
+	cd := CustomData{
+		CustomTypes: map[string]*CustomType{
+			"RuntimeKind": {
+				Type:    "RuntimeKind",
+				EnumMap: enumMap,
+			},
+		},
+	}
+
+	require.NoError(t, file.Write(
+		&file.JSONFileWriter{
+			PathToFile: filepath.Join(dirPath, "src/schema/custom_graphql.json"),
+			Config:     tmpCfg,
+			Data:       cd,
+		},
+	))
+
+	require.NoError(t, file.Write(&file.YamlFileWriter{
+		PathToFile: filepath.Join(dirPath, "ent.yml"),
+		Config:     tmpCfg,
+		Data: &codegen.ConfigurableConfig{
+			CustomGraphQLJSONPath: "src/schema/custom_graphql.json",
+		},
+	}))
+
+	resolverDir := filepath.Join(dirPath, "src", "graphql", "resolvers", "runtime")
+	require.NoError(t, os.MkdirAll(resolverDir, os.ModePerm))
+	code := testhelper.GetCodeWithSchema(`
+		import {gqlQuery} from "@snowtop/ent/graphql";
+
+		export class RuntimeResolver {
+			@gqlQuery({
+				class: "RuntimeResolver",
+				name: "runtimeReady",
+				type: Boolean,
+				async: true,
+			})
+			async runtimeReady() {
+				return true;
+			}
+		}
+	`)
+	require.NoError(t, os.WriteFile(filepath.Join(resolverDir, "runtime.ts"), []byte(code), os.ModePerm))
+
+	processor := &codegen.Processor{
+		Schema: schema,
+		Config: getConfig(t, dirPath),
+	}
+
+	s, err := buildSchema(processor, true)
+	require.NoError(t, err)
+
+	validateDefaultCustomTypes(t, s.customData)
+	enumTyp := s.customData.CustomTypes["RuntimeKind"]
+	require.NotNil(t, enumTyp)
+	require.Equal(t, enumMap, enumTyp.EnumMap)
+
+	require.Len(t, s.customData.Queries, 1)
+	require.Len(t, s.customData.Classes, 1)
+	require.Len(t, s.customData.Files, 1)
+
+	item := s.customData.Queries[0]
+	assert.Equal(t, "RuntimeResolver", item.Node)
+	assert.Equal(t, "runtimeReady", item.GraphQLName)
+	assert.Equal(t, "runtimeReady", item.FunctionName)
+	assert.Equal(t, AsyncFunction, item.FieldType)
+
+	require.Len(t, s.customQueries, 1)
+	gqlNode := s.customQueries[0]
+	assert.Equal(t, gqlNode.Field, &item)
+	assert.True(t, strings.HasSuffix(gqlNode.FilePath, "src/graphql/generated/resolvers/runtime_ready_query_type.ts"))
+}
+
 func TestCustomListQuery(t *testing.T) {
 	m := map[string]string{}
 

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -145,6 +145,7 @@ fixtures:
       - index.concurrently
       - index.where
       - custom_graphql.custom_mutation_return
+      - custom_graphql.json_with_decorators
       - pattern.struct_privacy_import
       - polymorphic.struct_field_codegen
       - field_edge.uuid_list_inverse
@@ -862,8 +863,14 @@ features:
 
   - id: custom_graphql.decorators
     owns: [custom_graphql.gqlField, custom_graphql.gqlObjectType, custom_graphql.gqlInputObjectType, custom_graphql.gqlQuery, custom_graphql.gqlMutation, custom_graphql.gqlConnection]
-    mode: skipped
-    skip_reason: Local decorator scanning becomes unstable after generated ent files exist; JSON custom GraphQL keeps mutation codegen covered while decorator scanning gets a focused fix.
+    mode: existing_test
+    test_refs:
+      - internal/graphql/custom_ts_test.go
+    rationale: Focused GraphQL tests cover decorator variants; the matrix covers the JSON-plus-decorator interaction separately.
+  - id: custom_graphql.json_with_decorators
+    owns: []
+    mode: explicit
+    rationale: customGraphQLJSONPath must be additive with decorator-discovered custom GraphQL definitions.
   - id: custom_graphql.custom_mutation_return
     owns: [custom_graphql.mutationReturnType]
     mode: explicit

--- a/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
+++ b/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
@@ -1,4 +1,6 @@
 contains:
+  - path: src/graphql/generated/resolvers/decorated_runtime_ready_query_type.ts
+    text: "return r.runtimeReady();"
   - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts
     text: "input.studbooks.map((i: any) => mustDecodeIDFromGQLID(i.toString()))"
   - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/graphql/resolvers/decorator_query.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/graphql/resolvers/decorator_query.ts
@@ -1,0 +1,21 @@
+import { gqlQuery } from "@snowtop/ent/graphql";
+
+export class DecoratedRuntimeResolver {
+  async runtimeReady(): Promise<boolean> {
+    return true;
+  }
+}
+
+gqlQuery({
+  class: "DecoratedRuntimeResolver",
+  name: "decoratedRuntimeReady",
+  type: Boolean,
+  async: true,
+})(
+  DecoratedRuntimeResolver.prototype,
+  "runtimeReady",
+  Object.getOwnPropertyDescriptor(
+    DecoratedRuntimeResolver.prototype,
+    "runtimeReady",
+  ),
+);

--- a/ts/src/scripts/custom_graphql.ts
+++ b/ts/src/scripts/custom_graphql.ts
@@ -279,34 +279,7 @@ async function processJSON(
   }
 }
 
-async function captureCustom(
-  filePath: string,
-  filesCsv: string | undefined,
-  jsonPath: string | undefined,
-  gqlCapture: typeof GQLCapture,
-) {
-  if (jsonPath !== undefined) {
-    const json = parseJSONC(
-      jsonPath,
-      fs.readFileSync(jsonPath, {
-        encoding: "utf8",
-      }),
-    );
-
-    processJSON(gqlCapture, json);
-
-    return;
-  }
-  if (filesCsv !== undefined) {
-    let files = filesCsv.split(",");
-    for (let i = 0; i < files.length; i++) {
-      // TODO fix. we have "src" in the path we get here
-      files[i] = path.join(filePath, "..", files[i]);
-    }
-
-    await requireFiles(files);
-    return;
-  }
+async function loadGraphQLDecoratorFiles(filePath: string) {
   // TODO delete all of this eventually
 
   // TODO configurable paths eventually
@@ -341,6 +314,39 @@ async function captureCustom(
     .filter(fileImportsGraphQLDecorators);
 
   await requireFiles(files);
+}
+
+async function captureCustom(
+  filePath: string,
+  filesCsv: string | undefined,
+  jsonPath: string | undefined,
+  gqlCapture: typeof GQLCapture,
+) {
+  if (jsonPath !== undefined) {
+    const json = parseJSONC(
+      jsonPath,
+      fs.readFileSync(jsonPath, {
+        encoding: "utf8",
+      }),
+    );
+
+    await processJSON(gqlCapture, json);
+    await loadGraphQLDecoratorFiles(filePath);
+
+    return;
+  }
+  if (filesCsv !== undefined) {
+    let files = filesCsv.split(",");
+    for (let i = 0; i < files.length; i++) {
+      // TODO fix. we have "src" in the path we get here
+      files[i] = path.join(filePath, "..", files[i]);
+    }
+
+    await requireFiles(files);
+    return;
+  }
+
+  await loadGraphQLDecoratorFiles(filePath);
 }
 
 function fileImportsGraphQLDecorators(file: string) {


### PR DESCRIPTION
## Summary
- keep customGraphQLJSONPath additive by scanning decorator files after loading JSON custom GraphQL data
- add a focused regression test for JSON config plus decorator-discovered queries
- add feature_stress matrix coverage and an assertion for the generated decorator query

## Tests
- DB_CONNECTION_STRING=sqlite:/// go test ./internal/graphql -run TestCustomGraphQLJSONPathAlsoLoadsDecorators -count=1 -v
- cd ts && npm run compile
- cd ts && npx biome check --diagnostic-level=error src/scripts/custom_graphql.ts ../testdata/codegen_matrix/fixtures/feature_stress/src/graphql/resolvers/decorator_query.ts
- go test ./internal/codegenmatrix -run TestFeatureCatalogClassifiesCodegenInputs -count=1 -v
- ENT_CODEGEN_MATRIX_FIXTURE=feature_stress go test ./internal/codegenmatrix -run TestCodegenMatrixFixtures -count=1 -v
- go test ./internal/codegenmatrix -count=1