### PR TITLE
Fix mixed trigger priority grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 ### Fixed
 
 - preserve trigger priority groups when individual triggers appear before and
-  after an explicitly grouped trigger list (#2019).
+  after an explicitly grouped trigger list (#2023).
 - update `uuid`, docs, test-helper, and standalone TypeScript package
   dependencies to patched versions (#2013).
 - avoid whitespace-only churn in generated `schema.py` and `schema.sql` files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- preserve trigger priority groups when individual triggers appear before and
+  after an explicitly grouped trigger list (#2019).
 - update `uuid`, docs, test-helper, and standalone TypeScript package
   dependencies to patched versions (#2013).
 - avoid whitespace-only churn in generated `schema.py` and `schema.sql` files

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -884,26 +884,20 @@ export class Orchestrator<
     >,
   ): Promise<void> {
     const groups: Trigger<TEnt, Builder<TEnt, TViewer>>[][] = [];
-    let lastArray = 0;
-    let prevWasArray = false;
-    for (let i = 0; i < triggers.length; i++) {
-      let t = triggers[i];
-      if (Array.isArray(t)) {
-        if (!prevWasArray) {
-          // @ts-ignore
-          groups.push(triggers.slice(lastArray, i));
+    let group: Trigger<TEnt, Builder<TEnt, TViewer>>[] = [];
+    for (const trigger of triggers) {
+      if (Array.isArray(trigger)) {
+        if (group.length) {
+          groups.push(group);
+          group = [];
         }
-        groups.push(t);
-
-        prevWasArray = true;
-        lastArray++;
+        groups.push(trigger);
       } else {
-        if (i === triggers.length - 1) {
-          // @ts-ignore
-          groups.push(triggers.slice(lastArray, i + 1));
-        }
-        prevWasArray = false;
+        group.push(trigger);
       }
+    }
+    if (group.length) {
+      groups.push(group);
     }
 
     for (const triggers of groups) {

--- a/ts/src/action/trigger_priority.test.ts
+++ b/ts/src/action/trigger_priority.test.ts
@@ -246,6 +246,50 @@ function commonTests() {
     expect(action.builder.getStoredData("key2b")).toBe("called");
   });
 
+  test("with individual triggers before and after a list", async () => {
+    const action = getInsertUserAction(
+      new Map([
+        ["FirstName", "Jon"],
+        ["LastName", "Snow"],
+      ]),
+    );
+    const calls = new Map<string, number>();
+    const recordCall = (key: string) => {
+      calls.set(key, (calls.get(key) ?? 0) + 1);
+      action.builder.storeData(key, "called");
+    };
+    action.getTriggers = () => [
+      {
+        changeset: () => {
+          recordCall("key1");
+        },
+      },
+      [
+        {
+          changeset: (builder: SimpleBuilder<User>) => {
+            expect(builder.getStoredData("key1")).toBe("called");
+            recordCall("key2");
+          },
+        },
+      ],
+      {
+        changeset: (builder: SimpleBuilder<User>) => {
+          expect(builder.getStoredData("key2")).toBe("called");
+          recordCall("key3");
+        },
+      },
+    ];
+
+    await action.saveX();
+    expect(calls).toEqual(
+      new Map([
+        ["key1", 1],
+        ["key2", 1],
+        ["key3", 1],
+      ]),
+    );
+  });
+
   test("combine all the things", async () => {
     const action = getInsertUserAction(
       new Map([


### PR DESCRIPTION
## Summary

- preserve trigger priority boundaries when bare triggers appear before and after an explicit trigger group
- replace the cursor-based grouping loop with type-safe incremental grouping
- add Postgres and SQLite regression coverage for ordering and exactly-once execution

## Testing

- cd ts && npm test -- src/action/trigger_priority.test.ts --runInBand
- cd ts && npm test -- --runInBand
- cd ts && npm run compile
- cd ts && npx biome check --diagnostic-level=error src/action/orchestrator.ts src/action/trigger_priority.test.ts
- git diff --check

Closes #2019