### PR TITLE
Manage tsent database pool lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- avoid opening the Go codegen database pool until first use and close it when
+  `tsent` commands finish.
 - preserve trigger priority groups when individual triggers appear before and
   after an explicitly grouped trigger list (#2023).
 - update `uuid`, docs, test-helper, and standalone TypeScript package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 ### Fixed
 
 - avoid opening the Go codegen database pool until first use and close it when
-  `tsent` commands finish.
+  `tsent` commands finish (#2024).
 - preserve trigger priority groups when individual triggers appear before and
   after an explicitly grouped trigger list (#2023).
 - update `uuid`, docs, test-helper, and standalone TypeScript package

--- a/ent/config/config.go
+++ b/ent/config/config.go
@@ -77,6 +77,12 @@ func (db *DBConfig) Init() (*sqlx.DB, error) {
 		fmt.Println("error opening db", err)
 		return nil, err
 	}
+	initialized := false
+	defer func() {
+		if !initialized {
+			_ = db2.Close()
+		}
+	}()
 
 	err = db2.Ping()
 	if err != nil {
@@ -104,6 +110,7 @@ func (db *DBConfig) Init() (*sqlx.DB, error) {
 			}
 		}
 	}
+	initialized = true
 	return db2, nil
 }
 

--- a/ent/config/config.go
+++ b/ent/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/joho/godotenv"
@@ -190,10 +191,22 @@ func init() {
 	}
 }
 
