### PR TITLE
Bump @snowtop/ent to 0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Changed
 
-- bump `@snowtop/ent` package metadata to 0.2.13 (#2012).
+- bump `@snowtop/ent` package metadata and exact references to 0.2.13 (#2012).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
-## [Unreleased]
+## [0.2.13]
+
+### Changed
+
+- bump `@snowtop/ent` package metadata to 0.2.13.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Changed
 
-- bump `@snowtop/ent` package metadata to 0.2.13.
+- bump `@snowtop/ent` package metadata to 0.2.13 (#2012).
 
 ### Fixed
 

--- a/examples/ent-local-guide/package-lock.json
+++ b/examples/ent-local-guide/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@snowtop/ent-postgis": "file:../../ts/packages/ent-postgis",
         "express": "4.22.1",
-        "graphql": "16.13.2",
+        "graphql": "16.12.0",
         "graphql-helix": "1.13.0",
         "graphql-type-json": "0.3.2",
         "pg": "8.20.0"
@@ -33,15 +33,15 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
-        "@types/jest": "^30.0.0",
-        "jest": "^30.2.0",
-        "pg": "^8.16.3",
-        "ts-jest": "^29.4.6"
+        "@snowtop/ent": "0.2.13",
+        "@types/jest": "30.0.0",
+        "jest": "30.3.0",
+        "pg": "8.20.0",
+        "ts-jest": "29.4.6"
       },
       "peerDependencies": {
         "@snowtop/ent": ">=0.2.8",
-        "pg": ">=8.0.0"
+        "pg": "8.20.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -72,7 +72,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1023,9 +1022,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -1040,8 +1039,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1049,13 +1048,17 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
       }
@@ -1063,6 +1066,14 @@
     "node_modules/@snowtop/ent-postgis": {
       "resolved": "../../ts/packages/ent-postgis",
       "link": true
+    },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@snowtop/ent/node_modules/argparse": {
       "version": "2.0.1",
@@ -1078,9 +1089,9 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -1089,16 +1100,16 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1116,9 +1127,9 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "engines": {
         "node": "20 || >=22"
       }
@@ -1150,6 +1161,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@snowtop/ent/node_modules/ts-node": {
@@ -1190,6 +1227,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
@@ -1361,7 +1403,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2014,7 +2056,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2927,11 +2968,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
-      "license": "MIT",
-      "peer": true,
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -3248,7 +3287,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4333,7 +4371,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -5277,7 +5314,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5302,7 +5338,8 @@
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/examples/ent-local-guide/package.json
+++ b/examples/ent-local-guide/package.json
@@ -27,10 +27,10 @@
     "tsconfig-paths": "4.2.0"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@snowtop/ent-postgis": "file:../../ts/packages/ent-postgis",
     "express": "4.22.1",
-    "graphql": "16.13.2",
+    "graphql": "16.12.0",
     "graphql-helix": "1.13.0",
     "graphql-type-json": "0.3.2",
     "pg": "8.20.0"

--- a/examples/ent-rsvp/backend/package-lock.json
+++ b/examples/ent-rsvp/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "6.12.0",
         "@sentry/tracing": "6.12.0",
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@snowtop/ent-email": "^0.1.0-rc1",
         "@snowtop/ent-passport": "^0.1.0-rc1",
         "@snowtop/ent-password": "^0.1.0-rc1",
@@ -1322,9 +1322,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -1348,13 +1348,17 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
         "@swc-node/register": {
           "optional": true
         },
         "better-sqlite3": {
+          "optional": true
+        },
+        "graphql-upload": {
           "optional": true
         }
       }
@@ -7290,9 +7294,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "requires": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/ent-rsvp/backend/package.json
+++ b/examples/ent-rsvp/backend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sentry/node": "6.12.0",
     "@sentry/tracing": "6.12.0",
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@snowtop/ent-email": "^0.1.0-rc1",
     "@snowtop/ent-passport": "^0.1.0-rc1",
     "@snowtop/ent-password": "^0.1.0-rc1",

--- a/examples/ent-semantic-notes/package-lock.json
+++ b/examples/ent-semantic-notes/package-lock.json
@@ -8,10 +8,10 @@
       "name": "ent-semantic-notes",
       "version": "0.0.1",
       "dependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@snowtop/ent-pgvector": "file:../../ts/packages/ent-pgvector",
         "express": "4.22.1",
-        "graphql": "16.13.2",
+        "graphql": "16.12.0",
         "graphql-helix": "1.13.0",
         "pg": "8.20.0"
       },
