### PR TITLE
Fix custom GraphQL script shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 ### Fixed
 
 - prevent custom GraphQL discovery from hanging when imported application code
-  leaves a database pool or another event-loop handle open (#2020).
+  leaves a database pool or another event-loop handle open (#2022).
 - update `uuid`, docs, test-helper, and standalone TypeScript package
   dependencies to patched versions (#2013).
 - avoid whitespace-only churn in generated `schema.py` and `schema.sql` files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- prevent custom GraphQL discovery from hanging when imported application code
+  leaves a database pool or another event-loop handle open (#2020).
 - update `uuid`, docs, test-helper, and standalone TypeScript package
   dependencies to patched versions (#2013).
 - avoid whitespace-only churn in generated `schema.py` and `schema.sql` files

--- a/ts/src/scripts/custom_graphql.test.ts
+++ b/ts/src/scripts/custom_graphql.test.ts
@@ -1,0 +1,77 @@
+import { spawn } from "child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import * as path from "path";
+
+describe("custom_graphql script", () => {
+  test("exits after writing output when an imported module leaves an active handle", async () => {
+    const fixtureRoot = await mkdtemp(
+      path.join(tmpdir(), "ent-custom-graphql-"),
+    );
+    const sourcePath = path.join(fixtureRoot, "src");
+    await mkdir(sourcePath);
+    await writeFile(
+      path.join(sourcePath, "active_handle.js"),
+      "setInterval(() => {}, 1000);\n",
+    );
+
+    try {
+      const result = await new Promise<{
+        code: number | null;
+        stdout: string;
+        stderr: string;
+        timedOut: boolean;
+      }>((resolve, reject) => {
+        const child = spawn(
+          process.execPath,
+          [
+            "-r",
+            "ts-node/register/transpile-only",
+            "-r",
+            "tsconfig-paths/register",
+            path.join(__dirname, "custom_graphql.ts"),
+            "--path",
+            sourcePath,
+            "--files",
+            "src/active_handle.js",
+          ],
+          {
+            cwd: path.resolve(__dirname, "../.."),
+            env: {
+              ...process.env,
+              GRAPHQL_PATH: "local",
+              LOCAL_SCRIPT_PATH: "1",
+            },
+          },
+        );
+        let stdout = "";
+        let stderr = "";
+        let timedOut = false;
+        child.stdout.on("data", (chunk) => {
+          stdout += chunk.toString();
+        });
+        child.stderr.on("data", (chunk) => {
+          stderr += chunk.toString();
+        });
+        child.on("error", reject);
+        child.on("close", (code) => {
+          clearTimeout(timeout);
+          resolve({ code, stdout, stderr, timedOut });
+        });
+        child.stdin.end();
+
+        const timeout = setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGKILL");
+        }, 3000);
+      });
+
+      expect(result.timedOut).toBe(false);
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(() => JSON.parse(result.stdout)).not.toThrow();
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 10000);
+});

--- a/ts/src/scripts/custom_graphql.ts
+++ b/ts/src/scripts/custom_graphql.ts
@@ -633,7 +633,10 @@ async function main() {
 }
 
 main()
-  .then()
+  // Imported application modules can leave database pools or other handles open.
+  // The awaited stdout write above is the script's final required work, so exit
+  // explicitly instead of waiting for the event loop to drain.
+  .then(() => exit(0))
   .catch((err) => {
     console.error(err);
     exit(1);


### PR DESCRIPTION
## Summary

- exit custom GraphQL discovery after its awaited stdout write completes
- add a regression test covering imported modules that leave active event-loop handles
- document the fix in the unreleased changelog

## Testing

- `cd ts && npm test -- src/scripts/custom_graphql.test.ts src/scripts/stdout.test.ts --runInBand`
- `cd ts && npm run compile`
- `cd ts && npx biome check --diagnostic-level=error src/scripts/custom_graphql.ts src/scripts/custom_graphql.test.ts src/scripts/stdout.ts src/scripts/stdout.test.ts`
- `DB_CONNECTION_STRING=sqlite:////private/tmp/ent-graphql-test.sqlite go test ./internal/graphql -run TestCustom -count=1`

Fixes #2020