### PR TITLE
Bump @snowtop/ent to 0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
-## [Unreleased]
-
-### Added
+## [0.2.11]
 
 ### Changed
 
 - pin JS and Python dependency declarations to locked versions (#1994).
+- bump `@snowtop/ent` package metadata and exact references to 0.2.11.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 ### Changed
 
 - pin JS and Python dependency declarations to locked versions (#1994).
-- bump `@snowtop/ent` package metadata and exact references to 0.2.11.
+- bump `@snowtop/ent` package metadata and exact references to 0.2.11 (#1995).
 
 ### Fixed
 

--- a/examples/ent-local-guide/package-lock.json
+++ b/examples/ent-local-guide/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@snowtop/ent-postgis": "file:../../ts/packages/ent-postgis",
         "express": "4.22.1",
         "graphql": "16.13.2",
@@ -33,7 +33,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0",
         "pg": "^8.16.3",
@@ -1023,39 +1023,39 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }

--- a/examples/ent-local-guide/package-lock.json
+++ b/examples/ent-local-guide/package-lock.json
@@ -1025,7 +1025,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/ent-local-guide/package-lock.json
+++ b/examples/ent-local-guide/package-lock.json
@@ -1025,7 +1025,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/ent-local-guide/package.json
+++ b/examples/ent-local-guide/package.json
@@ -27,7 +27,7 @@
     "tsconfig-paths": "4.2.0"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@snowtop/ent-postgis": "file:../../ts/packages/ent-postgis",
     "express": "4.22.1",
     "graphql": "16.13.2",

--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -1326,7 +1326,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "peer": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7328,7 +7328,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "peer": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -1326,7 +1326,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "peer": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7328,7 +7328,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "peer": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "6.12.0",
         "@sentry/tracing": "6.12.0",
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@snowtop/ent-email": "^0.1.0-rc1",
         "@snowtop/ent-passport": "^0.1.0-rc1",
         "@snowtop/ent-password": "^0.1.0-rc1",
@@ -1324,40 +1324,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "peer": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -7326,22 +7326,22 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "peer": true,
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "glob": {

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "6.12.0",
     "@sentry/tracing": "6.12.0",
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@snowtop/ent-email": "^0.1.0-rc1",
     "@snowtop/ent-passport": "^0.1.0-rc1",
     "@snowtop/ent-password": "^0.1.0-rc1",

--- a/examples/ent-semantic-notes/package-lock.json
+++ b/examples/ent-semantic-notes/package-lock.json
@@ -1019,7 +1019,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/ent-semantic-notes/package-lock.json
+++ b/examples/ent-semantic-notes/package-lock.json
@@ -1019,7 +1019,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/ent-semantic-notes/package-lock.json
+++ b/examples/ent-semantic-notes/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ent-semantic-notes",
       "version": "0.0.1",
       "dependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@snowtop/ent-pgvector": "file:../../ts/packages/ent-pgvector",
         "express": "4.22.1",
         "graphql": "16.13.2",
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6"
@@ -1017,39 +1017,39 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }

--- a/examples/ent-semantic-notes/package.json
+++ b/examples/ent-semantic-notes/package.json
@@ -11,7 +11,7 @@
     "upgrade": "npm run db:up && LOCAL_SCRIPT_PATH=true LOCAL_AUTO_SCHEMA=true go run ../../tsent/main.go upgrade"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@snowtop/ent-pgvector": "file:../../ts/packages/ent-pgvector",
     "express": "4.22.1",
     "graphql": "16.13.2",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@snowtop/ent-email": "^0.1.0-rc1",
         "@snowtop/ent-passport": "^0.1.0-rc1",
         "@snowtop/ent-password": "^0.1.0-rc1",
@@ -1248,39 +1248,39 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -7139,21 +7139,21 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "@types/node": {

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -1250,7 +1250,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -7141,7 +7141,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "requires": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -1250,7 +1250,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -7141,7 +7141,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "requires": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -38,7 +38,7 @@
     "tsconfig-paths": "3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@snowtop/ent-email": "^0.1.0-rc1",
     "@snowtop/ent-passport": "^0.1.0-rc1",
     "@snowtop/ent-password": "^0.1.0-rc1",

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -1223,7 +1223,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "peer": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -6700,7 +6700,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "peer": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -1223,7 +1223,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "peer": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -6700,7 +6700,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "peer": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@snowtop/ent-phonenumber": "^0.1.0-rc1",
         "@snowtop/ent-soft-delete": "^0.1.0",
         "@types/node": "15.14.9",
@@ -1221,40 +1221,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "peer": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -6698,22 +6698,22 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "peer": true,
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "@types/node": {

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -37,7 +37,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@snowtop/ent-phonenumber": "^0.1.0-rc1",
     "@snowtop/ent-soft-delete": "^0.1.0",
     "@types/node": "15.14.9",

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@snowtop/ent",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "MIT",
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/packages/ent-email/package-lock.json
+++ b/ts/packages/ent-email/package-lock.json
@@ -13,7 +13,7 @@
         "libphonenumber-js": "1.10.37"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "ts-jest": "29.0.3"
@@ -1123,40 +1123,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -5196,22 +5196,22 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "balanced-match": {

--- a/ts/packages/ent-email/package-lock.json
+++ b/ts/packages/ent-email/package-lock.json
@@ -1125,7 +1125,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5198,7 +5198,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-email/package-lock.json
+++ b/ts/packages/ent-email/package-lock.json
@@ -1125,7 +1125,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5198,7 +5198,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-email/package.json
+++ b/ts/packages/ent-email/package.json
@@ -33,7 +33,7 @@
     "libphonenumber-js": "1.10.37"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "ts-jest": "29.0.3"

--- a/ts/packages/ent-graphql-tests/package-lock.json
+++ b/ts/packages/ent-graphql-tests/package-lock.json
@@ -1154,7 +1154,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -6185,7 +6185,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-graphql-tests/package-lock.json
+++ b/ts/packages/ent-graphql-tests/package-lock.json
@@ -1154,7 +1154,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -6185,7 +6185,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-graphql-tests/package-lock.json
+++ b/ts/packages/ent-graphql-tests/package-lock.json
@@ -15,7 +15,7 @@
         "supertest": "6.1.6"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/express": "4.17.13",
         "@types/jest": "29.2.3",
         "graphql": "16.8.1",
@@ -1152,40 +1152,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -6183,22 +6183,22 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "balanced-match": {

--- a/ts/packages/ent-graphql-tests/package.json
+++ b/ts/packages/ent-graphql-tests/package.json
@@ -35,7 +35,7 @@
     "supertest": "6.1.6"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@types/express": "4.17.13",
     "@types/jest": "29.2.3",
     "graphql": "16.8.1",

--- a/ts/packages/ent-passport/package-lock.json
+++ b/ts/packages/ent-passport/package-lock.json
@@ -1426,7 +1426,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7322,7 +7322,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-passport/package-lock.json
+++ b/ts/packages/ent-passport/package-lock.json
@@ -16,7 +16,7 @@
         "passport-strategy": "1.0.0"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@snowtop/ent-graphql-tests": "^0.1.0",
         "@types/express-session": "1.17.4",
         "@types/jest": "29.0.3",
@@ -1424,40 +1424,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -7320,22 +7320,22 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "balanced-match": {

--- a/ts/packages/ent-passport/package-lock.json
+++ b/ts/packages/ent-passport/package-lock.json
@@ -1426,7 +1426,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7322,7 +7322,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-passport/package.json
+++ b/ts/packages/ent-passport/package.json
@@ -32,7 +32,7 @@
     "@snowtop/ent": ">=0.2.8"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@snowtop/ent-graphql-tests": "^0.1.0",
     "@types/express-session": "1.17.4",
     "@types/jest": "29.0.3",

--- a/ts/packages/ent-password/package-lock.json
+++ b/ts/packages/ent-password/package-lock.json
@@ -1167,7 +1167,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5283,7 +5283,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-password/package-lock.json
+++ b/ts/packages/ent-password/package-lock.json
@@ -1167,7 +1167,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5283,7 +5283,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-password/package-lock.json
+++ b/ts/packages/ent-password/package-lock.json
@@ -12,7 +12,7 @@
         "bcryptjs": "2.4.3"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "password-validator": "5.3.0",
@@ -1165,40 +1165,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -5281,22 +5281,22 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "ts-node": {

--- a/ts/packages/ent-password/package.json
+++ b/ts/packages/ent-password/package.json
@@ -32,7 +32,7 @@
     "bcryptjs": "2.4.3"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "password-validator": "5.3.0",

--- a/ts/packages/ent-pgvector/package-lock.json
+++ b/ts/packages/ent-pgvector/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/jest": "30.0.0",
         "jest": "30.3.0",
         "ts-jest": "29.4.6"
@@ -1368,40 +1368,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }

--- a/ts/packages/ent-pgvector/package-lock.json
+++ b/ts/packages/ent-pgvector/package-lock.json
@@ -1370,7 +1370,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-pgvector/package-lock.json
+++ b/ts/packages/ent-pgvector/package-lock.json
@@ -1370,7 +1370,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-pgvector/package.json
+++ b/ts/packages/ent-pgvector/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/lolopinto/ent#readme",
   "dependencies": {},
   "devDependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@types/jest": "30.0.0",
     "jest": "30.3.0",
     "ts-jest": "29.4.6"

--- a/ts/packages/ent-phonenumber/package-lock.json
+++ b/ts/packages/ent-phonenumber/package-lock.json
@@ -1166,7 +1166,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5273,7 +5273,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-phonenumber/package-lock.json
+++ b/ts/packages/ent-phonenumber/package-lock.json
@@ -12,7 +12,7 @@
         "libphonenumber-js": "1.10.15"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "ts-jest": "29.0.3"
@@ -1164,40 +1164,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -5271,22 +5271,22 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "ts-node": {

--- a/ts/packages/ent-phonenumber/package-lock.json
+++ b/ts/packages/ent-phonenumber/package-lock.json
@@ -1166,7 +1166,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5273,7 +5273,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-phonenumber/package.json
+++ b/ts/packages/ent-phonenumber/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/lolopinto/ent#readme",
   "devDependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "ts-jest": "29.0.3"

--- a/ts/packages/ent-postgis/package-lock.json
+++ b/ts/packages/ent-postgis/package-lock.json
@@ -1372,7 +1372,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-postgis/package-lock.json
+++ b/ts/packages/ent-postgis/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/jest": "30.0.0",
         "jest": "30.3.0",
         "pg": "8.20.0",
@@ -1370,40 +1370,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }

--- a/ts/packages/ent-postgis/package-lock.json
+++ b/ts/packages/ent-postgis/package-lock.json
@@ -1372,7 +1372,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-postgis/package.json
+++ b/ts/packages/ent-postgis/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/lolopinto/ent#readme",
   "dependencies": {},
   "devDependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@types/jest": "30.0.0",
     "jest": "30.3.0",
     "pg": "8.20.0",

--- a/ts/packages/ent-soft-delete/package-lock.json
+++ b/ts/packages/ent-soft-delete/package-lock.json
@@ -12,7 +12,7 @@
         "@types/express": "4.17.13"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.10",
+        "@snowtop/ent": "0.2.11",
         "@types/jest": "26.0.24",
         "jest": "26.6.3",
         "ts-jest": "26.5.6"
@@ -1042,40 +1042,40 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-compiler": "scripts/custom_compiler.js",
-        "ent-custom-graphql": "scripts/custom_graphql.js"
+        "ent-custom-graphql": "scripts/custom_graphql.js",
+        "ent-custom-compiler": "scripts/custom_compiler.js"
       },
       "engines": {
         "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "@swc-node/register": "^1.6.8",
-        "better-sqlite3": "^12.5.0",
-        "graphql": "^16.8.1"
+        "@swc-node/register": "1.6.8",
+        "better-sqlite3": "12.5.0",
+        "graphql": "16.12.0"
       },
       "peerDependenciesMeta": {
-        "@swc-node/register": {
+        "better-sqlite3": {
           "optional": true
         },
-        "better-sqlite3": {
+        "@swc-node/register": {
           "optional": true
         }
       }
@@ -7630,22 +7630,22 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.10.tgz",
-      "integrity": "sha512-GVHLpuqF+8JTALkUxGF7+Nr/a4QTz2JRUHJhH4MNRs80s7tLm0LuJ2Q3pLzsx6Zo455ah7pmzyaDZcknEorDiw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
+      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^25.0.3",
-        "dataloader": "^2.2.3",
-        "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
-        "luxon": "^3.7.2",
-        "pg": "^8.16.3",
-        "ts-node": "^11.0.0-beta.1",
-        "tsconfig-paths": "^4.2.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.9.3",
-        "uuid": "^9.0.1"
+        "@types/node": "25.0.3",
+        "dataloader": "2.2.3",
+        "glob": "13.0.0",
+        "js-yaml": "4.1.1",
+        "luxon": "3.7.2",
+        "pg": "8.16.3",
+        "ts-node": "11.0.0-beta.1",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "uuid": "9.0.1"
       },
       "dependencies": {
         "acorn-walk": {

--- a/ts/packages/ent-soft-delete/package-lock.json
+++ b/ts/packages/ent-soft-delete/package-lock.json
@@ -1044,7 +1044,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7632,7 +7632,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-H0aAL/MKC3BS0UkvfoTpVsNPJAfbHPLCWNvkj8ju/+k2yWVpu1eElgbb9iDmzXJ4Wgyg/NrpVxS833fOmjBOEQ==",
+      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-soft-delete/package-lock.json
+++ b/ts/packages/ent-soft-delete/package-lock.json
@@ -1044,7 +1044,7 @@
     "node_modules/@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7632,7 +7632,7 @@
     "@snowtop/ent": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-mGeT8KAHEtD8OyCrAk7SfDxxKmZuZICBhtOtRhd6ee/rshtUH89uXYG0XGH775fz5BPMXwgDLeoiVLw/VywZcw==",
+      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-soft-delete/package.json
+++ b/ts/packages/ent-soft-delete/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/lolopinto/ent#readme",
   "devDependencies": {
-    "@snowtop/ent": "0.2.10",
+    "@snowtop/ent": "0.2.11",
     "@types/jest": "26.0.24",
     "jest": "26.6.3",
     "ts-jest": "26.5.6"


### PR DESCRIPTION
## Summary
- bump @snowtop/ent package metadata and exact references to 0.2.11
- update package lockfiles to the published npm tarball integrity
- close out the 0.2.11 changelog with #1992, #1993, and #1994 entries

## Verification
- npm view @snowtop/ent@0.2.11 version dist.integrity dist.tarball dist-tags.latest
- npm publish ./dist --dry-run
- lockfile integrity check for @snowtop/ent@0.2.11