@@ -29,10 +29,10 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
-        "@types/jest": "^30.0.0",
-        "jest": "^30.2.0",
-        "ts-jest": "^29.4.6"
+        "@snowtop/ent": "0.2.13",
+        "@types/jest": "30.0.0",
+        "jest": "30.3.0",
+        "ts-jest": "29.4.6"
       },
       "peerDependencies": {
         "@snowtop/ent": ">=0.2.8"
@@ -66,7 +66,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1017,9 +1016,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -1034,8 +1033,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1043,13 +1042,17 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
       }
@@ -1057,6 +1060,14 @@
     "node_modules/@snowtop/ent-pgvector": {
       "resolved": "../../ts/packages/ent-pgvector",
       "link": true
+    },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@snowtop/ent/node_modules/argparse": {
       "version": "2.0.1",
@@ -1072,9 +1083,9 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -1083,16 +1094,16 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1110,9 +1121,9 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "engines": {
         "node": "20 || >=22"
       }
@@ -1144,6 +1155,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@snowtop/ent/node_modules/ts-node": {
@@ -1184,6 +1221,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
@@ -1355,7 +1397,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1997,7 +2039,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2910,11 +2951,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
-      "license": "MIT",
-      "peer": true,
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -3222,7 +3261,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4301,7 +4339,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -5245,7 +5282,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5270,7 +5306,8 @@
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/examples/ent-semantic-notes/package.json
+++ b/examples/ent-semantic-notes/package.json
@@ -11,10 +11,10 @@
     "upgrade": "npm run db:up && LOCAL_SCRIPT_PATH=true LOCAL_AUTO_SCHEMA=true go run ../../tsent/main.go upgrade"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@snowtop/ent-pgvector": "file:../../ts/packages/ent-pgvector",
     "express": "4.22.1",
-    "graphql": "16.13.2",
+    "graphql": "16.12.0",
     "graphql-helix": "1.13.0",
     "pg": "8.20.0"
   },

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@snowtop/ent-email": "^0.1.0-rc1",
         "@snowtop/ent-passport": "^0.1.0-rc1",
         "@snowtop/ent-password": "^0.1.0-rc1",
@@ -1247,9 +1247,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -1273,13 +1273,17 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
         "@swc-node/register": {
           "optional": true
         },
         "better-sqlite3": {
+          "optional": true
+        },
+        "graphql-upload": {
           "optional": true
         }
       }
@@ -7144,9 +7148,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "requires": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -38,7 +38,7 @@
     "tsconfig-paths": "3.11.0"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@snowtop/ent-email": "^0.1.0-rc1",
     "@snowtop/ent-passport": "^0.1.0-rc1",
     "@snowtop/ent-password": "^0.1.0-rc1",

--- a/examples/todo-sqlite/package-lock.json
+++ b/examples/todo-sqlite/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@snowtop/ent-phonenumber": "^0.1.0-rc1",
         "@snowtop/ent-soft-delete": "^0.1.0",
         "@types/node": "15.14.9",
         "@types/pg": "8.6.1",
-        "better-sqlite3": "12.6.2",
+        "better-sqlite3": "12.5.0",
         "express": "4.17.3",
-        "graphql": "16.8.1",
+        "graphql": "16.12.0",
         "graphql-helix": "1.12.0",
         "libphonenumber-js": "1.10.37",
         "luxon": "3.7.2"
@@ -137,7 +137,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
       "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.15.4",
@@ -1221,10 +1220,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
-      "peer": true,
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dependencies": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -1239,8 +1237,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1248,13 +1246,17 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
       }
