### PR TITLE
Bump @snowtop/ent to 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
-## [Unreleased]
-
-### Added
+## [0.2.12]
 
 ### Changed
 
 - remove obsolete v0.1 migration docs and CLI support (#1997).
+- bump `@snowtop/ent` package metadata and exact references to 0.2.12.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 ### Changed
 
 - remove obsolete v0.1 migration docs and CLI support (#1997).
-- bump `@snowtop/ent` package metadata and exact references to 0.2.12.
+- bump `@snowtop/ent` package metadata and exact references to 0.2.12 (#2007).
 
 ### Fixed
 

--- a/examples/ent-local-guide/package-lock.json
+++ b/examples/ent-local-guide/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@snowtop/ent-postgis": "file:../../ts/packages/ent-postgis",
         "express": "4.22.1",
         "graphql": "16.13.2",
@@ -33,7 +33,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0",
         "pg": "^8.16.3",
@@ -1023,9 +1023,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/ent-local-guide/package.json
+++ b/examples/ent-local-guide/package.json
@@ -27,7 +27,7 @@
     "tsconfig-paths": "4.2.0"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@snowtop/ent-postgis": "file:../../ts/packages/ent-postgis",
     "express": "4.22.1",
     "graphql": "16.13.2",

--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "6.12.0",
         "@sentry/tracing": "6.12.0",
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@snowtop/ent-email": "^0.1.0-rc1",
         "@snowtop/ent-passport": "^0.1.0-rc1",
         "@snowtop/ent-password": "^0.1.0-rc1",
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "peer": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7326,9 +7326,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "peer": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "6.12.0",
     "@sentry/tracing": "6.12.0",
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@snowtop/ent-email": "^0.1.0-rc1",
     "@snowtop/ent-passport": "^0.1.0-rc1",
     "@snowtop/ent-password": "^0.1.0-rc1",

--- a/examples/ent-semantic-notes/package-lock.json
+++ b/examples/ent-semantic-notes/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ent-semantic-notes",
       "version": "0.0.1",
       "dependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@snowtop/ent-pgvector": "file:../../ts/packages/ent-pgvector",
         "express": "4.22.1",
         "graphql": "16.13.2",
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6"
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/ent-semantic-notes/package.json
+++ b/examples/ent-semantic-notes/package.json
@@ -11,7 +11,7 @@
     "upgrade": "npm run db:up && LOCAL_SCRIPT_PATH=true LOCAL_AUTO_SCHEMA=true go run ../../tsent/main.go upgrade"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@snowtop/ent-pgvector": "file:../../ts/packages/ent-pgvector",
     "express": "4.22.1",
     "graphql": "16.13.2",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@snowtop/ent-email": "^0.1.0-rc1",
         "@snowtop/ent-passport": "^0.1.0-rc1",
         "@snowtop/ent-password": "^0.1.0-rc1",
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -7139,9 +7139,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "requires": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -38,7 +38,7 @@
     "tsconfig-paths": "3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@snowtop/ent-email": "^0.1.0-rc1",
     "@snowtop/ent-passport": "^0.1.0-rc1",
     "@snowtop/ent-password": "^0.1.0-rc1",

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@snowtop/ent-phonenumber": "^0.1.0-rc1",
         "@snowtop/ent-soft-delete": "^0.1.0",
         "@types/node": "15.14.9",
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "peer": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -6698,9 +6698,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "peer": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -37,7 +37,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@snowtop/ent-phonenumber": "^0.1.0-rc1",
     "@snowtop/ent-soft-delete": "^0.1.0",
     "@types/node": "15.14.9",

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@snowtop/ent",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "MIT",
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/packages/ent-email/package-lock.json
+++ b/ts/packages/ent-email/package-lock.json
@@ -13,7 +13,7 @@
         "libphonenumber-js": "1.10.37"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "ts-jest": "29.0.3"
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5196,9 +5196,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-email/package.json
+++ b/ts/packages/ent-email/package.json
@@ -33,7 +33,7 @@
     "libphonenumber-js": "1.10.37"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "ts-jest": "29.0.3"

--- a/ts/packages/ent-graphql-tests/package-lock.json
+++ b/ts/packages/ent-graphql-tests/package-lock.json
@@ -15,7 +15,7 @@
         "supertest": "6.1.6"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/express": "4.17.13",
         "@types/jest": "29.2.3",
         "graphql": "16.8.1",
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -6183,9 +6183,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-graphql-tests/package.json
+++ b/ts/packages/ent-graphql-tests/package.json
@@ -35,7 +35,7 @@
     "supertest": "6.1.6"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@types/express": "4.17.13",
     "@types/jest": "29.2.3",
     "graphql": "16.8.1",

--- a/ts/packages/ent-passport/package-lock.json
+++ b/ts/packages/ent-passport/package-lock.json
@@ -16,7 +16,7 @@
         "passport-strategy": "1.0.0"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@snowtop/ent-graphql-tests": "^0.1.0",
         "@types/express-session": "1.17.4",
         "@types/jest": "29.0.3",
@@ -1424,9 +1424,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7320,9 +7320,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-passport/package.json
+++ b/ts/packages/ent-passport/package.json
@@ -32,7 +32,7 @@
     "@snowtop/ent": ">=0.2.8"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@snowtop/ent-graphql-tests": "^0.1.0",
     "@types/express-session": "1.17.4",
     "@types/jest": "29.0.3",

--- a/ts/packages/ent-password/package-lock.json
+++ b/ts/packages/ent-password/package-lock.json
@@ -12,7 +12,7 @@
         "bcryptjs": "2.4.3"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "password-validator": "5.3.0",
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5281,9 +5281,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-password/package.json
+++ b/ts/packages/ent-password/package.json
@@ -32,7 +32,7 @@
     "bcryptjs": "2.4.3"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "password-validator": "5.3.0",

--- a/ts/packages/ent-pgvector/package-lock.json
+++ b/ts/packages/ent-pgvector/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/jest": "30.0.0",
         "jest": "30.3.0",
         "ts-jest": "29.4.6"
@@ -1368,9 +1368,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-pgvector/package.json
+++ b/ts/packages/ent-pgvector/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/lolopinto/ent#readme",
   "dependencies": {},
   "devDependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@types/jest": "30.0.0",
     "jest": "30.3.0",
     "ts-jest": "29.4.6"

--- a/ts/packages/ent-phonenumber/package-lock.json
+++ b/ts/packages/ent-phonenumber/package-lock.json
@@ -12,7 +12,7 @@
         "libphonenumber-js": "1.10.15"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "ts-jest": "29.0.3"
@@ -1164,9 +1164,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -5271,9 +5271,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-phonenumber/package.json
+++ b/ts/packages/ent-phonenumber/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/lolopinto/ent#readme",
   "devDependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "ts-jest": "29.0.3"

--- a/ts/packages/ent-postgis/package-lock.json
+++ b/ts/packages/ent-postgis/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/jest": "30.0.0",
         "jest": "30.3.0",
         "pg": "8.20.0",
@@ -1370,9 +1370,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-postgis/package.json
+++ b/ts/packages/ent-postgis/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/lolopinto/ent#readme",
   "dependencies": {},
   "devDependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@types/jest": "30.0.0",
     "jest": "30.3.0",
     "pg": "8.20.0",

--- a/ts/packages/ent-soft-delete/package-lock.json
+++ b/ts/packages/ent-soft-delete/package-lock.json
@@ -12,7 +12,7 @@
         "@types/express": "4.17.13"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.11",
+        "@snowtop/ent": "0.2.12",
         "@types/jest": "26.0.24",
         "jest": "26.6.3",
         "ts-jest": "26.5.6"
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -7630,9 +7630,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.11.tgz",
-      "integrity": "sha512-DfNdNdC2dUJl7oyo3lRnXIwk4is4w4s3hRVxC4/o7mPHqES2VtE+/ytgP6PwU4znmqhye32ksPH1Jf+d2YLxFw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
+      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-soft-delete/package.json
+++ b/ts/packages/ent-soft-delete/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/lolopinto/ent#readme",
   "devDependencies": {
-    "@snowtop/ent": "0.2.11",
+    "@snowtop/ent": "0.2.12",
     "@types/jest": "26.0.24",
     "jest": "26.6.3",
     "ts-jest": "26.5.6"


### PR DESCRIPTION
## Summary
- close the changelog for @snowtop/ent 0.2.12
- bump @snowtop/ent package metadata to 0.2.12
- update examples and package lockfiles to the published @snowtop/ent@0.2.12 tarball integrity

## Verification
- npm view @snowtop/ent@0.2.12 version dist.integrity dist.tarball dist-tags.latest
- cd ts && npm test -- --runInBand
- cd ts && npm run compile