### PR TITLE
Infer GraphQL node fields for struct UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
   dependencies to patched versions (#2013).
 - avoid whitespace-only churn in generated `schema.py` and `schema.sql` files
   after repeated codegen runs (#2016).
+- when GraphQL ID encoding is enabled, infer GraphQL Node fields for struct
+  UUID fields whose `...Id` name matches an existing Ent schema, without
+  requiring redundant edge metadata (#1762).
 
 ## [0.2.13]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
   after repeated codegen runs (#2016).
 - when GraphQL ID encoding is enabled, infer GraphQL Node fields for struct
   UUID fields whose `...Id` name matches an existing Ent schema, without
-  requiring redundant edge metadata (#1762).
+  requiring redundant edge metadata (#2021).
 
 ## [0.2.13]
 

--- a/internal/graphql/custom_ts_test.go
+++ b/internal/graphql/custom_ts_test.go
@@ -1497,3 +1497,62 @@ func TestCustomStructUUIDFieldInfersNodeFromName(t *testing.T) {
 	assert.Equal(t, "GraphQLID", rawIDObj.Fields[0].FieldType())
 	assert.False(t, rawIDObj.Fields[0].HasResolveFunction)
 }
+
+func TestCustomStructUUIDFieldInferenceAvoidsExplicitEdgeNameCollision(t *testing.T) {
+	schema := testhelper.ParseSchemaForTest(
+		t,
+		map[string]string{
+			"sheep_schema.ts": testhelper.GetCodeWithSchema(`
+				import {EntSchema, StringType} from "{schema}";
+
+				const Sheep = new EntSchema({
+					fields: {
+						name: StringType(),
+					},
+				});
+				export default Sheep;
+			`),
+			"farm_schema.ts": testhelper.GetCodeWithSchema(`
+				import {EntSchema, StructType, UUIDListType, UUIDType} from "{schema}";
+
+				const Farm = new EntSchema({
+					fields: {
+						animals: StructType({
+							tsType: "FarmAnimals",
+							fields: {
+								sheepId: UUIDType({nullable: true}),
+								sheepIds: UUIDListType({
+									fieldEdge: {
+										schema: "Sheep",
+									},
+								}),
+							},
+						}),
+					},
+				});
+				export default Farm;
+			`),
+		},
+	)
+
+	processor, err := codegen.NewTestCodegenProcessor(
+		"src/schema",
+		schema,
+		&codegen.CodegenConfig{DisableGraphQLRoot: true},
+	)
+	require.NoError(t, err)
+
+	ci := schema.CustomInterfaces["FarmAnimals"]
+	require.NotNil(t, ci)
+
+	obj, err := buildCustomInterfaceNode(processor, ci, &customInterfaceInfo{
+		name: ci.GQLName,
+	})
+	require.NoError(t, err)
+	require.Len(t, obj.Fields, 2)
+	assert.Equal(t, "sheepId", obj.Fields[0].Name)
+	assert.Equal(t, "GraphQLID", obj.Fields[0].FieldType())
+	assert.False(t, obj.Fields[0].HasResolveFunction)
+	assert.Equal(t, "sheep", obj.Fields[1].Name)
+	assert.True(t, obj.Fields[1].HasResolveFunction)
+}

--- a/internal/graphql/custom_ts_test.go
+++ b/internal/graphql/custom_ts_test.go
@@ -1358,3 +1358,142 @@ func TestCustomStructType(t *testing.T) {
 	// TODO
 	require.True(t, strings.Contains(typ.FilePath, "src/graphql/generated/resolvers/"))
 }
+
+func TestCustomStructUUIDFieldInfersNodeFromName(t *testing.T) {
+	schema := testhelper.ParseSchemaForTest(
+		t,
+		map[string]string{
+			"horse_schema.ts": testhelper.GetCodeWithSchema(`
+				import {EntSchema, StringType} from "{schema}";
+
+				const Horse = new EntSchema({
+					fields: {
+						name: StringType(),
+					},
+				});
+				export default Horse;
+			`),
+			"hidden_horse_schema.ts": testhelper.GetCodeWithSchema(`
+				import {EntSchema, StringType} from "{schema}";
+
+				const HiddenHorse = new EntSchema({
+					fields: {
+						name: StringType(),
+					},
+					hideFromGraphQL: true,
+				});
+				export default HiddenHorse;
+			`),
+			"competition_event_schema.ts": testhelper.GetCodeWithSchema(`
+				import {EntSchema, StringType, StructType, StructTypeAsList, UUIDType} from "{schema}";
+
+				const CompetitionEvent = new EntSchema({
+					fields: {
+						horses: StructTypeAsList({
+							tsType: "CompetitionEventHorseEntry",
+							fields: {
+								horseId: UUIDType({nullable: true}),
+								horseName: StringType({nullable: true}),
+							},
+						}),
+						rawHorseReference: StructType({
+							tsType: "RawHorseReference",
+							fields: {
+								horseId: UUIDType({disableBase64Encode: true}),
+							},
+						}),
+						horseLabel: StructType({
+							tsType: "HorseLabel",
+							fields: {
+								horseId: UUIDType({nullable: true}),
+								horse: StringType(),
+								hiddenHorseId: UUIDType({nullable: true}),
+							},
+						}),
+					},
+				});
+				export default CompetitionEvent;
+			`),
+		},
+	)
+
+	processor, err := codegen.NewTestCodegenProcessor(
+		"src/schema",
+		schema,
+		&codegen.CodegenConfig{DisableGraphQLRoot: true},
+	)
+	require.NoError(t, err)
+
+	ci := schema.CustomInterfaces["CompetitionEventHorseEntry"]
+	require.NotNil(t, ci)
+
+	obj, err := buildCustomInterfaceNode(processor, ci, &customInterfaceInfo{
+		name: ci.GQLName,
+	})
+	require.NoError(t, err)
+	require.Len(t, obj.Fields, 2)
+
+	horseField := obj.Fields[0]
+	assert.Equal(t, "horse", horseField.Name)
+	assert.Equal(t, "HorseType", horseField.FieldType())
+	assert.True(t, horseField.HasResolveFunction)
+	assert.Equal(t, []string{
+		"if (obj.horseId === null || obj.horseId === undefined)	{ return null;}",
+		"return Horse.load(context.getViewer(), obj.horseId);",
+	}, horseField.FunctionContents)
+	require.Len(t, horseField.ExtraImports, 1)
+	assert.Equal(t, "Horse", horseField.ExtraImports[0].Import)
+
+	horseNameField := obj.Fields[1]
+	assert.Equal(t, "horseName", horseNameField.Name)
+	assert.False(t, horseNameField.HasResolveFunction)
+
+	rawCI := schema.CustomInterfaces["RawHorseReference"]
+	require.NotNil(t, rawCI)
+
+	rawObj, err := buildCustomInterfaceNode(processor, rawCI, &customInterfaceInfo{
+		name: rawCI.GQLName,
+	})
+	require.NoError(t, err)
+	require.Len(t, rawObj.Fields, 1)
+
+	rawHorseIDField := rawObj.Fields[0]
+	assert.Equal(t, "horseId", rawHorseIDField.Name)
+	assert.Equal(t, "new GraphQLNonNull(GraphQLID)", rawHorseIDField.FieldType())
+	assert.False(t, rawHorseIDField.HasResolveFunction)
+
+	labelCI := schema.CustomInterfaces["HorseLabel"]
+	require.NotNil(t, labelCI)
+
+	labelObj, err := buildCustomInterfaceNode(processor, labelCI, &customInterfaceInfo{
+		name: labelCI.GQLName,
+	})
+	require.NoError(t, err)
+	require.Len(t, labelObj.Fields, 3)
+	assert.Equal(t, "horseId", labelObj.Fields[0].Name)
+	assert.Equal(t, "GraphQLID", labelObj.Fields[0].FieldType())
+	assert.False(t, labelObj.Fields[0].HasResolveFunction)
+	assert.Equal(t, "horse", labelObj.Fields[1].Name)
+	assert.Equal(t, "hiddenHorseId", labelObj.Fields[2].Name)
+	assert.Equal(t, "GraphQLID", labelObj.Fields[2].FieldType())
+	assert.False(t, labelObj.Fields[2].HasResolveFunction)
+
+	rawIDProcessor, err := codegen.NewTestCodegenProcessor(
+		"src/schema",
+		schema,
+		&codegen.CodegenConfig{
+			DisableGraphQLRoot:    true,
+			DisableBase64Encoding: true,
+		},
+	)
+	require.NoError(t, err)
+
+	rawIDObj, err := buildCustomInterfaceNode(rawIDProcessor, ci, &customInterfaceInfo{
+		name: ci.GQLName,
+	})
+	require.NoError(t, err)
+	require.Len(t, rawIDObj.Fields, 2)
+	assert.Equal(t, "horseId", rawIDObj.Fields[0].Name)
+	assert.Equal(t, "GraphQLID", rawIDObj.Fields[0].FieldType())
+	assert.False(t, rawIDObj.Fields[0].HasResolveFunction)
+}

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -3489,6 +3489,37 @@ type customInterfaceInfo struct {
 	imports  []string
 }
 
+func getDeclaredStructFieldEdgeInfo(f *field.Field) *base.FieldEdgeInfo {
+	if fieldEdge := f.FieldEdgeInfo(); fieldEdge != nil {
+		return fieldEdge
+	}
+	if fkey := f.ForeignKeyInfo(); fkey != nil {
+		return &base.FieldEdgeInfo{
+			Schema: fkey.Schema,
+		}
+	}
+	return nil
+}
+
+func getStructFieldGraphQLName(processor *codegen.Processor, f *field.Field) string {
+	fieldEdge := getDeclaredStructFieldEdgeInfo(f)
+	if fieldEdge == nil {
+		return f.GetGraphQLName()
+	}
+
+	e, err := edge.GetFieldEdge(
+		processor.Config,
+		f.FieldName,
+		fieldEdge,
+		f.Nullable(),
+		f.GetFieldType(),
+	)
+	if err != nil || e == nil {
+		return f.GetGraphQLName()
+	}
+	return e.GraphQLEdgeName()
+}
+
 func inferStructFieldEdge(processor *codegen.Processor, ci *customtype.CustomInterface, f *field.Field) *base.FieldEdgeInfo {
 	if !processor.Config.Base64EncodeIDs() {
 		return nil
@@ -3514,7 +3545,7 @@ func inferStructFieldEdge(processor *codegen.Processor, ci *customtype.CustomInt
 
 	graphQLName := names.ToGraphQLName(processor.Config, fieldName)
 	for _, other := range ci.Fields {
-		if other != f && other.ExposeToGraphQL() && other.GetGraphQLName() == graphQLName {
+		if other != f && other.ExposeToGraphQL() && getStructFieldGraphQLName(processor, other) == graphQLName {
 			return nil
 		}
 	}
@@ -3586,18 +3617,9 @@ func buildCustomInterfaceNode(processor *codegen.Processor, ci *customtype.Custo
 		fieldName := fmt.Sprintf("obj.%s", f.TsFieldName(processor.Config))
 
 		if !ciInfo.input {
-			fieldEdge := f.FieldEdgeInfo()
-
+			fieldEdge := getDeclaredStructFieldEdgeInfo(f)
 			if fieldEdge == nil {
-				if fkey := f.ForeignKeyInfo(); fkey != nil {
-					// handle types declared with foreignKey
-					// TODO should probably throw since this doesn't actually make sense since the foreignKey won't be respected
-					fieldEdge = &base.FieldEdgeInfo{
-						Schema: fkey.Schema,
-					}
-				} else {
-					fieldEdge = inferStructFieldEdge(processor, ci, f)
-				}
+				fieldEdge = inferStructFieldEdge(processor, ci, f)
 			}
 
 			// should exist for id fields...

--- a/internal/graphql/generate_ts_code.go
+++ b/internal/graphql/generate_ts_code.go
@@ -3489,6 +3489,52 @@ type customInterfaceInfo struct {
 	imports  []string
 }
 
+func inferStructFieldEdge(processor *codegen.Processor, ci *customtype.CustomInterface, f *field.Field) *base.FieldEdgeInfo {
+	if !processor.Config.Base64EncodeIDs() {
+		return nil
+	}
+
+	switch typ := f.GetFieldType().(type) {
+	case *enttype.IDType:
+		if typ.DisableBase64Encode {
+			return nil
+		}
+	case *enttype.NullableIDType:
+		if typ.DisableBase64Encode {
+			return nil
+		}
+	default:
+		return nil
+	}
+
+	fieldName, valid := base.TranslateIDSuffix(f.FieldName)
+	if !valid {
+		return nil
+	}
+
+	graphQLName := names.ToGraphQLName(processor.Config, fieldName)
+	for _, other := range ci.Fields {
+		if other != f && other.ExposeToGraphQL() && other.GetGraphQLName() == graphQLName {
+			return nil
+		}
+	}
+	for _, other := range ci.NonEntFields {
+		if other.ExposeToGraphQL() && other.GetGraphQLName() == graphQLName {
+			return nil
+		}
+	}
+
+	schemaName := names.ToClassType(fieldName)
+	nodeData, err := processor.Schema.GetNodeDataForNode(schemaName)
+	if err != nil || nodeData.HideFromGraphQL {
+		return nil
+	}
+
+	return &base.FieldEdgeInfo{
+		Schema: schemaName,
+	}
+}
+
 // similar to buildCustomInputNode but different...
 // buildCustomInputNode is used for action inputs
 // while this is used for StructType. can probably eventually be used together
@@ -3549,6 +3595,8 @@ func buildCustomInterfaceNode(processor *codegen.Processor, ci *customtype.Custo
 					fieldEdge = &base.FieldEdgeInfo{
 						Schema: fkey.Schema,
 					}
+				} else {
+					fieldEdge = inferStructFieldEdge(processor, ci, f)
 				}
 			}
 

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -148,6 +148,7 @@ fixtures:
       - custom_graphql.custom_mutation_return
       - custom_graphql.json_with_decorators
       - custom_graphql.custom_type_metadata
+      - struct.uuid_node_inference
       - pattern.struct_privacy_import
       - polymorphic.struct_field_codegen
       - field_edge.uuid_list_inverse
@@ -913,6 +914,10 @@ features:
       - ts/src/action/transformed_orchestrator.test.ts
       - examples/simple/src/ent/tests/transform_write_struct_input.test.ts
     rationale: Runtime transformWrite/input-shape behavior is covered outside compile-only codegen matrix.
+  - id: struct.uuid_node_inference
+    owns: []
+    mode: explicit
+    rationale: An ID-suffixed UUID struct field matching an Ent must render and compile as a GraphQL Node field without redundant edge metadata.
   - id: pattern.struct_privacy_import
     owns: []
     mode: explicit

--- a/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
+++ b/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
@@ -1,6 +1,8 @@
 contains:
   - path: src/graphql/generated/resolvers/decorated_runtime_ready_query_type.ts
     text: "return r.runtimeReady();"
+  - path: src/graphql/generated/resolvers/payment_audit_entry_type.ts
+    text: "return Horse.load(context.getViewer(), obj.horseId);"
   - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts
     text: "input.studbooks.map((i: any) => mustDecodeIDFromGQLID(i.toString()))"
   - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts

--- a/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
+++ b/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
@@ -3,6 +3,10 @@ contains:
     text: "return r.runtimeReady();"
   - path: src/graphql/generated/resolvers/payment_audit_entry_type.ts
     text: "return Horse.load(context.getViewer(), obj.horseId);"
+  - path: src/graphql/generated/resolvers/payment_sheep_edge_collision_type.ts
+    text: "sheepId: {"
+  - path: src/graphql/generated/resolvers/payment_sheep_edge_collision_type.ts
+    text: "const objs = await Sheep.loadMany("
   - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts
     text: "input.studbooks.map((i: any) => mustDecodeIDFromGQLID(i.toString()))"
   - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/payment_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/payment_schema.ts
@@ -240,6 +240,19 @@ const PaymentSchema = new EntSchema({
         }),
       },
     }),
+    sheepEdgeCollision: StructType({
+      tsType: "PaymentSheepEdgeCollision",
+      fields: {
+        sheepID: UUIDType({
+          nullable: true,
+        }),
+        sheepIDs: UUIDListType({
+          fieldEdge: {
+            schema: "Sheep",
+          },
+        }),
+      },
+    }),
     nestedObject: StructType({
       tsType: "PaymentNestedObject",
       nullable: true,

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/payment_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/payment_schema.ts
@@ -228,6 +228,9 @@ const PaymentSchema = new EntSchema({
         changedByType: StringType({
           nullable: true,
         }),
+        horseID: UUIDType({
+          nullable: true,
+        }),
         comment: StringType({
           storageKey: "comment_text",
           nullable: true,

--- a/testdata/codegen_matrix/fixtures/feature_stress/src/schema/sheep_schema.ts
+++ b/testdata/codegen_matrix/fixtures/feature_stress/src/schema/sheep_schema.ts
@@ -1,0 +1,9 @@
+import { EntSchema, StringType } from "@snowtop/ent/schema";
+
+const SheepSchema = new EntSchema({
+  fields: {
+    name: StringType(),
+  },
+});
+
+export default SheepSchema;


### PR DESCRIPTION
## Summary

- infer GraphQL Node fields for UUID fields nested in structs when an Id-suffixed field matches an existing GraphQL-visible Ent schema
- preserve explicit fieldEdge and foreignKey behavior while avoiding raw-ID, hidden-schema, and field-name collision cases
- add unit coverage plus generated TypeScript coverage in the Node/pg and Bun/Bun codegen matrix

## Testing

- `go test ./internal/graphql -count=1`
- `go test ./internal/codegenmatrix -count=1`
- focused `feature_stress` matrix in `node_pg` and `bun_bun`
- `git diff --check`

Follow-up to #1762, specifically the [reported remaining case](https://github.com/lolopinto/ent/issues/1762#issuecomment-5006680856).