@@ -1299,11 +1301,9 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/@types/node": {
-      "version": "25.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
-      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
-      "license": "MIT",
-      "peer": true,
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1386,7 +1386,6 @@
       "integrity": "sha512-7dKgTyxJjlrMwFZYb1auj3Xq0D8ZBe+5oeIgfMlRU05doXZypYJe0LAk0yjj3WdbwYzpF+T1PLxwTWizI0pckw==",
       "devOptional": true,
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.1",
         "@swc/types": "^0.1.5"
@@ -1574,20 +1573,6 @@
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "devOptional": true
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
@@ -1765,8 +1750,7 @@
     "node_modules/@types/node": {
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
-      "peer": true
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
@@ -2070,12 +2054,10 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
+      "integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
       "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -2469,13 +2451,6 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2564,9 +2539,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "node_modules/detect-libc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "engines": {
         "node": ">=8"
       }
@@ -2635,9 +2610,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3054,10 +3029,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-      "peer": true,
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -3384,7 +3358,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.3.1.tgz",
       "integrity": "sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.3.1",
         "@jest/types": "^29.3.1",
@@ -4114,6 +4087,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4289,9 +4263,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4308,9 +4282,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
-      "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -4319,12 +4293,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4549,15 +4520,13 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/pg": {
-      "version": "8.17.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
-      "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
-      "license": "MIT",
-      "peer": true,
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dependencies": {
-        "pg-connection-string": "^2.10.1",
-        "pg-pool": "^3.11.0",
-        "pg-protocol": "^1.11.0",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -4565,7 +4534,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.2.7"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -4577,17 +4546,15 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
-      "license": "MIT",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.10.1.tgz",
-      "integrity": "sha512-iNzslsoeSH2/gmDDKiyMqF64DATUCWj3YJ0wP14kqcsf2TUklwimd+66yYojKwZCA7h2yRNLGug71hCBA2a4sw==",
-      "license": "MIT"
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig=="
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -4598,10 +4565,9 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
-      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
-      "license": "MIT",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "peerDependencies": {
         "pg": ">=8.0"
       }
@@ -4631,7 +4597,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-      "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -4705,16 +4670,17 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
+        "napi-build-utils": "^2.0.0",
         "node-abi": "^3.3.0",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
@@ -4781,9 +4747,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -5099,7 +5065,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
       "engines": {
         "node": ">= 10.x"
       }
@@ -5314,9 +5279,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -5546,7 +5511,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5711,7 +5675,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.6.2",
@@ -5752,16 +5717,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -5857,7 +5812,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
       "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.15.4",
@@ -6698,10 +6652,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
-      "peer": true,
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "requires": {
         "@types/node": "25.0.3",
         "dataloader": "2.2.3",
@@ -6717,10 +6670,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "25.0.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
-          "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
-          "peer": true,
+          "version": "25.0.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+          "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
           "requires": {
             "undici-types": "~7.16.0"
           }
@@ -6798,7 +6750,6 @@
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.100.tgz",
       "integrity": "sha512-7dKgTyxJjlrMwFZYb1auj3Xq0D8ZBe+5oeIgfMlRU05doXZypYJe0LAk0yjj3WdbwYzpF+T1PLxwTWizI0pckw==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@swc/core-darwin-arm64": "1.3.100",
         "@swc/core-darwin-x64": "1.3.100",
@@ -6887,18 +6838,6 @@
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "devOptional": true
-    },
-    "@tsconfig/node10": {
-      "version": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "dev": true,
-      "optional": true
-    },
-    "@tsconfig/node12": {
-      "version": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "dev": true,
-      "optional": true
     },
     "@tsconfig/node14": {
       "version": "1.0.1",
@@ -7077,8 +7016,7 @@
     "@types/node": {
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
-      "peer": true
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
     },
     "@types/pg": {
       "version": "8.6.1",
@@ -7317,10 +7255,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
-      "peer": true,
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
+      "integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -7615,12 +7552,6 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
-    "create-require": {
-      "version": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "optional": true
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7687,9 +7618,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-libc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -7737,9 +7668,9 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -8049,10 +7980,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-      "peer": true
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="
     },
     "graphql-helix": {
       "version": "1.12.0",
@@ -8284,7 +8214,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.3.1.tgz",
       "integrity": "sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jest/core": "^29.3.1",
         "@jest/types": "^29.3.1",
@@ -8843,6 +8772,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -8965,9 +8895,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -8981,20 +8911,17 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "node-abi": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
-      "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "requires": {
         "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.8.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+          "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ=="
         }
       }
     },
@@ -9154,29 +9081,28 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pg": {
-      "version": "8.17.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
-      "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
-      "peer": true,
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "requires": {
-        "pg-cloudflare": "^1.3.0",
-        "pg-connection-string": "^2.10.1",
-        "pg-pool": "^3.11.0",
-        "pg-protocol": "^1.11.0",
+        "pg-cloudflare": "^1.2.7",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       }
     },
     "pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.10.1.tgz",
-      "integrity": "sha512-iNzslsoeSH2/gmDDKiyMqF64DATUCWj3YJ0wP14kqcsf2TUklwimd+66yYojKwZCA7h2yRNLGug71hCBA2a4sw=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -9184,9 +9110,9 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-pool": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
-      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "requires": {}
     },
     "pg-protocol": {
@@ -9259,16 +9185,16 @@
       }
     },
     "prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