-var cfg *Config
+var (
+	cfg      *Config
+	cfgMutex sync.RWMutex
+)
 
 // Get returns the singleton config for the application
 func Get() *Config {
+	cfgMutex.RLock()
+	current := cfg
+	cfgMutex.RUnlock()
+	if current != nil {
+		return current
+	}
+
+	cfgMutex.Lock()
+	defer cfgMutex.Unlock()
 	if cfg == nil {
 		cfg = &Config{
 			DB: loadDBConfig(),
@@ -233,6 +246,8 @@ func GetConnectionStr() string {
 }
 
 func ResetConfig(rdbi *DBConfig) {
+	cfgMutex.Lock()
+	defer cfgMutex.Unlock()
 	cfg = &Config{
 		DB: rdbi,
 	}

--- a/ent/config/config_test.go
+++ b/ent/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,12 @@ type testData struct {
 	sqlAlchemyURI string
 	only          bool
 	skip          bool
+}
+
+func clearConfig() {
+	cfgMutex.Lock()
+	defer cfgMutex.Unlock()
+	cfg = nil
 }
 
 func TestConfig(t *testing.T) {
@@ -73,7 +80,7 @@ func TestConfig(t *testing.T) {
 			continue
 		}
 		t.Run(name, func(t *testing.T) {
-			cfg = nil
+			clearConfig()
 			os.Setenv("DB_CONNECTION_STRING", test.connStringEnv)
 
 			assert.Equal(t, GetConnectionStr(), test.expConnStr)
@@ -92,5 +99,37 @@ func TestConfig(t *testing.T) {
 
 			os.Unsetenv("DB_CONNECTION_STRING")
 		})
+	}
+}
+
+func TestConcurrentGet(t *testing.T) {
+	clearConfig()
+	t.Cleanup(clearConfig)
+	t.Setenv("DB_CONNECTION_STRING", "sqlite:///:memory:")
+
+	const goroutines = 32
+	start := make(chan struct{})
+	configs := make(chan *Config, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			configs <- Get()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(configs)
+
+	var first *Config
+	for current := range configs {
+		if first == nil {
+			first = current
+			continue
+		}
+		assert.Same(t, first, current)
 	}
 }

--- a/ent/data/data.go
+++ b/ent/data/data.go
@@ -13,15 +13,25 @@ import (
 var db *sqlx.DB
 var dbMutex sync.RWMutex
 
-// init() initializes the database connection pool for use later
-// init function called as package is initalized. Maybe make this explicit with InitDB()?
-func init() {
-	cfg := config.Get()
-	var err error
-	db, err = cfg.DB.Init()
-	if err != nil {
-		log.Fatal(err)
+func initDB() error {
+	if db != nil {
+		return nil
 	}
+
+	cfg := config.Get()
+	db2, err := cfg.DB.Init()
+	if err != nil {
+		return err
+	}
+	db = db2
+	return nil
+}
+
+// InitDB initializes the database connection pool if it has not been initialized.
+func InitDB() error {
+	dbMutex.Lock()
+	defer dbMutex.Unlock()
+	return initDB()
 }
 
 // GetSQLAlchemyDatabaseURIgo returns the databause uri needed by sqlalchemy to generate a schema file
@@ -29,17 +39,26 @@ func GetSQLAlchemyDatabaseURIgo() string {
 	return config.Get().DB.GetSQLAlchemyDatabaseURIgo()
 }
 
-// DBConn returns a database connection pool to the DB for use
+// DBConn returns a database connection pool to the DB for use, initializing it
+// on first access.
 func DBConn() *sqlx.DB {
 	dbMutex.Lock()
 	defer dbMutex.Unlock()
+	if err := initDB(); err != nil {
+		log.Fatal(err)
+	}
 	return db
 }
 
 // CloseDB closes the database connection pool
 func CloseDB() error {
+	dbMutex.Lock()
+	defer dbMutex.Unlock()
+
 	if db != nil {
-		return db.Close()
+		err := db.Close()
+		db = nil
+		return err
 	}
 	return nil
 }
@@ -55,7 +74,7 @@ func ResetDB(db2 *sqlx.DB, rdbi *config.DBConfig) error {
 			return err
 		}
 	}
-	*db = *db2
+	db = db2
 	config.ResetConfig(rdbi)
 	return nil
 }

--- a/ent/data/data_test.go
+++ b/ent/data/data_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/jmoiron/sqlx"
+	"github.com/lolopinto/ent/ent/config"
+	"github.com/lolopinto/ent/ent/data"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSQLite(t *testing.T) {
@@ -43,4 +46,29 @@ func doTest(t *testing.T, file string) {
 	err = row.MapScan(g)
 	assert.NoError(t, err)
 	assert.Equal(t, g["col"], int64(1))
+}
+
+func TestDBLifecycle(t *testing.T) {
+	t.Setenv("ENT_DEV_SCHEMA_ENABLED", "false")
+	require.NoError(t, data.CloseDB())
+	t.Cleanup(func() {
+		require.NoError(t, data.CloseDB())
+	})
+
+	config.ResetConfig(&config.DBConfig{
+		Dialect:  "sqlite",
+		FilePath: ":memory:",
+	})
+
+	require.NoError(t, data.InitDB())
+	first := data.DBConn()
+	require.NoError(t, first.Ping())
+	require.Same(t, first, data.DBConn())
+
+	require.NoError(t, data.CloseDB())
+	require.Error(t, first.Ping())
+
+	second := data.DBConn()
+	require.NotSame(t, first, second)
+	require.NoError(t, second.Ping())
 }

--- a/tsent/cmd/root.go
+++ b/tsent/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/lolopinto/ent/ent/data"
 	"github.com/lolopinto/ent/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -128,10 +129,24 @@ func init() {
 	pruneSchemasCmd.Flags().BoolVar(&pruneSchemasInfo.force, "force", false, "delete schemas instead of dry-run")
 }
 
+func runAndCloseDB(execute func() error, closeDB func() error) (commandErr, closeErr error) {
+	defer func() {
+		closeErr = closeDB()
+	}()
+	commandErr = execute()
+	return
+}
+
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("%s \n  %s\n", util.WrapRed("Error"), err.Error())
+	commandErr, closeErr := runAndCloseDB(rootCmd.Execute, data.CloseDB)
+	if commandErr != nil {
+		fmt.Printf("%s \n  %s\n", util.WrapRed("Error"), commandErr.Error())
 		fmt.Println(rootCmd.UsageString())
+	}
+	if closeErr != nil {
+		fmt.Printf("%s \n  failed to close database: %s\n", util.WrapRed("Error"), closeErr.Error())
+	}
+	if commandErr != nil || closeErr != nil {
 		os.Exit(1)
 	}
 }

--- a/tsent/cmd/root_test.go
+++ b/tsent/cmd/root_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunAndCloseDB(t *testing.T) {
+	tests := []struct {
+		name       string
+		commandErr error
+		closeErr   error
+	}{
+		{name: "success"},
+		{
+			name:       "command and close errors",
+			commandErr: errors.New("command failed"),
+			closeErr:   errors.New("close failed"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			events := []string{}
+			commandErr, closeErr := runAndCloseDB(
+				func() error {
+					events = append(events, "execute")
+					return test.commandErr
+				},
+				func() error {
+					events = append(events, "close")
+					return test.closeErr
+				},
+			)
+
+			require.Equal(t, []string{"execute", "close"}, events)
+			require.ErrorIs(t, commandErr, test.commandErr)
+			require.ErrorIs(t, closeErr, test.closeErr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- initialize the Go database pool lazily on first database access instead of from a package initializer
- synchronize lazy configuration initialization for concurrent first-use callers
- close and clear the pool when a `tsent` command returns, including command-error paths
- close partially initialized pools when ping or dev-schema setup fails

## Context

This is a lifecycle follow-up to #2020 and #2022. The `SELECT * FROM assoc_edge_config` query discussed there is performed by the Go schema parser. That idle Go connection was not what kept the Node child alive, but the package-global pool was opened eagerly and had no explicit CLI shutdown owner.

With this change, commands such as `tsent --help` no longer require database configuration, real database access still initializes the pool on demand, and the CLI releases it deterministically when the command finishes.

## Validation

- `go test ./ent/config ./ent/data ./tsent/cmd -count=1`
- `go test -race ./ent/config ./ent/data ./tsent/cmd -count=1`
- 16 simultaneous `GenLoadAssocEdges` calls through `go run -race`
- `go vet ./ent/config ./ent/data ./tsent/cmd`
- `tsent --help` through `go run` with `DB_CONNECTION_STRING` unset and a deliberately missing database config path
- `go test ./... -count=1` reached and passed the codegen matrix; the overall run requires Postgres and had expected Postgres-only failures under the local SQLite fallback

Follow-up to #2020 and #2022.
