### PR TITLE
Accept RFC 9562 UUID field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
-- allow UUID fields to accept canonical UUIDv6, UUIDv7, UUIDv8, and other UUID bit layouts without rejecting them during action validation.
+- allow UUID fields to accept canonical UUIDv6, UUIDv7, UUIDv8, and other UUID bit layouts without rejecting them during action validation (#2006).
 - avoid misclassifying imported GraphQL enum custom types as scalars and stop emitting unused GraphQLByte custom metadata (#2004).
 - preserve digit-sensitive generated DB column, TS enum, and GraphQL enum names after in-house case conversion changes (#2003).
 - fix flaky Postgres test connection reuse in CI (#1998).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- allow UUID fields to accept canonical UUIDv6, UUIDv7, UUIDv8, and other UUID bit layouts without rejecting them during action validation.
 - avoid misclassifying imported GraphQL enum custom types as scalars and stop emitting unused GraphQLByte custom metadata (#2004).
 - preserve digit-sensitive generated DB column, TS enum, and GraphQL enum names after in-house case conversion changes (#2003).
 - fix flaky Postgres test connection reuse in CI (#1998).

--- a/ts/src/schema/field.ts
+++ b/ts/src/schema/field.ts
@@ -1,6 +1,5 @@
 import { DateTime } from "luxon";
 import { isPromise } from "util/types";
-import { validate } from "uuid";
 import { Builder } from "../action/action";
 import { Ent, WriteOperation } from "../core/base";
 import DB, { Dialect } from "../core/db";
@@ -16,6 +15,9 @@ import {
   PolymorphicOptions,
   Type,
 } from "./schema";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export abstract class BaseField {
   name: string;
@@ -115,7 +117,7 @@ export class UUIDField extends BaseField implements Field {
   }
 
   async valid(val: any) {
-    if (typeof val === "string" && !validate(val)) {
+    if (typeof val === "string" && !UUID_REGEX.test(val)) {
       return false;
     }
     if (!this.options?.fieldEdge?.enforceSchema) {

--- a/ts/src/schema/uuid_field.test.ts
+++ b/ts/src/schema/uuid_field.test.ts
@@ -528,6 +528,36 @@ test("invalid uuid", async () => {
   });
 });
 
+test.each([
+  ["v6", "1ec9414c-232a-6b00-b3c8-9e6bdeced846"],
+  ["v7", "01890f22-725b-7cc1-98c4-dc0c0c07398f"],
+  ["v8", "00000000-0000-8000-8000-000000000000"],
+  ["v7 with non-RFC-4122 variant", "04d89468-4011-70d0-fb3b-257954ec217c"],
+])("valid uuid accepts %s", async (_name, uuid) => {
+  expect(await UUIDType().valid(uuid)).toBe(true);
+});
+
+test("saving uuid accepts UUIDv7 with non-RFC-4122 variant", async () => {
+  class Account extends User {}
+  const AccountSchema = getBuilderSchemaFromFields(
+    {
+      fake_id: UUIDType(),
+    },
+    Account,
+  );
+  const uuid = "d4c824b8-a0d1-700e-c0e9-e3b7984ddff4";
+
+  await doSQLiteTestFromSchemas([AccountSchema], async () => {
+    const accountAction = getInsertAction(
+      AccountSchema,
+      new Map<string, any>([["fake_id", uuid]]),
+    );
+
+    const account = await accountAction.saveX();
+    expect(account.data.fake_id).toBe(uuid);
+  });
+});
+
 test("builder valid uuid", async () => {
   const UserSchema = getBuilderSchemaFromFields(
     {


### PR DESCRIPTION
## Summary
- replace uuid@9 validate() in UUIDField with canonical UUID string validation
- allow UUIDv6, UUIDv7, UUIDv8, and non-RFC-4122 variant layouts accepted by UUID columns
- add regression coverage for direct validation and action saves

## Tests
- cd ts && npm test -- src/schema/uuid_field.test.ts --runInBand
- cd ts && npm run compile
- cd ts && npm test -- --runInBand