+        "napi-build-utils": "^2.0.0",
         "node-abi": "^3.3.0",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
@@ -9316,9 +9242,9 @@
       }
     },
     "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -9699,9 +9625,9 @@
       "dev": true
     },
     "tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -9862,8 +9788,7 @@
     "typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "peer": true
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
     },
     "undici-types": {
       "version": "7.16.0",
@@ -9983,7 +9908,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "17.6.2",
@@ -10018,12 +9944,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
-    },
-    "yn": {
-      "version": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "optional": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/examples/todo-sqlite/package.json
+++ b/examples/todo-sqlite/package.json
@@ -37,14 +37,14 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@snowtop/ent-phonenumber": "^0.1.0-rc1",
     "@snowtop/ent-soft-delete": "^0.1.0",
     "@types/node": "15.14.9",
     "@types/pg": "8.6.1",
-    "better-sqlite3": "12.6.2",
+    "better-sqlite3": "12.5.0",
     "express": "4.17.3",
-    "graphql": "16.8.1",
+    "graphql": "16.12.0",
     "graphql-helix": "1.12.0",
     "libphonenumber-js": "1.10.37",
     "luxon": "3.7.2"

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@snowtop/ent",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "@types/node": "25.0.3",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowtop/ent",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "snowtop ent framework",
   "main": "index.js",
   "types": "index.d.ts",

--- a/ts/packages/ent-email/package-lock.json
+++ b/ts/packages/ent-email/package-lock.json
@@ -13,7 +13,7 @@
         "libphonenumber-js": "1.10.37"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "ts-jest": "29.0.3"
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -1141,8 +1141,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1150,15 +1150,28 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@snowtop/ent/node_modules/balanced-match": {
@@ -1171,9 +1184,9 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1183,17 +1196,17 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1253,6 +1266,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -2169,9 +2188,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -3442,23 +3461,23 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -3466,7 +3485,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.2.7"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -3478,16 +3497,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "node_modules/pg-int8": {
@@ -3500,18 +3519,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "node_modules/pg-types": {
@@ -5196,9 +5215,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",
@@ -5214,6 +5233,15 @@
         "uuid": "9.0.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "25.0.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+          "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~7.16.0"
+          }
+        },
         "balanced-match": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5221,23 +5249,23 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+          "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
           }
         },
         "glob": {
-          "version": "13.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-          "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+          "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
           "dev": true,
           "requires": {
-            "minimatch": "^10.2.2",
-            "minipass": "^7.1.3",
-            "path-scurry": "^2.0.2"
+            "minimatch": "^10.1.1",
+            "minipass": "^7.1.2",
+            "path-scurry": "^2.0.0"
           }
         },
         "minimatch": {
@@ -5267,6 +5295,12 @@
             "make-error": "^1.1.1",
             "v8-compile-cache-lib": "^3.0.1"
           }
+        },
+        "undici-types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+          "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+          "dev": true
         }
       }
     },
@@ -5987,9 +6021,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true
     },
