### PR TITLE
Fix full-text index autogen comparison

### DIFF
--- a/docker_CHANGELOG.md
+++ b/docker_CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Changelog for the npm version are [here](/CHANGELOG.md).
 
+## [Unreleased]
+
+### Fixed
+
+- avoid generating redundant or plain btree migrations for existing Postgres
+  full-text expression indexes.
+
 ## [0.3.6]
 
 ### Changed

--- a/docker_CHANGELOG.md
+++ b/docker_CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog for the npm version are [here](/CHANGELOG.md).
 ### Fixed
 
 - avoid generating redundant or plain btree migrations for existing Postgres
-  full-text expression indexes.
+  full-text expression indexes (#2014).
 
 ## [0.3.6]
 

--- a/python/auto_schema/auto_schema/compare.py
+++ b/python/auto_schema/auto_schema/compare.py
@@ -592,6 +592,7 @@ def _compare_indexes(autogen_context: AutogenContext,
     raw_db_indexes = _get_raw_db_indexes(
         autogen_context, conn_table)
     all_conn_indexes = raw_db_indexes.get('all')
+    raw_only_conn_indexes = raw_db_indexes.get('missing')
     conn_indexes = {}
     meta_indexes = {}
 
@@ -623,7 +624,7 @@ def _compare_indexes(autogen_context: AutogenContext,
 
             if is_full_text_index(index):
                 # automerge trying to add it again, remove it from here...
-                to_remove = op.index_name in conn_indexes
+                to_remove = op.index_name in all_conn_indexes
 
                 if to_remove:
                     to_remove_list.append(op)
@@ -670,7 +671,58 @@ def _compare_indexes(autogen_context: AutogenContext,
     for op in to_remove_list:
         modify_table_ops.ops.remove(op)
 
+    for name, raw_index in raw_only_conn_indexes.items():
+        if name in meta_indexes:
+            continue
+        if not _raw_index_is_full_text(raw_index):
+            continue
+        modify_table_ops.ops.append(
+            ops.DropFullTextIndexOp(
+                name,
+                tname,
+                info=_get_full_text_index_info(None, raw_index),
+                table=conn_table,
+            )
+        )
+
     for name, index in meta_indexes.items():
+
+        if is_full_text_index(index) and name in all_conn_indexes:
+            if _full_text_index_signatures_differ(
+                index,
+                conn_indexes.get(name),
+                all_conn_indexes.get(name, {}),
+            ):
+                _remove_generic_index_ops(modify_table_ops, name)
+
+                conn_index = conn_indexes.get(name)
+                if conn_index is None or is_full_text_index(conn_index):
+                    modify_table_ops.ops.append(
+                        ops.DropFullTextIndexOp(
+                            name,
+                            tname,
+                            info=_get_full_text_index_info(
+                                conn_index,
+                                all_conn_indexes.get(name, {}),
+                            ),
+                            table=conn_table,
+                        )
+                    )
+                else:
+                    modify_table_ops.ops.append(
+                        alembicops.DropIndexOp.from_index(conn_index))
+
+                modify_table_ops.ops.append(
+                    ops.CreateFullTextIndexOp(
+                        index.name,
+                        index.table.name,
+                        schema=schema,
+                        table=index.table,
+                        unique=index.unique,
+                        info=index.info,
+                    )
+                )
+            continue
 
         # if index is there and postgresql_using changes, drop the index and add it again
         # should hopefully be a one-time migration change...
@@ -919,6 +971,134 @@ def _get_db_index_storage_rows(
             'schema_name': schema_name,
         },
     )
+
+
+def _remove_generic_index_ops(
+    modify_table_ops: alembicops.ModifyTableOps,
+    name: str,
+):
+    modify_table_ops.ops = [
+        op for op in modify_table_ops.ops
+        if not (
+            isinstance(op, (alembicops.CreateIndexOp, alembicops.DropIndexOp))
+            and op.index_name == name
+        )
+    ]
+
+
+def _normalize_full_text_using(using):
+    if using in (None, False, ''):
+        return 'gin'
+    return str(using)
+
+
+def _normalize_full_text_column(column):
+    normalized = str(column).strip()
+    if normalized.endswith('::text'):
+        normalized = normalized[:-6]
+    if '.' in normalized:
+        normalized = normalized.rsplit('.', 1)[1]
+    return normalized.strip().strip('"')
+
+
+def _normalize_full_text_expression(expression):
+    if expression is None:
+        return None
+    return re.sub(r'\s+', ' ', str(expression).strip())
+
+
+def _get_full_text_index_info(
+    index: sa.Index | None, raw_index: dict[str, Any]
+) -> dict[str, Any]:
+    info = dict(index.info or {}) if index is not None else {}
+    if not info.get('postgresql_using'):
+        info['postgresql_using'] = (
+            raw_index.get('postgresql_using')
+            or (
+                _get_index_kwarg(index, 'postgresql_using')
+                if index is not None else None
+            )
+            or 'gin'
+        )
+    if not info.get('postgresql_using_internals'):
+        internals = raw_index.get('postgresql_using_internals')
+        if (
+            internals is None
+            and index is not None
+            and len(index.expressions) == 1
+        ):
+            internals = normalize_clause_text(index.expressions[0], None)
+        info['postgresql_using_internals'] = internals
+
+    for key in ('postgresql_concurrently', 'postgresql_where'):
+        if info.get(key) not in (None, False):
+            continue
+        if index is None:
+            continue
+        value = _get_index_kwarg(index, key)
+        if value not in (None, False):
+            info[key] = value
+
+    return info
+
+
+def _get_full_text_index_signature(
+    index: sa.Index | None, raw_index: dict[str, Any]
+) -> dict[str, Any]:
+    info = _get_full_text_index_info(index, raw_index)
+    using = _normalize_full_text_using(info.get('postgresql_using'))
+    internals = info.get('postgresql_using_internals')
+    if internals is None:
+        return {
+            'postgresql_using': using,
+            'postgresql_using_internals': None,
+        }
+
+    parsed = _parse_postgres_using_internals(internals, using)
+    fulltext = parsed.get('fulltext') if parsed is not None else None
+    if fulltext is not None:
+        return {
+            'postgresql_using': _normalize_full_text_using(
+                fulltext.get('indexType') or using
+            ),
+            'language': fulltext.get('language'),
+            'columns': [
+                _normalize_full_text_column(col)
+                for col in parsed.get('columns', [])
+            ],
+            'is_full_text_expression': True,
+        }
+
+    if parsed is not None and parsed.get('columns') is not None:
+        return {
+            'postgresql_using': using,
+            'columns': [
+                _normalize_full_text_column(col)
+                for col in parsed.get('columns', [])
+            ],
+            'is_full_text_expression': False,
+        }
+
+    return {
+        'postgresql_using': using,
+        'postgresql_using_internals': _normalize_full_text_expression(internals),
+    }
+
+
+def _full_text_index_signatures_differ(
+    meta_index: sa.Index, conn_index: sa.Index | None, raw_index: dict[str, Any]
+) -> bool:
+    return (
+        _get_full_text_index_signature(meta_index, {})
+        != _get_full_text_index_signature(conn_index, raw_index)
+    )
+
+
+def _raw_index_is_full_text(raw_index: dict[str, Any]) -> bool:
+    return _get_full_text_index_signature(None, raw_index).get(
+        'is_full_text_expression'
+    ) is True
+
 
 def _normalize_index_using(using):
     if using in (None, False, '', 'btree'):

--- a/python/auto_schema/tests/conftest.py
+++ b/python/auto_schema/tests/conftest.py
@@ -866,6 +866,25 @@ def metadata_with_multicolumn_fulltext_search_index(metadata_with_table):
     return metadata_with_table
 
 
+def metadata_with_multicolumn_coalesce_fulltext_search_index(metadata_with_table):
+    sa.Table('accounts',
+             metadata_with_table,
+             schema_item.FullTextIndex("accounts_full_text_idx",
+                                       info={
+                                           'postgresql_using': 'gin',
+                                           'postgresql_using_internals': (
+                                               "to_tsvector('english', "
+                                               "coalesce(first_name, '') || "
+                                               "' ' || coalesce(last_name, ''))"
+                                           ),
+                                           'columns': ['first_name', 'last_name'],
+                                       }
+                                       ),
+             extend_existing=True
+             )
+    return metadata_with_table
+
+
 @ pytest.fixture
 def metadata_with_multicolumn_fulltext_search():
     metadata = metadata_with_base_table_restored()

--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -1681,16 +1681,77 @@ class TestPostgresRunner(BaseTestRunner):
             validate_schema=False
         )
 
-    @ pytest.mark.usefixtures("metadata_with_multicolumn_fulltext_search")
-    # TODO this is failed because of index comparisons
-    # this doesn't work because indexes are wrong. why we have validate false in
-    # make_changes_and_restore
-    @ pytest.mark.xfail()
     def test_multi_col_full_text_create(self, new_test_runner, metadata_with_multicolumn_fulltext_search):
         r = new_test_runner(
             metadata_with_multicolumn_fulltext_search)
         testingutils.run_and_validate_with_standard_metadata_tables(
             r, metadata_with_multicolumn_fulltext_search)
+        assert r.compute_changes() == []
+
+    def test_multi_col_coalesce_full_text_create_no_changes(
+        self,
+        new_test_runner,
+        metadata_with_table,
+    ):
+        conftest.metadata_with_multicolumn_coalesce_fulltext_search_index(
+            metadata_with_table)
+        r = new_test_runner(metadata_with_table)
+        testingutils.run_and_validate_with_standard_metadata_tables(
+            r, metadata_with_table)
+        assert r.compute_changes() == []
+
+    def test_multi_col_full_text_index_method_change_uses_full_text_ops(
+        self,
+        new_test_runner,
+        metadata_with_multicolumn_fulltext_search,
+    ):
+        r = new_test_runner(metadata_with_multicolumn_fulltext_search)
+        testingutils.run_and_validate_with_standard_metadata_tables(
+            r, metadata_with_multicolumn_fulltext_search)
+
+        index = next(
+            index for index in r.get_metadata().tables['accounts'].indexes
+            if index.name == 'accounts_full_text_idx'
+        )
+        index.info['postgresql_using'] = 'gist'
+
+        r2 = new_test_runner(r.get_metadata(), r)
+        diff = r2.compute_changes()
+        assert len(diff) == 1
+        modify_op = diff[0]
+        assert isinstance(modify_op, alembicops.ModifyTableOps)
+        assert len(modify_op.ops) == 2
+        assert isinstance(modify_op.ops[0], ops.DropFullTextIndexOp)
+        assert isinstance(modify_op.ops[1], ops.CreateFullTextIndexOp)
+        expected_message = (
+            'drop full text index accounts_full_text_idx from accounts\n'
+            'add full text index accounts_full_text_idx to accounts'
+        )
+        assert r2.revision_message(diff) == expected_message
+
+    def test_multi_col_full_text_replaces_plain_index_with_full_text_op(
+        self,
+        new_test_runner,
+        metadata_with_table,
+    ):
+        r = new_test_runner(metadata_with_table)
+        testingutils.run_and_validate_with_standard_metadata_tables(
+            r, metadata_with_table)
+        r.get_connection().execute(sa.text(
+            'CREATE INDEX accounts_full_text_idx '
+            'ON accounts (first_name, last_name)'
+        ))
+
+        conftest.metadata_with_multicolumn_fulltext_search_index(
+            metadata_with_table)
+        r2 = new_test_runner(metadata_with_table, r)
+        diff = r2.compute_changes()
+        assert len(diff) == 1
+        modify_op = diff[0]
+        assert isinstance(modify_op, alembicops.ModifyTableOps)
+        assert len(modify_op.ops) == 2
+        assert isinstance(modify_op.ops[0], alembicops.DropIndexOp)
+        assert isinstance(modify_op.ops[1], ops.CreateFullTextIndexOp)
 
     @ pytest.mark.usefixtures("metadata_with_table")
     def test_multi_col_full_text_index_added_and_removed(self, new_test_runner, metadata_with_table):

--- a/python/auto_schema/tests/testingutils.py
+++ b/python/auto_schema/tests/testingutils.py
@@ -1,4 +1,7 @@
 import os
+
+from alembic.autogenerate.api import AutogenContext
+from alembic.migration import MigrationContext
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from auto_schema.clause_text import get_clause_text
@@ -398,10 +401,52 @@ def _sort_fn(item):
     return type(item).__name__ + item.name
 
 
-def _validate_indexes(schema_table: sa.Table, db_table: sa.Table, metadata: sa.MetaData, dialect: String):
+def _validate_indexes(
+    schema_table: sa.Table,
+    db_table: sa.Table,
+    metadata: sa.MetaData,
+    dialect: String,
+):
     # sort indexes so that the order for both are the same
     schema_indexes = sorted(schema_table.indexes, key=_sort_fn)
     db_indexes = sorted(db_table.indexes, key=_sort_fn)
+
+    if dialect == 'postgresql':
+        migration_context = MigrationContext.configure(connection=metadata.bind)
+        autogen_context = AutogenContext(migration_context)
+        raw_db_indexes = compare._get_raw_db_indexes(
+            autogen_context,
+            db_table,
+        ).get('all', {})
+        validated_full_text_index_names = set()
+        for schema_index in schema_indexes:
+            if not isinstance(schema_index, schema_item.FullTextIndex):
+                continue
+
+            raw_index = raw_db_indexes.get(schema_index.name)
+            assert raw_index is not None
+            db_index = next(
+                (
+                    index for index in db_indexes
+                    if index.name == schema_index.name
+                ),
+                None,
+            )
+            assert not compare._full_text_index_signatures_differ(
+                schema_index,
+                db_index,
+                raw_index,
+            )
+            validated_full_text_index_names.add(schema_index.name)
+
+        schema_indexes = [
+            index for index in schema_indexes
+            if index.name not in validated_full_text_index_names
+        ]
+        db_indexes = [
+            index for index in db_indexes
+            if index.name not in validated_full_text_index_names
+        ]
 
     assert len(schema_indexes) == len(db_indexes)
     for schema_index, db_index in zip(schema_indexes, db_indexes):


### PR DESCRIPTION
## Summary
- compare Postgres full-text expression indexes using raw pg_catalog index metadata
- avoid redundant no-op migrations and avoid recreating full-text indexes as plain btree indexes
- add Postgres regressions for no-op, coalesced expression, index method changes, and bad plain-index replacement

## Verification
- /tmp/ent-auto-schema-venv/bin/python -m pytest tests -q
- /tmp/ent-auto-schema-venv/bin/ruff check --select E9,F63,F7,F82 auto_schema/compare.py tests/conftest.py tests/runner_test.py tests/testingutils.py
- git diff --check