### PR TITLE
Accept GraphQL literal records in struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- accept GraphQL literal input records in struct and union fields, including
+  nested lists, and preserve validation errors for unprintable values (#2029).
 - update `uuid`, docs, test-helper, and standalone TypeScript package
   dependencies to patched versions (#2013).
 - avoid whitespace-only churn in generated `schema.py` and `schema.sql` files

--- a/examples/todo-sqlite/src/graphql/tests/account.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/account.test.ts
@@ -94,6 +94,9 @@ test("create with prefs", async () => {
 });
 
 test("create with literal structs and nested struct lists", async () => {
+  // Keep the struct values inline: expectMutation supplies JSON variables, which
+  // do not exercise GraphQL's null-prototype literal inputs. Using $phone shows
+  // that variables elsewhere in the request do not prevent the struct failure.
   const result = await graphql({
     schema,
     source: `mutation($phone: String!) {

--- a/examples/todo-sqlite/src/graphql/tests/account.test.ts
+++ b/examples/todo-sqlite/src/graphql/tests/account.test.ts
@@ -1,4 +1,5 @@
-import { IDViewer } from "@snowtop/ent";
+import { IDViewer, LoggedOutViewer } from "@snowtop/ent";
+import { graphql } from "graphql";
 import {
   expectMutation,
   expectQueryFromRoot,
@@ -90,6 +91,47 @@ test("create with prefs", async () => {
       ],
     ],
   );
+});
+
+test("create with literal structs and nested struct lists", async () => {
+  const result = await graphql({
+    schema,
+    source: `mutation($phone: String!) {
+      createAccount(input: {
+        name: "Literal structs"
+        phone_number: $phone
+        account_prefs: {finished_nux: true, enable_notifs: false, preferred_language: "en_US"}
+        account_prefs_list: [{finished_nux: false, enable_notifs: true, preferred_language: "fr_FR"}]
+        country_infos: [{countries: [{
+          name: "France", code: "FR", capital: {name: "Paris", population: "2100000"}
+        }]}]
+      }) { account { id } }
+    }`,
+    variableValues: { phone: randomPhoneNumber() },
+    contextValue: { getViewer: () => new LoggedOutViewer() },
+  });
+  expect(result.errors).toBeUndefined();
+  const id = (result.data as any).createAccount.account.id;
+  const account = await Account.loadX(new IDViewer(id), id);
+  expect(account.accountPrefs).toStrictEqual({
+    finishedNux: true,
+    enableNotifs: false,
+    preferredLanguage: "en_US",
+  });
+  expect(account.accountPrefsList).toStrictEqual([
+    { finishedNux: false, enableNotifs: true, preferredLanguage: "fr_FR" },
+  ]);
+  expect(account.countryInfos).toStrictEqual([
+    {
+      countries: [
+        {
+          name: "France",
+          code: "FR",
+          capital: { name: "Paris", population: "2100000" },
+        },
+      ],
+    },
+  ]);
 });
 
 test("viewer_can_see", async () => {

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -906,6 +906,14 @@ features:
     mode: explicit
     rationale: Imported custom GraphQL enum types must not be serialized as scalars, and unused optional scalar helpers must not churn custom_schema.json.
 
+  - id: struct.graphql_literal_input_runtime
+    owns: []
+    mode: existing_test
+    test_refs:
+      - ts/src/schema/struct_input.test.ts
+      - ts/src/action/orchestrator.test.ts
+      - examples/todo-sqlite/src/graphql/tests/account.test.ts
+    rationale: Null-prototype GraphQL literal records require runtime validation and formatting; generated mutations and nested structs/lists are exercised outside the compile-only matrix.
   - id: transform_write.struct_input_runtime
     owns: []
     mode: existing_test

--- a/ts/src/action/orchestrator.test.ts
+++ b/ts/src/action/orchestrator.test.ts
@@ -584,6 +584,38 @@ function getInsertUserBuilder(
 }
 
 function commonTests() {
+  test.each([
+    false,
+    true,
+  ])("invalid null-prototype struct (list=%s) preserves validation error", async (list) => {
+    const value = Object.assign(Object.create(null), { label: "x" });
+    const structOptions = {
+      tsType: "Detail",
+      fields: { label: StringType({ minLen: 2 }) },
+    };
+    const schema = getBuilderSchemaFromFields(
+      {
+        detail: list
+          ? StructTypeAsList(structOptions)
+          : StructType(structOptions),
+      },
+      User,
+    );
+    const builder = new SimpleBuilder(
+      new LoggedOutViewer(),
+      schema,
+      new Map([["detail", list ? [value] : value]]),
+      WriteOperation.Insert,
+      null,
+    );
+    const errors = await builder.orchestrator.validWithErrors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/^invalid field detail with value /);
+    expect(errors[0].message).not.toContain(
+      "Cannot convert object to primitive value",
+    );
+  });
+
   beforeAll(async () => {
     // does assoc_edge_config loader need to be cleared?
     for (const edge of edges) {

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -56,6 +56,18 @@ import { RawQueryOperation } from "./operations";
 type MaybeNull<T extends Ent> = T | null;
 type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
 
+function invalidFieldError(fieldName: string, value: any): Error {
+  let description: string;
+  try {
+    description = `${value}`;
+  } catch {
+    // Null-prototype records (and lists containing them) cannot be coerced
+    // to strings. Diagnostic formatting must not hide a validation failure.
+    description = "[unprintable value]";
+  }
+  return new Error(`invalid field ${fieldName} with value ${description}`);
+}
+
 export interface OrchestratorOptions<
   TEnt extends Ent<TViewer>,
   TInput extends Data,
@@ -1164,7 +1176,7 @@ export class Orchestrator<
           valid = await valid;
         }
         if (!valid) {
-          return new Error(`invalid field ${fieldName} with value ${value}`);
+          return invalidFieldError(fieldName, value);
         }
       }
       // keep track of dependencies to resolve
@@ -1178,7 +1190,7 @@ export class Orchestrator<
           valid = await valid;
         }
         if (!valid) {
-          return new Error(`invalid field ${fieldName} with value ${value}`);
+          return invalidFieldError(fieldName, value);
         }
       }
 

--- a/ts/src/schema/struct_field.ts
+++ b/ts/src/schema/struct_field.ts
@@ -69,7 +69,7 @@ export class StructField extends BaseField implements Field {
   }
 
   formatImpl(obj: any, nested?: boolean) {
-    if (!(obj instanceof Object)) {
+    if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
       throw new Error("valid was not called");
     }
     let ret: Object = {};
@@ -164,7 +164,8 @@ export class StructField extends BaseField implements Field {
   }
 
   private async validImpl(obj: any) {
-    if (!(obj instanceof Object)) {
+    // GraphQL literal input records have a null prototype.
+    if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
       return false;
     }
 
@@ -303,10 +304,6 @@ export class StructField extends BaseField implements Field {
       );
       return valid.every((b) => b);
     }
-    if (!(obj instanceof Object)) {
-      return false;
-    }
-
     return this.validImpl(obj);
   }
 }

--- a/ts/src/schema/struct_field.ts
+++ b/ts/src/schema/struct_field.ts
@@ -164,7 +164,11 @@ export class StructField extends BaseField implements Field {
   }
 
   private async validImpl(obj: any) {
-    // GraphQL literal input records have a null prototype.
+    // GraphQL.js valueFromAST turns inline objects such as prefs: {enabled: true}
+    // into null-prototype records, which fail instanceof Object. Objects supplied
+    // in the JSON variables payload use ordinary prototypes instead. A struct
+    // can still be inline when other values use variables; object-valued variable
+    // defaults also go through valueFromAST when the variable is omitted.
     if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
       return false;
     }

--- a/ts/src/schema/struct_input.test.ts
+++ b/ts/src/schema/struct_input.test.ts
@@ -1,0 +1,195 @@
+import {
+  buildSchema,
+  GraphQLInputObjectType,
+  parseValue,
+  valueFromAST,
+} from "graphql";
+import { clearGlobalSchema, setGlobalSchema } from "../core/global_schema";
+import { StringType, TimestampType } from "./field";
+import { StructType, StructTypeAsList } from "./struct_field";
+import { UnionType } from "./union_field";
+
+const schema = buildSchema(`
+  input DetailInput { displayName: String! }
+  input ProfileInput {
+    detail: DetailInput!
+    contacts: [DetailInput!]!
+  }
+  type Query { unused: Boolean }
+`);
+
+function literal(source: string, type = "DetailInput") {
+  return valueFromAST(
+    parseValue(source),
+    schema.getType(type) as GraphQLInputObjectType,
+  ) as Record<string, any>;
+}
+
+function detail() {
+  return StructType({
+    tsType: "Detail",
+    fields: { displayName: StringType({ minLen: 2, toUpperCase: true }) },
+  });
+}
+
+test.each([
+  "literal",
+  "variable",
+])("nested struct/list %s input", async (kind) => {
+  const f = StructType({
+    tsType: "Profile",
+    fields: {
+      detail: detail(),
+      contacts: StructTypeAsList({
+        tsType: "Contacts",
+        fields: detail().type.subFields!,
+        validateUniqueKey: "displayName",
+      }),
+    },
+  });
+  const input =
+    kind === "literal"
+      ? literal(
+          '{detail: {displayName: "alice"}, contacts: [{displayName: "bob"}]}',
+          "ProfileInput",
+        )
+      : JSON.parse(
+          '{"detail":{"displayName":"alice"},"contacts":[{"displayName":"bob"}]}',
+        );
+  const prototype = kind === "literal" ? null : Object.prototype;
+  expect(Object.getPrototypeOf(input.detail)).toBe(prototype);
+  expect(Object.getPrototypeOf(input.contacts[0])).toBe(prototype);
+  expect(await f.valid(input)).toBe(true);
+  const expected = {
+    detail: { display_name: "ALICE" },
+    contacts: [{ display_name: "BOB" }],
+  };
+  expect(f.format(input)).toBe(JSON.stringify(expected));
+  expect(f.format(input, true)).toStrictEqual(expected);
+  expect(Object.getPrototypeOf(input.detail)).toBe(prototype);
+  expect(input.detail.displayName).toBe("alice");
+  input.contacts.push(input.contacts[0]);
+  expect(await f.valid(input)).toBe(false);
+});
+
+test("global structs adapt literal records between scalar and list fields", async () => {
+  setGlobalSchema({
+    fields: {
+      detail: detail(),
+      details: StructTypeAsList({
+        tsType: "Details",
+        fields: detail().type.subFields!,
+      }),
+    },
+  });
+  try {
+    for (const globalType of ["Detail", "Details"]) {
+      const input = literal('{displayName: "alice"}');
+      const scalar = StructType({ globalType });
+      expect(await scalar.valid(input)).toBe(true);
+      expect(scalar.format(input)).toBe('{"display_name":"ALICE"}');
+      const list = StructTypeAsList({ globalType });
+      expect(await list.valid([input])).toBe(true);
+      expect(list.format([input])).toBe('[{"display_name":"ALICE"}]');
+    }
+  } finally {
+    clearGlobalSchema();
+  }
+});
+
+test("nested union accepts literal records and still requires one valid member", async () => {
+  const union = UnionType({
+    tsType: "Contact",
+    fields: {
+      person: detail(),
+      organization: StructType({
+        tsType: "Organization",
+        fields: { company: StringType() },
+      }),
+    },
+  });
+  const f = StructType({ tsType: "Wrapper", fields: { contact: union } });
+  const contact = literal('{displayName: "alice"}');
+  const input = Object.assign(Object.create(null), { contact });
+  expect(await f.valid(input)).toBe(true);
+  expect(f.format(input)).toBe('{"contact":{"display_name":"ALICE"}}');
+  expect(Object.getPrototypeOf(contact)).toBe(null);
+  expect(Object.keys(contact)).toEqual(["displayName"]);
+  expect(await union.valid(literal('{displayName: "a"}'))).toBe(false);
+  contact.company = "Acme";
+  expect(await union.valid(contact)).toBe(false);
+});
+
+test("invalid literal records still fail their field validators", async () => {
+  expect(await detail().valid(literal('{displayName: "a"}'))).toBe(false);
+  expect(await detail().valid(Object.create(null))).toBe(false);
+  const failure = new Error("field validator failed");
+  const f = StructType({
+    tsType: "Throwing",
+    fields: {
+      displayName: Object.assign(StringType(), {
+        valid: () => {
+          throw failure;
+        },
+      }),
+    },
+  });
+  await expect(f.valid(literal('{displayName: "alice"}'))).rejects.toBe(
+    failure,
+  );
+});
+
+test.each([
+  undefined,
+  null,
+  false,
+  1,
+  "text",
+  Symbol("value"),
+  [],
+  [1],
+  () => {},
+])("rejects non-record input %p even with only nullable fields", async (input) => {
+  const f = StructType({
+    tsType: "Optional",
+    fields: { name: StringType({ nullable: true }) },
+  });
+  const union = UnionType({ tsType: "OptionalUnion", fields: { optional: f } });
+  const list = StructTypeAsList({
+    tsType: "OptionalList",
+    fields: f.type.subFields!,
+  });
+  expect(await f.valid(input)).toBe(false);
+  expect(() => f.format(input)).toThrow("valid was not called");
+  expect(await union.valid(input)).toBe(false);
+  expect(() => union.format(input)).toThrow("valid was not called");
+  expect(await list.valid([input])).toBe(false);
+  if (!Array.isArray(input)) {
+    expect(await list.valid(input)).toBe(false);
+  }
+});
+
+test("class instances and nested Dates retain their identity", async () => {
+  class Detail {
+    displayName = "alice";
+  }
+  const value = new Detail();
+  const date = new Date("2026-01-02T00:00:00.000Z");
+  const validate = jest.fn((input) => input === date);
+  const f = StructType({
+    tsType: "WithDate",
+    fields: {
+      detail: detail(),
+      at: TimestampType({ valid: validate }),
+    },
+  });
+  const input = { detail: value, at: date };
+  expect(await f.valid(input)).toBe(true);
+  expect(validate).toHaveBeenCalledWith(date);
+  expect(f.format(input)).toBe(
+    '{"detail":{"display_name":"ALICE"},"at":"2026-01-02T00:00:00.000Z"}',
+  );
+  expect(input.detail).toBe(value);
+  expect(input.detail).toBeInstanceOf(Detail);
+  expect(input.at).toBe(date);
+});

--- a/ts/src/schema/union_field.ts
+++ b/ts/src/schema/union_field.ts
@@ -45,7 +45,7 @@ export class UnionField extends BaseField implements FieldOptions {
   }
 
   format(obj: any) {
-    if (!(obj instanceof Object)) {
+    if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
       throw new Error("valid was not called");
     }
     const k = obj[KEY];
@@ -69,7 +69,8 @@ export class UnionField extends BaseField implements FieldOptions {
   }
 
   async valid(obj: any): Promise<boolean> {
-    if (!(obj instanceof Object)) {
+    // Accept the same record shapes as the member struct fields.
+    if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
       return false;
     }
     let promises: Promise<validResult>[] = [];


### PR DESCRIPTION
GraphQL literal object inputs use null-prototype records, which `StructField` and `UnionField` rejected. Constructing the action validation error could then throw `Cannot convert object to primitive value`, hiding the original failure.

Accept record-shaped inputs during struct and union validation and formatting, including nested lists and global structs. Preserve class instances and child validators, reject arrays/functions as scalar structs, and retain the field-validation error when its value cannot be printed.

Regression coverage includes `valueFromAST` inputs, ordinary inputs, nested/global structs and lists, union matching, invalid shapes, class/Date identity, and a generated GraphQL mutation that reloads persisted values. The runtime behavior is classified in the codegen matrix catalog.

Validation completed with Node 24:

- After merging current main: 261 struct/union, action, transformed-action and trigger-priority tests passed across disposable PostgreSQL and SQLite databases.
- Generated SQLite account GraphQL tests: 4 passed, exercising the rebuilt local runtime and existing variable-input mutations.
- The new literal mutation fails against the original runtime and passes with the fix.
- TypeScript package compile, example typecheck, matrix catalog checks, formatting, and full-diff review passed.

The full example matrix and Docker/codegen rebuilds were not rerun for this focused change. The generated consumer test used the checked-in generated example with a temporary Jest override pointing to local `ts/dist`.