@@ -6948,38 +6982,38 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "11.3.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-          "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+          "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
           "dev": true
         }
       }
     },
     "pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "requires": {
-        "pg-cloudflare": "^1.3.0",
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-cloudflare": "^1.2.7",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       }
     },
     "pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "pg-int8": {
@@ -6989,16 +7023,16 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "requires": {}
     },
     "pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "pg-types": {

--- a/ts/packages/ent-email/package.json
+++ b/ts/packages/ent-email/package.json
@@ -33,7 +33,7 @@
     "libphonenumber-js": "1.10.37"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "ts-jest": "29.0.3"

--- a/ts/packages/ent-graphql-tests/package-lock.json
+++ b/ts/packages/ent-graphql-tests/package-lock.json
@@ -15,7 +15,7 @@
         "supertest": "6.1.6"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@types/express": "4.17.13",
         "@types/jest": "29.2.3",
         "graphql": "16.12.0",
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -1179,13 +1179,17 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
         "@swc-node/register": {
           "optional": true
         },
         "better-sqlite3": {
+          "optional": true
+        },
+        "graphql-upload": {
           "optional": true
         }
       }
@@ -6213,9 +6217,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",

--- a/ts/packages/ent-graphql-tests/package.json
+++ b/ts/packages/ent-graphql-tests/package.json
@@ -35,7 +35,7 @@
     "supertest": "6.1.6"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@types/express": "4.17.13",
     "@types/jest": "29.2.3",
     "graphql": "16.12.0",

--- a/ts/packages/ent-passport/package-lock.json
+++ b/ts/packages/ent-passport/package-lock.json
@@ -16,14 +16,14 @@
         "passport-strategy": "1.0.0"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@snowtop/ent-graphql-tests": "^0.1.0",
         "@types/express-session": "1.17.4",
         "@types/jest": "29.0.3",
         "@types/passport-strategy": "0.2.35",
         "@types/supertest": "2.0.11",
         "express": "4.18.1",
-        "graphql": "16.13.2",
+        "graphql": "16.12.0",
         "jest": "29.1.1",
         "jest-expect-message": "1.1.3",
         "jest-mock": "29.1.1",
@@ -1424,9 +1424,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -1442,8 +1442,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1451,13 +1451,17 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
       }
@@ -1479,6 +1483,15 @@
         "jest-expect-message": "^1.1.3"
       }
     },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@snowtop/ent/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1489,9 +1502,9 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1501,17 +1514,17 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1530,6 +1543,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "dev": true,
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@snowtop/ent/node_modules/ts-node": {
@@ -1571,6 +1611,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -2978,9 +3024,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -5050,9 +5096,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "engines": {
         "node": "20 || >=22"
@@ -7320,9 +7366,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",
@@ -7338,6 +7384,15 @@
         "uuid": "9.0.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "25.0.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+          "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~7.16.0"
+          }
+        },
         "balanced-match": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -7345,23 +7400,23 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+          "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
           }
         },
         "glob": {
-          "version": "13.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-          "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+          "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
           "dev": true,
           "requires": {
-            "minimatch": "^10.2.2",
-            "minipass": "^7.1.3",
-            "path-scurry": "^2.0.2"
+            "minimatch": "^10.1.1",
+            "minipass": "^7.1.2",
+            "path-scurry": "^2.0.0"
           }
         },
         "minimatch": {
@@ -7371,6 +7426,20 @@
           "dev": true,
           "requires": {
             "brace-expansion": "^5.0.5"
+          }
+        },
+        "pg": {
+          "version": "8.16.3",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+          "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+          "dev": true,
+          "requires": {
+            "pg-cloudflare": "^1.2.7",
+            "pg-connection-string": "^2.9.1",
+            "pg-pool": "^3.10.1",
+            "pg-protocol": "^1.10.3",
+            "pg-types": "2.2.0",
+            "pgpass": "1.0.5"
           }
         },
         "ts-node": {
@@ -7391,6 +7460,12 @@
             "make-error": "^1.1.1",
             "v8-compile-cache-lib": "^3.0.1"
           }
+        },
+        "undici-types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+          "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+          "dev": true
         }
       }
     },
