### PR TITLE
Stabilize generated schema output formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 - update `uuid`, docs, test-helper, and standalone TypeScript package
   dependencies to patched versions (#2013).
+- avoid whitespace-only churn in generated `schema.py` and `schema.sql` files
+  after repeated codegen runs (#2016).
 
 ## [0.2.13]
 

--- a/internal/file/file_writer_test.go
+++ b/internal/file/file_writer_test.go
@@ -1,0 +1,30 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplatedBasedFileWriterTrimsGeneratedPythonTrailingWhitespace(t *testing.T) {
+	tmpDir := t.TempDir()
+	templatePath := filepath.Join(tmpDir, "schema.tmpl")
+	contents := "first line" + "  \n" +
+		"blank line follows\n" +
+		"   \n" +
+		"last line" + "\t \n\n"
+
+	require.NoError(t, os.WriteFile(templatePath, []byte(contents), 0o644))
+
+	writer := &TemplatedBasedFileWriter{
+		AbsPathToTemplate: templatePath,
+		TemplateName:      "schema.tmpl",
+		PathToFile:        "schema.py",
+	}
+
+	b, err := writer.generateBytes()
+	require.NoError(t, err)
+	require.Equal(t, "first line\nblank line follows\n\nlast line\n", string(b))
+}

--- a/internal/file/template_file_writer.go
+++ b/internal/file/template_file_writer.go
@@ -36,7 +36,23 @@ func (fw *TemplatedBasedFileWriter) generateBytes() ([]byte, error) {
 	if strings.HasSuffix(fw.getPathToFile(), ".ts") {
 		return fw.addImports(buf)
 	}
+	if strings.HasSuffix(fw.getPathToFile(), ".py") {
+		return normalizeGeneratedText(buf.Bytes()), nil
+	}
 	return buf.Bytes(), nil
+}
+
+func normalizeGeneratedText(b []byte) []byte {
+	s := strings.TrimRight(string(b), " \t\r\n")
+	if s == "" {
+		return []byte{}
+	}
+
+	lines := strings.Split(s, "\n")
+	for idx := range lines {
+		lines[idx] = strings.TrimRight(lines[idx], " \t\r")
+	}
+	return []byte(strings.Join(lines, "\n") + "\n")
 }
 
 func (fw *TemplatedBasedFileWriter) addImports(buf *bytes.Buffer) ([]byte, error) {

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -969,11 +969,14 @@ class Runner(object):
             custom_sql_buffer = self._get_custom_sql(connection, dialect, as_buffer=True)
 
             # add custom sql at the end
-            buffer.write(custom_sql_buffer.getvalue())
+            custom_sql = custom_sql_buffer.getvalue()
+            custom_sql_buffer.close()
+            buffer.write(custom_sql)
             sql = _normalize_generated_file_text(buffer.getvalue())
         finally:
             # restore this
             sa.Table._sorted_constraints = prev_sort
+            buffer.close()
 
         if file is not None:
             with open(file, 'w') as f:

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -42,6 +42,14 @@ from .schema_item import CustomSQLAlchemyType
 from .util.os import delete_py_files
 
 
+def _normalize_generated_file_text(contents: str) -> str:
+    contents = contents.rstrip()
+    if contents == "":
+        return ""
+
+    return "\n".join(line.rstrip() for line in contents.splitlines()) + "\n"
+
+
 class Runner(object):
     # Dev schema isolation contract (Postgres only):
     # - default include_public = False (strict isolation)
@@ -923,10 +931,7 @@ class Runner(object):
     def all_sql(self, file=None, database=''):
         (migrations, connection, dialect, mc) = self.migrations_against_empty(database=database)
     
-        # default is stdout so let's use it
-        buffer = sys.stdout
-        if file is not None:
-            buffer = open(file, 'w')
+        buffer = io.StringIO()
 
         # use different migrations context with as_sql so that we don't have issues
         opts = Runner.get_opts()
@@ -954,20 +959,27 @@ class Runner(object):
 
         operations = Operations(mc2)
 
-        # create alembic table to start
-        mc2._version.create(bind=mc2.connection)
+        try:
+            # create alembic table to start
+            mc2._version.create(bind=mc2.connection)
 
-        for op in migrations.upgrade_ops.ops:
-            invoke(op)
-        
-        custom_sql_buffer = self._get_custom_sql(connection, dialect, as_buffer=True)
+            for op in migrations.upgrade_ops.ops:
+                invoke(op)
 
-        # add custom sql at the end
-        buffer.write(custom_sql_buffer.getvalue())
-        buffer.close()
-        
-        # restore this
-        sa.Table._sorted_constraints = prev_sort
+            custom_sql_buffer = self._get_custom_sql(connection, dialect, as_buffer=True)
+
+            # add custom sql at the end
+            buffer.write(custom_sql_buffer.getvalue())
+            sql = _normalize_generated_file_text(buffer.getvalue())
+        finally:
+            # restore this
+            sa.Table._sorted_constraints = prev_sort
+
+        if file is not None:
+            with open(file, 'w') as f:
+                f.write(sql)
+        else:
+            sys.stdout.write(sql)
         
 
 

--- a/python/auto_schema/tests/runner_test.py
+++ b/python/auto_schema/tests/runner_test.py
@@ -22,6 +22,20 @@ def _get_revision_file(r, rev="head"):
     return testingutils.find_file_by_revision(r, revisions[0])
 
 
+def test_normalize_generated_file_text_trims_trailing_whitespace():
+    contents = (
+        "CREATE TABLE accounts (" + "  \n"
+        "    id INTEGER" + "\t \n"
+        ");" + " \n\n"
+        "   \n"
+    )
+
+    assert (
+        runner._normalize_generated_file_text(contents)
+        == "CREATE TABLE accounts (\n    id INTEGER\n);\n"
+    )
+
+
 def _db_extension_metadata(
     *,
     name: str,
@@ -2034,6 +2048,10 @@ class TestSqliteRunner(BaseTestRunner):
 
         with open(file) as f:
             sql = f.read()
+
+        assert sql.endswith("\n")
+        assert not sql.endswith("\n\n")
+        assert all(line == line.rstrip() for line in sql.splitlines())
 
         create_idx = sql.index("CREATE TABLE assoc_edge_config")
         insert_idx = sql.index("INSERT INTO assoc_edge_config")


### PR DESCRIPTION
## Summary
- trim trailing whitespace from generated Python schema files written through the Go template writer
- normalize `auto_schema --all_sql` / `--run_and_all_sql` output before writing `schema.sql`, including exactly one final newline
- add focused regression coverage for generated `schema.py` and `schema.sql` formatting

## Why
Generated database schema outputs are checked in by examples and consumers. Alembic SQL output and the Go schema template path can produce whitespace-only rewrites even when the schema has not changed. Normalizing these two `src/schema` outputs keeps repeated codegen runs from creating avoidable diffs while preserving the rendered SQL and Python content.

## Testing
- `go test ./internal/file`
- `/Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 -m pytest tests/runner_test.py::test_normalize_generated_file_text_trims_trailing_whitespace tests/runner_test.py::TestSqliteRunner::test_all_sql_adds_edges_after_assoc_edge_config_table`
- `git diff --check`