### PR TITLE
Fix dynamic import aliases in custom compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- rewrite path aliases in dynamic imports so compiled Node applications can
+  load deferred modules (#2027).
 - avoid opening the Go codegen database pool until first use and close it when
   `tsent` commands finish (#2024).
 - preserve trigger priority groups when individual triggers appear before and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 - rewrite path aliases in dynamic imports so compiled Node applications can
   load deferred modules, while preserving package resolution and explicit
-  dependency remappings (#2027).
+  dependency remappings when emitting into a different directory (#2027).
 - avoid opening the Go codegen database pool until first use and close it when
   `tsent` commands finish (#2024).
 - preserve trigger priority groups when individual triggers appear before and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
-- rewrite path aliases in dynamic imports so compiled Node applications can
-  load deferred modules with the correct runtime extensions, package resolution,
-  and dependency remappings when emitting into a different directory (#2027).
+- rewrite path aliases in dynamic imports so compiled Node applications load
+  deferred modules using TypeScript's selected targets and runtime extensions,
+  preserving package resolution and explicit dependency remappings outside
+  output directories (#2027).
 - avoid opening the Go codegen database pool until first use and close it when
   `tsent` commands finish (#2024).
 - preserve trigger priority groups when individual triggers appear before and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 ### Fixed
 
 - rewrite path aliases in dynamic imports so compiled Node applications can
-  load deferred modules, while preserving package resolution and explicit
-  dependency remappings when emitting into a different directory (#2027).
+  load deferred modules with the correct runtime extensions, package resolution,
+  and dependency remappings when emitting into a different directory (#2027).
 - avoid opening the Go codegen database pool until first use and close it when
   `tsent` commands finish (#2024).
 - preserve trigger priority groups when individual triggers appear before and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 ### Fixed
 
 - rewrite path aliases in dynamic imports so compiled Node applications can
-  load deferred modules, while preserving package imports mapped to declaration
-  files or installed dependencies (#2027).
+  load deferred modules, while preserving package resolution and explicit
+  dependency remappings (#2027).
 - avoid opening the Go codegen database pool until first use and close it when
   `tsent` commands finish (#2024).
 - preserve trigger priority groups when individual triggers appear before and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 ### Fixed
 
 - rewrite path aliases in dynamic imports so compiled Node applications can
-  load deferred modules (#2027).
+  load deferred modules, while preserving package imports mapped to declaration
+  files (#2027).
 - avoid opening the Go codegen database pool until first use and close it when
   `tsent` commands finish (#2024).
 - preserve trigger priority groups when individual triggers appear before and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 - rewrite path aliases in dynamic imports so compiled Node applications can
   load deferred modules, while preserving package imports mapped to declaration
-  files (#2027).
+  files or installed dependencies (#2027).
 - avoid opening the Go codegen database pool until first use and close it when
   `tsent` commands finish (#2024).
 - preserve trigger priority groups when individual triggers appear before and

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -907,6 +907,13 @@ features:
     mode: explicit
     rationale: Imported custom GraphQL enum types must not be serialized as scalars, and unused optional scalar helpers must not churn custom_schema.json.
 
+  - id: custom_compiler.dynamic_import_aliases
+    owns: []
+    mode: existing_test
+    test_refs:
+      - ts/src/scripts/custom_compiler.test.ts
+    rationale: The custom compiler must rewrite deferred path aliases in emitted JavaScript; focused CLI tests execute the compiled output in Node, including CommonJS privacy/model loading and ESNext output with explicit JS extensions and import options.
+
   - id: transform_write.struct_input_runtime
     owns: []
     mode: existing_test

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -1,0 +1,230 @@
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import ts from "typescript";
+
+let testRoot: string;
+let compiler: string;
+
+function write(root: string, name: string, contents: string) {
+  const file = path.join(root, name);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents);
+}
+
+beforeAll(() => {
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ent-custom-compiler-"));
+  const toolRoot = path.join(testRoot, "tool");
+  // Compile the CLI under test independently of dist so stale builds cannot pass.
+  for (const name of ["scripts/custom_compiler", "tsc/compilerOptions"]) {
+    const source = fs.readFileSync(
+      path.join(__dirname, "..", `${name}.ts`),
+      "utf8",
+    );
+    write(
+      toolRoot,
+      `${name}.js`,
+      ts.transpileModule(source, {
+        compilerOptions: {
+          module: ts.ModuleKind.CommonJS,
+          target: ts.ScriptTarget.ES2020,
+          esModuleInterop: true,
+        },
+      }).outputText,
+    );
+  }
+  fs.symlinkSync(
+    path.resolve(__dirname, "../../node_modules"),
+    path.join(toolRoot, "node_modules"),
+    "dir",
+  );
+  compiler = path.join(toolRoot, "scripts/custom_compiler.js");
+});
+
+afterAll(() => {
+  if (testRoot) {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+function fixture(
+  files: Record<string, string>,
+  options: Record<string, unknown> = {},
+  esm = false,
+) {
+  const root = fs.mkdtempSync(path.join(testRoot, "app-"));
+  write(
+    root,
+    "package.json",
+    JSON.stringify({ type: esm ? "module" : "commonjs" }),
+  );
+  write(
+    root,
+    "tsconfig.json",
+    JSON.stringify({
+      compilerOptions: {
+        module: esm ? "esnext" : "commonjs",
+        moduleResolution: "node",
+        target: "es2020",
+        rootDir: "src",
+        outDir: "dist",
+        baseUrl: ".",
+        paths: { "src/*": ["./src/*"], "*": ["*"] },
+        esModuleInterop: true,
+        skipLibCheck: true,
+        ...options,
+      },
+      include: ["src/**/*.ts"],
+    }),
+  );
+  for (const [name, contents] of Object.entries(files)) {
+    write(root, name, contents);
+  }
+  return root;
+}
+
+function compile(root: string) {
+  return spawnSync(process.execPath, [compiler], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 30000,
+  });
+}
+
+function run(root: string) {
+  const compiled = compile(root);
+  expect({
+    status: compiled.status,
+    stderr: compiled.stderr,
+    error: compiled.error,
+  }).toEqual({ status: 0, stderr: "", error: undefined });
+  const result = spawnSync(process.execPath, ["dist/main.js"], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 30000,
+  });
+  expect({
+    status: result.status,
+    stderr: result.stderr,
+    error: result.error,
+  }).toEqual({ status: 0, stderr: "", error: undefined });
+  return result.stdout.trim();
+}
+
+test("compiled CommonJS defers privacy/model aliases until the policy runs", () => {
+  const root = fixture({
+    "src/main.ts": `
+      import { Policy } from "src/privacy/policy";
+      import { events } from "src/state";
+      async function main() {
+        if (events.length) throw new Error("model loaded before privacy check");
+        const contact = await new Policy().apply();
+        console.log(JSON.stringify([contact.name, events]));
+      }
+      main().catch(error => { console.error(error); process.exitCode = 1; });
+    `,
+    "src/state.ts": `export const events: string[] = [];`,
+    "src/privacy/policy.ts": `
+      import type { Contact } from "src/ent";
+      export class Policy {
+        async apply(): Promise<Contact> {
+          const { Contact } = await import("src/ent");
+          return new Contact();
+        }
+      }
+    `,
+    "src/ent/index.ts": `
+      import { events } from "src/state";
+      events.push("model");
+      export class Contact { name = "Ada"; }
+    `,
+  });
+  expect(run(root)).toBe('["Ada",["model"]]');
+});
+
+test("compiled CommonJS rewrites literal aliases and preserves other module expressions", () => {
+  const root = fixture({
+    "src/main.ts": `
+      import assert from "node:assert/strict";
+      import { exported } from "src/exports";
+      async function main() {
+        const relative = "./foo";
+        const loader = { load: () => import("src/foo") };
+        assert.equal((await loader.load()).value, "foo");
+        assert.equal((await import(\`src/foo\`)).value, "foo");
+        assert.equal((await import("src/\\u0066oo")).value, "foo");
+        assert.equal((await import("src/foo.js")).value, "foo");
+        assert.equal((await import("./foo")).value, "foo");
+        assert.equal((await import(relative)).value, "foo");
+        assert.equal((await import(\`\${relative}\`)).value, "foo");
+        assert.equal((await import("node:path")).basename("a/b"), "b");
+        assert.equal((await import("src-extra/value")).value, "package");
+        assert.equal((await import("src.ts-package/value")).value, "package");
+        assert.equal((await import("src/.ts-cache/value")).value, "directory");
+        assert.equal(await (await import("src/contact/bar/loader")).load(), "file");
+        assert.equal(exported, "foo");
+        console.log("ok");
+      }
+      main().catch(error => { console.error(error); process.exitCode = 1; });
+    `,
+    "src/foo.ts": `export const value = "foo";`,
+    "src/exports.ts": `export { value as exported } from "src/foo"; export type { Type } from "src/types";`,
+    "src/types.ts": `throw new Error("type-only module loaded"); export interface Type { value: string }`,
+    "src/.ts-cache/value.ts": `export const value = "directory";`,
+    "src/contact.ts": `export const value = "file";`,
+    "src/contact/bar/loader.ts": `export async function load() { return (await import("src/contact")).value; }`,
+    "node_modules/src-extra/value.js": `exports.value = "package";`,
+    "node_modules/src.ts-package/value.js": `exports.value = "package";`,
+  });
+  expect(run(root)).toBe("ok");
+});
+
+test("ESNext output preserves explicit JS extensions and dynamic import options in Node ESM", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+      import assert from "node:assert/strict";
+      import { exported } from "src/exports.js";
+      import type { Type } from "src/types.js";
+      const load = () => import("src/foo.js");
+      assert.equal((await load()).value, exported);
+      assert.equal((await import("./foo.js")).value, "foo");
+      assert.equal((await import("node:path")).basename("a/b"), "b");
+      assert.equal((await import("src/data.json", { with: { type: "json" } })).default.value, "json");
+      assert.equal((await import("src/data.json", (await import("src/options.js")).options)).default.value, "json");
+      console.log("ok");
+    `,
+      "src/foo.ts": `export const value = "foo";`,
+      "src/exports.ts": `export { value as exported } from "src/foo.js"; export type { Type } from "src/types.js";`,
+      "src/types.ts": `throw new Error("type-only module loaded"); export interface Type { value: string }`,
+      "src/options.ts": `export const options = { with: { type: "json" } };`,
+      "src/data.json": `{"value":"json"}`,
+    },
+    { resolveJsonModule: true },
+    true,
+  );
+  expect(run(root)).toBe("ok");
+});
+
+test("does not rewrite imports without configured paths", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `import("./foo").then(mod => console.log(mod.value));`,
+      "src/foo.ts": `export const value = "relative";`,
+    },
+    { paths: undefined },
+  );
+  expect(run(root)).toBe("relative");
+});
+
+test("retains nonzero exit and error reporting when emit is skipped", () => {
+  const root = fixture(
+    { "src/main.ts": `const value: string = 42;` },
+    { noEmitOnError: true },
+  );
+  const result = compile(root);
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain("error emitting code");
+  expect(fs.existsSync(path.join(root, "dist/main.js"))).toBe(false);
+});

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -255,6 +255,36 @@ test("ESNext output preserves explicit JS extensions and dynamic import options 
 });
 
 test.each([
+  { outDir: undefined, absolute: false },
+  { outDir: "src", absolute: false },
+  { outDir: "src", absolute: true },
+])("loads in-place JSON aliases with outDir $outDir (absolute: $absolute)", ({
+  outDir,
+  absolute,
+}) => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+      import { value } from "src/data.json";
+      import { exported } from "./exports";
+      import("src/data.json").then(mod => console.log([value, exported, mod.value].join(",")));
+    `,
+      "src/exports.ts": 'export { value as exported } from "src/data.json";',
+      "src/data.json": '{"value":"json"}',
+    },
+    { outDir, resolveJsonModule: true },
+  );
+  if (absolute) {
+    const config = JSON.parse(
+      fs.readFileSync(path.join(root, "tsconfig.json"), "utf8"),
+    );
+    config.compilerOptions.outDir = path.join(root, "src");
+    write(root, "tsconfig.json", JSON.stringify(config));
+  }
+  expect(run(root, "src/main.js")).toBe("json,json,json");
+});
+
+test.each([
   { pattern: "vendor/*.js", target: "./src/*", specifier: "vendor/value.js" },
   {
     pattern: "alias/value.js",
@@ -552,6 +582,31 @@ test.each([
   expect(run(root, "dist/src/main.js")).toBe("modern,modern,modern");
 });
 
+test.each([
+  undefined,
+  "es5",
+])("uses the effective CommonJS default with target %s", (target) => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+      import { value } from "dep";
+      import { exported } from "./exports";
+      import("dep").then(mod => console.log([value, exported, mod.value].join(",")));
+    `,
+      "src/exports.ts": 'export { value as exported } from "dep";',
+      "node_modules/dep/package.json": JSON.stringify({
+        main: "legacy.js",
+        exports: "./modern.js",
+      }),
+      "node_modules/dep/legacy.js": 'exports.value = "legacy";',
+      "node_modules/dep/modern.js": 'exports.value = "modern";',
+    },
+    { module: undefined, target, paths: { dep: ["./node_modules/dep"] } },
+  );
+  fs.mkdirSync(path.join(root, "dist/node_modules/dep"), { recursive: true });
+  expect(run(root)).toBe("modern,modern,modern");
+});
+
 test("preserves CommonJS package exports through a symlink outside its root", () => {
   const root = fixture(
     {
@@ -631,6 +686,28 @@ test.each([
     { rootDir, outDir, paths: { "vendor/*": ["./node_modules/dep/*"] } },
   );
   expect(run(root, entry)).toBe("package,package,package");
+});
+
+test("composite aliases use the configured output directory", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+      import { value } from "alias/value";
+      import { exported } from "./exports";
+      import("alias/value").then(mod => console.log([value, exported, mod.value].join(",")));
+    `,
+      "src/exports.ts": 'export { value as exported } from "alias/value";',
+      "node_modules/dep/value.js": 'exports.value = "javascript";',
+    },
+    {
+      composite: true,
+      rootDir: undefined,
+      paths: { "alias/*": ["./node_modules/dep/*"] },
+    },
+  );
+  expect(run(root, "dist/src/main.js")).toBe(
+    "javascript,javascript,javascript",
+  );
 });
 
 test.each([
@@ -735,7 +812,14 @@ test.each([
   expect(run(root, "dist/src/main.js")).toBe("mapped,mapped,mapped");
 });
 
-test("ESNext explicit remapping does not substitute the package's import condition", () => {
+test.each([
+  { module: "esnext", target: "es2020" },
+  { module: undefined, target: "es2015" },
+  { module: undefined, target: "es2020" },
+])("ESM explicit remapping does not substitute the package's import condition (module: $module, target: $target)", ({
+  module,
+  target,
+}) => {
   const root = fixture(
     {
       "src/main.ts": `
@@ -752,7 +836,12 @@ test("ESNext explicit remapping does not substitute the package's import conditi
       "node_modules/dep/require.cjs": `exports.value = "mapped";`,
       "node_modules/dep/require.d.cts": `export declare const value: string;`,
     },
-    { rootDir: ".", paths: { dep: ["./node_modules/dep/require.cjs"] } },
+    {
+      module,
+      target,
+      rootDir: ".",
+      paths: { dep: ["./node_modules/dep/require.cjs"] },
+    },
     true,
   );
   expect(run(root, "dist/src/main.js")).toBe("mapped,mapped,mapped");

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -440,6 +440,45 @@ test.each([
 });
 
 test.each([
+  { packageName: "dep", esm: false },
+  { packageName: "dep", esm: true },
+  { packageName: "@scope/dep", esm: false },
+  { packageName: "@scope/dep", esm: true },
+])("preserves package exports with a trailing slash on $packageName (ESM: $esm)", ({
+  packageName,
+  esm,
+}) => {
+  const packageRoot = `node_modules/${packageName}`;
+  const root = fixture(
+    {
+      "src/main.ts": `
+      import { value } from "${packageName}";
+      import { exported } from "./exports.js";
+      import("${packageName}").then(mod => console.log([value, exported, mod.value].join(",")));
+    `,
+      "src/exports.ts": `export { value as exported } from "${packageName}";`,
+      [`${packageRoot}/package.json`]: JSON.stringify({
+        type: esm ? "module" : "commonjs",
+        main: "legacy.js",
+        exports: {
+          import: "./modern.js",
+          require: esm ? "./legacy.js" : "./modern.js",
+        },
+      }),
+      [`${packageRoot}/legacy.js`]: esm
+        ? 'export const value = "legacy";'
+        : 'exports.value = "legacy";',
+      [`${packageRoot}/modern.js`]: esm
+        ? 'export const value = "modern";'
+        : 'exports.value = "modern";',
+    },
+    { rootDir: ".", paths: { [packageName]: [`./${packageRoot}/`] } },
+    esm,
+  );
+  expect(run(root, "dist/src/main.js")).toBe("modern,modern,modern");
+});
+
+test.each([
   { esm: false, outDir: undefined, entry: "src/main.js" },
   { esm: false, outDir: "dist", entry: "dist/main.js" },
   { esm: true, outDir: "dist", entry: "dist/main.js" },
@@ -645,6 +684,22 @@ test.each([
     packageName: "dep",
     runtime: "value/impl.js",
     esm: false,
+  },
+  {
+    specifier: "dep/value",
+    pattern: "dep/value",
+    target: "./node_modules/dep/value/",
+    packageName: "dep",
+    runtime: "value/index.js",
+    esm: false,
+  },
+  {
+    specifier: "dep/value",
+    pattern: "dep/value",
+    target: "./node_modules/dep/value/",
+    packageName: "dep",
+    runtime: "value/index.js",
+    esm: true,
   },
 ])("applies explicit package subpath remapping from $specifier to $target", ({
   specifier,

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -480,6 +480,63 @@ test.each([
   expect(run(root, entry)).toBe("mapped,mapped,mapped");
 });
 
+test.each([
+  { subpath: "", unrelatedEntry: false },
+  { subpath: "/value", unrelatedEntry: true },
+])("skips a nearer CommonJS package without the requested entry: dep$subpath", ({
+  subpath,
+  unrelatedEntry,
+}) => {
+  const specifier = `dep${subpath}`;
+  const root = fixture(
+    {
+      "src/main.ts": `
+      import { value } from "${specifier}";
+      import { exported } from "./exports";
+      import("${specifier}").then(mod => console.log([value, exported, mod.value].join(",")));
+    `,
+      "src/exports.ts": `export { value as exported } from "${specifier}";`,
+      "node_modules/dep/package.json": JSON.stringify({
+        main: "legacy.js",
+        exports: { ".": "./modern.js", "./value": "./modern.js" },
+      }),
+      "node_modules/dep/legacy.js": 'exports.value = "legacy";',
+      "node_modules/dep/value.js": 'exports.value = "legacy";',
+      "node_modules/dep/modern.js": 'exports.value = "modern";',
+      ...(unrelatedEntry
+        ? { "dist/node_modules/dep/index.js": 'exports.value = "unrelated";' }
+        : {}),
+    },
+    { rootDir: ".", paths: { [specifier]: [`./node_modules/${specifier}`] } },
+  );
+  fs.mkdirSync(path.join(root, "dist/node_modules/dep"), { recursive: true });
+  expect(run(root, "dist/src/main.js")).toBe("modern,modern,modern");
+});
+
+test("preserves CommonJS package exports through a symlink outside its root", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+      import { value } from "dep";
+      import("dep").then(mod => console.log([value, mod.value].join(",")));
+    `,
+      "node_modules/dep/package.json": JSON.stringify({
+        main: "legacy.js",
+        exports: "./linked/modern.js",
+      }),
+      "node_modules/dep/legacy.js": 'exports.value = "legacy";',
+      "linked-build/modern.js": 'exports.value = "modern";',
+    },
+    { paths: { dep: ["./node_modules/dep"] } },
+  );
+  fs.symlinkSync(
+    path.join(root, "linked-build"),
+    path.join(root, "node_modules/dep/linked"),
+    "dir",
+  );
+  expect(run(root)).toBe("modern,modern");
+});
+
 test("preserves native ESM import conditions for the mapped package installation", () => {
   const root = fixture(
     {
@@ -898,16 +955,68 @@ test.each([
   expect(run(root)).toBe("mapped");
 });
 
-test("uses moduleSuffixes for JavaScript outside the emitted sources", () => {
+test.each([
+  { declarations: false, plainFile: true },
+  { declarations: true, plainFile: true },
+  { declarations: true, plainFile: false },
+])("uses moduleSuffixes for external JavaScript (declarations: $declarations, plain file: $plainFile)", ({
+  declarations,
+  plainFile,
+}) => {
   const root = fixture(
     {
-      "src/main.ts": `import("vendor/value").then(mod => console.log(mod.value));`,
+      "src/main.ts": `
+        import { value } from "vendor/value";
+        import { exported } from "./exports";
+        import("vendor/value").then(mod => console.log([value, exported, mod.value].join(",")));
+      `,
+      "src/exports.ts": 'export { value as exported } from "vendor/value";',
       "vendor/value.native.js": 'exports.value = "native-js";',
-      "vendor/value.js": 'exports.value = "wrong-default";',
+      ...(plainFile
+        ? { "vendor/value.js": 'exports.value = "wrong-default";' }
+        : {}),
+      ...(declarations
+        ? { "vendor/value.native.d.ts": "export declare const value: string;" }
+        : {}),
     },
     { paths: { "vendor/*": ["./vendor/*"] }, moduleSuffixes: [".native", ""] },
   );
-  expect(run(root)).toBe("native-js");
+  expect(run(root)).toBe("native-js,native-js,native-js");
+});
+
+test("moduleSuffixes preserve explicit declaration-only mappings", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `import("vendor/value").then(mod => console.log(mod.value));`,
+      "vendor/value.native.d.ts": "export declare const value: string;",
+      "vendor/value.native.js": 'exports.value = "wrong-local";',
+      "node_modules/vendor/value.js": 'exports.value = "package";',
+    },
+    {
+      paths: { "vendor/*": ["./vendor/*.native.d.ts"] },
+      moduleSuffixes: [".native", ""],
+    },
+  );
+  expect(run(root)).toBe("package");
+});
+
+test("moduleSuffixes use package main when companion types live elsewhere", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `import("vendor/dep").then(mod => console.log(mod.value));`,
+      "vendor/dep/package.json": JSON.stringify({
+        types: "types/index.d.ts",
+        main: "lib/entry.js",
+      }),
+      "vendor/dep/types/index.d.ts": "export declare const value: string;",
+      "vendor/dep/types/index.native.js":
+        'exports.value = "wrong-types-companion";',
+      "vendor/dep/types/index.js": 'exports.value = "wrong-types-companion";',
+      "vendor/dep/lib/entry.js": 'exports.value = "runtime-main";',
+    },
+    { paths: { "vendor/*": ["./vendor/*"] }, moduleSuffixes: [".native", ""] },
+  );
+  expect(run(root)).toBe("runtime-main");
 });
 
 test("retains nonzero exit and error reporting when emit is skipped", () => {

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -254,6 +254,35 @@ test("ESNext output preserves explicit JS extensions and dynamic import options 
   expect(run(root)).toBe("ok");
 });
 
+test.each([
+  { pattern: "vendor/*.js", target: "./src/*", specifier: "vendor/value.js" },
+  {
+    pattern: "alias/value.js",
+    target: "./src/value.ts",
+    specifier: "alias/value.js",
+  },
+])("preserves an explicit ESM extension when $pattern maps to $target", ({
+  pattern,
+  target,
+  specifier,
+}) => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+      import { value } from "${specifier}";
+      import { exported } from "./exports.js";
+      const dynamic = await import("${specifier}");
+      console.log([value, exported, dynamic.value].join(","));
+    `,
+      "src/exports.ts": `export { value as exported } from "${specifier}";`,
+      "src/value.ts": 'export const value = "mapped";',
+    },
+    { paths: { [pattern]: [target] } },
+    true,
+  );
+  expect(run(root)).toBe("mapped,mapped,mapped");
+});
+
 test("does not rewrite imports without configured paths", () => {
   const root = fixture(
     {

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -219,16 +219,48 @@ test("does not rewrite imports without configured paths", () => {
 });
 
 test.each([
-  { extension: "d.ts", pattern: "dep", specifier: "dep", esm: false },
-  { extension: "d.mts", pattern: "dep", specifier: "dep", esm: true },
-  { extension: "d.cts", pattern: "dep/*", specifier: "dep/value", esm: false },
-])("preserves package imports mapped to $extension declarations ($pattern)", ({
-  extension,
+  {
+    target: "./types/dep.d.ts",
+    declaration: "types/dep.d.ts",
+    pattern: "dep",
+    specifier: "dep",
+    esm: false,
+  },
+  {
+    target: "./types/dep.d.mts",
+    declaration: "types/dep.d.mts",
+    pattern: "dep",
+    specifier: "dep",
+    esm: true,
+  },
+  {
+    target: "./types/*.d.cts",
+    declaration: "types/value.d.cts",
+    pattern: "dep/*",
+    specifier: "dep/value",
+    esm: false,
+  },
+  {
+    target: "./types/dep",
+    declaration: "types/dep.d.ts",
+    pattern: "dep",
+    specifier: "dep",
+    esm: false,
+  },
+  {
+    target: "./types/dep",
+    declaration: "types/dep/index.d.ts",
+    pattern: "dep",
+    specifier: "dep",
+    esm: false,
+  },
+])("preserves package imports when $target resolves to $declaration", ({
+  target,
+  declaration,
   pattern,
   specifier,
   esm,
 }) => {
-  const declarationName = pattern.includes("*") ? "value" : "dep";
   const root = fixture(
     {
       "src/main.ts": `
@@ -244,7 +276,7 @@ test.each([
           main().catch(error => { console.error(error); process.exitCode = 1; });
         `,
       "src/exports.ts": `export { value as exported } from "${specifier}";`,
-      [`types/${declarationName}.${extension}`]: `export declare const value: string;`,
+      [declaration]: `export declare const value: string;`,
       "node_modules/dep/package.json": JSON.stringify({
         type: esm ? "module" : "commonjs",
         exports: { ".": "./index.js", "./value": "./index.js" },
@@ -254,15 +286,36 @@ test.each([
         : `exports.value = "package";`,
     },
     {
-      paths: {
-        [pattern]: [
-          pattern.includes("*")
-            ? `./types/*.${extension}`
-            : `./types/dep.${extension}`,
-        ],
-      },
+      paths: { [pattern]: [target] },
     },
     esm,
+  );
+  expect(run(root)).toBe("ok");
+});
+
+test("rewrites aliases to JavaScript modules with companion declarations", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+        import assert from "node:assert/strict";
+        import { value } from "vendor/dep.js";
+        import { exported } from "./exports.js";
+        async function main() {
+          assert.equal(value, "javascript");
+          assert.equal(exported, "javascript");
+          assert.equal((await import("vendor/dep.js")).value, "javascript");
+          assert.equal((await import("vendor/directory")).value, "directory");
+          console.log("ok");
+        }
+        main().catch(error => { console.error(error); process.exitCode = 1; });
+      `,
+      "src/exports.ts": `export { value as exported } from "vendor/dep.js";`,
+      "vendor/dep.js": `exports.value = "javascript";`,
+      "vendor/dep.d.ts": `export declare const value: string;`,
+      "vendor/directory/index.js": `exports.value = "directory";`,
+      "vendor/directory/index.d.ts": `export declare const value: string;`,
+    },
+    { paths: { "vendor/*": ["./vendor/*"] } },
   );
   expect(run(root)).toBe("ok");
 });

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -218,6 +218,55 @@ test("does not rewrite imports without configured paths", () => {
   expect(run(root)).toBe("relative");
 });
 
+test.each([
+  { extension: "d.ts", pattern: "dep", specifier: "dep", esm: false },
+  { extension: "d.mts", pattern: "dep", specifier: "dep", esm: true },
+  { extension: "d.cts", pattern: "dep/*", specifier: "dep/value", esm: false },
+])("preserves package imports mapped to $extension declarations ($pattern)", ({
+  extension,
+  pattern,
+  specifier,
+  esm,
+}) => {
+  const declarationName = pattern.includes("*") ? "value" : "dep";
+  const root = fixture(
+    {
+      "src/main.ts": `
+          import assert from "node:assert/strict";
+          import { value } from "${specifier}";
+          import { exported } from "./exports.js";
+          async function main() {
+            assert.equal(value, "package");
+            assert.equal(exported, "package");
+            assert.equal((await import("${specifier}")).value, "package");
+            console.log("ok");
+          }
+          main().catch(error => { console.error(error); process.exitCode = 1; });
+        `,
+      "src/exports.ts": `export { value as exported } from "${specifier}";`,
+      [`types/${declarationName}.${extension}`]: `export declare const value: string;`,
+      "node_modules/dep/package.json": JSON.stringify({
+        type: esm ? "module" : "commonjs",
+        exports: { ".": "./index.js", "./value": "./index.js" },
+      }),
+      "node_modules/dep/index.js": esm
+        ? `export const value = "package";`
+        : `exports.value = "package";`,
+    },
+    {
+      paths: {
+        [pattern]: [
+          pattern.includes("*")
+            ? `./types/*.${extension}`
+            : `./types/dep.${extension}`,
+        ],
+      },
+    },
+    esm,
+  );
+  expect(run(root)).toBe("ok");
+});
+
 test("retains nonzero exit and error reporting when emit is skipped", () => {
   const root = fixture(
     { "src/main.ts": `const value: string = 42;` },

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -363,7 +363,23 @@ test.each([
   expect(run(root, "dist/src/main.js")).toBe("ok");
 });
 
-test("rewrites aliases that rename an installed dependency", () => {
+test.each([
+  { rootDir: "src", outDir: "dist", entry: "dist/main.js" },
+  { rootDir: ".", outDir: "dist", entry: "dist/src/main.js" },
+  { rootDir: undefined, outDir: "build/js", entry: "build/js/main.js" },
+  { rootDir: "src", outDir: undefined, entry: "src/main.js" },
+  {
+    rootDir: undefined,
+    outDir: "build/js",
+    entry: "build/js/src/main.js",
+    extraSource: true,
+  },
+])("rewrites renamed dependencies with rootDir $rootDir and outDir $outDir", ({
+  rootDir,
+  outDir,
+  entry,
+  extraSource,
+}) => {
   const root = fixture(
     {
       "src/main.ts": `
@@ -374,10 +390,38 @@ test("rewrites aliases that rename an installed dependency", () => {
       "src/exports.ts": `export { value as exported } from "vendor/value";`,
       "node_modules/dep/value.js": `exports.value = "package";`,
       "node_modules/dep/value.d.ts": `export declare const value: string;`,
+      ...(extraSource ? { "scripts/extra.ts": "export const value = 1;" } : {}),
     },
-    { paths: { "vendor/*": ["./node_modules/dep/*"] } },
+    { rootDir, outDir, paths: { "vendor/*": ["./node_modules/dep/*"] } },
   );
-  expect(run(root)).toBe("package,package,package");
+  expect(run(root, entry)).toBe("package,package,package");
+});
+
+test.each([
+  "index",
+  "index.js",
+  "lib/entry",
+])("preserves equivalent package entry mapping to dep/%s", (entry) => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+          import { value } from "dep";
+          import { exported } from "./exports";
+          import("dep").then(mod => console.log([value, exported, mod.value].join(",")));
+        `,
+      "src/exports.ts": `export { value as exported } from "dep";`,
+      "node_modules/dep/package.json": JSON.stringify({
+        main: entry.endsWith(".js") ? entry : `${entry}.js`,
+      }),
+      [`node_modules/dep/${entry.endsWith(".js") ? entry : `${entry}.js`}`]: `exports.value = "package";`,
+      "node_modules/@types/dep/index.d.ts": `export declare const value: string;`,
+    },
+    { rootDir: ".", paths: { dep: [`./node_modules/dep/${entry}`] } },
+  );
+  expect(run(root, "dist/src/main.js")).toBe("package,package,package");
+  expect(
+    fs.readFileSync(path.join(root, "dist/src/main.js"), "utf8"),
+  ).toContain('require("dep")');
 });
 
 test.each([
@@ -433,10 +477,48 @@ test.each([
         : `exports.value = "mapped";`,
       [`${packageRoot}/${runtime.replace(/\.js$/, ".d.ts")}`]: `export declare const value: string;`,
     },
-    { paths: { [pattern]: [target] } },
+    { rootDir: ".", paths: { [pattern]: [target] } },
     esm,
   );
-  expect(run(root)).toBe("mapped,mapped,mapped");
+  expect(run(root, "dist/src/main.js")).toBe("mapped,mapped,mapped");
+});
+
+test("ESNext explicit remapping does not substitute the package's import condition", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+        import { value } from "dep";
+        import { exported } from "./exports.js";
+        import("dep").then(mod => console.log([value, exported, mod.value].join(",")));
+      `,
+      "src/exports.ts": `export { value as exported } from "dep";`,
+      "node_modules/dep/package.json": JSON.stringify({
+        type: "module",
+        exports: { import: "./import.js", require: "./require.cjs" },
+      }),
+      "node_modules/dep/import.js": `export const value = "original";`,
+      "node_modules/dep/require.cjs": `exports.value = "mapped";`,
+      "node_modules/dep/require.d.cts": `export declare const value: string;`,
+    },
+    { rootDir: ".", paths: { dep: ["./node_modules/dep/require.cjs"] } },
+    true,
+  );
+  expect(run(root, "dist/src/main.js")).toBe("mapped,mapped,mapped");
+});
+
+test.each([
+  false,
+  true,
+])("resolves JavaScript aliases with allowJs %s after moving the importer", (allowJs) => {
+  const root = fixture(
+    {
+      "src/main.ts": `import { value } from "vendor/value"; console.log(value);`,
+      "vendor/value.js": `exports.value = "javascript";`,
+    },
+    { rootDir: ".", allowJs, paths: { "vendor/*": ["./vendor/*"] } },
+  );
+  expect(run(root, "dist/src/main.js")).toBe("javascript");
+  expect(fs.existsSync(path.join(root, "dist/vendor/value.js"))).toBe(allowJs);
 });
 
 test("rewrites aliases to JavaScript modules with companion declarations", () => {
@@ -464,6 +546,18 @@ test("rewrites aliases to JavaScript modules with companion declarations", () =>
     { paths: { "vendor/*": ["./vendor/*"] } },
   );
   expect(run(root)).toBe("ok");
+});
+
+test("prefers emitted TypeScript over existing JavaScript beside the source", () => {
+  const root = fixture({
+    "src/main.ts": `
+      import { value } from "src/value.js";
+      import("src/value").then(mod => console.log([value, mod.value].join(",")));
+    `,
+    "src/value.ts": `export const value = "compiled";`,
+    "src/value.js": `exports.value = "stale";`,
+  });
+  expect(run(root)).toBe("compiled,compiled");
 });
 
 test("retains nonzero exit and error reporting when emit is skipped", () => {

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -143,6 +143,53 @@ test("compiled CommonJS defers privacy/model aliases until the policy runs", () 
   expect(run(root)).toBe('["Ada",["model"]]');
 });
 
+test.each([
+  {
+    jsx: "react",
+    esm: false,
+    target: "./src/*.tsx",
+    specifier: "views/component",
+  },
+  {
+    jsx: "react",
+    esm: true,
+    target: "./src/*.tsx",
+    specifier: "views/component",
+  },
+  {
+    jsx: "react",
+    esm: false,
+    target: "./src/*",
+    specifier: "views/component.tsx",
+  },
+  {
+    jsx: "preserve",
+    esm: false,
+    target: "./src/*.tsx",
+    specifier: "views/component",
+  },
+])("uses the emitted TSX extension for $specifier (jsx: $jsx, ESM: $esm)", ({
+  jsx,
+  esm,
+  target,
+  specifier,
+}) => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+        import { value } from "${specifier}";
+        import { exported } from "./exports.js";
+        import("${specifier}").then(mod => console.log([value, exported, mod.value].join(",")));
+      `,
+      "src/exports.ts": `export { value as exported } from "${specifier}";`,
+      "src/component.tsx": `export const value = "tsx";`,
+    },
+    { jsx, paths: { "views/*": [target] } },
+    esm,
+  );
+  expect(run(root)).toBe("tsx,tsx,tsx");
+});
+
 test("compiled CommonJS rewrites literal aliases and preserves other module expressions", () => {
   const root = fixture({
     "src/main.ts": `
@@ -361,6 +408,70 @@ test.each([
     esm,
   );
   expect(run(root, "dist/src/main.js")).toBe("ok");
+});
+
+test.each([
+  { esm: false, outDir: undefined, entry: "src/main.js" },
+  { esm: false, outDir: "dist", entry: "dist/main.js" },
+  { esm: true, outDir: "dist", entry: "dist/main.js" },
+])("loads the mapped nested package installation (ESM: $esm, outDir: $outDir)", ({
+  esm,
+  outDir,
+  entry,
+}) => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+        import { value } from "dep/value";
+        import { exported } from "./exports.js";
+        import("dep/value").then(mod => console.log([value, exported, mod.value].join(",")));
+      `,
+      "src/exports.ts": `export { value as exported } from "dep/value";`,
+      "node_modules/dep/package.json": JSON.stringify({
+        type: esm ? "module" : "commonjs",
+        exports: { "./value": "./value.js" },
+      }),
+      "node_modules/dep/value.js": esm
+        ? `export const value = "top-level";`
+        : `exports.value = "top-level";`,
+      "node_modules/vendor/node_modules/dep/package.json": JSON.stringify({
+        type: esm ? "module" : "commonjs",
+      }),
+      "node_modules/vendor/node_modules/dep/value.js": esm
+        ? `export const value = "mapped";`
+        : `exports.value = "mapped";`,
+      "node_modules/vendor/node_modules/dep/value.d.ts": `export declare const value: string;`,
+    },
+    {
+      outDir,
+      paths: { "dep/*": ["./node_modules/vendor/node_modules/dep/*"] },
+    },
+    esm,
+  );
+  expect(run(root, entry)).toBe("mapped,mapped,mapped");
+});
+
+test("preserves native ESM import conditions for the mapped package installation", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+        import { value } from "dep/value";
+        import { exported } from "./exports.js";
+        import("dep/value").then(mod => console.log([value, exported, mod.value].join(",")));
+      `,
+      "src/exports.ts": `export { value as exported } from "dep/value";`,
+      "node_modules/dep/package.json": JSON.stringify({
+        type: "module",
+        exports: { "./value": { import: "./import.js" } },
+      }),
+      "node_modules/dep/import.js": `export const value = "import";`,
+      "node_modules/dep/value.js": `export const value = "physical";`,
+      "node_modules/dep/value.d.ts": `export declare const value: string;`,
+    },
+    { paths: { "dep/*": ["./node_modules/dep/*"] } },
+    true,
+  );
+  expect(run(root)).toBe("import,import,import");
 });
 
 test.each([

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -294,12 +294,19 @@ test.each([
 });
 
 test.each([
-  { packageName: "dep", subpath: "", declarations: true, esm: false },
-  { packageName: "dep", subpath: "", declarations: false, esm: false },
+  { packageName: "dep", subpath: "", declarations: "bundled", esm: false },
+  { packageName: "dep", subpath: "", declarations: "none", esm: false },
+  { packageName: "dep", subpath: "", declarations: "separate", esm: false },
   {
     packageName: "@scope/dep",
     subpath: "/value",
-    declarations: true,
+    declarations: "bundled",
+    esm: true,
+  },
+  {
+    packageName: "@scope/dep",
+    subpath: "/value",
+    declarations: "separate",
     esm: true,
   },
 ])("preserves node_modules mappings for $packageName$subpath (declarations: $declarations, ESM: $esm)", ({
@@ -311,6 +318,10 @@ test.each([
   const specifier = packageName + subpath;
   const pattern = packageName + (subpath ? "/*" : "");
   const packageRoot = `node_modules/${packageName}`;
+  const declarationRoot =
+    declarations === "separate"
+      ? `node_modules/@types/${packageName.replace(/^@/, "").replace("/", "__")}`
+      : packageRoot;
   const root = fixture(
     {
       "src/main.ts": `
@@ -329,7 +340,7 @@ test.each([
       [`${packageRoot}/package.json`]: JSON.stringify({
         type: esm ? "module" : "commonjs",
         main: "index.js",
-        ...(declarations ? { types: "index.d.ts" } : {}),
+        ...(declarations === "bundled" ? { types: "index.d.ts" } : {}),
         exports: { ".": "./index.js", "./value": "./index.js" },
       }),
       [`${packageRoot}/index.js`]: esm
@@ -339,10 +350,10 @@ test.each([
       [`${packageRoot}/value.js`]: esm
         ? `export const value = "mapped-file";`
         : `exports.value = "mapped-file";`,
-      ...(declarations
+      ...(declarations !== "none"
         ? {
-            [`${packageRoot}/index.d.ts`]: `export declare const value: string;`,
-            [`${packageRoot}/value.d.ts`]: `export declare const value: string;`,
+            [`${declarationRoot}/index.d.ts`]: `export declare const value: string;`,
+            [`${declarationRoot}/value.d.ts`]: `export declare const value: string;`,
           }
         : {}),
     },
@@ -367,6 +378,65 @@ test("rewrites aliases that rename an installed dependency", () => {
     { paths: { "vendor/*": ["./node_modules/dep/*"] } },
   );
   expect(run(root)).toBe("package,package,package");
+});
+
+test.each([
+  {
+    specifier: "dep/value",
+    pattern: "dep/*",
+    target: "./node_modules/dep/lib/*",
+    packageName: "dep",
+    runtime: "lib/value.js",
+    esm: false,
+  },
+  {
+    specifier: "@scope/dep/value.js",
+    pattern: "@scope/dep/*",
+    target: "./node_modules/@scope/dep/lib/*",
+    packageName: "@scope/dep",
+    runtime: "lib/value.js",
+    esm: true,
+  },
+  {
+    specifier: "dep/value",
+    pattern: "dep/value",
+    target: "./node_modules/dep/value/impl.js",
+    packageName: "dep",
+    runtime: "value/impl.js",
+    esm: false,
+  },
+])("applies explicit package subpath remapping from $specifier to $target", ({
+  specifier,
+  pattern,
+  target,
+  packageName,
+  runtime,
+  esm,
+}) => {
+  const packageRoot = `node_modules/${packageName}`;
+  const root = fixture(
+    {
+      "src/main.ts": `
+        import { value } from "${specifier}";
+        import { exported } from "./exports.js";
+        import("${specifier}").then(mod => console.log([value, exported, mod.value].join(",")));
+      `,
+      "src/exports.ts": `export { value as exported } from "${specifier}";`,
+      [`${packageRoot}/package.json`]: JSON.stringify({
+        type: esm ? "module" : "commonjs",
+      }),
+      [`${packageRoot}/value.js`]: esm
+        ? `export const value = "original";`
+        : `exports.value = "original";`,
+      [`${packageRoot}/${runtime}`]: esm
+        ? `export const value = "mapped";`
+        : `exports.value = "mapped";`,
+      [`${packageRoot}/${runtime.replace(/\.js$/, ".d.ts")}`]: `export declare const value: string;`,
+    },
+    { paths: { [pattern]: [target] } },
+    esm,
+  );
+  expect(run(root)).toBe("mapped,mapped,mapped");
 });
 
 test("rewrites aliases to JavaScript modules with companion declarations", () => {

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -671,6 +671,216 @@ test("prefers emitted TypeScript over existing JavaScript beside the source", ()
   expect(run(root)).toBe("compiled,compiled");
 });
 
+test.each<{
+  name: string;
+  paths: Record<string, string[]>;
+  files: Record<string, string>;
+  expected: string;
+  dynamicOnly?: boolean;
+  esm?: boolean;
+}>([
+  {
+    name: "absent first fallback in a dynamic import",
+    paths: { "dep/*": ["./overrides/*", "./node_modules/dep/*"] },
+    files: {},
+    expected: "package",
+    dynamicOnly: true,
+  },
+  {
+    name: "valid first JavaScript override",
+    paths: { "dep/*": ["./overrides/*", "./node_modules/dep/*"] },
+    files: { "overrides/value.js": 'exports.value = "override";' },
+    expected: "override",
+  },
+  {
+    name: "third fallback after two missing candidates",
+    paths: {
+      "dep/*": ["./missing/*", "./also-missing/*", "./node_modules/dep/*"],
+    },
+    files: {},
+    expected: "package",
+  },
+  {
+    name: "normal package lookup after all mappings fail",
+    paths: { "dep/*": ["./overrides/*"] },
+    files: {},
+    expected: "package",
+  },
+  {
+    name: "later TypeScript source before an earlier JavaScript candidate",
+    paths: { "dep/*": ["./overrides/*", "./src/typed/*"] },
+    files: {
+      "overrides/value.js": 'exports.value = "wrong-js";',
+      "src/typed/value.ts": 'export const value = "typed";',
+    },
+    expected: "typed",
+  },
+  {
+    name: "later declarations before an earlier JavaScript candidate",
+    paths: { "dep/*": ["./overrides/*", "./types/*", "./src/typed/*"] },
+    files: {
+      "overrides/value.js": 'exports.value = "wrong-js";',
+      "types/value.d.ts": "export declare const value: string;",
+      "src/typed/value.ts": 'export const value = "wrong-ts";',
+    },
+    expected: "package",
+  },
+  {
+    name: "explicit declarations before a runtime candidate",
+    paths: { "dep/*": ["./types/*.d.ts", "./overrides/*"] },
+    files: {
+      "types/value.d.ts": "export declare const value: string;",
+      "overrides/value.js": 'exports.value = "wrong-js";',
+    },
+    expected: "package",
+  },
+  {
+    name: "exact pattern before an earlier wildcard",
+    paths: {
+      "dep/*": ["./overrides/*"],
+      "dep/value": ["./node_modules/dep/value"],
+    },
+    files: { "overrides/value.js": 'exports.value = "wrong-pattern";' },
+    expected: "package",
+  },
+  {
+    name: "longest prefix before an earlier wildcard",
+    paths: { "dep/*": ["./overrides/*"], "dep/v*": ["./node_modules/dep/v*"] },
+    files: { "overrides/value.js": 'exports.value = "wrong-pattern";' },
+    expected: "package",
+  },
+  {
+    name: "normal lookup instead of a less-specific pattern",
+    paths: { "dep/*": ["./overrides/*"], "dep/value": ["./missing/value"] },
+    files: { "overrides/value.js": 'exports.value = "wrong-pattern";' },
+    expected: "package",
+  },
+  {
+    name: "native ESM exports after a missing fallback",
+    paths: { "dep/*": ["./overrides/*", "./node_modules/dep/*"] },
+    files: {},
+    expected: "package",
+    esm: true,
+  },
+])("follows TypeScript mapping selection: $name", ({
+  paths,
+  files,
+  expected,
+  dynamicOnly,
+  esm = false,
+}) => {
+  const root = fixture(
+    {
+      "src/main.ts": dynamicOnly
+        ? `import("dep/value").then(mod => console.log(mod.value));`
+        : `
+          import { value } from "dep/value";
+          import { exported } from "./exports.js";
+          import("dep/value").then(mod => console.log([value, exported, mod.value].join(",")));
+        `,
+      "src/exports.ts": 'export { value as exported } from "dep/value";',
+      "node_modules/dep/package.json": JSON.stringify({
+        type: esm ? "module" : "commonjs",
+        exports: { "./value": esm ? { import: "./import.js" } : "./value.js" },
+      }),
+      "node_modules/dep/value.js": esm
+        ? 'export const value = "physical";'
+        : 'exports.value = "package";',
+      "node_modules/dep/import.js": 'export const value = "package";',
+      ...files,
+    },
+    { rootDir: ".", paths },
+    esm,
+  );
+  expect(run(root, "dist/src/main.js")).toBe(
+    dynamicOnly ? expected : [expected, expected, expected].join(","),
+  );
+});
+
+test.each([
+  true,
+  false,
+])("uses the resolved directory entry with an index decoy: %s", (indexDecoy) => {
+  const root = fixture({
+    "src/main.ts": `
+      import { value } from "src/dep";
+      import { exported } from "./exports";
+      import("src/dep").then(mod => console.log([value, exported, mod.value].join(",")));
+    `,
+    "src/exports.ts": 'export { value as exported } from "src/dep";',
+    "src/dep/package.json": JSON.stringify({ main: "lib/value.js" }),
+    "src/dep/lib/value.ts": 'export const value = "selected-main";',
+    ...(indexDecoy
+      ? { "src/dep/index.ts": 'export const value = "wrong-index";' }
+      : {}),
+  });
+  expect(run(root)).toBe("selected-main,selected-main,selected-main");
+});
+
+test("uses the emitted JSX extension for an extensionless TSX alias", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `import("src/component").then(mod => console.log(mod.value));`,
+      "src/component.tsx": 'export const value = "jsx-output";',
+    },
+    { jsx: "preserve" },
+  );
+  expect(run(root)).toBe("jsx-output");
+});
+
+test("uses the source selected by moduleSuffixes", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `import("src/value").then(mod => console.log(mod.value));`,
+      "src/value.native.ts": 'export const value = "native";',
+      "src/value.ts": 'export const value = "wrong-default";',
+    },
+    { moduleSuffixes: [".native", ""] },
+  );
+  expect(run(root)).toBe("native");
+});
+
+test.each([
+  false,
+  true,
+])("rewrites an empty wildcard match with a sibling file: %s", (sibling) => {
+  const root = fixture(
+    {
+      "src/main.ts": `import("src/").then(mod => console.log(mod.value));`,
+      "src/index.ts": 'export const value = "empty-match";',
+      ...(sibling ? { "src.ts": 'export const value = "wrong-file";' } : {}),
+    },
+    { rootDir: "." },
+  );
+  expect(run(root, "dist/src/main.js")).toBe("empty-match");
+});
+
+test.each([
+  "./src",
+  undefined,
+])("resolves path mappings with baseUrl %s", (baseUrl) => {
+  const root = fixture(
+    {
+      "src/main.ts": `import("alias/value").then(mod => console.log(mod.value));`,
+      "src/value.ts": 'export const value = "mapped";',
+    },
+    { baseUrl, paths: { "alias/*": [baseUrl ? "./*" : "./src/*"] } },
+  );
+  expect(run(root)).toBe("mapped");
+});
+
+test("uses moduleSuffixes for JavaScript outside the emitted sources", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `import("vendor/value").then(mod => console.log(mod.value));`,
+      "vendor/value.native.js": 'exports.value = "native-js";',
+      "vendor/value.js": 'exports.value = "wrong-default";',
+    },
+    { paths: { "vendor/*": ["./vendor/*"] }, moduleSuffixes: [".native", ""] },
+  );
+  expect(run(root)).toBe("native-js");
+});
+
 test("retains nonzero exit and error reporting when emit is skipped", () => {
   const root = fixture(
     { "src/main.ts": `const value: string = 42;` },

--- a/ts/src/scripts/custom_compiler.test.ts
+++ b/ts/src/scripts/custom_compiler.test.ts
@@ -92,14 +92,14 @@ function compile(root: string) {
   });
 }
 
-function run(root: string) {
+function run(root: string, entry = "dist/main.js") {
   const compiled = compile(root);
   expect({
     status: compiled.status,
     stderr: compiled.stderr,
     error: compiled.error,
   }).toEqual({ status: 0, stderr: "", error: undefined });
-  const result = spawnSync(process.execPath, ["dist/main.js"], {
+  const result = spawnSync(process.execPath, [entry], {
     cwd: root,
     encoding: "utf8",
     timeout: 30000,
@@ -291,6 +291,82 @@ test.each([
     esm,
   );
   expect(run(root)).toBe("ok");
+});
+
+test.each([
+  { packageName: "dep", subpath: "", declarations: true, esm: false },
+  { packageName: "dep", subpath: "", declarations: false, esm: false },
+  {
+    packageName: "@scope/dep",
+    subpath: "/value",
+    declarations: true,
+    esm: true,
+  },
+])("preserves node_modules mappings for $packageName$subpath (declarations: $declarations, ESM: $esm)", ({
+  packageName,
+  subpath,
+  declarations,
+  esm,
+}) => {
+  const specifier = packageName + subpath;
+  const pattern = packageName + (subpath ? "/*" : "");
+  const packageRoot = `node_modules/${packageName}`;
+  const root = fixture(
+    {
+      "src/main.ts": `
+        import assert from "node:assert/strict";
+        import { value } from "${specifier}";
+        import { exported } from "./exports.js";
+        async function main() {
+          assert.equal(value, "package");
+          assert.equal(exported, "package");
+          assert.equal((await import("${specifier}")).value, "package");
+          console.log("ok");
+        }
+        main().catch(error => { console.error(error); process.exitCode = 1; });
+      `,
+      "src/exports.ts": `export { value as exported } from "${specifier}";`,
+      [`${packageRoot}/package.json`]: JSON.stringify({
+        type: esm ? "module" : "commonjs",
+        main: "index.js",
+        ...(declarations ? { types: "index.d.ts" } : {}),
+        exports: { ".": "./index.js", "./value": "./index.js" },
+      }),
+      [`${packageRoot}/index.js`]: esm
+        ? `export const value = "package";`
+        : `exports.value = "package";`,
+      // Preserve package exports instead of loading the paths target directly.
+      [`${packageRoot}/value.js`]: esm
+        ? `export const value = "mapped-file";`
+        : `exports.value = "mapped-file";`,
+      ...(declarations
+        ? {
+            [`${packageRoot}/index.d.ts`]: `export declare const value: string;`,
+            [`${packageRoot}/value.d.ts`]: `export declare const value: string;`,
+          }
+        : {}),
+    },
+    { rootDir: ".", paths: { [pattern]: [`./node_modules/${pattern}`] } },
+    esm,
+  );
+  expect(run(root, "dist/src/main.js")).toBe("ok");
+});
+
+test("rewrites aliases that rename an installed dependency", () => {
+  const root = fixture(
+    {
+      "src/main.ts": `
+        import { value } from "vendor/value";
+        import { exported } from "./exports";
+        import("vendor/value").then(mod => console.log([value, exported, mod.value].join(",")));
+      `,
+      "src/exports.ts": `export { value as exported } from "vendor/value";`,
+      "node_modules/dep/value.js": `exports.value = "package";`,
+      "node_modules/dep/value.d.ts": `export declare const value: string;`,
+    },
+    { paths: { "vendor/*": ["./node_modules/dep/*"] } },
+  );
+  expect(run(root)).toBe("package,package,package");
 });
 
 test("rewrites aliases to JavaScript modules with companion declarations", () => {

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -27,8 +27,13 @@ class Compiler {
         if (key === "*") {
           continue;
         }
-        // always make sure it starts at the beginning...
-        this.regexMap.set(key, new RegExp("^" + key, "i"));
+        // Match the whole, case-sensitive TS path pattern, including the slash
+        // in aliases such as src/*; packages like src-extra must stay intact.
+        const pattern = key
+          .split("*")
+          .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+          .join("(.*)");
+        this.regexMap.set(key, new RegExp("^" + pattern + "$"));
       }
     }
     // TODO should be taking baseUrl and using that instead of using cwd and assuming baseUrl == "."
@@ -77,7 +82,8 @@ class Compiler {
       }
       let value = paths[key];
 
-      if (r.test(moduleName)) {
+      const match = moduleName.match(r);
+      if (match) {
         // substitute...
         // can this be more than one?
         // not for now...
@@ -87,9 +93,8 @@ class Compiler {
           console.error("incorrectly formatted regex");
           continue;
         }
-        str = str.substr(0, lastIdx);
-        let resolvedFileName =
-          path.join(this.cwd, moduleName.replace(r, str)) + ".ts";
+        str = str.replace("*", () => match[1]);
+        let resolvedFileName = path.join(this.cwd, str) + ".ts";
         //          console.log(resolvedFileName);
         return {
           resolvedFileName,
@@ -201,8 +206,6 @@ class Compiler {
         paths: ts.MapLike<string[]> | undefined,
         text: string,
       ): string | undefined {
-        // remove quotes
-        text = text.slice(1, -1);
         let relPath: string | undefined;
 
         for (const key in paths) {
@@ -213,21 +216,18 @@ class Compiler {
           let value = paths[key];
           let str = value[0];
 
-          if (!r.test(text)) {
+          const match = text.match(r);
+          if (!match) {
             continue;
           }
-          let idx = text.indexOf("/");
-          let strIdx = str.indexOf("*");
-          if (idx === -1 || strIdx === -1) {
-            continue;
-          }
+          const targetPath = path.resolve(
+            cwd,
+            str.replace("*", () => match[1] ?? ""),
+          );
           relPath = path.relative(
             // just because of how imports work. it's relative from directory not current path
             path.dirname(fullPath),
-            path.join(
-              text.substring(0, idx).replace(r, str.substring(0, strIdx)),
-              text.substring(idx),
-            ),
+            targetPath,
           );
           // if file ends with "..", we've reached a case where we're trying to
           // import something like foo/contact(.ts) from within foo/contact/bar/baz/page.ts
@@ -235,15 +235,11 @@ class Compiler {
           if (relPath.endsWith("..")) {
             // there's an actual local file here not root of directory, try that instead
             // (if root of directory and there's ambiguity, we should use "contact/")
-            if (ts.sys.fileExists(text + ".ts")) {
-              let text2 = text + ".ts";
+            if (ts.sys.fileExists(targetPath + ".ts")) {
               relPath = path.relative(
                 // just because of how imports work. it's relative from directory not current path
                 path.dirname(fullPath),
-                path.join(
-                  text2.substring(0, idx).replace(r, str.substring(0, strIdx)),
-                  text2.substring(idx),
-                ),
+                targetPath + ".ts",
               );
             }
           }
@@ -252,19 +248,18 @@ class Compiler {
           }
 
           // tsc removes this by default so we need to also do it
-          let tsIdx = relPath.indexOf(".ts");
-          if (tsIdx !== -1) {
-            relPath = relPath.substring(0, tsIdx);
+          if (relPath.endsWith(".ts")) {
+            relPath = relPath.slice(0, -3);
           }
           return relPath;
         }
       }
 
-      function visitor(node: ts.Node) {
+      function visitor(node: ts.Node): ts.VisitResult<ts.Node> {
         if (node.kind === ts.SyntaxKind.ImportDeclaration) {
           let importNode = node as ts.ImportDeclaration;
 
-          let text = importNode.moduleSpecifier.getText();
+          let text = (importNode.moduleSpecifier as ts.StringLiteral).text;
           let relPath = checkPath(paths, text);
           if (relPath) {
             // update the node...
@@ -280,7 +275,9 @@ class Compiler {
         if (node.kind === ts.SyntaxKind.ExportDeclaration) {
           let exportNode = node as ts.ExportDeclaration;
 
-          let text = exportNode.moduleSpecifier?.getText();
+          let text = (
+            exportNode.moduleSpecifier as ts.StringLiteral | undefined
+          )?.text;
 
           if (text) {
             let relPath = checkPath(paths, text);
@@ -295,6 +292,29 @@ class Compiler {
                 exportNode.assertClause,
               );
             }
+          }
+        }
+        // Dynamic imports are CallExpressions and may be nested in methods,
+        // callbacks, or another import's options. Visit children before updating
+        // the specifier so those expressions retain their normal behavior.
+        node = ts.visitEachChild(node, visitor, context);
+        if (
+          ts.isCallExpression(node) &&
+          node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+          node.arguments.length > 0 &&
+          ts.isStringLiteralLike(node.arguments[0])
+        ) {
+          const relPath = checkPath(paths, node.arguments[0].text);
+          if (relPath) {
+            return ts.factory.updateCallExpression(
+              node,
+              node.expression,
+              node.typeArguments,
+              [
+                ts.factory.createStringLiteral(relPath),
+                ...node.arguments.slice(1),
+              ],
+            );
           }
         }
         return node;

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -231,27 +231,19 @@ class Compiler {
           if (declarationFilePattern.test(targetPath)) {
             return undefined;
           }
-          const resolvedPath = resolveModule(text, fullPath)?.resolvedFileName;
-          // Installed dependencies stay outside outDir. Keep Node's package
-          // resolution (including exports) instead of making them relative to
-          // emitted source files. Match the package name so aliases that rename
-          // a dependency still get rewritten. The external-library flag alone
-          // is insufficient when TypeScript resolves paths against a relative
-          // baseUrl and returns a filename starting with node_modules/.
-          const packageName = text
-            .split("/")
-            .slice(0, text.startsWith("@") ? 2 : 1)
-            .join(path.sep);
+          // Installed dependencies stay outside outDir. Preserve Node's package
+          // lookup only when the mapping keeps the entire specifier unchanged;
+          // dep/value -> dep/lib/value is an explicit remap that must still apply.
+          // Check the mapped runtime path because TS may find declarations in a
+          // separate @types package instead of alongside the JavaScript.
           if (
-            resolvedPath &&
-            path
-              .resolve(cwd, resolvedPath)
-              .includes(
-                `${path.sep}node_modules${path.sep}${packageName}${path.sep}`,
-              )
+            targetPath.endsWith(
+              `${path.sep}node_modules${path.sep}${text.split("/").join(path.sep)}`,
+            )
           ) {
             return undefined;
           }
+          const resolvedPath = resolveModule(text, fullPath)?.resolvedFileName;
           if (resolvedPath && declarationFilePattern.test(resolvedPath)) {
             // Extensionless paths can resolve to dep.d.ts or dep/index.d.ts.
             // A JavaScript module may also have companion declarations, so

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -232,6 +232,26 @@ class Compiler {
             return undefined;
           }
           const resolvedPath = resolveModule(text, fullPath)?.resolvedFileName;
+          // Installed dependencies stay outside outDir. Keep Node's package
+          // resolution (including exports) instead of making them relative to
+          // emitted source files. Match the package name so aliases that rename
+          // a dependency still get rewritten. The external-library flag alone
+          // is insufficient when TypeScript resolves paths against a relative
+          // baseUrl and returns a filename starting with node_modules/.
+          const packageName = text
+            .split("/")
+            .slice(0, text.startsWith("@") ? 2 : 1)
+            .join(path.sep);
+          if (
+            resolvedPath &&
+            path
+              .resolve(cwd, resolvedPath)
+              .includes(
+                `${path.sep}node_modules${path.sep}${packageName}${path.sep}`,
+              )
+          ) {
+            return undefined;
+          }
           if (resolvedPath && declarationFilePattern.test(resolvedPath)) {
             // Extensionless paths can resolve to dep.d.ts or dep/index.d.ts.
             // A JavaScript module may also have companion declarations, so

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -3,6 +3,7 @@
 import ts from "typescript";
 import * as path from "path";
 import * as glob from "glob";
+import { createRequire } from "module";
 import { readCompilerOptions } from "../tsc/compilerOptions";
 
 // TODO this should probably be its own package but for now it's here
@@ -240,6 +241,52 @@ class Compiler {
           )[0],
         ));
       }
+      let outputRequire: NodeJS.Require | undefined;
+      function getOutputRequire() {
+        return (outputRequire ??= createRequire(getOutputPath()));
+      }
+
+      function usesPackageInstallation(
+        packageName: string,
+        mappedRoot: string,
+      ) {
+        const outputDirectory = path.dirname(getOutputPath());
+        const scopeFile = ts.findConfigFile(
+          outputDirectory,
+          ts.sys.fileExists,
+          "package.json",
+        );
+        const scope =
+          scopeFile && JSON.parse(ts.sys.readFile(scopeFile) ?? "{}");
+        // Package self-references precede node_modules lookup. Otherwise, inspect
+        // Node's package search directories without selecting require/import exports.
+        const installedRoot =
+          scopeFile && scope.name === packageName && scope.exports != null
+            ? path.dirname(scopeFile)
+            : getOutputRequire()
+                .resolve.paths(packageName)
+                ?.filter((directory) => {
+                  if (commonJS) return true;
+                  // Native ESM does not search NODE_PATH or global module directories.
+                  const relative = path.relative(
+                    path.dirname(directory),
+                    outputDirectory,
+                  );
+                  return (
+                    path.basename(directory) === "node_modules" &&
+                    relative !== ".." &&
+                    !relative.startsWith(".." + path.sep) &&
+                    !path.isAbsolute(relative)
+                  );
+                })
+                .map((directory) => path.join(directory, packageName))
+                .find((directory) => ts.sys.directoryExists(directory));
+        return (
+          installedRoot !== undefined &&
+          (ts.sys.realpath?.(installedRoot) ?? installedRoot) ===
+            (ts.sys.realpath?.(mappedRoot) ?? mappedRoot)
+        );
+      }
 
       function checkPath(
         paths: ts.MapLike<string[]> | undefined,
@@ -269,16 +316,27 @@ class Compiler {
             return undefined;
           }
           // Installed dependencies stay outside outDir. Preserve Node's package
-          // lookup only when the mapping keeps the entire specifier unchanged;
+          // lookup only when the mapping keeps the specifier and installation unchanged;
           // dep/value -> dep/lib/value is an explicit remap that must still apply.
           // Check the mapped runtime path because TS may find declarations in a
           // separate @types package instead of alongside the JavaScript.
+          const packagePath = text.split("/").join(path.sep);
           if (
             targetPath.endsWith(
-              `${path.sep}node_modules${path.sep}${text.split("/").join(path.sep)}`,
+              `${path.sep}node_modules${path.sep}${packagePath}`,
             )
           ) {
-            return undefined;
+            const packageName = text
+              .split("/")
+              .slice(0, text.startsWith("@") ? 2 : 1)
+              .join("/");
+            const mappedRoot = path.join(
+              targetPath.slice(0, -packagePath.length),
+              packageName,
+            );
+            if (usesPackageInstallation(packageName, mappedRoot)) {
+              return undefined;
+            }
           }
           const resolvedPath = resolveModule(text, fullPath)?.resolvedFileName;
           let runtimePath: string | undefined;
@@ -314,10 +372,7 @@ class Compiler {
               // require.resolve uses CommonJS export conditions; an ESM import
               // of the same package may intentionally select another entry.
               try {
-                if (
-                  require.resolve(text, { paths: [outputDirectory] }) ===
-                  runtimePath
-                ) {
+                if (getOutputRequire().resolve(text) === runtimePath) {
                   return undefined;
                 }
               } catch {
@@ -360,6 +415,19 @@ class Compiler {
           // tsc removes this by default so we need to also do it
           if (relPath.endsWith(".ts")) {
             relPath = relPath.slice(0, -3);
+          } else if (
+            /\.(tsx|mts|cts)$/.test(relPath) &&
+            sourcePath &&
+            emittedFiles.has(sourcePath)
+          ) {
+            const emittedPath = ts.getOutputFileNames(
+              emitConfig,
+              sourcePath,
+              !ts.sys.useCaseSensitiveFileNames,
+            )[0];
+            relPath =
+              relPath.slice(0, -path.extname(relPath).length) +
+              path.extname(emittedPath);
           }
           return relPath;
         }

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -449,10 +449,12 @@ class Compiler {
           )
           .split(path.sep)
           .join("/");
-        // Preserve the existing extensionless convention for TS/CommonJS
-        // aliases; explicit runtime extensions and JSX/MJS/CJS outputs keep theirs.
+        // Preserve the existing extensionless convention for TS/CommonJS aliases.
+        // Runtime extensions in the original specifier or target, and JSX/MJS/CJS
+        // outputs, keep their emitted extension even if substitution removes it.
         if (
           relPath.endsWith(".js") &&
+          !/\.(js|jsx|mjs|cjs)$/.test(text) &&
           !/\.(js|jsx|mjs|cjs|tsx|mts|cts)$/.test(targetPath)
         ) {
           relPath = relPath.slice(0, -3);

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -178,6 +178,8 @@ class Compiler {
     let cwd = this.cwd;
     let paths = this.options.paths;
     let regexMap = this.regexMap;
+    const resolveModule = this.standardModules.bind(this);
+    const declarationFilePattern = /\.d\.(ts|mts|cts)$/;
     return function (node: ts.SourceFile) {
       // don't do anything with declaration files
       // nothing to do here
@@ -226,8 +228,21 @@ class Compiler {
           );
           // Declaration mappings supply types, not runtime modules. Preserve
           // the original specifier so Node can still load the actual package.
-          if (/\.d\.(ts|mts|cts)$/.test(targetPath)) {
+          if (declarationFilePattern.test(targetPath)) {
             return undefined;
+          }
+          const resolvedPath = resolveModule(text, fullPath)?.resolvedFileName;
+          if (resolvedPath && declarationFilePattern.test(resolvedPath)) {
+            // Extensionless paths can resolve to dep.d.ts or dep/index.d.ts.
+            // A JavaScript module may also have companion declarations, so
+            // retain rewriting when the mapped target has a runtime module.
+            try {
+              if (declarationFilePattern.test(require.resolve(targetPath))) {
+                return undefined;
+              }
+            } catch {
+              return undefined;
+            }
           }
           relPath = path.relative(
             // just because of how imports work. it's relative from directory not current path

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -25,9 +25,6 @@ class Compiler {
     this.options = readCompilerOptions(".");
     if (this.options.paths) {
       for (let key in this.options.paths) {
-        if (key === "*") {
-          continue;
-        }
         // Match the whole, case-sensitive TS path pattern, including the slash
         // in aliases such as src/*; packages like src-extra must stay intact.
         const pattern = key
@@ -37,7 +34,6 @@ class Compiler {
         this.regexMap.set(key, new RegExp("^" + pattern + "$"));
       }
     }
-    // TODO should be taking baseUrl and using that instead of using cwd and assuming baseUrl == "."
     this.cwd = process.cwd();
 
     // set resolvers
@@ -45,63 +41,125 @@ class Compiler {
       // standard
       this.standardModules.bind(this),
 
-      // resolvePaths based on tsconfig's paths
-      this.resolvePaths.bind(this),
-
       // use node or other location paths
       this.otherLocations.bind(this),
     ];
   }
 
-  private standardModules(moduleName: string, containingFile: string) {
+  private standardModules(
+    moduleName: string,
+    containingFile: string,
+    options = this.options,
+  ) {
+    const host: ts.ModuleResolutionHost = {
+      fileExists: ts.sys.fileExists,
+      readFile: ts.sys.readFile,
+      getCurrentDirectory: () => this.cwd,
+    };
     let result = ts.resolveModuleName(
       moduleName,
       containingFile,
-      this.options,
-      {
-        fileExists: ts.sys.fileExists,
-        readFile: ts.sys.readFile,
-      },
+      options,
+      host,
     );
+    if (!result.resolvedModule && options.paths) {
+      const key = this.matchPathPattern(moduleName);
+      if (key && moduleName.match(this.regexMap.get(key)!)?.[1] === "") {
+        // TS leaves the substitution's star intact for an empty capture.
+        // Retain this compiler's existing empty-alias behavior only after
+        // ordinary TS resolution fails, and use it for both emit and the host.
+        result = ts.resolveModuleName(
+          moduleName,
+          containingFile,
+          {
+            ...options,
+            paths: {
+              [moduleName]: options.paths[key].map((value) =>
+                value.replace("*", ""),
+              ),
+            },
+          },
+          host,
+        );
+      }
+    }
     return result.resolvedModule;
   }
 
-  private resolvePaths(
-    moduleName: string,
-    _containingFile: string,
-  ): ts.ResolvedModule | undefined {
-    //      console.log("resolvePaths", moduleName);
-    if (!this.options.paths) {
+  private matchPathPattern(moduleName: string) {
+    const paths = this.options.paths;
+    if (!paths) {
       return undefined;
     }
-
-    let paths = this.options.paths;
-    for (let key in paths) {
-      let r = this.regexMap.get(key);
-      if (!r) {
-        continue;
-      }
-      let value = paths[key];
-
-      const match = moduleName.match(r);
-      if (match) {
-        // substitute...
-        // can this be more than one?
-        // not for now...
-        let str = value[0];
-        let lastIdx = value[0].lastIndexOf("*");
-        if (lastIdx === -1) {
-          console.error("incorrectly formatted regex");
-          continue;
+    // TypeScript selects an exact key first, then the matching wildcard with
+    // the longest prefix. It does not fall back to less-specific patterns.
+    let key =
+      Object.prototype.hasOwnProperty.call(paths, moduleName) &&
+      !moduleName.includes("*")
+        ? moduleName
+        : undefined;
+    if (key === undefined) {
+      let prefixLength = -1;
+      for (const [pattern, regex] of this.regexMap) {
+        const prefix = pattern.indexOf("*");
+        if (prefix > prefixLength && regex.test(moduleName)) {
+          key = pattern;
+          prefixLength = prefix;
         }
-        str = str.replace("*", () => match[1]);
-        let resolvedFileName = path.join(this.cwd, str) + ".ts";
-        //          console.log(resolvedFileName);
-        return {
-          resolvedFileName,
-        };
       }
     }
+    return key;
+  }
+
+  private resolvePathMapping(moduleName: string, containingFile: string) {
+    const paths = this.options.paths;
+    const key = this.matchPathPattern(moduleName);
+    // Keep the historical catch-all behavior: it is not an emitted alias.
+    if (!paths || key === undefined || key === "*") return undefined;
+    const resolvedModule = this.standardModules(moduleName, containingFile);
+    if (!resolvedModule) return undefined;
+    const canonical = (file: string) => {
+      const absolute = path.resolve(this.cwd, file);
+      return ts.sys.useCaseSensitiveFileNames
+        ? absolute
+        : absolute.toLowerCase();
+    };
+    const resolvedPath = canonical(resolvedModule.resolvedFileName);
+    const wildcard = moduleName.match(this.regexMap.get(key)!)?.[1];
+    const pathsBase = this.options.baseUrl ?? this.options.pathsBasePath;
+    const baseDirectory = path.resolve(
+      this.cwd,
+      typeof pathsBase === "string" ? pathsBase : ".",
+    );
+
+    for (const substitution of paths[key]) {
+      const expanded =
+        wildcard !== undefined
+          ? substitution.replace("*", () => wildcard)
+          : substitution;
+      // A trailing slash requires directory resolution even when a sibling
+      // file with the same basename exists.
+      const targetPath =
+        path.resolve(baseDirectory, expanded) +
+        (/[\\/]$/.test(expanded) ? path.sep : "");
+      // Resolve each candidate as an absolute module so a missing candidate
+      // cannot silently fall through to the original package or its @types.
+      // Compare against the full resolution: TS may choose a later typed file
+      // before an earlier JS candidate. An explicit paths filename is loaded
+      // directly by TS before extension substitution, so retain that match too.
+      const candidate = this.standardModules(targetPath, containingFile, {
+        ...this.options,
+        paths: undefined,
+      });
+      if (
+        (canonical(targetPath) === resolvedPath &&
+          ts.sys.fileExists(targetPath)) ||
+        (candidate && canonical(candidate.resolvedFileName) === resolvedPath)
+      ) {
+        return { targetPath, resolvedModule };
+      }
+    }
+    // Normal package/baseUrl lookup won after the selected pattern failed.
     return undefined;
   }
 
@@ -178,8 +236,7 @@ class Compiler {
   private transformer(program: ts.Program, context: ts.TransformationContext) {
     let cwd = this.cwd;
     let paths = this.options.paths;
-    let regexMap = this.regexMap;
-    const resolveModule = this.standardModules.bind(this);
+    const resolveMapping = this.resolvePathMapping.bind(this);
     const declarationFilePattern = /\.d\.(ts|mts|cts)$/;
     const commonJS = this.options.module === ts.ModuleKind.CommonJS;
     const emitConfig: ts.ParsedCommandLine = {
@@ -288,149 +345,119 @@ class Compiler {
         );
       }
 
-      function checkPath(
-        paths: ts.MapLike<string[]> | undefined,
-        text: string,
-      ): string | undefined {
-        let relPath: string | undefined;
-
-        for (const key in paths) {
-          let r = regexMap.get(key);
-          if (!r) {
-            continue;
-          }
-          let value = paths[key];
-          let str = value[0];
-
-          const match = text.match(r);
-          if (!match) {
-            continue;
-          }
-          const targetPath = path.resolve(
-            cwd,
-            str.replace("*", () => match[1] ?? ""),
+      function checkPath(text: string): string | undefined {
+        const mapping = resolveMapping(text, fullPath);
+        if (!mapping) return undefined;
+        const { targetPath, resolvedModule } = mapping;
+        const resolvedPath = resolvedModule.resolvedFileName;
+        // Declaration mappings supply types, not runtime modules. Preserve
+        // the original specifier so Node can still load the actual package.
+        if (declarationFilePattern.test(targetPath)) {
+          return undefined;
+        }
+        // Installed dependencies stay outside outDir. Preserve Node's package
+        // lookup only when the mapping keeps the specifier and installation unchanged;
+        // dep/value -> dep/lib/value is an explicit remap that must still apply.
+        // Check the mapped runtime path because TS may find declarations in a
+        // separate @types package instead of alongside the JavaScript.
+        const packagePath = text.split("/").join(path.sep);
+        if (
+          targetPath.endsWith(
+            `${path.sep}node_modules${path.sep}${packagePath}`,
+          )
+        ) {
+          const packageName = text
+            .split("/")
+            .slice(0, text.startsWith("@") ? 2 : 1)
+            .join("/");
+          const mappedRoot = path.join(
+            targetPath.slice(0, -packagePath.length),
+            packageName,
           );
-          // Declaration mappings supply types, not runtime modules. Preserve
-          // the original specifier so Node can still load the actual package.
-          if (declarationFilePattern.test(targetPath)) {
+          if (usesPackageInstallation(packageName, mappedRoot)) {
             return undefined;
           }
-          // Installed dependencies stay outside outDir. Preserve Node's package
-          // lookup only when the mapping keeps the specifier and installation unchanged;
-          // dep/value -> dep/lib/value is an explicit remap that must still apply.
-          // Check the mapped runtime path because TS may find declarations in a
-          // separate @types package instead of alongside the JavaScript.
-          const packagePath = text.split("/").join(path.sep);
-          if (
-            targetPath.endsWith(
-              `${path.sep}node_modules${path.sep}${packagePath}`,
-            )
-          ) {
-            const packageName = text
-              .split("/")
-              .slice(0, text.startsWith("@") ? 2 : 1)
-              .join("/");
-            const mappedRoot = path.join(
-              targetPath.slice(0, -packagePath.length),
-              packageName,
-            );
-            if (usesPackageInstallation(packageName, mappedRoot)) {
-              return undefined;
-            }
-          }
-          const resolvedPath = resolveModule(text, fullPath)?.resolvedFileName;
-          let runtimePath: string | undefined;
-          try {
-            runtimePath = require.resolve(targetPath);
-          } catch {
-            // TypeScript source aliases need not have JavaScript on disk yet.
-          }
-          if (resolvedPath && declarationFilePattern.test(resolvedPath)) {
-            // Extensionless paths can resolve to dep.d.ts or dep/index.d.ts.
-            // A JavaScript module may also have companion declarations, so
-            // retain rewriting when the mapped target has a runtime module.
-            if (!runtimePath || declarationFilePattern.test(runtimePath)) {
-              return undefined;
-            }
-          }
-          // TypeScript extension substitution wins over stale JavaScript beside
-          // a source file: that import must continue to use the freshly emitted code.
-          const sourcePath =
-            resolvedPath && !declarationFilePattern.test(resolvedPath)
-              ? path.resolve(cwd, resolvedPath)
-              : runtimePath;
-          if (
-            runtimePath &&
-            sourcePath &&
-            (!emittedFiles.has(sourcePath) ||
-              sourcePath.split(path.sep).includes("node_modules"))
-          ) {
-            // This runtime module is not copied with the application's sources.
-            // Use the emitted importer's directory, including inferred rootDir.
-            const outputDirectory = path.dirname(getOutputPath());
-            if (commonJS) {
-              // require.resolve uses CommonJS export conditions; an ESM import
-              // of the same package may intentionally select another entry.
-              try {
-                if (getOutputRequire().resolve(text) === runtimePath) {
-                  return undefined;
-                }
-              } catch {
-                // A renamed dependency may have no corresponding bare package.
-              }
-            }
-            // Use the actual runtime filename so native ESM receives an extension
-            // and directory mappings reach their package entry point.
-            const externalPath = path
-              .relative(outputDirectory, runtimePath)
-              .split(path.sep)
-              .join("/");
-            return externalPath.startsWith("../")
-              ? externalPath
-              : "./" + externalPath;
-          }
-          relPath = path.relative(
-            // just because of how imports work. it's relative from directory not current path
-            path.dirname(fullPath),
-            targetPath,
-          );
-          // if file ends with "..", we've reached a case where we're trying to
-          // import something like foo/contact(.ts) from within foo/contact/bar/baz/page.ts
-          // and we're confused about it so we need to detect that case and handle it
-          if (relPath.endsWith("..")) {
-            // there's an actual local file here not root of directory, try that instead
-            // (if root of directory and there's ambiguity, we should use "contact/")
-            if (ts.sys.fileExists(targetPath + ".ts")) {
-              relPath = path.relative(
-                // just because of how imports work. it's relative from directory not current path
-                path.dirname(fullPath),
-                targetPath + ".ts",
-              );
-            }
-          }
-          if (!relPath.startsWith("..")) {
-            relPath = "./" + relPath;
-          }
-
-          // tsc removes this by default so we need to also do it
-          if (relPath.endsWith(".ts")) {
-            relPath = relPath.slice(0, -3);
-          } else if (
-            /\.(tsx|mts|cts)$/.test(relPath) &&
-            sourcePath &&
-            emittedFiles.has(sourcePath)
-          ) {
-            const emittedPath = ts.getOutputFileNames(
-              emitConfig,
-              sourcePath,
-              !ts.sys.useCaseSensitiveFileNames,
-            )[0];
-            relPath =
-              relPath.slice(0, -path.extname(relPath).length) +
-              path.extname(emittedPath);
-          }
-          return relPath;
         }
+        let runtimePath: string | undefined;
+        try {
+          runtimePath = require.resolve(targetPath);
+        } catch {
+          // TypeScript source aliases need not have JavaScript on disk yet.
+        }
+        if (/\.(js|jsx|mjs|cjs|json)$/.test(resolvedPath)) {
+          // Module suffixes and directory metadata can select a different
+          // runtime file from Node's resolution of the configured path.
+          runtimePath = path.resolve(cwd, resolvedPath);
+        }
+        if (resolvedPath && declarationFilePattern.test(resolvedPath)) {
+          // Extensionless paths can resolve to dep.d.ts or dep/index.d.ts.
+          // A JavaScript module may also have companion declarations, so
+          // retain rewriting when the mapped target has a runtime module.
+          if (!runtimePath || declarationFilePattern.test(runtimePath)) {
+            return undefined;
+          }
+        }
+        // TypeScript extension substitution wins over stale JavaScript beside
+        // a source file: that import must continue to use the freshly emitted code.
+        const sourcePath =
+          resolvedPath && !declarationFilePattern.test(resolvedPath)
+            ? path.resolve(cwd, resolvedPath)
+            : runtimePath;
+        if (
+          runtimePath &&
+          sourcePath &&
+          (!emittedFiles.has(sourcePath) ||
+            sourcePath.split(path.sep).includes("node_modules"))
+        ) {
+          // This runtime module is not copied with the application's sources.
+          // Use the emitted importer's directory, including inferred rootDir.
+          const outputDirectory = path.dirname(getOutputPath());
+          if (commonJS) {
+            // require.resolve uses CommonJS export conditions; an ESM import
+            // of the same package may intentionally select another entry.
+            try {
+              if (getOutputRequire().resolve(text) === runtimePath) {
+                return undefined;
+              }
+            } catch {
+              // A renamed dependency may have no corresponding bare package.
+            }
+          }
+          // Use the actual runtime filename so native ESM receives an extension
+          // and directory mappings reach their package entry point.
+          const externalPath = path
+            .relative(outputDirectory, runtimePath)
+            .split(path.sep)
+            .join("/");
+          return externalPath.startsWith("../")
+            ? externalPath
+            : "./" + externalPath;
+        }
+        if (!sourcePath || !emittedFiles.has(sourcePath)) return undefined;
+        // Use the source TypeScript selected, not the configured directory or
+        // basename. Its emitted filename reflects package entries, moduleSuffixes,
+        // and JSX mode even when package.json is not copied into outDir.
+        const emittedPath = ts.getOutputFileNames(
+          emitConfig,
+          sourcePath,
+          !ts.sys.useCaseSensitiveFileNames,
+        )[0];
+        let relPath = path
+          .relative(
+            path.dirname(getOutputPath()),
+            path.resolve(cwd, emittedPath),
+          )
+          .split(path.sep)
+          .join("/");
+        // Preserve the existing extensionless convention for TS/CommonJS
+        // aliases; explicit runtime extensions and JSX/MJS/CJS outputs keep theirs.
+        if (
+          relPath.endsWith(".js") &&
+          !/\.(js|jsx|mjs|cjs|tsx|mts|cts)$/.test(targetPath)
+        ) {
+          relPath = relPath.slice(0, -3);
+        }
+        return relPath.startsWith("../") ? relPath : "./" + relPath;
       }
 
       function visitor(node: ts.Node): ts.VisitResult<ts.Node> {
@@ -438,7 +465,7 @@ class Compiler {
           let importNode = node as ts.ImportDeclaration;
 
           let text = (importNode.moduleSpecifier as ts.StringLiteral).text;
-          let relPath = checkPath(paths, text);
+          let relPath = checkPath(text);
           if (relPath) {
             // update the node...
             return ts.factory.updateImportDeclaration(
@@ -458,7 +485,7 @@ class Compiler {
           )?.text;
 
           if (text) {
-            let relPath = checkPath(paths, text);
+            let relPath = checkPath(text);
             if (relPath) {
               // update the node...
               return ts.factory.updateExportDeclaration(
@@ -482,7 +509,7 @@ class Compiler {
           node.arguments.length > 0 &&
           ts.isStringLiteralLike(node.arguments[0])
         ) {
-          const relPath = checkPath(paths, node.arguments[0].text);
+          const relPath = checkPath(node.arguments[0].text);
           if (relPath) {
             return ts.factory.updateCallExpression(
               node,

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -22,7 +22,16 @@ class Compiler {
     private sourceFiles: string[],
     private moduleSearchLocations: string[],
   ) {
+    this.cwd = process.cwd();
     this.options = readCompilerOptions(".");
+    // Composite builds use the config directory as their default root. Normalize
+    // it for both the actual program and output prediction, not just the latter.
+    if (typeof this.options.configFilePath === "string") {
+      this.options.configFilePath = path.resolve(
+        this.cwd,
+        this.options.configFilePath,
+      );
+    }
     if (this.options.paths) {
       for (let key in this.options.paths) {
         // Match the whole, case-sensitive TS path pattern, including the slash
@@ -34,7 +43,6 @@ class Compiler {
         this.regexMap.set(key, new RegExp("^" + pattern + "$"));
       }
     }
-    this.cwd = process.cwd();
 
     // set resolvers
     this.resolvers = [
@@ -260,17 +268,16 @@ class Compiler {
     const resolveRuntime = this.resolveRuntimeModule.bind(this);
     const moduleSuffixes = this.options.moduleSuffixes;
     const declarationFilePattern = /\.d\.(ts|mts|cts)$/;
-    const commonJS = this.options.module === ts.ModuleKind.CommonJS;
+    // Match TypeScript's emit default: ES2015+ targets use ES2015 modules;
+    // omitted/older targets use CommonJS unless module is explicitly configured.
+    const moduleKind =
+      this.options.module ??
+      ((this.options.target ?? ts.ScriptTarget.ES5) >= ts.ScriptTarget.ES2015
+        ? ts.ModuleKind.ES2015
+        : ts.ModuleKind.CommonJS);
+    const commonJS = moduleKind === ts.ModuleKind.CommonJS;
     const emitConfig: ts.ParsedCommandLine = {
-      options: {
-        ...this.options,
-        configFilePath: path.resolve(
-          cwd,
-          typeof this.options.configFilePath === "string"
-            ? this.options.configFilePath
-            : "tsconfig.json",
-        ),
-      },
+      options: this.options,
       fileNames: program
         .getSourceFiles()
         .filter(
@@ -283,7 +290,7 @@ class Compiler {
         ),
       errors: [],
     };
-    const emittedFiles = new Set(
+    const localSources = new Set(
       emitConfig.fileNames.map((file) => path.resolve(file)),
     );
     return function (node: ts.SourceFile) {
@@ -453,11 +460,19 @@ class Compiler {
           resolvedPath && !declarationFilePattern.test(resolvedPath)
             ? path.resolve(cwd, resolvedPath)
             : runtimePath;
+        const emittedPath =
+          sourcePath && localSources.has(sourcePath)
+            ? ts.getOutputFileNames(
+                emitConfig,
+                sourcePath,
+                !ts.sys.useCaseSensitiveFileNames,
+              )[0]
+            : undefined;
+        // In-place JSON belongs to the program but has no emitted copy.
         if (
           runtimePath &&
           sourcePath &&
-          (!emittedFiles.has(sourcePath) ||
-            sourcePath.split(path.sep).includes("node_modules"))
+          (!emittedPath || sourcePath.split(path.sep).includes("node_modules"))
         ) {
           // This runtime module is not copied with the application's sources.
           // Use the emitted importer's directory, including inferred rootDir.
@@ -483,15 +498,10 @@ class Compiler {
             ? externalPath
             : "./" + externalPath;
         }
-        if (!sourcePath || !emittedFiles.has(sourcePath)) return undefined;
+        if (!emittedPath) return undefined;
         // Use the source TypeScript selected, not the configured directory or
         // basename. Its emitted filename reflects package entries, moduleSuffixes,
         // and JSX mode even when package.json is not copied into outDir.
-        const emittedPath = ts.getOutputFileNames(
-          emitConfig,
-          sourcePath,
-          !ts.sys.useCaseSensitiveFileNames,
-        )[0];
         let relPath = path
           .relative(
             path.dirname(getOutputPath()),

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -403,17 +403,22 @@ class Compiler {
         // Check the mapped runtime path because TS may find declarations in a
         // separate @types package instead of alongside the JavaScript.
         const packagePath = text.split("/").join(path.sep);
+        const packageName = text
+          .split("/")
+          .slice(0, text.startsWith("@") ? 2 : 1)
+          .join("/");
+        // A package root is already a directory; its trailing slash does not
+        // bypass exports. Keep slashes meaningful on explicit subpath remaps,
+        // where dep/value/ can select a directory instead of dep/value.js.
+        const identityTarget =
+          text === packageName ? path.resolve(targetPath) : targetPath;
         if (
-          targetPath.endsWith(
+          identityTarget.endsWith(
             `${path.sep}node_modules${path.sep}${packagePath}`,
           )
         ) {
-          const packageName = text
-            .split("/")
-            .slice(0, text.startsWith("@") ? 2 : 1)
-            .join("/");
           const mappedRoot = path.join(
-            targetPath.slice(0, -packagePath.length),
+            identityTarget.slice(0, -packagePath.length),
             packageName,
           );
           if (usesPackageInstallation(packageName, mappedRoot, text)) {

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -174,12 +174,38 @@ class Compiler {
     return resolvedModules;
   }
 
-  private transformer(context: ts.TransformationContext) {
+  private transformer(program: ts.Program, context: ts.TransformationContext) {
     let cwd = this.cwd;
     let paths = this.options.paths;
     let regexMap = this.regexMap;
     const resolveModule = this.standardModules.bind(this);
     const declarationFilePattern = /\.d\.(ts|mts|cts)$/;
+    const commonJS = this.options.module === ts.ModuleKind.CommonJS;
+    const emitConfig: ts.ParsedCommandLine = {
+      options: {
+        ...this.options,
+        configFilePath: path.resolve(
+          cwd,
+          typeof this.options.configFilePath === "string"
+            ? this.options.configFilePath
+            : "tsconfig.json",
+        ),
+      },
+      fileNames: program
+        .getSourceFiles()
+        .filter(
+          (file) =>
+            !file.isDeclarationFile &&
+            !program.isSourceFileFromExternalLibrary(file),
+        )
+        .map((file) =>
+          path.resolve(cwd, file.fileName).split(path.sep).join("/"),
+        ),
+      errors: [],
+    };
+    const emittedFiles = new Set(
+      emitConfig.fileNames.map((file) => path.resolve(file)),
+    );
     return function (node: ts.SourceFile) {
       // don't do anything with declaration files
       // nothing to do here
@@ -202,6 +228,17 @@ class Compiler {
       let relativePath = path.relative(cwd, fullPath);
       if (relativePath.startsWith("..")) {
         return node;
+      }
+      let outputPath: string | undefined;
+      function getOutputPath() {
+        return (outputPath ??= path.resolve(
+          cwd,
+          ts.getOutputFileNames(
+            emitConfig,
+            fullPath,
+            !ts.sys.useCaseSensitiveFileNames,
+          )[0],
+        ));
       }
 
       function checkPath(
@@ -244,17 +281,58 @@ class Compiler {
             return undefined;
           }
           const resolvedPath = resolveModule(text, fullPath)?.resolvedFileName;
+          let runtimePath: string | undefined;
+          try {
+            runtimePath = require.resolve(targetPath);
+          } catch {
+            // TypeScript source aliases need not have JavaScript on disk yet.
+          }
           if (resolvedPath && declarationFilePattern.test(resolvedPath)) {
             // Extensionless paths can resolve to dep.d.ts or dep/index.d.ts.
             // A JavaScript module may also have companion declarations, so
             // retain rewriting when the mapped target has a runtime module.
-            try {
-              if (declarationFilePattern.test(require.resolve(targetPath))) {
-                return undefined;
-              }
-            } catch {
+            if (!runtimePath || declarationFilePattern.test(runtimePath)) {
               return undefined;
             }
+          }
+          // TypeScript extension substitution wins over stale JavaScript beside
+          // a source file: that import must continue to use the freshly emitted code.
+          const sourcePath =
+            resolvedPath && !declarationFilePattern.test(resolvedPath)
+              ? path.resolve(cwd, resolvedPath)
+              : runtimePath;
+          if (
+            runtimePath &&
+            sourcePath &&
+            (!emittedFiles.has(sourcePath) ||
+              sourcePath.split(path.sep).includes("node_modules"))
+          ) {
+            // This runtime module is not copied with the application's sources.
+            // Use the emitted importer's directory, including inferred rootDir.
+            const outputDirectory = path.dirname(getOutputPath());
+            if (commonJS) {
+              // require.resolve uses CommonJS export conditions; an ESM import
+              // of the same package may intentionally select another entry.
+              try {
+                if (
+                  require.resolve(text, { paths: [outputDirectory] }) ===
+                  runtimePath
+                ) {
+                  return undefined;
+                }
+              } catch {
+                // A renamed dependency may have no corresponding bare package.
+              }
+            }
+            // Use the actual runtime filename so native ESM receives an extension
+            // and directory mappings reach their package entry point.
+            const externalPath = path
+              .relative(outputDirectory, runtimePath)
+              .split(path.sep)
+              .join("/");
+            return externalPath.startsWith("../")
+              ? externalPath
+              : "./" + externalPath;
           }
           relPath = path.relative(
             // just because of how imports work. it's relative from directory not current path
@@ -360,7 +438,7 @@ class Compiler {
     const host = this.createCompilerHost();
     const program = ts.createProgram(this.sourceFiles, this.options, host);
     let emitResult = program.emit(undefined, undefined, undefined, undefined, {
-      before: [this.transformer.bind(this)],
+      before: [(context) => this.transformer(program, context)],
     });
     if (emitResult.emitSkipped) {
       console.error("error emitting code");

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -224,6 +224,11 @@ class Compiler {
             cwd,
             str.replace("*", () => match[1] ?? ""),
           );
+          // Declaration mappings supply types, not runtime modules. Preserve
+          // the original specifier so Node can still load the actual package.
+          if (/\.d\.(ts|mts|cts)$/.test(targetPath)) {
+            return undefined;
+          }
           relPath = path.relative(
             // just because of how imports work. it's relative from directory not current path
             path.dirname(fullPath),

--- a/ts/src/scripts/custom_compiler.ts
+++ b/ts/src/scripts/custom_compiler.ts
@@ -173,6 +173,26 @@ class Compiler {
     return undefined;
   }
 
+  private resolveRuntimeModule(targetPath: string, containingFile: string) {
+    // Ask TS to apply moduleSuffixes to runtime files, independently of companion
+    // declarations. Directory lookups still use package main rather than assuming
+    // that a declaration's neighboring JavaScript is the package entry point.
+    const resolved = ts.resolveModuleName(
+      targetPath,
+      containingFile,
+      { ...this.options, paths: undefined },
+      {
+        fileExists: (file) =>
+          !/\.(ts|tsx|mts|cts)$/.test(file) && ts.sys.fileExists(file),
+        readFile: ts.sys.readFile,
+        getCurrentDirectory: () => this.cwd,
+      },
+    ).resolvedModule?.resolvedFileName;
+    return resolved && /\.(js|jsx|mjs|cjs|json)$/.test(resolved)
+      ? path.resolve(this.cwd, resolved)
+      : undefined;
+  }
+
   private createCompilerHost(): ts.CompilerHost {
     return {
       getSourceFile: this.getSourceFile,
@@ -237,6 +257,8 @@ class Compiler {
     let cwd = this.cwd;
     let paths = this.options.paths;
     const resolveMapping = this.resolvePathMapping.bind(this);
+    const resolveRuntime = this.resolveRuntimeModule.bind(this);
+    const moduleSuffixes = this.options.moduleSuffixes;
     const declarationFilePattern = /\.d\.(ts|mts|cts)$/;
     const commonJS = this.options.module === ts.ModuleKind.CommonJS;
     const emitConfig: ts.ParsedCommandLine = {
@@ -306,7 +328,28 @@ class Compiler {
       function usesPackageInstallation(
         packageName: string,
         mappedRoot: string,
+        specifier: string,
       ) {
+        if (commonJS) {
+          // Node can skip an existing package directory that lacks the requested
+          // entry. Compare actual resolution from both lookup locations, including
+          // exports, subpaths, and symlinks whose destination is outside the package.
+          try {
+            const mappedSearchRoot = path.resolve(
+              mappedRoot,
+              ...packageName.split("/").map(() => ".."),
+            );
+            const mappedRequire = createRequire(
+              path.join(mappedSearchRoot, "__ent_resolve__.js"),
+            );
+            return (
+              getOutputRequire().resolve(specifier) ===
+              mappedRequire.resolve(specifier)
+            );
+          } catch {
+            return false;
+          }
+        }
         const outputDirectory = path.dirname(getOutputPath());
         const scopeFile = ts.findConfigFile(
           outputDirectory,
@@ -315,15 +358,14 @@ class Compiler {
         );
         const scope =
           scopeFile && JSON.parse(ts.sys.readFile(scopeFile) ?? "{}");
-        // Package self-references precede node_modules lookup. Otherwise, inspect
-        // Node's package search directories without selecting require/import exports.
+        // Native ESM package self-references precede node_modules lookup. Inspect
+        // its package search directories without applying CommonJS export conditions.
         const installedRoot =
           scopeFile && scope.name === packageName && scope.exports != null
             ? path.dirname(scopeFile)
             : getOutputRequire()
                 .resolve.paths(packageName)
                 ?.filter((directory) => {
-                  if (commonJS) return true;
                   // Native ESM does not search NODE_PATH or global module directories.
                   const relative = path.relative(
                     path.dirname(directory),
@@ -374,7 +416,7 @@ class Compiler {
             targetPath.slice(0, -packagePath.length),
             packageName,
           );
-          if (usesPackageInstallation(packageName, mappedRoot)) {
+          if (usesPackageInstallation(packageName, mappedRoot, text)) {
             return undefined;
           }
         }
@@ -390,6 +432,9 @@ class Compiler {
           runtimePath = path.resolve(cwd, resolvedPath);
         }
         if (resolvedPath && declarationFilePattern.test(resolvedPath)) {
+          if (moduleSuffixes?.length) {
+            runtimePath = resolveRuntime(targetPath, fullPath) ?? runtimePath;
+          }
           // Extensionless paths can resolve to dep.d.ts or dep/index.d.ts.
           // A JavaScript module may also have companion declarations, so
           // retain rewriting when the mapped target has a runtime module.


### PR DESCRIPTION
`ent-custom-compiler` leaves dynamic imports such as `await import("src/ent")` unresolved in emitted JavaScript. Applications can pass Jest tests with alias mappings and then fail in Node with `Cannot find module 'src/ent'`, including deferred model loading in privacy checks.

Visit nested expressions and rewrite literal dynamic-import aliases while preserving import options, unrelated package and relative imports, and type-only behavior. Match complete, case-sensitive path patterns so `src/*` does not capture packages such as `src-extra`. Follow TypeScript's selected exact or longest-prefix pattern and resolved fallback candidate, including its preference for typed files over JavaScript. Failed mappings retain normal package lookup. Preserve the compiler's existing empty-wildcard behavior when ordinary TypeScript resolution fails. Runtime package handling follows TypeScript's effective module mode, including target-dependent defaults when `module` is omitted.

Derive local destinations from the emitted file TypeScript selected, including directory package entries, `moduleSuffixes`, and TSX output extensions. Explicit runtime extensions in the original import survive substitutions such as `vendor/*.js` to `./src/*` or an exact mapping to a `.ts` file. Existing JavaScript beside a TypeScript source cannot override freshly emitted code. Composite builds honor the configured output directory, and in-place JSON aliases reference the existing runtime file. External JavaScript uses its resolved runtime filename, honoring `moduleSuffixes` even when companion declarations are present, and remains relative to the emitted importer, accounting for explicit or inferred `rootDir` and nested `outDir`.

Preserve declaration-only package mappings, including extensionless declaration files and separate `@types` packages. Identity mappings into `node_modules`, including package roots with a trailing slash, preserve package resolution and ESM export conditions when they select the same installation from the emitted importer. CommonJS checks actual full-specifier resolution from both package lookup locations, preserving exports through symlinks and skipping nearer directories that lack the requested entry. Equivalent CommonJS entries such as `dep` mapped to `node_modules/dep/index` stay bare. Explicit subpath remappings and nested dependency installations retain their configured destination outside `outDir`.

The regressions compile the CLI and fixture applications, then execute emitted JavaScript in separate Node processes. Coverage includes deferred privacy/model loading, static imports and re-exports, declaration mappings, package entries and conditional exports, dependency remappings, mapping fallback and priority, directory resolution, JavaScript sources, TSX, module suffixes, and JSON import options. This change does not expand NodeNext or extensionless native-ESM support for local source aliases.

Validation with Node 24.12.0:

- `cd ts && npm test -- src/scripts/custom_compiler.test.ts --runInBand` — all 82 focused tests pass.
- `cd ts && npm run compile`
- `ENT_CODEGEN_MATRIX_FIXTURE=feature_stress ENT_CODEGEN_MATRIX_RUNTIME=node go test ./internal/codegenmatrix -count=1 -v` — generated TypeScript, idempotence, and catalog checks pass.
- Focused Biome checks and `git diff --check` pass.
- Full example and full codegen matrices were not rerun for this follow-up.