@@ -8543,9 +8618,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true
     },
     "graphql-helix": {
@@ -10108,9 +10183,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "11.3.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-          "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+          "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
           "dev": true
         }
       }

--- a/ts/packages/ent-passport/package.json
+++ b/ts/packages/ent-passport/package.json
@@ -32,14 +32,14 @@
     "@snowtop/ent": ">=0.2.8"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@snowtop/ent-graphql-tests": "^0.1.0",
     "@types/express-session": "1.17.4",
     "@types/jest": "29.0.3",
     "@types/passport-strategy": "0.2.35",
     "@types/supertest": "2.0.11",
     "express": "4.18.1",
-    "graphql": "16.13.2",
+    "graphql": "16.12.0",
     "jest": "29.1.1",
     "jest-expect-message": "1.1.3",
     "jest-mock": "29.1.1",

--- a/ts/packages/ent-password/package-lock.json
+++ b/ts/packages/ent-password/package-lock.json
@@ -12,7 +12,7 @@
         "bcryptjs": "2.4.3"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "password-validator": "5.3.0",
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -1183,8 +1183,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1192,15 +1192,28 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@snowtop/ent/node_modules/ts-node": {
@@ -1242,6 +1255,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -1594,9 +1613,9 @@
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2134,17 +2153,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2166,9 +2185,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -3452,23 +3471,23 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -3476,7 +3495,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.2.7"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -3488,16 +3507,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "node_modules/pg-int8": {
@@ -3510,18 +3529,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "node_modules/pg-types": {
@@ -5281,9 +5300,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",
@@ -5299,6 +5318,15 @@
         "uuid": "9.0.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "25.0.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+          "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~7.16.0"
+          }
+        },
         "ts-node": {
           "version": "11.0.0-beta.1",
           "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-11.0.0-beta.1.tgz",
@@ -5317,6 +5345,12 @@
             "make-error": "^1.1.1",
             "v8-compile-cache-lib": "^3.0.1"
           }
+        },
+        "undici-types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+          "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+          "dev": true
         }
       }
     },
@@ -5623,9 +5657,9 @@
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "requires": {
         "balanced-match": "^4.0.2"
@@ -6016,14 +6050,14 @@
       "dev": true
     },
     "glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "requires": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       }
     },
     "globals": {
@@ -6039,9 +6073,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true
     },
@@ -7009,38 +7043,38 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "11.3.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-          "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+          "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
           "dev": true
         }
       }
     },
     "pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "requires": {
-        "pg-cloudflare": "^1.3.0",
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-cloudflare": "^1.2.7",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       }
     },
     "pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "pg-int8": {
@@ -7050,16 +7084,16 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "requires": {}
     },
     "pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "pg-types": {

--- a/ts/packages/ent-password/package.json
+++ b/ts/packages/ent-password/package.json
@@ -32,7 +32,7 @@
     "bcryptjs": "2.4.3"
   },
   "devDependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "password-validator": "5.3.0",

--- a/ts/packages/ent-pgvector/package-lock.json
+++ b/ts/packages/ent-pgvector/package-lock.json
@@ -9,15 +9,14 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@types/jest": "30.0.0",
         "jest": "30.3.0",
         "ts-jest": "29.4.6"
       },
       "peerDependencies": {
         "@snowtop/ent": ">=0.2.8"
-      },
-      "dependencies": {}
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1368,9 +1367,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -1386,8 +1385,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1395,16 +1394,35 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -2030,9 +2048,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2566,17 +2584,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2589,9 +2607,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -3992,23 +4010,23 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -4016,7 +4034,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.2.7"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -4028,16 +4046,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "node_modules/pg-int8": {
@@ -4050,18 +4068,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "node_modules/pg-types": {

--- a/ts/packages/ent-pgvector/package.json
+++ b/ts/packages/ent-pgvector/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/lolopinto/ent#readme",
   "dependencies": {},
   "devDependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@types/jest": "30.0.0",
     "jest": "30.3.0",
     "ts-jest": "29.4.6"

--- a/ts/packages/ent-phonenumber/package-lock.json
+++ b/ts/packages/ent-phonenumber/package-lock.json
@@ -12,7 +12,7 @@
         "libphonenumber-js": "1.10.15"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@types/jest": "29.2.4",
         "jest": "29.3.1",
         "ts-jest": "29.0.3"
@@ -1164,9 +1164,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -1182,8 +1182,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1191,15 +1191,28 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@snowtop/ent/node_modules/ts-node": {
@@ -1241,6 +1254,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -1588,9 +1607,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2128,17 +2147,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2160,9 +2179,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -3442,23 +3461,23 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -3466,7 +3485,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.2.7"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -3478,16 +3497,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "node_modules/pg-int8": {
@@ -3500,18 +3519,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "node_modules/pg-types": {
@@ -5271,9 +5290,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",
@@ -5289,6 +5308,15 @@
         "uuid": "9.0.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "25.0.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+          "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~7.16.0"
+          }
+        },
         "ts-node": {
           "version": "11.0.0-beta.1",
           "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-11.0.0-beta.1.tgz",
@@ -5307,6 +5335,12 @@
             "make-error": "^1.1.1",
             "v8-compile-cache-lib": "^3.0.1"
           }
+        },
+        "undici-types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+          "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+          "dev": true
         }
       }
     },
@@ -5608,9 +5642,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "requires": {
         "balanced-match": "^4.0.2"
@@ -6001,14 +6035,14 @@
       "dev": true
     },
     "glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "requires": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       }
     },
     "globals": {
@@ -6024,9 +6058,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true
     },
@@ -6993,38 +7027,38 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "11.3.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-          "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+          "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
           "dev": true
         }
       }
     },
     "pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "requires": {
-        "pg-cloudflare": "^1.3.0",
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-cloudflare": "^1.2.7",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       }
     },
     "pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "pg-int8": {
@@ -7034,16 +7068,16 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "requires": {}
     },
     "pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "pg-types": {

--- a/ts/packages/ent-phonenumber/package.json
+++ b/ts/packages/ent-phonenumber/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/lolopinto/ent#readme",
   "devDependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@types/jest": "29.2.4",
     "jest": "29.3.1",
     "ts-jest": "29.0.3"

--- a/ts/packages/ent-postgis/package-lock.json
+++ b/ts/packages/ent-postgis/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@types/jest": "30.0.0",
         "jest": "30.3.0",
         "pg": "8.20.0",
@@ -18,8 +18,7 @@
       "peerDependencies": {
         "@snowtop/ent": ">=0.2.8",
         "pg": "8.20.0"
-      },
-      "dependencies": {}
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1370,9 +1369,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -1388,8 +1387,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1397,16 +1396,62 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "dev": true,
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -2032,9 +2077,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2568,17 +2613,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2591,9 +2636,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -3994,9 +4039,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "engines": {
         "node": "20 || >=22"

--- a/ts/packages/ent-postgis/package.json
+++ b/ts/packages/ent-postgis/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/lolopinto/ent#readme",
   "dependencies": {},
   "devDependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@types/jest": "30.0.0",
     "jest": "30.3.0",
     "pg": "8.20.0",

--- a/ts/packages/ent-soft-delete/package-lock.json
+++ b/ts/packages/ent-soft-delete/package-lock.json
@@ -12,7 +12,7 @@
         "@types/express": "4.17.13"
       },
       "devDependencies": {
-        "@snowtop/ent": "0.2.12",
+        "@snowtop/ent": "0.2.13",
         "@types/jest": "26.0.24",
         "jest": "26.6.3",
         "ts-jest": "26.5.6"
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "dependencies": {
         "@types/node": "25.0.3",
@@ -1060,8 +1060,8 @@
         "uuid": "9.0.1"
       },
       "bin": {
-        "ent-custom-graphql": "scripts/custom_graphql.js",
-        "ent-custom-compiler": "scripts/custom_compiler.js"
+        "ent-custom-compiler": "scripts/custom_compiler.js",
+        "ent-custom-graphql": "scripts/custom_graphql.js"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1069,15 +1069,28 @@
       "peerDependencies": {
         "@swc-node/register": "1.6.8",
         "better-sqlite3": "12.5.0",
-        "graphql": "16.12.0"
+        "graphql": "16.12.0",
+        "graphql-upload": "15.0.2"
       },
       "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
-        "@swc-node/register": {
+        "graphql-upload": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@snowtop/ent/node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@snowtop/ent/node_modules/acorn-walk": {
@@ -1102,9 +1115,9 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1114,17 +1127,17 @@
       }
     },
     "node_modules/@snowtop/ent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1197,6 +1210,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/@snowtop/ent/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true
     },
     "node_modules/@snowtop/ent/node_modules/uuid": {
       "version": "9.0.1",
@@ -2912,9 +2931,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -4725,23 +4744,23 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -4749,7 +4768,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.2.7"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -4761,16 +4780,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "node_modules/pg-int8": {
@@ -4783,18 +4802,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "node_modules/pg-types": {
@@ -7630,9 +7649,9 @@
       }
     },
     "@snowtop/ent": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.12.tgz",
-      "integrity": "sha512-Xc7cQAYwoodU2FHh/7lPMqJ0DN563BYbtoSzMzjto2oCCMiRPq9MD2JXllDFVXafVEh58/TWHgXMf3CRWiEtJg==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@snowtop/ent/-/ent-0.2.13.tgz",
+      "integrity": "sha512-sW/iWl0owEFVTJFEZWN6XrO/MRR5NOgfpcXd3cOoYsSVRfKPj6sB85RKcB9GzmH8fUoF4b1ocn22s2+N1nR11w==",
       "dev": true,
       "requires": {
         "@types/node": "25.0.3",
@@ -7648,6 +7667,15 @@
         "uuid": "9.0.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "25.0.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+          "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~7.16.0"
+          }
+        },
         "acorn-walk": {
           "version": "8.3.5",
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -7664,23 +7692,23 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+          "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
           }
         },
         "glob": {
-          "version": "13.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-          "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+          "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
           "dev": true,
           "requires": {
-            "minimatch": "^10.2.2",
-            "minipass": "^7.1.3",
-            "path-scurry": "^2.0.2"
+            "minimatch": "^10.1.1",
+            "minipass": "^7.1.2",
+            "path-scurry": "^2.0.0"
           }
         },
         "minimatch": {
@@ -7715,6 +7743,12 @@
           "version": "5.9.3",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
           "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+          "dev": true
+        },
+        "undici-types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+          "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
           "dev": true
         },
         "uuid": {
@@ -9092,9 +9126,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "dev": true,
       "peer": true
     },
@@ -10491,38 +10525,38 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "11.3.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-          "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+          "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
           "dev": true
         }
       }
     },
     "pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "requires": {
-        "pg-cloudflare": "^1.3.0",
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-cloudflare": "^1.2.7",
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       }
     },
     "pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "dev": true,
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "dev": true
     },
     "pg-int8": {
@@ -10532,16 +10566,16 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "dev": true,
       "requires": {}
     },
     "pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "dev": true
     },
     "pg-types": {

--- a/ts/packages/ent-soft-delete/package.json
+++ b/ts/packages/ent-soft-delete/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/lolopinto/ent#readme",
   "devDependencies": {
-    "@snowtop/ent": "0.2.12",
+    "@snowtop/ent": "0.2.13",
     "@types/jest": "26.0.24",
     "jest": "26.6.3",
     "ts-jest": "26.5.6"


### PR DESCRIPTION
## Summary
- bump @snowtop/ent package metadata to 0.2.13
- update exact @snowtop/ent refs and lockfiles to the published 0.2.13 tarball
- align example/helper package GraphQL and SQLite pins where needed so npm can resolve Ent's exact peers

## Validation
- npm view @snowtop/ent@0.2.13 version dist.tarball dist.integrity dist.shasum peerDependencies peerDependenciesMeta --json
- cd ts && npm run prepare-code
- cd ts && npm test -- src/graphql/graphql_custom.test.ts src/graphql/tests/file_upload.test.ts --runInBand
- cd ts/dist && npm pack --dry-run --json
- verified all exact @snowtop/ent package refs point at 0.2.13
- verified all @snowtop/ent lockfile entries use the published 0.2.13 integrity
- git diff --check
