### PR TITLE
Preserve external tables during migration codegen

### DIFF
--- a/.github/workflows/go_ci.yml
+++ b/.github/workflows/go_ci.yml
@@ -8,6 +8,7 @@ on:
       - 'internal/**.go'
       - 'internal/**.tmpl'
       - 'testdata/codegen_matrix/**'
+      - 'python/**'
       - 'ts/src/**'
       - .github/workflows/go_ci.yml
 
@@ -54,11 +55,9 @@ jobs:
         cache: pip
         cache-dependency-path: python/Pipfile.lock
       
-    - name: Install auto_schema
-      # Older auto_schema releases pin SQLAlchemy 2.0.18, which fails during
-      # import on Python 3.14. Keep python-dateutil in the published package:
-      # Alembic needs it when auto_schema generates timezone-aware revisions.
-      run: python3 -m pip install wheel auto_schema==0.0.36
+    - name: Install local auto_schema
+      # Exercise the Go/Python protocol together, including unreleased options.
+      run: python3 -m pip install wheel ./python/auto_schema
 
     - name: Setup nodejs
       uses: actions/setup-node@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ## [Unreleased]
 
+### Added
+
+- support `codegen.ignoreTables` to preserve externally managed tables and their
+  foreign-key dependencies during migration codegen and schema SQL generation
+  (#2030).
+
 ### Fixed
 
 - avoid opening the Go codegen database pool until first use and close it when

--- a/docs/docs/advanced-topics/configuration.md
+++ b/docs/docs/advanced-topics/configuration.md
@@ -75,10 +75,10 @@ database definition. Ent-declared foreign keys targeting ignored tables are also
 rejected. External migrations own foreign keys crossing this ownership boundary,
 including existing foreign keys on managed tables that reference ignored tables.
 Autogeneration preserves those foreign keys. Destructive changes to their tables
-or endpoint columns, removal of referenced unique keys, and seed-row changes
-that could cascade into external rows fail before generating a migration;
-unrelated managed changes continue normally. Coordinate the external migration
-before changing an endpoint.
+or endpoint columns, removal of the supporting unique key, and seed-row changes
+that could cascade through managed tables into external rows fail before
+generating a migration; unrelated managed changes continue normally. Coordinate
+the external migration before changing an endpoint.
 
 The option governs new autogeneration. It does not rewrite previously committed
 revisions or interpret handwritten SQL. Explicit upgrade/downgrade, numeric

--- a/docs/docs/advanced-topics/configuration.md
+++ b/docs/docs/advanced-topics/configuration.md
@@ -31,11 +31,63 @@ The following properties can be configured:
 - `defaultGraphQLMutationName`: default names for graphql actions|mutations is nounVerb e.g. userCreate. If you wanna change it to verbNoun e.g. createUser, set this field to `VERB_NOUN`
 - `defaultGraphQLFieldFormat`: default format for fields is lowerCamelCase e.g. firstName. If you wanna change it to snake_case e.g. first_name, set this field to snake_case
 - `schemaSQLFilePath`: if we should generate schema.sql file and path to generate it
+- `ignoreTables`: external table names excluded from migration autogeneration; see [External tables](#external-tables).
 - `globalImportPath`: path to add to src/ent/internal.ts so that it's included everywhere. Where things like [global augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#global-augmentation) can be done
 - `userOverridenFiles`: list of files to not override during codegen i.e. because there's a bug in codegen and the user has decided to override it.
 - `transformLoadMethod`: if set, overrides the loadNoTransform(X) methods to be this instead of the default loadNoTransform(X)
 - `transformDeleteMethod`: if set, overrides the saveWithoutTransform(X) methods to be this instead of the default saveWithoutTransform(X)
 - `disableDefaultExportForActions`: by default, actions are exported with `export default`. This changes that to named defaults.
+
+### External tables
+
+Use `codegen.ignoreTables` when another system owns tables in the same database:
+
+```yaml title="ent.yml"
+codegen:
+  ignoreTables:
+    - auth.*
+    - public.session
+    - billing_accounts
+```
+
+Entries are case-sensitive exact identifiers: `table`, `schema.table`, or
+`schema.*`. Identifiers start with an ASCII letter or underscore and may then
+contain letters, digits, underscores, or `$`. Quoted identifiers, whitespace,
+and table-prefix globs such as `public.auth_*` are rejected. `auth.*` means every
+table in the schema named `auth`; it does not match `public.auth_users`.
+
+An unqualified entry applies to the connection's default schema (`current_schema()`
+on Postgres, normally `public`; `main` on SQLite). With dev schemas enabled, it
+applies to the active dev schema. A qualified `public.session` entry never hides
+`session` in a dev schema. These rules do not expand Ent's schema comparison scope
+or enable public fallback. Existing PostGIS/system-table exclusions still apply.
+Omitting this option retains the existing behavior.
+
+Ignored tables retain their rows, indexes, and constraints during autogeneration.
+The rules apply to change inspection, generated migrations, `schema.sql`,
+`all_sql`, and `squash all`. Generated SQL contains the managed schema; provision
+external tables separately when bootstrapping a database. The comparison database
+for `all_sql` may contain ignored tables but must contain no managed tables.
+
+An entry matching an Ent-generated table is an error. Remove its Ent schema
+before marking it external; this option does not turn an Ent node into a partial
+database definition. Ent-declared foreign keys targeting ignored tables are also
+rejected. External migrations own foreign keys crossing this ownership boundary,
+including existing foreign keys on managed tables that reference ignored tables.
+Autogeneration preserves those foreign keys. Destructive changes to their tables
+or endpoint columns, removal of referenced unique keys, and seed-row changes
+that could cascade into external rows fail before generating a migration;
+unrelated managed changes continue normally. Coordinate the external migration
+before changing an endpoint.
+
+The option governs new autogeneration. It does not rewrite previously committed
+revisions or interpret handwritten SQL. Explicit upgrade/downgrade, numeric
+squash, progressive SQL, and custom SQL still execute/replay their existing
+migrations. Review those migrations when transferring table ownership.
+
+The standalone Python CLI accepts the same entries as repeated arguments, for
+example `--ignore_table='auth.*' --ignore_table=public.session`. Go codegen passes
+these arguments automatically; no Python dependency changes are required.
 
 ### PrivacyConfig
 

--- a/docs/docs/advanced-topics/configuration.md
+++ b/docs/docs/advanced-topics/configuration.md
@@ -75,10 +75,11 @@ database definition. Ent-declared foreign keys targeting ignored tables are also
 rejected. External migrations own foreign keys crossing this ownership boundary,
 including existing foreign keys on managed tables that reference ignored tables.
 Autogeneration preserves those foreign keys. Destructive changes to their tables
-or endpoint columns, removal of the supporting unique key, and seed-row changes
+or endpoint columns, removal of the supporting unique key, and seed-row or edge changes
 that could cascade through managed tables into external rows fail before
-generating a migration; unrelated managed changes continue normally. Coordinate
-the external migration before changing an endpoint.
+generating a migration. Dependency checks account for foreign keys added,
+replaced, or removed earlier in that migration; unrelated managed changes continue
+normally. Coordinate the external migration before changing an endpoint.
 
 The option governs new autogeneration. It does not rewrite previously committed
 revisions or interpret handwritten SQL. Explicit upgrade/downgrade, numeric

--- a/internal/auto_schema/auto_schema.go
+++ b/internal/auto_schema/auto_schema.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/lolopinto/ent/ent/data"
@@ -31,6 +32,7 @@ func RunPythonCommandWriter(cfg codegenapi.Config, w io.Writer, extraArgs ...str
 		fmt.Sprintf("-s=%s", pathToConfigs),
 		fmt.Sprintf("-e=%s", data.GetSQLAlchemyDatabaseURIgo()),
 	}
+	args = append(args, ignoreTableArgs(cfg.IgnoreTables())...)
 
 	if cfg.DebugMode() {
 		args = append(args, "--debug")
@@ -84,6 +86,18 @@ func RunPythonCommandWriter(cfg codegenapi.Config, w io.Writer, extraArgs ...str
 		return errors.New(errMsg)
 	}
 	return nil
+}
+
+func ignoreTableArgs(patterns []string) []string {
+	patterns = append([]string(nil), patterns...)
+	sort.Strings(patterns)
+	var args []string
+	for i, pattern := range patterns {
+		if i == 0 || pattern != patterns[i-1] {
+			args = append(args, "--ignore_table="+pattern)
+		}
+	}
+	return args
 }
 
 func trimErrorMsg(berr *bytes.Buffer, local bool) string {

--- a/internal/auto_schema/auto_schema_test.go
+++ b/internal/auto_schema/auto_schema_test.go
@@ -1,0 +1,14 @@
+package auto_schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnoreTableArgs(t *testing.T) {
+	patterns := []string{"public.session", "auth.*", "session", "auth.*"}
+	require.Equal(t, []string{"--ignore_table=auth.*", "--ignore_table=public.session", "--ignore_table=session"}, ignoreTableArgs(patterns))
+	require.Equal(t, "public.session", patterns[0])
+	require.Empty(t, ignoreTableArgs(nil))
+}

--- a/internal/codegen/codegenapi/api.go
+++ b/internal/codegen/codegenapi/api.go
@@ -99,6 +99,7 @@ type Config interface {
 	GetAssocEdgePath() *ImportedObject
 	CustomSQLInclude() []string
 	CustomSQLExclude() []string
+	IgnoreTables() []string
 }
 
 // DummyConfig exists for tests/legacy paths which need Configs and don't want to create the production one
@@ -165,6 +166,10 @@ func (cfg DummyConfig) CustomSQLInclude() []string {
 
 func (cfg DummyConfig) CustomSQLExclude() []string {
 	return []string{}
+}
+
+func (cfg DummyConfig) IgnoreTables() []string {
+	return nil
 }
 
 var _ Config = &DummyConfig{}

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -739,6 +740,9 @@ func parseConfig(absPathToRoot string) (*ConfigurableConfig, error) {
 			return nil, err
 		}
 		if c.Codegen != nil {
+			if err := ValidateIgnoreTables(c.Codegen.IgnoreTables); err != nil {
+				return nil, err
+			}
 			c.Codegen.init()
 		}
 		return &c, nil
@@ -796,6 +800,7 @@ func cloneConfig(cfg *ConfigurableConfig) *ConfigurableConfig {
 }
 
 type CodegenConfig struct {
+	IgnoreTables                   []string                         `yaml:"ignoreTables"`
 	DefaultEntPolicy               *PrivacyConfig                   `yaml:"defaultEntPolicy"`
 	DefaultActionPolicy            *PrivacyConfig                   `yaml:"defaultActionPolicy"`
 	Prettier                       *PrettierConfig                  `yaml:"prettier"`
@@ -843,6 +848,7 @@ func cloneDevSchema(cfg *DevSchemaConfig) *DevSchemaConfig {
 
 func (cfg *CodegenConfig) Clone() *CodegenConfig {
 	return &CodegenConfig{
+		IgnoreTables:                   append([]string(nil), cfg.IgnoreTables...),
 		DefaultEntPolicy:               clonePrivacyConfig(cfg.DefaultEntPolicy),
 		DefaultActionPolicy:            clonePrivacyConfig(cfg.DefaultActionPolicy),
 		Prettier:                       clonePrettierConfig(cfg.Prettier),
@@ -866,6 +872,25 @@ func (cfg *CodegenConfig) Clone() *CodegenConfig {
 		TransformLoadMethod:            cfg.TransformLoadMethod,
 		DisableDefaultExportForActions: cfg.DisableDefaultExportForActions,
 	}
+}
+
+// IgnoreTables identifies externally owned tables, not Ent schema nodes.
+func (cfg *Config) IgnoreTables() []string {
+	if codegen := cfg.getCodegenConfig(); codegen != nil {
+		return append([]string(nil), codegen.IgnoreTables...)
+	}
+	return nil
+}
+
+var ignoreTablePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_$]*(\.(\*|[A-Za-z_][A-Za-z0-9_$]*))?$`)
+
+func ValidateIgnoreTables(patterns []string) error {
+	for _, pattern := range patterns {
+		if !ignoreTablePattern.MatchString(pattern) {
+			return fmt.Errorf("invalid codegen.ignoreTables entry %q: expected table, schema.table, or schema.* (no prefix globs or quoted identifiers)", pattern)
+		}
+	}
+	return nil
 }
 
 func (c *CodegenConfig) init() {

--- a/internal/codegen/ignore_tables_test.go
+++ b/internal/codegen/ignore_tables_test.go
@@ -1,0 +1,39 @@
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnoreTablesConfig(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ent.yml"), []byte("codegen:\n  ignoreTables: [user, public.session, auth.*]\n"), 0600))
+	cfg, err := ReadConfig(root)
+	require.NoError(t, err)
+	require.Equal(t, []string{"user", "public.session", "auth.*"}, cfg.Codegen.IgnoreTables)
+	cloned := cfg.Clone()
+	cloned.Codegen.IgnoreTables[0] = "changed"
+	require.Equal(t, "user", cfg.Codegen.IgnoreTables[0])
+	config := &Config{config: cfg}
+	require.Equal(t, cfg.Codegen.IgnoreTables, config.IgnoreTables())
+	config.IgnoreTables()[0] = "changed"
+	require.Equal(t, "user", cfg.Codegen.IgnoreTables[0])
+	require.Empty(t, (&Config{}).IgnoreTables())
+}
+
+func TestIgnoreTablesGrammar(t *testing.T) {
+	for _, pattern := range []string{"user", "public.session", "auth.*", "some_schema.table1", "CaseSensitive", "table$"} {
+		require.NoError(t, ValidateIgnoreTables([]string{pattern}))
+	}
+	for _, pattern := range []string{"", "*", "auth*", "public.auth_*", "auth.*.x", ".user", "auth.", " auth.user", "auth.user ", "\"auth\".user", "auth.user;drop"} {
+		t.Run(pattern, func(t *testing.T) {
+			root := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(root, "ent.yml"), []byte("codegen:\n  ignoreTables: ['"+pattern+"']\n"), 0600))
+			_, err := ReadConfig(root)
+			require.ErrorContains(t, err, "invalid codegen.ignoreTables")
+		})
+	}
+}

--- a/internal/codegenmatrix/codegen_matrix_test.go
+++ b/internal/codegenmatrix/codegen_matrix_test.go
@@ -504,7 +504,7 @@ func replaceHarnessPlaceholders(t *testing.T, appRoot string) {
 
 func postgresDatabaseName(t *testing.T) string {
 	t.Helper()
-	hash := sha256.Sum256([]byte(t.Name()))
+	hash := sha256.Sum256([]byte(t.Name() + ":" + t.TempDir()))
 	return fmt.Sprintf("codegen_matrix_%s", hex.EncodeToString(hash[:])[:16])
 }
 
@@ -526,6 +526,7 @@ func runCodegenFixture(t *testing.T, repo, appRoot string, fixture fixture) {
 	t.Setenv("LOCAL_SCRIPT_PATH", "true")
 	t.Setenv("GRAPHQL_PATH", filepath.Join(repo, "ts", "src", "graphql"))
 	configureFixtureDatabase(t, fixture)
+	verifyExternalTables := prepareExternalTables(t, fixture, appRoot)
 	tsentBinary := buildTsentBinary(t, repo)
 
 	// The first pass bootstraps generated files and build metadata. The second
@@ -540,6 +541,7 @@ func runCodegenFixture(t *testing.T, repo, appRoot string, fixture fixture) {
 	secondHash := hashGeneratedSnapshot(secondSnapshot)
 	require.Equal(t, firstHash, secondHash, "codegen fixture is not idempotent; changed files: %s\n%s", strings.Join(changedSnapshotFiles(firstSnapshot, secondSnapshot), ", "), snapshotChangeSummary(firstSnapshot, secondSnapshot))
 
+	verifyExternalTables()
 	runFixtureGeneratedAssertions(t, appRoot)
 
 	cmd := exec.Command(filepath.Join(repo, "ts", "node_modules", ".bin", "tsc"), "--noEmit", "--project", filepath.Join(appRoot, "tsconfig.generated.json"))
@@ -879,6 +881,7 @@ func syntheticOwners() []string {
 		"custom_graphql.gqlConnection",
 		"custom_graphql.mutationReturnType",
 		"codegen.prettier",
+		"codegen.ignoreTables",
 	}
 }
 

--- a/internal/codegenmatrix/external_tables_test.go
+++ b/internal/codegenmatrix/external_tables_test.go
@@ -1,0 +1,94 @@
+package codegenmatrix
+
+import (
+	"database/sql"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// Exercise Go config -> Python autogen -> applied DB and generated SQL together.
+func prepareExternalTables(t *testing.T, fixture fixture, appRoot string) func() {
+	t.Helper()
+	if !fixtureCovers(fixture, "codegen.ignore_tables") {
+		return func() {}
+	}
+	dsn := os.Getenv("DB_CONNECTION_STRING")
+	driver := "postgres"
+	emptyDatabase := ""
+	if fixture.Dialect == "sqlite" {
+		driver = "sqlite3"
+		dsn = strings.TrimPrefix(dsn, "sqlite:///")
+		emptyDatabase = filepath.Join(t.TempDir(), "empty.sqlite")
+	} else {
+		emptyDSN := createIsolatedPostgresDatabase(t, dsn)
+		emptyURL, err := url.Parse(emptyDSN)
+		require.NoError(t, err)
+		emptyDatabase = strings.TrimPrefix(emptyURL.Path, "/")
+	}
+	db, err := sql.Open(driver, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	for _, stmt := range []string{
+		"CREATE TABLE external_accounts (id INTEGER PRIMARY KEY)",
+		"CREATE TABLE external_sessions (id INTEGER PRIMARY KEY, account_id INTEGER REFERENCES external_accounts(id), token TEXT NOT NULL UNIQUE, CONSTRAINT session_positive CHECK (id > 0))",
+		"CREATE INDEX external_session_account_idx ON external_sessions(account_id)",
+		"INSERT INTO external_accounts VALUES (1)",
+		"INSERT INTO external_sessions VALUES (1, 1, 'keep-me')",
+	} {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err)
+	}
+	if fixture.Dialect == "postgres" {
+		_, err := db.Exec("CREATE SCHEMA auth; CREATE TABLE auth.sessions (id INTEGER PRIMARY KEY); INSERT INTO auth.sessions VALUES (42)")
+		require.NoError(t, err)
+	}
+	configPath := filepath.Join(appRoot, "ent.yml")
+	contents, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	var cfg map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(contents, &cfg))
+	cfg["codegen"].(map[string]interface{})["databaseToCompareTo"] = emptyDatabase
+	contents, err = yaml.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, contents, fileMode))
+	return func() {
+		var token string
+		require.NoError(t, db.QueryRow("SELECT token FROM external_sessions WHERE id = 1").Scan(&token))
+		require.Equal(t, "keep-me", token)
+		var indexCount int
+		if fixture.Dialect == "postgres" {
+			require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'external_session_account_idx'").Scan(&indexCount))
+			var id int
+			require.NoError(t, db.QueryRow("SELECT id FROM auth.sessions").Scan(&id))
+			require.Equal(t, 42, id)
+		} else {
+			require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'external_session_account_idx'").Scan(&indexCount))
+		}
+		require.Equal(t, 1, indexCount)
+		contents, err := os.ReadFile(filepath.Join(appRoot, "src/schema/schema.sql"))
+		require.NoError(t, err)
+		require.Contains(t, string(contents), "CREATE TABLE")
+		require.NotContains(t, string(contents), "external_accounts")
+		require.NotContains(t, string(contents), "external_sessions")
+		require.NotContains(t, string(contents), "auth.sessions")
+
+		// Verify the policy against an actual Go-generated FK, including the
+		// ignored target's generated definition. This is read-only inspection.
+		cmd := exec.Command("auto_schema", "--schema="+filepath.Join(appRoot, "src/schema"),
+			"--engine="+os.Getenv("DB_CONNECTION_STRING"), "--changes",
+			"--ignore_table=matrix_core_users")
+		// The legacy CLI reports errors on stderr; the Go launcher treats
+		// that diagnostic as failure even when the CLI exits with status 0.
+		out, _ := cmd.CombinedOutput()
+		require.Contains(t, string(out), "managed foreign key")
+		require.Contains(t, string(out), "ignored table")
+	}
+}

--- a/internal/codegenmatrix/external_tables_test.go
+++ b/internal/codegenmatrix/external_tables_test.go
@@ -82,8 +82,12 @@ func prepareExternalTables(t *testing.T, fixture fixture, appRoot string) func()
 
 		// Verify the policy against an actual Go-generated FK, including the
 		// ignored target's generated definition. This is read-only inspection.
+		engineURL := os.Getenv("DB_CONNECTION_STRING")
+		if strings.HasPrefix(engineURL, "postgres://") {
+			engineURL = "postgresql://" + strings.TrimPrefix(engineURL, "postgres://")
+		}
 		cmd := exec.Command("auto_schema", "--schema="+filepath.Join(appRoot, "src/schema"),
-			"--engine="+os.Getenv("DB_CONNECTION_STRING"), "--changes",
+			"--engine="+engineURL, "--changes",
 			"--ignore_table=matrix_core_users")
 		// The legacy CLI reports errors on stderr; the Go launcher treats
 		// that diagnostic as failure even when the CLI exits with status 0.

--- a/python/auto_schema/auto_schema/cli/__init__.py
+++ b/python/auto_schema/auto_schema/cli/__init__.py
@@ -36,6 +36,10 @@ parser.add_argument(
     help='if set, include public in search_path (true/false). defaults to false when db_schema is set',
 )
 parser.add_argument('-f', '--fix_edges', help='fix edges in schema into db')
+parser.add_argument(
+    '--ignore_table', action='append', default=[],
+    help='external table: table, schema.table, or schema.*; repeat for multiple entries',
+)
 parser.add_argument('-u', '--upgrade', help='upgrade')
 # this is getting bad and needs to be changed soon to something that's more extensible and makes more sense
 parser.add_argument('-d', '--downgrade', help='downgrade')

--- a/python/auto_schema/auto_schema/compare.py
+++ b/python/auto_schema/auto_schema/compare.py
@@ -17,6 +17,7 @@ from auto_schema.clause_text import normalize_clause_text
 from auto_schema.schema_item import FullTextIndex
 
 from . import ops
+from . import config
 
 
 def _normalize_db_extension(extension: dict[str, Any]) -> dict[str, Any]:
@@ -142,6 +143,8 @@ def compare_extensions(autogen_context, upgrade_ops, schemas):
 
 @comparators.dispatch_for("schema", priority=DispatchPriority.LAST)
 def compare_edges(autogen_context, upgrade_ops, schemas):
+    if config.external_tables.matches("assoc_edge_config", reflected=True):
+        return
     db_edges = {}
 
     for sch in schemas:
@@ -321,8 +324,8 @@ def compare_data(autogen_context, upgrade_ops, schemas):
     data = autogen_context.metadata.info.setdefault("data", {})
 
     inspector = autogen_context.inspector
-    db_metadata = sa.MetaData()
-    db_metadata.reflect(inspector.bind)
+    table_names = {name for name in inspector.get_table_names()
+                   if autogen_context.run_name_filters(name, "table", {"schema_name": None})}
 
     for sch in schemas:
         sch = _get_schema_key(sch)
@@ -332,6 +335,11 @@ def compare_data(autogen_context, upgrade_ops, schemas):
 
         schema_data = data.get(sch, {})
         for table_name in schema_data:
+            if config.external_tables.matches(table_name) or (
+                table_name not in autogen_context.metadata.tables
+                and config.external_tables.matches(table_name, reflected=True)
+            ):
+                continue
             table_data = schema_data[table_name]
 
             pkeys = table_data.get('pkeys', None)
@@ -347,7 +355,7 @@ def compare_data(autogen_context, upgrade_ops, schemas):
             data_rows = {_create_tuple_key(row, pkeys): row for row in rows}
 
             # new table. need to add
-            if not table_name in db_metadata.tables:
+            if table_name not in table_names:
                 upgrade_ops.ops.append(ops.AddRowsOp(
                     table_name, pkeys, rows))
             else:
@@ -410,13 +418,19 @@ def compare_schema(autogen_context, upgrade_ops, schemas):
     inspector = autogen_context.inspector
 
     db_metadata = sa.MetaData()
-    db_metadata.reflect(inspector.bind)
+    db_metadata.reflect(
+        inspector.bind,
+        only=lambda name, metadata: autogen_context.run_name_filters(
+            name, "table", {"schema_name": None}
+        ),
+        resolve_fks=False,
+    )
 
     # TODO schema not being used
     # https://github.com/lolopinto/ent/issues/123
     for sch in schemas:
         conn_tables = {
-            table.name: table for table in db_metadata.sorted_tables}
+            table.name: table for table in db_metadata.tables.values()}
         metadata_tables = {
             table.name: table for table in autogen_context.metadata.sorted_tables}
 
@@ -431,6 +445,8 @@ def compare_schema(autogen_context, upgrade_ops, schemas):
         for name in metadata_tables:
             if not name in conn_tables:
                 _check_new_table(metadata_tables[name], upgrade_ops, sch)
+
+    config.external_tables.guard_dependencies(autogen_context, upgrade_ops, config.schema_name)
 
 
 def _check_removed_table(metadata_table, upgrade_ops, sch):

--- a/python/auto_schema/auto_schema/config.py
+++ b/python/auto_schema/auto_schema/config.py
@@ -1,4 +1,5 @@
 from typing import Any, TextIO
+from .external_tables import ExternalTables
 
 # set in runner.Runner.__init__
 metadata: Any | None = None
@@ -8,3 +9,4 @@ output_buffer: TextIO | None = None
 # dev branch schema support (set in Runner.__init__)
 schema_name: str | None = None
 include_public: bool | None = None
+external_tables = ExternalTables()

--- a/python/auto_schema/auto_schema/external_tables.py
+++ b/python/auto_schema/auto_schema/external_tables.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import sqlalchemy as sa
 from alembic.operations import ops
-from .ops import RemoveRowsOp, ModifyRowsOp
+from .ops import RemoveRowsOp, ModifyRowsOp, RemoveEdgesOp, ModifyEdgeOp
 
 
 _PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_$]*(?:\.(?:\*|[A-Za-z_][A-Za-z0-9_$]*))?")
@@ -24,6 +24,7 @@ class _ForeignKey:
     onupdate: str
     supporting_index: str | None = None
     supporting_constraint: str | None = None
+    name: str | None = None
 
 
 class ExternalTables:
@@ -117,7 +118,7 @@ class ExternalTables:
                        ARRAY(SELECT a.attname FROM unnest(fk.confkey) WITH ORDINALITY AS k(num, ord)
                              JOIN pg_attribute a ON a.attrelid = fk.confrelid AND a.attnum = k.num
                              ORDER BY k.ord),
-                       fk.confdeltype, fk.confupdtype, key_index.relname, key_constraint.conname
+                       fk.confdeltype, fk.confupdtype, key_index.relname, key_constraint.conname, fk.conname
                 FROM pg_constraint fk
                 JOIN pg_class source ON source.oid = fk.conrelid
                 JOIN pg_namespace source_ns ON source_ns.oid = source.relnamespace
@@ -130,10 +131,10 @@ class ExternalTables:
                 WHERE fk.contype = 'f'
                   AND (source_ns.nspname = ANY(:schemas) OR target_ns.nspname = ANY(:schemas))
             """), {'schemas': sorted(schemas)})
-            for source_schema, source, target_schema, target, columns, target_columns, delete, update, index, constraint in rows:
+            for source_schema, source, target_schema, target, columns, target_columns, delete, update, index, constraint, name in rows:
                 yield _ForeignKey((source_schema, source), (target_schema, target),
                                   tuple(columns), tuple(target_columns),
-                                  _PG_ACTIONS[delete], _PG_ACTIONS[update], index, constraint)
+                                  _PG_ACTIONS[delete], _PG_ACTIONS[update], index, constraint, name)
             return
 
         inspector = autogen_context.inspector
@@ -146,7 +147,49 @@ class ExternalTables:
                     yield _ForeignKey((schema, table), (target_schema, target),
                                       tuple(fk['constrained_columns']), tuple(fk['referred_columns']),
                                       options.get('ondelete', 'NO ACTION').upper(),
-                                      options.get('onupdate', 'NO ACTION').upper())
+                                      options.get('onupdate', 'NO ACTION').upper(), name=fk['name'])
+
+    def _foreign_key_from_constraint(self, constraint):
+        schema, target, _ = constraint.elements[0]._column_tokens
+        return _ForeignKey(
+            (self.schema_for(constraint.table.name, constraint.table.schema), constraint.table.name),
+            (self.schema_for(target, schema), target),
+            tuple(fk.parent.name for fk in constraint.elements),
+            tuple(fk._column_tokens[2] for fk in constraint.elements),
+            (constraint.ondelete or 'NO ACTION').upper(),
+            (constraint.onupdate or 'NO ACTION').upper(), name=constraint.name,
+        )
+
+    def _advance_dependencies(self, incoming, op):
+        """Track the FK graph at each point in the emitted migration."""
+        if isinstance(op, ops.CreateForeignKeyOp):
+            fk = self._foreign_key_from_constraint(op.to_constraint())
+            incoming[fk.target].append(fk)
+        elif isinstance(op, ops.CreateTableOp):
+            for constraint in op.to_table().foreign_key_constraints:
+                fk = self._foreign_key_from_constraint(constraint)
+                incoming[fk.target].append(fk)
+        elif isinstance(op, ops.DropConstraintOp) and op.constraint_type == 'foreignkey':
+            source = (self.schema_for(op.table_name, op.schema, reflected=True), op.table_name)
+            # Named constraints are scoped to their source table. For unnamed
+            # SQLite FKs, use the reflected constraint's complete endpoints.
+            removed = self._foreign_key_from_constraint(op.to_constraint()) if op.constraint_name is None else None
+            for target, dependencies in incoming.items():
+                incoming[target] = [fk for fk in dependencies if not (
+                    fk.source == source and (
+                        fk.name == op.constraint_name if removed is None else
+                        fk.target == removed.target and fk.columns == removed.columns
+                        and fk.target_columns == removed.target_columns
+                    )
+                )]
+        elif isinstance(op, (ops.DropTableOp, ops.DropColumnOp)):
+            table = (self.schema_for(op.table_name, op.schema, reflected=True), op.table_name)
+            column = getattr(op, 'column_name', None)
+            for target, dependencies in incoming.items():
+                incoming[target] = [fk for fk in dependencies if not (
+                    (fk.source == table and (column is None or column in fk.columns)) or
+                    (fk.target == table and (column is None or column in fk.target_columns))
+                )]
 
     def _seed_change_crosses_boundary(self, incoming, table, columns=None):
         # None represents deletion; a column set represents an update. Tracking
@@ -181,22 +224,24 @@ class ExternalTables:
         if not self.patterns or not upgrade_ops.ops:
             return
 
-        dangerous = []
-
-        def collect(container):
+        def flatten(container):
             for op in container.ops:
                 if isinstance(op, ops.OpContainer):
-                    collect(op)
-                elif isinstance(op, (ops.DropTableOp, ops.DropColumnOp, ops.DropIndexOp,
-                                     ops.DropConstraintOp, RemoveRowsOp, ModifyRowsOp)) or (
-                    isinstance(op, ops.AlterColumnOp) and (
-                        op.modify_type is not None or op.modify_name is not None
-                    )
-                ):
-                    dangerous.append(op)
+                    yield from flatten(op)
+                else:
+                    yield op
 
-        collect(upgrade_ops)
-        if not dangerous:
+        def is_dangerous(op):
+            return isinstance(op, (ops.DropTableOp, ops.DropColumnOp, ops.DropIndexOp,
+                                   ops.DropConstraintOp, RemoveRowsOp, ModifyRowsOp,
+                                   RemoveEdgesOp, ModifyEdgeOp)) or (
+                isinstance(op, ops.AlterColumnOp) and (
+                    op.modify_type is not None or op.modify_name is not None
+                )
+            )
+
+        planned = list(flatten(upgrade_ops))
+        if not any(is_dangerous(op) for op in planned):
             return
 
         inspector = autogen_context.inspector
@@ -213,7 +258,27 @@ class ExternalTables:
                 endpoints.update((*fk.target, c) for c in fk.target_columns)
                 referenced_keys[fk.target].append(fk)
 
-        for op in dangerous:
+        for op in planned:
+            if isinstance(op, (RemoveEdgesOp, ModifyEdgeOp)):
+                # Edge renderers/implementations address this unqualified table;
+                # op.schema is the logical 'public' key even in dev/SQLite mode.
+                table = (self.schema_for('assoc_edge_config', reflected=True), 'assoc_edge_config')
+                changed = None
+                if isinstance(op, ModifyEdgeOp):
+                    # Rendering omits timestamps; the implementation always
+                    # writes updated_at and leaves created_at alone.
+                    old = op.old_edge or {}
+                    changed = frozenset({'updated_at'} | {
+                        c for c in op.new_edge if c not in ('created_at', 'updated_at')
+                        and (str(op.new_edge[c]) != str(old.get(c))
+                             if c in ('edge_type', 'inverse_edge_type') else op.new_edge[c] != old.get(c))
+                    })
+                if self._seed_change_crosses_boundary(incoming, table, changed):
+                    self._raise_dependency_error(*table)
+                continue
+            if not is_dangerous(op):
+                self._advance_dependencies(incoming, op)
+                continue
             schema = self.schema_for(op.table_name, op.schema, reflected=True)
             column = getattr(op, "column_name", None)
             blocked = (schema, op.table_name, column) in endpoints
@@ -240,6 +305,10 @@ class ExternalTables:
                     blocked = any(set(fk.target_columns) == set(
                         key.get('column_names') or key.get('constrained_columns') or []
                     ) for fk in dependencies for key in keys)
+            elif isinstance(op, ops.DropTableOp) and autogen_context.connection.dialect.name == 'sqlite':
+                # SQLite runs an implicit DELETE before dropping a table, so
+                # its current cascades can modify rows in surviving tables.
+                blocked = blocked or self._seed_change_crosses_boundary(incoming, (schema, op.table_name))
             elif isinstance(op, RemoveRowsOp):
                 blocked = self._seed_change_crosses_boundary(incoming, (schema, op.table_name))
             elif isinstance(op, ModifyRowsOp):
@@ -247,8 +316,13 @@ class ExternalTables:
                            for c in set(row) | set(old) if row.get(c) != old.get(c)}
                 blocked = self._seed_change_crosses_boundary(incoming, (schema, op.table_name), frozenset(changed))
             if blocked:
-                raise ValueError(
-                    f"cannot change {schema}.{op.table_name}"
-                    f"{'.' + column if column else ''}: foreign key crosses an "
-                    "ignoreTables ownership boundary; coordinate an external migration first"
-                )
+                self._raise_dependency_error(schema, op.table_name, column)
+            self._advance_dependencies(incoming, op)
+
+    @staticmethod
+    def _raise_dependency_error(schema, table, column=None):
+        raise ValueError(
+            f"cannot change {schema}.{table}"
+            f"{'.' + column if column else ''}: foreign key crosses an "
+            "ignoreTables ownership boundary; coordinate an external migration first"
+        )

--- a/python/auto_schema/auto_schema/external_tables.py
+++ b/python/auto_schema/auto_schema/external_tables.py
@@ -1,6 +1,8 @@
 """Ownership rules shared by reflection, autogenerate and empty-DB compares."""
 
 import re
+from collections import defaultdict
+from dataclasses import dataclass
 
 import sqlalchemy as sa
 from alembic.operations import ops
@@ -8,6 +10,20 @@ from .ops import RemoveRowsOp, ModifyRowsOp
 
 
 _PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_$]*(?:\.(?:\*|[A-Za-z_][A-Za-z0-9_$]*))?")
+_PG_ACTIONS = {'a': 'NO ACTION', 'r': 'RESTRICT', 'c': 'CASCADE',
+               'n': 'SET NULL', 'd': 'SET DEFAULT'}
+
+
+@dataclass
+class _ForeignKey:
+    source: tuple[str, str]
+    target: tuple[str, str]
+    columns: tuple[str, ...]
+    target_columns: tuple[str, ...]
+    ondelete: str
+    onupdate: str
+    supporting_index: str | None = None
+    supporting_constraint: str | None = None
 
 
 class ExternalTables:
@@ -82,6 +98,80 @@ class ExternalTables:
                 return True
         return False
 
+    def _foreign_keys(self, autogen_context, dev_schema):
+        schemas = {self.default_schema}
+        if not dev_schema:
+            schemas.update(p.split('.')[0] for p in self.patterns if '.' in p)
+
+        if autogen_context.connection.dialect.name == 'postgresql':
+            # Read dependency metadata touching our scope, including inbound
+            # FKs, without reflecting or comparing tables in other schemas.
+            # conindid identifies the actual supporting key, even when multiple
+            # unique indexes cover the same referenced columns.
+            rows = autogen_context.connection.execute(sa.text("""
+                SELECT source_ns.nspname, source.relname,
+                       target_ns.nspname, target.relname,
+                       ARRAY(SELECT a.attname FROM unnest(fk.conkey) WITH ORDINALITY AS k(num, ord)
+                             JOIN pg_attribute a ON a.attrelid = fk.conrelid AND a.attnum = k.num
+                             ORDER BY k.ord),
+                       ARRAY(SELECT a.attname FROM unnest(fk.confkey) WITH ORDINALITY AS k(num, ord)
+                             JOIN pg_attribute a ON a.attrelid = fk.confrelid AND a.attnum = k.num
+                             ORDER BY k.ord),
+                       fk.confdeltype, fk.confupdtype, key_index.relname, key_constraint.conname
+                FROM pg_constraint fk
+                JOIN pg_class source ON source.oid = fk.conrelid
+                JOIN pg_namespace source_ns ON source_ns.oid = source.relnamespace
+                JOIN pg_class target ON target.oid = fk.confrelid
+                JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace
+                JOIN pg_class key_index ON key_index.oid = fk.conindid
+                LEFT JOIN pg_constraint key_constraint
+                  ON key_constraint.conrelid = fk.confrelid AND key_constraint.conindid = fk.conindid
+                 AND key_constraint.contype IN ('p', 'u')
+                WHERE fk.contype = 'f'
+                  AND (source_ns.nspname = ANY(:schemas) OR target_ns.nspname = ANY(:schemas))
+            """), {'schemas': sorted(schemas)})
+            for source_schema, source, target_schema, target, columns, target_columns, delete, update, index, constraint in rows:
+                yield _ForeignKey((source_schema, source), (target_schema, target),
+                                  tuple(columns), tuple(target_columns),
+                                  _PG_ACTIONS[delete], _PG_ACTIONS[update], index, constraint)
+            return
+
+        inspector = autogen_context.inspector
+        for schema in sorted(schemas & set(inspector.get_schema_names())):
+            for table in inspector.get_table_names(schema=schema):
+                for fk in inspector.get_foreign_keys(table, schema=schema):
+                    target = fk['referred_table']
+                    target_schema = self.schema_for(target, fk['referred_schema'], reflected=True)
+                    options = fk.get('options', {})
+                    yield _ForeignKey((schema, table), (target_schema, target),
+                                      tuple(fk['constrained_columns']), tuple(fk['referred_columns']),
+                                      options.get('ondelete', 'NO ACTION').upper(),
+                                      options.get('onupdate', 'NO ACTION').upper())
+
+    def _seed_change_crosses_boundary(self, incoming, table, columns=None):
+        # None represents deletion; a column set represents an update. Tracking
+        # both lets DELETE SET NULL/DEFAULT continue through ON UPDATE cascades.
+        pending = [(table, columns)]
+        seen = set()
+        while pending:
+            table, columns = pending.pop()
+            if (table, columns) in seen:
+                continue
+            seen.add((table, columns))
+            for fk in incoming.get(table, []):
+                if columns is not None and not columns.intersection(fk.target_columns):
+                    continue
+                if self.matches(fk.source[1], fk.source[0]):
+                    return True
+                action = fk.ondelete if columns is None else fk.onupdate
+                if action == 'CASCADE':
+                    changed = None if columns is None else frozenset(
+                        source for source, target in zip(fk.columns, fk.target_columns) if target in columns)
+                    pending.append((fk.source, changed))
+                elif action in ('SET NULL', 'SET DEFAULT'):
+                    pending.append((fk.source, frozenset(fk.columns)))
+        return False
+
     def guard_dependencies(self, autogen_context, upgrade_ops, dev_schema=None):
         """Fail before emitting destructive changes to an external FK endpoint.
 
@@ -110,55 +200,18 @@ class ExternalTables:
             return
 
         inspector = autogen_context.inspector
-        # Include explicit external schemas without widening Ent's comparison
-        # scope. Dev-schema mode reflects only its own schema's tables.
-        schemas = {self.default_schema}
-        if not dev_schema:
-            schemas.update(p.split(".")[0] for p in self.patterns if "." in p)
-        available = set(inspector.get_schema_names())
         endpoints = set()
-        referenced = set()
-
-        def add_dependency(schema, table, columns, target_schema, target, target_columns):
-            endpoints.add((schema, table, None))
-            endpoints.add((target_schema, target, None))
-            endpoints.update((schema, table, c) for c in columns)
-            endpoints.update((target_schema, target, c) for c in target_columns)
-            referenced.add((target_schema, target, None))
-            referenced.update((target_schema, target, c) for c in target_columns)
-
-        for schema in sorted(schemas & available):
-            for table in inspector.get_table_names(schema=schema):
-                owner_external = self.matches(table, schema)
-                for fk in inspector.get_foreign_keys(table, schema=schema):
-                    target = fk["referred_table"]
-                    target_schema = self.schema_for(target, fk["referred_schema"], reflected=True)
-                    if not owner_external and not self.matches(target, target_schema):
-                        continue
-                    add_dependency(schema, table, fk["constrained_columns"],
-                                   target_schema, target, fk["referred_columns"])
-
-        if dev_schema:
-            # Inspect dependencies *on the dev schema*, without reflecting or
-            # comparing tables in public or other schemas. Postgres may rewrite
-            # an inbound FK implicitly when ALTER TYPE changes its target.
-            rows = autogen_context.connection.execute(sa.text("""
-                SELECT source_ns.nspname, source.relname, target.relname,
-                       ARRAY(SELECT a.attname FROM unnest(fk.conkey) AS k(num)
-                             JOIN pg_attribute a ON a.attrelid = fk.conrelid AND a.attnum = k.num),
-                       ARRAY(SELECT a.attname FROM unnest(fk.confkey) AS k(num)
-                             JOIN pg_attribute a ON a.attrelid = fk.confrelid AND a.attnum = k.num)
-                FROM pg_constraint fk
-                JOIN pg_class source ON source.oid = fk.conrelid
-                JOIN pg_namespace source_ns ON source_ns.oid = source.relnamespace
-                JOIN pg_class target ON target.oid = fk.confrelid
-                JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace
-                WHERE fk.contype = 'f' AND target_ns.nspname = :schema
-                  AND source_ns.nspname <> :schema
-            """), {"schema": dev_schema})
-            for source_schema, source, target, columns, target_columns in rows:
-                if self.matches(source, source_schema):
-                    add_dependency(source_schema, source, columns, dev_schema, target, target_columns)
+        referenced_keys = defaultdict(list)
+        incoming = defaultdict(list)
+        for fk in self._foreign_keys(autogen_context, dev_schema):
+            # Managed-to-managed FKs are needed to find indirect cascades.
+            incoming[fk.target].append(fk)
+            if self.matches(fk.source[1], fk.source[0]) or self.matches(fk.target[1], fk.target[0]):
+                endpoints.add((*fk.source, None))
+                endpoints.add((*fk.target, None))
+                endpoints.update((*fk.source, c) for c in fk.columns)
+                endpoints.update((*fk.target, c) for c in fk.target_columns)
+                referenced_keys[fk.target].append(fk)
 
         for op in dangerous:
             schema = self.schema_for(op.table_name, op.schema, reflected=True)
@@ -167,21 +220,32 @@ class ExternalTables:
             if isinstance(op, (ops.DropIndexOp, ops.DropConstraintOp)):
                 # Only keys supporting an external FK are protected. Ordinary
                 # managed indexes and checks can still change.
-                if isinstance(op, ops.DropIndexOp):
+                dependencies = referenced_keys.get((schema, op.table_name), [])
+                if autogen_context.connection.dialect.name == 'postgresql':
+                    blocked = any(
+                        fk.supporting_index == op.index_name if isinstance(op, ops.DropIndexOp)
+                        else fk.supporting_constraint == op.constraint_name
+                        for fk in dependencies
+                    )
+                elif isinstance(op, ops.DropIndexOp):
                     keys = [i for i in inspector.get_indexes(op.table_name, schema=schema)
                             if i["name"] == op.index_name and i.get("unique")]
                 else:
                     keys = inspector.get_unique_constraints(op.table_name, schema=schema)
                     keys.append(inspector.get_pk_constraint(op.table_name, schema=schema))
                     keys = [k for k in keys if k["name"] == op.constraint_name]
-                blocked = any((schema, op.table_name, c) in referenced
-                              for key in keys for c in (key.get("column_names") or key.get("constrained_columns") or []))
+                if autogen_context.connection.dialect.name != 'postgresql':
+                    # SQLite resolves an FK against a complete unique key, not
+                    # any key containing one of its columns.
+                    blocked = any(set(fk.target_columns) == set(
+                        key.get('column_names') or key.get('constrained_columns') or []
+                    ) for fk in dependencies for key in keys)
             elif isinstance(op, RemoveRowsOp):
-                blocked = (schema, op.table_name, None) in referenced
+                blocked = self._seed_change_crosses_boundary(incoming, (schema, op.table_name))
             elif isinstance(op, ModifyRowsOp):
                 changed = {c for row, old in zip(op.rows, op.old_rows)
                            for c in set(row) | set(old) if row.get(c) != old.get(c)}
-                blocked = any((schema, op.table_name, c) in referenced for c in changed)
+                blocked = self._seed_change_crosses_boundary(incoming, (schema, op.table_name), frozenset(changed))
             if blocked:
                 raise ValueError(
                     f"cannot change {schema}.{op.table_name}"

--- a/python/auto_schema/auto_schema/external_tables.py
+++ b/python/auto_schema/auto_schema/external_tables.py
@@ -1,0 +1,190 @@
+"""Ownership rules shared by reflection, autogenerate and empty-DB compares."""
+
+import re
+
+import sqlalchemy as sa
+from alembic.operations import ops
+from .ops import RemoveRowsOp, ModifyRowsOp
+
+
+_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_$]*(?:\.(?:\*|[A-Za-z_][A-Za-z0-9_$]*))?")
+
+
+class ExternalTables:
+    def __init__(self, patterns=()):
+        if not isinstance(patterns, (list, tuple)):
+            raise ValueError("ignore_table must be a list of table, schema.table, or schema.* entries")
+        for pattern in patterns:
+            if not isinstance(pattern, str) or not _PATTERN.fullmatch(pattern):
+                raise ValueError(
+                    f"invalid ignore_table entry {pattern!r}: expected table, schema.table, "
+                    "or schema.* (no prefix globs or quoted identifiers)"
+                )
+        self.patterns = tuple(sorted(set(patterns)))
+        self.default_schema = None
+        self.visible_schemas = {}
+
+    def configure(self, connection, schema_name=None):
+        self.default_schema = schema_name or connection.dialect.default_schema_name
+        self.visible_schemas = {}
+        if not self.patterns and not schema_name:
+            return
+        if connection.dialect.name == "postgresql":
+            self.default_schema = schema_name or connection.scalar(sa.text("SELECT current_schema()"))
+            # schema=None in SQLAlchemy means visible via search_path, which need
+            # not mean current_schema(). Keep same-named tables distinct.
+            self.visible_schemas = dict(connection.execute(sa.text("""
+                SELECT c.relname, n.nspname
+                FROM pg_catalog.pg_class c
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relkind IN ('r', 'p') AND pg_catalog.pg_table_is_visible(c.oid)
+            """)).all())
+
+    def schema_for(self, name, schema=None, reflected=False):
+        if schema is not None:
+            return schema
+        if reflected:
+            return self.visible_schemas.get(name, self.default_schema)
+        return self.default_schema
+
+    def matches(self, name, schema=None, reflected=False):
+        schema = self.schema_for(name, schema, reflected)
+        for pattern in self.patterns:
+            if "." not in pattern:
+                if schema == self.default_schema and name == pattern:
+                    return True
+            else:
+                pattern_schema, table = pattern.split(".")
+                if schema == pattern_schema and (table == "*" or name == table):
+                    return True
+        return False
+
+    def validate_metadata(self, metadata):
+        for table in metadata.tables.values():
+            if self.matches(table.name, table.schema):
+                raise ValueError(
+                    f"ignoreTables matches managed table {table.fullname!r}; "
+                    "remove its Ent schema before declaring it external"
+                )
+            for fk in table.foreign_keys:
+                schema, name, _ = fk._column_tokens
+                if self.matches(name, schema):
+                    raise ValueError(
+                        f"managed foreign key {table.fullname}.{fk.parent.name} references "
+                        f"ignored table {fk.target_fullname!r}; manage this foreign key "
+                        "in an external migration instead"
+                    )
+
+    def foreign_key_is_external(self, constraint, reflected=False):
+        for fk in constraint.elements:
+            schema, table, _ = fk._column_tokens
+            if self.matches(table, schema, reflected):
+                return True
+        return False
+
+    def guard_dependencies(self, autogen_context, upgrade_ops, dev_schema=None):
+        """Fail before emitting destructive changes to an external FK endpoint.
+
+        External migrations own FKs crossing the ownership boundary, including
+        existing FKs on a managed table that point to an external table.
+        """
+        if not self.patterns or not upgrade_ops.ops:
+            return
+
+        dangerous = []
+
+        def collect(container):
+            for op in container.ops:
+                if isinstance(op, ops.OpContainer):
+                    collect(op)
+                elif isinstance(op, (ops.DropTableOp, ops.DropColumnOp, ops.DropIndexOp,
+                                     ops.DropConstraintOp, RemoveRowsOp, ModifyRowsOp)) or (
+                    isinstance(op, ops.AlterColumnOp) and (
+                        op.modify_type is not None or op.modify_name is not None
+                    )
+                ):
+                    dangerous.append(op)
+
+        collect(upgrade_ops)
+        if not dangerous:
+            return
+
+        inspector = autogen_context.inspector
+        # Include explicit external schemas without widening Ent's comparison
+        # scope. Dev-schema mode reflects only its own schema's tables.
+        schemas = {self.default_schema}
+        if not dev_schema:
+            schemas.update(p.split(".")[0] for p in self.patterns if "." in p)
+        available = set(inspector.get_schema_names())
+        endpoints = set()
+        referenced = set()
+
+        def add_dependency(schema, table, columns, target_schema, target, target_columns):
+            endpoints.add((schema, table, None))
+            endpoints.add((target_schema, target, None))
+            endpoints.update((schema, table, c) for c in columns)
+            endpoints.update((target_schema, target, c) for c in target_columns)
+            referenced.add((target_schema, target, None))
+            referenced.update((target_schema, target, c) for c in target_columns)
+
+        for schema in sorted(schemas & available):
+            for table in inspector.get_table_names(schema=schema):
+                owner_external = self.matches(table, schema)
+                for fk in inspector.get_foreign_keys(table, schema=schema):
+                    target = fk["referred_table"]
+                    target_schema = self.schema_for(target, fk["referred_schema"], reflected=True)
+                    if not owner_external and not self.matches(target, target_schema):
+                        continue
+                    add_dependency(schema, table, fk["constrained_columns"],
+                                   target_schema, target, fk["referred_columns"])
+
+        if dev_schema:
+            # Inspect dependencies *on the dev schema*, without reflecting or
+            # comparing tables in public or other schemas. Postgres may rewrite
+            # an inbound FK implicitly when ALTER TYPE changes its target.
+            rows = autogen_context.connection.execute(sa.text("""
+                SELECT source_ns.nspname, source.relname, target.relname,
+                       ARRAY(SELECT a.attname FROM unnest(fk.conkey) AS k(num)
+                             JOIN pg_attribute a ON a.attrelid = fk.conrelid AND a.attnum = k.num),
+                       ARRAY(SELECT a.attname FROM unnest(fk.confkey) AS k(num)
+                             JOIN pg_attribute a ON a.attrelid = fk.confrelid AND a.attnum = k.num)
+                FROM pg_constraint fk
+                JOIN pg_class source ON source.oid = fk.conrelid
+                JOIN pg_namespace source_ns ON source_ns.oid = source.relnamespace
+                JOIN pg_class target ON target.oid = fk.confrelid
+                JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace
+                WHERE fk.contype = 'f' AND target_ns.nspname = :schema
+                  AND source_ns.nspname <> :schema
+            """), {"schema": dev_schema})
+            for source_schema, source, target, columns, target_columns in rows:
+                if self.matches(source, source_schema):
+                    add_dependency(source_schema, source, columns, dev_schema, target, target_columns)
+
+        for op in dangerous:
+            schema = self.schema_for(op.table_name, op.schema, reflected=True)
+            column = getattr(op, "column_name", None)
+            blocked = (schema, op.table_name, column) in endpoints
+            if isinstance(op, (ops.DropIndexOp, ops.DropConstraintOp)):
+                # Only keys supporting an external FK are protected. Ordinary
+                # managed indexes and checks can still change.
+                if isinstance(op, ops.DropIndexOp):
+                    keys = [i for i in inspector.get_indexes(op.table_name, schema=schema)
+                            if i["name"] == op.index_name and i.get("unique")]
+                else:
+                    keys = inspector.get_unique_constraints(op.table_name, schema=schema)
+                    keys.append(inspector.get_pk_constraint(op.table_name, schema=schema))
+                    keys = [k for k in keys if k["name"] == op.constraint_name]
+                blocked = any((schema, op.table_name, c) in referenced
+                              for key in keys for c in (key.get("column_names") or key.get("constrained_columns") or []))
+            elif isinstance(op, RemoveRowsOp):
+                blocked = (schema, op.table_name, None) in referenced
+            elif isinstance(op, ModifyRowsOp):
+                changed = {c for row, old in zip(op.rows, op.old_rows)
+                           for c in set(row) | set(old) if row.get(c) != old.get(c)}
+                blocked = any((schema, op.table_name, c) in referenced for c in changed)
+            if blocked:
+                raise ValueError(
+                    f"cannot change {schema}.{op.table_name}"
+                    f"{'.' + column if column else ''}: foreign key crosses an "
+                    "ignoreTables ownership boundary; coordinate an external migration first"
+                )

--- a/python/auto_schema/auto_schema/runner.py
+++ b/python/auto_schema/auto_schema/runner.py
@@ -40,6 +40,7 @@ from . import ops_impl
 from . import csv
 from .schema_item import CustomSQLAlchemyType
 from .util.os import delete_py_files
+from .external_tables import ExternalTables
 
 
 def _normalize_generated_file_text(contents: str) -> str:
@@ -69,6 +70,7 @@ class Runner(object):
         self.engine = engine
         self.connection = connection
         self.args: Mapping[str, Any] = args or {}
+        external_tables = ExternalTables(self.args.get("ignore_table", []))
 
         config.metadata = self.metadata
         config.engine = self.engine
@@ -85,6 +87,9 @@ class Runner(object):
             )
         config.schema_name = self.schema_name
         config.include_public = self.include_public
+        external_tables.configure(connection, self.schema_name)
+        external_tables.validate_metadata(metadata)
+        config.external_tables = external_tables
 
         sql = self.args.get('sql', None)
         if sql is not None and sql.lower() != 'true':
@@ -236,6 +241,7 @@ class Runner(object):
     @contextmanager
     def dev_schema_compare_search_path(cls, connection):
         if not config.schema_name:
+            config.external_tables.configure(connection)
             yield
             return
 
@@ -253,6 +259,7 @@ class Runner(object):
         )
         connection.execute(sa.text(f"SET search_path TO {compare_search_path}"))
         try:
+            config.external_tables.configure(connection, config.schema_name)
             yield
         finally:
             connection.execute(sa.text(f"SET search_path TO {runtime_search_path}"))
@@ -326,6 +333,7 @@ class Runner(object):
     def fix_edges(cls, metadata, args):
         if not isinstance(args, Mapping):
             args = vars(args)
+        external_tables = ExternalTables(args.get("ignore_table", []))
         connection = args.get("connection")
         if connection is None:
             engine = sa.create_engine(args["engine"])
@@ -339,6 +347,11 @@ class Runner(object):
                 include_public,
                 extension_schemas=cls.get_extension_search_path_schemas(metadata),
             )
+
+        external_tables.configure(connection, schema)
+        external_tables.validate_metadata(metadata)
+        if external_tables.matches("assoc_edge_config"):
+            raise ValueError("cannot fix_edges: assoc_edge_config is an ignored table")
 
         mc = MigrationContext.configure(
             connection=connection,
@@ -448,6 +461,15 @@ class Runner(object):
 
     @classmethod
     def include_object(cls, object, name, type, reflected, compare_to):
+        table = object if type == "table" else getattr(object, "table", None)
+        if table is not None:
+            if config.external_tables.matches(table.name, table.schema, reflected):
+                return False
+            if config.schema_name and reflected:
+                if config.external_tables.schema_for(table.name, table.schema, True) != config.schema_name:
+                    return False
+        if type == "foreign_key_constraint" and config.external_tables.foreign_key_is_external(object, reflected):
+            return False
         if config.schema_name and reflected:
             schema = getattr(object, "schema", None)
             if schema is None:
@@ -465,14 +487,19 @@ class Runner(object):
 
     @classmethod
     def include_name(cls, name, type, parent_names):
-        if not config.schema_name:
-            return True
-        if type == "schema":
+        if type == "schema" and config.schema_name:
             return name is None or name == config.schema_name
         schema = None
         if parent_names:
             schema = parent_names.get("schema_name") or parent_names.get("schema")
-        if schema is not None and schema != config.schema_name:
+        table = name if type == "table" else (parent_names or {}).get("table_name")
+        if table is not None:
+            if table in Runner.exclude_tables().split(','):
+                return False
+            if config.external_tables.matches(table, schema, reflected=True):
+                return False
+            schema = config.external_tables.schema_for(table, schema, reflected=True)
+        if config.schema_name and schema is not None and schema != config.schema_name:
             return False
         return True
 
@@ -710,8 +737,11 @@ class Runner(object):
         
         location = self.cmd.alembic_cfg.get_main_option('version_locations')
         
-        (migrations, connection, dialect, mc) = self.migrations_against_empty(database=database)
+        with self._empty_database_migrations(database) as result:
+            self._squash_all(result, message, revision, location)
 
+    def _squash_all(self, result, message, revision, location):
+        (migrations, connection, dialect, mc) = result
         (custom_sql_upgrade_ops, custom_sql_downgrade_ops) = self._get_custom_sql(connection, dialect, as_ops=True)
         migrations.upgrade_ops.ops.extend(custom_sql_upgrade_ops)
 
@@ -907,11 +937,15 @@ class Runner(object):
                 ),
             )
 
+        config.external_tables.configure(connection, self.schema_name)
         inspector = sa.inspect(connection)
         table_names = inspector.get_table_names(schema=self.schema_name or None)
         excluded_tables = set(Runner.exclude_tables().split(','))
         table_names = [name for name in table_names if name not in excluded_tables]
+        table_names = [name for name in table_names if not config.external_tables.matches(name, self.schema_name, reflected=True)]
         if len(table_names) != 0:
+            connection.close()
+            engine.dispose()
             raise Exception(
                 "to compare from base tables, cannot have any tables in database. "
                 f"have {len(table_names)}"
@@ -922,14 +956,33 @@ class Runner(object):
             dialect_name=dialect,
             opts=Runner.get_opts(),
         )
-        with Runner.dev_schema_compare_search_path(connection):
-            migrations = produce_migrations(mc, self.metadata)
+        try:
+            with Runner.dev_schema_compare_search_path(connection):
+                migrations = produce_migrations(mc, self.metadata)
+        except Exception:
+            connection.close()
+            engine.dispose()
+            raise
         return (migrations, connection, dialect, mc)
                     
+    @contextmanager
+    def _empty_database_migrations(self, database):
+        result = self.migrations_against_empty(database=database)
+        connection = result[1]
+        try:
+            yield result
+        finally:
+            connection.close()
+            connection.engine.dispose()
+
     # doesn't invoke env.py. completely different flow
     # progressive_sql and upgrade range do go through offline path
     def all_sql(self, file=None, database=''):
-        (migrations, connection, dialect, mc) = self.migrations_against_empty(database=database)
+        with self._empty_database_migrations(database) as result:
+            self._all_sql(result, file)
+
+    def _all_sql(self, result, file):
+        (migrations, connection, dialect, mc) = result
     
         buffer = io.StringIO()
 

--- a/python/auto_schema/tests/external_mutations_test.py
+++ b/python/auto_schema/tests/external_mutations_test.py
@@ -1,0 +1,182 @@
+from pathlib import Path
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from alembic.autogenerate.api import AutogenContext
+from alembic.operations import ops
+
+from auto_schema.external_tables import ExternalTables
+from auto_schema.ops import RemoveRowsOp
+from tests.external_tables_test import cascade_runner, change_parent_seed
+
+
+def edge_runner(new_test_runner, metadata, reference='edge_type', dev_schema=False):
+    edges = metadata.info['edges']['public']
+    edge = edges['UserToFollowersEdge']
+    # Timestamps are equal for edges inserted together, so that key case only
+    # needs one edge. Deletion cases deliberately keep a second edge/table alive.
+    if reference != 'updated_at':
+        edges['OtherEdge'] = dict(edge, edge_name='OtherEdge', edge_table='other_edges',
+                                  edge_type=uuid.uuid4() if isinstance(edge['edge_type'], uuid.UUID) else 2)
+        if reference == 'symmetric_edge':
+            edges['OtherEdge']['symmetric_edge'] = True
+    table = metadata.tables['assoc_edge_config']
+    if reference != 'edge_type':
+        sa.Index('edge_reference_key', table.c[reference], unique=True)
+    args = {'ignore_table': ['edge_preferences']}
+    if dev_schema:
+        args = {'db_schema': 'ent_dev_external_mutations', 'ignore_table': ['auth.*']}
+    r = new_test_runner(metadata, args_override=args)
+    r.run()
+    r.connection.commit()
+    external = 'edge_preferences'
+    target = 'assoc_edge_config'
+    if dev_schema:
+        r.connection.execute(sa.text('CREATE SCHEMA auth'))
+        external = 'auth.edge_preferences'
+        target = 'ent_dev_external_mutations.assoc_edge_config'
+    column_type = table.c[reference].type.compile(dialect=r.connection.dialect)
+    r.connection.execute(sa.text(f'CREATE TABLE {external} (id INTEGER PRIMARY KEY, value {column_type} REFERENCES {target}({reference}) ON DELETE CASCADE ON UPDATE CASCADE)'))
+    r.connection.execute(sa.text(f"INSERT INTO {external} SELECT 1, {reference} FROM {target} WHERE edge_name = 'UserToFollowersEdge'"))
+    r.connection.commit()
+    return r, external
+
+
+def assert_rejected_without_changes(r, external):
+    before = list(r.connection.execute(sa.text(f'SELECT * FROM {external}')))
+    revisions = list(Path(r.schema_path, 'versions').glob('*.py'))
+    with pytest.raises(ValueError, match='ownership boundary'):
+        r.compute_changes()
+    assert list(r.connection.execute(sa.text(f'SELECT * FROM {external}'))) == before
+    assert list(Path(r.schema_path, 'versions').glob('*.py')) == revisions
+
+
+class ExternalEdgeMutationTests:
+    @pytest.mark.parametrize('operation,reference', [('delete', 'edge_type'), ('update', 'edge_table'),
+                                                    ('update', 'updated_at')])
+    def test_edge_mutations_protect_external_rows(self, new_test_runner, metadata_with_one_edge, operation, reference):
+        r, external = edge_runner(new_test_runner, metadata_with_one_edge, reference)
+        edges = r.metadata.info['edges']['public']
+        if operation == 'delete':
+            del edges['UserToFollowersEdge']
+        else:
+            edges['UserToFollowersEdge']['edge_table'] = 'renamed_edges'
+        assert_rejected_without_changes(r, external)
+
+    @pytest.mark.parametrize('reference', ['edge_type', 'symmetric_edge'])
+    def test_unrelated_edge_update_remains_managed(self, new_test_runner, metadata_with_one_edge, reference):
+        r, external = edge_runner(new_test_runner, metadata_with_one_edge, reference)
+        before = list(r.connection.execute(sa.text(f'SELECT * FROM {external}')))
+        r.metadata.info['edges']['public']['UserToFollowersEdge']['edge_table'] = 'renamed_edges'
+        r.run()
+        r.connection.commit()
+        assert r.compute_changes() == []
+        assert r.connection.scalar(sa.text("SELECT edge_table FROM assoc_edge_config WHERE edge_name = 'UserToFollowersEdge'")) == 'renamed_edges'
+        assert list(r.connection.execute(sa.text(f'SELECT * FROM {external}'))) == before
+
+
+class TestSQLiteExternalEdgeMutations(ExternalEdgeMutationTests):
+    def test_table_drop_cannot_cascade_before_managed_fk_removal(self, new_test_runner):
+        r = cascade_runner(new_test_runner)
+        # SQLite DROP TABLE implicitly deletes its rows, including cascades.
+        with r.connection.begin_nested() as savepoint:
+            r.connection.execute(sa.text('DROP TABLE parents'))
+            assert r.connection.scalar(sa.text('SELECT COUNT(*) FROM sessions')) == 0
+            savepoint.rollback()
+        metadata = sa.MetaData()
+        sa.Table('children', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                 sa.Column('code', sa.Integer(), server_default='20'),
+                 sa.UniqueConstraint('code', name='children_code_key'))
+        r = new_test_runner(metadata, r, args_override={'ignore_table': ['sessions']})
+        assert_rejected_without_changes(r, 'sessions')
+
+
+class TestPostgresExternalEdgeMutations(ExternalEdgeMutationTests):
+    def test_pending_cascade_change_also_protects_edge_removal(self, new_test_runner, metadata_with_one_edge):
+        metadata = metadata_with_one_edge
+        edges = metadata.info['edges']['public']
+        edges['OtherEdge'] = dict(edges['UserToFollowersEdge'], edge_name='OtherEdge', edge_type=uuid.uuid4())
+        links = sa.Table('edge_links', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                         sa.Column('edge_type', sa.UUID()),
+                         sa.ForeignKeyConstraint(['edge_type'], ['assoc_edge_config.edge_type'],
+                                                 name='edge_links_config_fkey', ondelete='NO ACTION'))
+        r = new_test_runner(metadata, args_override={'ignore_table': ['edge_preferences']})
+        r.run()
+        r.connection.commit()
+        r.connection.execute(links.insert().values(id=1, edge_type=edges['UserToFollowersEdge']['edge_type']))
+        r.connection.execute(sa.text('CREATE TABLE edge_preferences (id INTEGER PRIMARY KEY, link_id INTEGER REFERENCES edge_links(id) ON DELETE CASCADE)'))
+        r.connection.execute(sa.text('INSERT INTO edge_preferences VALUES (2, 1)'))
+        r.connection.commit()
+        next(iter(links.foreign_key_constraints)).ondelete = 'CASCADE'
+        del edges['UserToFollowersEdge']
+        assert_rejected_without_changes(r, 'edge_preferences')
+
+    @pytest.mark.parametrize('operation,reference', [('delete', 'edge_type'), ('update', 'edge_table')])
+    def test_dev_schema_edge_mutations_protect_external_rows(self, new_test_runner, metadata_with_one_edge, operation, reference):
+        r, external = edge_runner(new_test_runner, metadata_with_one_edge, reference, dev_schema=True)
+        edges = r.metadata.info['edges']['public']
+        if operation == 'delete':
+            del edges['UserToFollowersEdge']
+        else:
+            edges['UserToFollowersEdge']['edge_table'] = 'renamed_edges'
+        assert_rejected_without_changes(r, external)
+
+
+class TestPostgresExternalMutations:
+    @pytest.mark.parametrize('change', ['replace', 'add'])
+    @pytest.mark.parametrize('operation,action', [('delete', 'CASCADE'), ('delete', 'SET NULL'),
+                                                ('update_key', 'CASCADE')])
+    def test_pending_cascade_change_protects_external_rows(self, new_test_runner, change, operation, action):
+        r = cascade_runner(new_test_runner, ondelete='NO ACTION', onupdate='NO ACTION')
+        if change == 'add':
+            r.connection.execute(sa.text('ALTER TABLE children DROP CONSTRAINT children_parent_fkey'))
+            r.connection.commit()
+        fk = next(iter(r.metadata.tables['children'].foreign_key_constraints))
+        if operation == 'delete':
+            fk.ondelete = action
+        else:
+            fk.onupdate = action
+        change_parent_seed(r, operation)
+        assert_rejected_without_changes(r, 'sessions')
+        assert not list(Path(r.schema_path, 'versions').glob('*.py'))
+
+    @pytest.mark.parametrize('change', ['replace', 'remove'])
+    def test_removing_cascade_before_seed_delete_allows_safe_change(self, new_test_runner, change):
+        r = cascade_runner(new_test_runner)
+        r.connection.execute(sa.text('UPDATE children SET code = 20'))
+        r.connection.commit()
+        children = r.metadata.tables['children']
+        fk = next(iter(children.foreign_key_constraints))
+        if change == 'replace':
+            fk.ondelete = 'NO ACTION'
+        else:
+            children.constraints.remove(fk)
+        change_parent_seed(r, 'delete')
+        diff = r.compute_changes()
+        # Reflection/seed reads use one connection, migration DDL uses another.
+        r.connection.commit()
+        r._apply_changes(diff)
+        r.connection.commit()
+        assert r.compute_changes() == []
+        assert list(r.connection.execute(sa.text('SELECT * FROM sessions'))) == [(4, 20)]
+        assert r.connection.scalar(sa.text('SELECT COUNT(*) FROM parents')) == 1
+
+    def test_later_fk_removal_cannot_justify_earlier_seed_delete(self, new_test_runner):
+        r = cascade_runner(new_test_runner)
+        fk = next(iter(r.metadata.tables['children'].foreign_key_constraints))
+        planned = ops.UpgradeOps([
+            RemoveRowsOp('parents', ['id'], [{'id': 1}]),
+            ops.ModifyTableOps('children', [ops.DropConstraintOp.from_constraint(fk)]),
+        ])
+        rules = ExternalTables(['sessions'])
+        rules.configure(r.connection)
+        with pytest.raises(ValueError, match='ownership boundary'):
+            rules.guard_dependencies(AutogenContext(r._migration_context()), planned)
+
+    def test_pending_cascade_into_external_schema_in_dev_mode(self, new_test_runner):
+        r = cascade_runner(new_test_runner, ondelete='NO ACTION', dev_schema=True)
+        fk = next(iter(r.metadata.tables['children'].foreign_key_constraints))
+        fk.ondelete = 'CASCADE'
+        change_parent_seed(r, 'delete')
+        assert_rejected_without_changes(r, 'auth.sessions')

--- a/python/auto_schema/tests/external_tables_test.py
+++ b/python/auto_schema/tests/external_tables_test.py
@@ -1,0 +1,319 @@
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+from auto_schema.external_tables import ExternalTables
+from auto_schema.runner import Runner
+
+
+@pytest.mark.parametrize('bad', ['', '*', 'auth*', 'public.auth_*', 'auth.*.x', '.user', 'auth.', ' auth.user', 'auth.user ', '"auth".user', 'auth.user;drop', None, 3])
+def test_invalid_ignore_table_grammar(bad):
+    with pytest.raises(ValueError, match='expected table'):
+        ExternalTables([bad])
+
+
+def test_exact_default_and_qualified_matching():
+    rules = ExternalTables(['user', 'auth.*', 'public.session'])
+    rules.default_schema = 'public'
+    rules.visible_schemas = {'hidden': 'auth', 'user': 'other'}
+    assert rules.matches('user')
+    assert not rules.matches('user', 'other')
+    assert not rules.matches('user', reflected=True)
+    assert rules.matches('hidden', reflected=True)
+    assert rules.matches('user', 'auth')
+    assert rules.matches('session', 'public')
+    assert not rules.matches('auth_user')
+    assert not rules.matches('session', 'other')
+
+
+def managed_metadata(with_change=False):
+    metadata = sa.MetaData()
+    columns = [sa.Column('id', sa.Integer(), primary_key=True), sa.Column('external_id', sa.String(50))]
+    if with_change:
+        columns.append(sa.Column('label', sa.Text()))
+    sa.Table('accounts', metadata, *columns)
+    if with_change:
+        sa.Table('managed_new', metadata, sa.Column('id', sa.Integer(), primary_key=True))
+    return metadata
+
+
+def external_snapshot(connection, schema=None):
+    inspector = sa.inspect(connection)
+    result = {}
+    for name in ['identities', 'sessions']:
+        table = sa.Table(name, sa.MetaData(), autoload_with=connection, schema=schema)
+        result[name] = {
+            'columns': [(c['name'], str(c['type']), c['nullable']) for c in inspector.get_columns(name, schema=schema)],
+            'indexes': inspector.get_indexes(name, schema=schema),
+            'unique': inspector.get_unique_constraints(name, schema=schema),
+            'checks': inspector.get_check_constraints(name, schema=schema),
+            'fks': inspector.get_foreign_keys(name, schema=schema),
+            'rows': list(connection.execute(sa.select(table)).all()),
+        }
+    return result
+
+
+def create_external_tables(r, schema=None):
+    connection = r.connection
+    if schema:
+        connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+    metadata = sa.MetaData()
+    identity = sa.Table('identities', metadata, sa.Column('id', sa.String(50), primary_key=True), schema=schema)
+    target = f'{schema}.identities.id' if schema else 'identities.id'
+    accounts = sa.Table('accounts', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('external_id', sa.String(50)),
+        sa.ForeignKeyConstraint(['external_id'], [target], name='accounts_external_fkey'))
+    sessions = sa.Table('sessions', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('account_id', sa.Integer()), sa.Column('token', sa.Text(), nullable=False),
+        sa.UniqueConstraint('token', name='sessions_token_key'),
+        sa.CheckConstraint('id > 0', name='sessions_positive'),
+        sa.ForeignKeyConstraint(['account_id'], ['accounts.id'], name='sessions_account_fkey'), schema=schema)
+    sa.Index('sessions_account_idx', sessions.c.account_id)
+    metadata.create_all(connection)
+    connection.execute(identity.insert().values(id='external-1'))
+    connection.execute(accounts.insert().values(id=1, external_id='external-1'))
+    connection.execute(sessions.insert().values(id=1, account_id=1, token='keep-me'))
+    connection.commit()
+
+
+class ExternalTablesTests:
+    @pytest.mark.parametrize('qualified', [False, True])
+    def test_preserve_external_objects_and_apply_managed_change(self, new_test_runner, qualified):
+        default = 'public' if 'Postgres' in type(self).__name__ else 'main'
+        patterns = [f'{default}.identities', f'{default}.sessions'] if qualified else ['identities', 'sessions']
+        args = {'ignore_table': patterns}
+        r = new_test_runner(managed_metadata(True), args_override=args)
+        create_external_tables(r)
+        before = external_snapshot(r.connection)
+        r.connection.commit()
+        r.run()
+        r.connection.commit()
+        assert external_snapshot(r.connection) == before
+        assert 'label' in [c['name'] for c in sa.inspect(r.connection).get_columns('accounts')]
+        assert sa.inspect(r.connection).has_table('managed_new')
+        assert sa.inspect(r.connection).get_foreign_keys('accounts')[0]['name'] == 'accounts_external_fkey'
+        assert r.compute_changes() == []
+        versions = list(Path(r.schema_path, 'versions').glob('*.py'))
+        assert len(versions) == 1
+        assert 'sessions' not in versions[0].read_text()
+        assert 'identities' not in versions[0].read_text()
+        r.run()
+        assert list(Path(r.schema_path, 'versions').glob('*.py')) == versions
+
+    @pytest.mark.parametrize('operation', ['drop_table', 'drop_referenced_column', 'drop_referencing_column', 'alter_type'])
+    def test_reject_destructive_managed_fk_endpoint_changes(self, new_test_runner, operation):
+        args = {'ignore_table': ['identities', 'sessions']}
+        metadata = managed_metadata()
+        r = new_test_runner(metadata, args_override=args)
+        create_external_tables(r)
+        before = external_snapshot(r.connection)
+        if operation == 'drop_table':
+            metadata.remove(metadata.tables['accounts'])
+        elif operation == 'drop_referenced_column':
+            metadata.tables['accounts']._columns.remove(metadata.tables['accounts'].c.id)
+        elif operation == 'drop_referencing_column':
+            metadata.tables['accounts']._columns.remove(metadata.tables['accounts'].c.external_id)
+        else:
+            metadata.tables['accounts'].c.external_id.type = sa.Text()
+        with pytest.raises(ValueError, match='ownership boundary'):
+            r.run()
+        assert external_snapshot(r.connection) == before
+        assert not list(Path(r.schema_path, 'versions').glob('*.py'))
+
+    def test_metadata_conflicts_fail_closed(self, new_test_runner):
+        r = new_test_runner(managed_metadata())
+        with pytest.raises(ValueError, match='matches managed table'):
+            new_test_runner(managed_metadata(), r, args_override={'ignore_table': ['accounts']})
+        metadata = managed_metadata()
+        metadata.tables['accounts'].append_constraint(sa.ForeignKeyConstraint(['external_id'], ['identities.id']))
+        with pytest.raises(ValueError, match='external migration instead'):
+            new_test_runner(metadata, r, args_override={'ignore_table': ['identities']})
+
+    def test_sql_and_squash_are_deterministic(self, new_test_runner, tmp_path):
+        args = {'ignore_table': ['identities', 'sessions']}
+        r = new_test_runner(managed_metadata(True), args_override=args)
+        create_external_tables(r)
+        r.run()
+        r.connection.commit()
+        before = external_snapshot(r.connection)
+        if r.connection.dialect.name == 'postgresql':
+            empty = new_test_runner(sa.MetaData(), new_database=True)
+            database = empty.connection.engine.url.database
+            # Restore the active runner's module configuration.
+            r = new_test_runner(managed_metadata(True), r, args_override=args)
+        else:
+            database = str(tmp_path / 'empty.db')
+        output = tmp_path / 'schema.sql'
+        r.all_sql(str(output), database=database)
+        sql = output.read_text()
+        assert 'CREATE TABLE accounts' in sql
+        assert 'CREATE TABLE managed_new' in sql
+        assert 'sessions' not in sql and 'identities' not in sql
+        r.all_sql(str(output), database=database)
+        assert output.read_text() == sql
+        r.squash_all(database=database)
+        revisions = list(Path(r.schema_path, 'versions').glob('*.py'))
+        assert len(revisions) == 1
+        assert 'sessions' not in revisions[0].read_text()
+        assert 'identities' not in revisions[0].read_text()
+        assert r.compute_changes() == []
+        assert external_snapshot(r.connection) == before
+
+    def test_empty_compare_allows_external_tables_but_rejects_managed_tables(self, new_test_runner, tmp_path):
+        args = {'ignore_table': ['sessions']}
+        r = new_test_runner(managed_metadata(), args_override=args)
+        if r.connection.dialect.name == 'postgresql':
+            empty = new_test_runner(sa.MetaData(), new_database=True)
+            engine = empty.engine
+            database = engine.url.database
+            r = new_test_runner(managed_metadata(), r, args_override=args)
+        else:
+            database = str(tmp_path / 'external-only.db')
+            engine = sa.create_engine('sqlite:///' + database)
+        try:
+            with engine.begin() as conn:
+                conn.execute(sa.text('CREATE TABLE sessions (id INTEGER PRIMARY KEY, token TEXT UNIQUE)'))
+                conn.execute(sa.text("INSERT INTO sessions VALUES (1, 'preserved')"))
+            output = tmp_path / 'external-only.sql'
+            r.all_sql(str(output), database=database)
+            assert 'CREATE TABLE accounts' in output.read_text()
+            assert 'sessions' not in output.read_text()
+            with engine.begin() as conn:
+                assert conn.scalar(sa.text('SELECT token FROM sessions')) == 'preserved'
+                sql = output.read_text()
+                if conn.dialect.name == 'sqlite':
+                    conn.connection.driver_connection.executescript(sql)
+                else:
+                    conn.exec_driver_sql(sql)
+                assert sa.inspect(conn).has_table('accounts')
+                assert conn.scalar(sa.text('SELECT token FROM sessions')) == 'preserved'
+            with pytest.raises(Exception, match='cannot have any tables'):
+                r.all_sql(str(output), database=database)
+        finally:
+            if r.connection.dialect.name == 'sqlite':
+                engine.dispose()
+
+    def test_seed_data_cannot_delete_externally_referenced_rows(self, new_test_runner):
+        r = new_test_runner(managed_metadata(), args_override={'ignore_table': ['identities', 'sessions']})
+        create_external_tables(r)
+        r.metadata.info['data'] = {'public': {'accounts': {'pkeys': ['id'], 'rows': []}}}
+        before = external_snapshot(r.connection)
+        with pytest.raises(ValueError, match='ownership boundary'):
+            r.run()
+        assert external_snapshot(r.connection) == before
+
+    def test_ignored_seed_data_is_not_touched(self, new_test_runner):
+        r = new_test_runner(managed_metadata(), args_override={'ignore_table': ['identities', 'sessions']})
+        create_external_tables(r)
+        r.metadata.info['data'] = {'public': {'sessions': {'pkeys': ['id'], 'rows': []}}}
+        assert r.compute_changes() == []
+        assert r.connection.scalar(sa.text('SELECT token FROM sessions')) == 'keep-me'
+
+    def test_fix_edges_respects_external_ownership(self, new_test_runner):
+        r = new_test_runner(sa.MetaData())
+        with pytest.raises(ValueError, match='cannot fix_edges'):
+            Runner.fix_edges(r.metadata, {'connection': r.connection, 'ignore_table': ['assoc_edge_config']})
+
+    def test_removing_unique_key_used_by_external_fk_is_rejected(self, new_test_runner):
+        metadata = sa.MetaData()
+        table = sa.Table('accounts', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                         sa.Column('code', sa.String(20)), sa.Column('label', sa.Text()))
+        r = new_test_runner(metadata, args_override={'ignore_table': ['sessions']})
+        r.connection.execute(sa.text('CREATE TABLE accounts (id INTEGER NOT NULL PRIMARY KEY, code VARCHAR(20), label TEXT)'))
+        r.connection.execute(sa.text('CREATE UNIQUE INDEX accounts_code_key ON accounts(code)'))
+        r.connection.execute(sa.text('CREATE TABLE sessions (id INTEGER PRIMARY KEY, code VARCHAR(20) REFERENCES accounts(code) ON DELETE CASCADE)'))
+        r.connection.execute(sa.text("INSERT INTO accounts VALUES (1, 'a', 'keep')"))
+        r.connection.execute(sa.text("INSERT INTO sessions VALUES (1, 'a')"))
+        r.connection.commit()
+        with pytest.raises(ValueError, match='ownership boundary'):
+            r.run()
+        # An unrelated index and seed update remain managed.
+        sa.Index('accounts_code_key', table.c.code, unique=True)
+        sa.Index('accounts_label_idx', table.c.label)
+        metadata.info['data'] = {'public': {'accounts': {'pkeys': ['id'], 'rows': [{'id': 1, 'code': 'a', 'label': 'updated'}]}}}
+        r.run()
+        r.connection.commit()
+        assert r.compute_changes() == []
+        assert r.connection.scalar(sa.text('SELECT label FROM accounts')) == 'updated'
+        assert r.connection.scalar(sa.text('SELECT code FROM sessions')) == 'a'
+
+
+class TestSQLiteExternalTables(ExternalTablesTests):
+    pass
+
+
+class TestPostgresExternalTables(ExternalTablesTests):
+    @pytest.mark.parametrize('patterns', [['auth.*'], ['auth.identities', 'auth.sessions']])
+    def test_named_schema_and_search_path(self, new_test_runner, patterns):
+        r = new_test_runner(managed_metadata(True), args_override={'ignore_table': patterns})
+        create_external_tables(r, schema='auth')
+        r.connection.execute(sa.text('CREATE TABLE public.auth_sessions (id integer)'))
+        r.connection.execute(sa.text('SET search_path TO public, auth'))
+        before = external_snapshot(r.connection, 'auth')
+        # Real SQLAlchemy introspection reports these as schema=None when visible.
+        assert 'sessions' in sa.inspect(r.connection).get_table_names()
+        assert r.connection.dialect.default_schema_name == 'public'
+        assert r.connection.scalar(sa.text('SELECT current_schema()')) == 'public'
+        r.connection.commit()
+        r.run()
+        r.connection.commit()
+        assert external_snapshot(r.connection, 'auth') == before
+        assert not sa.inspect(r.connection).has_table('auth_sessions', schema='public')
+        assert r.compute_changes() == []
+        assert 'label' in [c['name'] for c in sa.inspect(r.connection).get_columns('accounts')]
+
+    def test_external_enum_is_not_dropped(self, new_test_runner):
+        r = new_test_runner(managed_metadata(True), args_override={'ignore_table': ['identities', 'sessions']})
+        create_external_tables(r)
+        r.connection.execute(sa.text("CREATE TYPE external_status AS ENUM ('ready', 'expired')"))
+        r.connection.execute(sa.text("ALTER TABLE sessions ADD COLUMN status external_status DEFAULT 'ready'"))
+        r.connection.commit()
+        r.run()
+        r.connection.commit()
+        assert r.connection.scalar(sa.text('SELECT status FROM sessions')) == 'ready'
+        assert r.compute_changes() == []
+
+    @pytest.mark.parametrize('include_public', [False, True])
+    def test_dev_schema_isolation(self, new_test_runner, include_public):
+        r = new_test_runner(sa.MetaData())
+        r.connection.execute(sa.text('CREATE TABLE public.accounts (id integer primary key)'))
+        r.connection.execute(sa.text('CREATE TABLE public.sessions (id integer primary key)'))
+        r.connection.execute(sa.text('INSERT INTO public.sessions VALUES (12)'))
+        r.connection.commit()
+        args = {'db_schema': 'ent_dev_external_test', 'db_schema_include_public': include_public,
+                'ignore_table': ['sessions', 'public.accounts', 'auth.*']}
+        r = new_test_runner(managed_metadata(True), r, args_override=args)
+        r.connection.execute(sa.text('CREATE TABLE sessions (id integer primary key)'))
+        r.connection.execute(sa.text('INSERT INTO sessions VALUES (42)'))
+        r.connection.commit()
+        r.run()
+        r.connection.commit()
+        assert 'label' in [c['name'] for c in sa.inspect(r.connection).get_columns('accounts', schema='ent_dev_external_test')]
+        assert r.connection.scalar(sa.text('SELECT id FROM public.sessions')) == 12
+        assert r.connection.scalar(sa.text('SELECT id FROM ent_dev_external_test.sessions')) == 42
+        assert r.compute_changes() == []
+
+    @pytest.mark.parametrize('direction', ['incoming', 'outgoing'])
+    def test_dev_schema_guards_cross_schema_fk_dependencies(self, new_test_runner, direction):
+        metadata = sa.MetaData()
+        table = sa.Table('accounts', metadata, sa.Column('id', sa.String(20), primary_key=True))
+        r = new_test_runner(metadata, args_override={
+            'db_schema': 'ent_dev_external_test', 'ignore_table': ['auth.*']})
+        r.connection.execute(sa.text('CREATE SCHEMA auth'))
+        if direction == 'incoming':
+            r.connection.execute(sa.text('CREATE TABLE accounts (id VARCHAR(20) PRIMARY KEY)'))
+            r.connection.execute(sa.text('CREATE TABLE auth.sessions (id VARCHAR(20) PRIMARY KEY REFERENCES ent_dev_external_test.accounts(id))'))
+            r.connection.execute(sa.text("INSERT INTO accounts VALUES ('keep')"))
+            r.connection.execute(sa.text("INSERT INTO auth.sessions VALUES ('keep')"))
+        else:
+            r.connection.execute(sa.text('CREATE TABLE auth.sessions (id VARCHAR(20) PRIMARY KEY)'))
+            r.connection.execute(sa.text('CREATE TABLE accounts (id VARCHAR(20) PRIMARY KEY REFERENCES auth.sessions(id))'))
+            r.connection.execute(sa.text("INSERT INTO auth.sessions VALUES ('keep')"))
+            r.connection.execute(sa.text("INSERT INTO accounts VALUES ('keep')"))
+        r.connection.commit()
+        table.c.id.type = sa.Text()
+        with pytest.raises(ValueError, match='ownership boundary'):
+            r.run()
+        assert r.connection.scalar(sa.text('SELECT id FROM auth.sessions')) == 'keep'
+        assert not list(Path(r.schema_path, 'versions').glob('*.py'))

--- a/python/auto_schema/tests/external_tables_test.py
+++ b/python/auto_schema/tests/external_tables_test.py
@@ -77,6 +77,46 @@ def create_external_tables(r, schema=None):
     connection.commit()
 
 
+def cascade_runner(new_test_runner, ondelete='CASCADE', onupdate='CASCADE', dev_schema=False):
+    metadata = sa.MetaData()
+    parents = sa.Table('parents', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                       sa.Column('code', sa.Integer()), sa.Column('label', sa.Text()),
+                       sa.UniqueConstraint('code', name='parents_code_key'))
+    children = sa.Table('children', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                        sa.Column('code', sa.Integer(), server_default='20'),
+                        sa.UniqueConstraint('code', name='children_code_key'),
+                        sa.ForeignKeyConstraint(['code'], ['parents.code'], name='children_parent_fkey',
+                                                ondelete=ondelete, onupdate=onupdate))
+    args = {'ignore_table': ['sessions']}
+    if dev_schema:
+        args = {'db_schema': 'ent_dev_external_test', 'ignore_table': ['auth.*']}
+    r = new_test_runner(metadata, args_override=args)
+    if r.connection.dialect.name == 'sqlite':
+        r.connection.execute(sa.text('PRAGMA foreign_keys=ON'))
+    metadata.create_all(r.connection)
+    sessions = 'sessions'
+    target = 'children'
+    if dev_schema:
+        r.connection.execute(sa.text('CREATE SCHEMA auth'))
+        sessions = 'auth.sessions'
+        target = 'ent_dev_external_test.children'
+    r.connection.execute(sa.text(f'CREATE TABLE {sessions} (id INTEGER PRIMARY KEY, code INTEGER REFERENCES {target}(code) ON DELETE CASCADE ON UPDATE CASCADE)'))
+    r.connection.execute(parents.insert(), [{'id': 1, 'code': 10, 'label': 'keep'},
+                                          {'id': 2, 'code': 20, 'label': 'other'}])
+    r.connection.execute(children.insert().values(id=3, code=10))
+    r.connection.execute(sa.text(f'INSERT INTO {sessions} VALUES (4, 10)'))
+    r.connection.commit()
+    return r
+
+
+def change_parent_seed(r, operation):
+    rows = [{'id': 2, 'code': 20, 'label': 'other'}]
+    if operation != 'delete':
+        rows.append({'id': 1, 'code': 11 if operation == 'update_key' else 10,
+                     'label': 'updated' if operation == 'update_label' else 'keep'})
+    r.metadata.info['data'] = {'public': {'parents': {'pkeys': ['id'], 'rows': rows}}}
+
+
 class ExternalTablesTests:
     @pytest.mark.parametrize('qualified', [False, True])
     def test_preserve_external_objects_and_apply_managed_change(self, new_test_runner, qualified):
@@ -203,6 +243,96 @@ class ExternalTablesTests:
             r.run()
         assert external_snapshot(r.connection) == before
 
+    def test_seed_delete_cannot_cascade_through_managed_tables(self, new_test_runner):
+        metadata = sa.MetaData()
+        parents = sa.Table('parents', metadata, sa.Column('id', sa.Integer(), primary_key=True))
+        children = sa.Table('children', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                            sa.Column('parent_id', sa.Integer()),
+                            sa.ForeignKeyConstraint(['parent_id'], ['parents.id'],
+                                                    name='children_parent_fkey', ondelete='CASCADE'))
+        r = new_test_runner(metadata, args_override={'ignore_table': ['sessions']})
+        if r.connection.dialect.name == 'sqlite':
+            r.connection.execute(sa.text('PRAGMA foreign_keys=ON'))
+        metadata.create_all(r.connection)
+        r.connection.execute(sa.text('CREATE TABLE sessions (id INTEGER PRIMARY KEY, child_id INTEGER REFERENCES children(id) ON DELETE CASCADE)'))
+        r.connection.execute(parents.insert().values(id=1))
+        r.connection.execute(children.insert().values(id=2, parent_id=1))
+        r.connection.execute(sa.text('INSERT INTO sessions VALUES (3, 2)'))
+        r.connection.commit()
+        metadata.info['data'] = {'public': {'parents': {'pkeys': ['id'], 'rows': []}}}
+        with pytest.raises(ValueError, match='ownership boundary'):
+            r.run()
+        assert list(r.connection.execute(sa.text('SELECT * FROM sessions'))) == [(3, 2)]
+        assert not list(Path(r.schema_path, 'versions').glob('*.py'))
+
+    def test_removing_unrelated_overlapping_unique_index_is_allowed(self, new_test_runner):
+        metadata = sa.MetaData()
+        sa.Table('accounts', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                 sa.Column('label', sa.Text()))
+        r = new_test_runner(metadata, args_override={'ignore_table': ['sessions']})
+        metadata.create_all(r.connection)
+        r.connection.execute(sa.text('CREATE UNIQUE INDEX accounts_id_label_key ON accounts(id, label)'))
+        r.connection.execute(sa.text('CREATE TABLE sessions (id INTEGER PRIMARY KEY, account_id INTEGER REFERENCES accounts(id))'))
+        r.connection.execute(sa.text("INSERT INTO accounts VALUES (1, 'keep')"))
+        r.connection.execute(sa.text('INSERT INTO sessions VALUES (2, 1)'))
+        r.connection.commit()
+        r.run()
+        r.connection.commit()
+        assert r.compute_changes() == []
+        assert 'accounts_id_label_key' not in {i['name'] for i in sa.inspect(r.connection).get_indexes('accounts')}
+        assert list(r.connection.execute(sa.text('SELECT * FROM sessions'))) == [(2, 1)]
+
+    @pytest.mark.parametrize('operation,ondelete', [('delete', 'CASCADE'), ('update_key', 'CASCADE'),
+                                                   ('delete', 'SET NULL'), ('delete', 'SET DEFAULT')])
+    def test_seed_changes_cannot_reach_external_rows_indirectly(self, new_test_runner, operation, ondelete):
+        r = cascade_runner(new_test_runner, ondelete=ondelete)
+        change_parent_seed(r, operation)
+        with pytest.raises(ValueError, match='ownership boundary'):
+            r.run()
+        assert list(r.connection.execute(sa.text('SELECT * FROM sessions'))) == [(4, 10)]
+        assert r.connection.scalar(sa.text('SELECT code FROM children')) == 10
+        assert not list(Path(r.schema_path, 'versions').glob('*.py'))
+
+    def test_unrelated_seed_updates_remain_managed_with_cascades(self, new_test_runner):
+        r = cascade_runner(new_test_runner)
+        change_parent_seed(r, 'update_label')
+        r.run()
+        r.connection.commit()
+        assert r.compute_changes() == []
+        assert r.connection.scalar(sa.text('SELECT label FROM parents WHERE id = 1')) == 'updated'
+        assert list(r.connection.execute(sa.text('SELECT * FROM sessions'))) == [(4, 10)]
+
+    def test_managed_cascade_cycle_without_external_dependents_allows_seed_update(self, new_test_runner):
+        metadata = sa.MetaData()
+        parents = sa.Table('parents', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                           sa.Column('code', sa.Integer()), sa.UniqueConstraint('code', name='parents_code_key'),
+                           sa.ForeignKeyConstraint(['code'], ['parents.code'], name='parents_self_fkey',
+                                                   onupdate='CASCADE'))
+        r = new_test_runner(metadata, args_override={'ignore_table': ['sessions']})
+        metadata.create_all(r.connection)
+        r.connection.execute(sa.text('CREATE TABLE sessions (id INTEGER PRIMARY KEY)'))
+        r.connection.execute(parents.insert().values(id=1, code=10))
+        r.connection.commit()
+        metadata.info['data'] = {'public': {'parents': {'pkeys': ['id'], 'rows': [{'id': 1, 'code': 11}]}}}
+        r.run()
+        r.connection.commit()
+        assert r.connection.scalar(sa.text('SELECT code FROM parents')) == 11
+        assert r.compute_changes() == []
+
+    @pytest.mark.parametrize('action', ['NO ACTION', 'RESTRICT'])
+    def test_non_cascading_managed_dependency_does_not_block_unreferenced_seed_delete(self, new_test_runner, action):
+        r = cascade_runner(new_test_runner, ondelete=action)
+        # The removed parent has no children; the other parent has external
+        # dependents behind a managed FK that cannot propagate a deletion.
+        r.connection.execute(sa.text('UPDATE children SET code = 20'))
+        r.connection.commit()
+        change_parent_seed(r, 'delete')
+        r.run()
+        r.connection.commit()
+        assert r.compute_changes() == []
+        assert r.connection.scalar(sa.text('SELECT COUNT(*) FROM parents')) == 1
+        assert list(r.connection.execute(sa.text('SELECT * FROM sessions'))) == [(4, 20)]
+
     def test_ignored_seed_data_is_not_touched(self, new_test_runner):
         r = new_test_runner(managed_metadata(), args_override={'ignore_table': ['identities', 'sessions']})
         create_external_tables(r)
@@ -244,6 +374,52 @@ class TestSQLiteExternalTables(ExternalTablesTests):
 
 
 class TestPostgresExternalTables(ExternalTablesTests):
+    def test_removing_supporting_composite_unique_constraint_is_rejected(self, new_test_runner):
+        metadata = sa.MetaData()
+        sa.Table('accounts', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                 sa.Column('code', sa.Integer()), sa.Column('label', sa.Text()))
+        r = new_test_runner(metadata, args_override={'ignore_table': ['sessions']})
+        metadata.create_all(r.connection)
+        r.connection.execute(sa.text('ALTER TABLE accounts ADD CONSTRAINT accounts_code_label_key UNIQUE (code, label)'))
+        r.connection.execute(sa.text('CREATE TABLE sessions (id INTEGER PRIMARY KEY, code INTEGER, label TEXT, FOREIGN KEY (code, label) REFERENCES accounts(code, label))'))
+        r.connection.commit()
+        with pytest.raises(ValueError, match='ownership boundary'):
+            r.run()
+        assert 'accounts_code_label_key' in {k['name'] for k in sa.inspect(r.connection).get_unique_constraints('accounts')}
+        assert not list(Path(r.schema_path, 'versions').glob('*.py'))
+
+    @pytest.mark.parametrize('kind,columns', [('INDEX', 'id'), ('CONSTRAINT', 'id'),
+                                             ('CONSTRAINT', 'id, label')])
+    def test_remove_unused_unique_key_when_external_fk_uses_primary_key(self, new_test_runner, kind, columns):
+        metadata = sa.MetaData()
+        sa.Table('accounts', metadata, sa.Column('id', sa.Integer(), primary_key=True),
+                 sa.Column('label', sa.Text()))
+        r = new_test_runner(metadata, args_override={'ignore_table': ['sessions']})
+        metadata.create_all(r.connection)
+        r.connection.execute(sa.text('CREATE TABLE sessions (id INTEGER PRIMARY KEY, account_id INTEGER REFERENCES accounts(id))'))
+        if kind == 'INDEX':
+            r.connection.execute(sa.text(f'CREATE UNIQUE INDEX unused_key ON accounts({columns})'))
+        else:
+            r.connection.execute(sa.text(f'ALTER TABLE accounts ADD CONSTRAINT unused_key UNIQUE ({columns})'))
+        r.connection.execute(sa.text("INSERT INTO accounts VALUES (1, 'keep')"))
+        r.connection.execute(sa.text('INSERT INTO sessions VALUES (2, 1)'))
+        r.connection.commit()
+        r.run()
+        r.connection.commit()
+        assert r.compute_changes() == []
+        assert 'unused_key' not in {i['name'] for i in sa.inspect(r.connection).get_indexes('accounts')}
+        assert list(r.connection.execute(sa.text('SELECT * FROM sessions'))) == [(2, 1)]
+
+    @pytest.mark.parametrize('operation,ondelete', [('delete', 'CASCADE'), ('update_key', 'CASCADE'),
+                                                   ('delete', 'SET NULL'), ('delete', 'SET DEFAULT')])
+    def test_indirect_cascade_into_external_schema_in_dev_mode(self, new_test_runner, operation, ondelete):
+        r = cascade_runner(new_test_runner, ondelete=ondelete, dev_schema=True)
+        change_parent_seed(r, operation)
+        with pytest.raises(ValueError, match='ownership boundary'):
+            r.run()
+        assert list(r.connection.execute(sa.text('SELECT * FROM auth.sessions'))) == [(4, 10)]
+        assert not list(Path(r.schema_path, 'versions').glob('*.py'))
+
     @pytest.mark.parametrize('patterns', [['auth.*'], ['auth.identities', 'auth.sessions']])
     def test_named_schema_and_search_path(self, new_test_runner, patterns):
         r = new_test_runner(managed_metadata(True), args_override={'ignore_table': patterns})

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -272,7 +272,7 @@ features:
     owns: [codegen.ignoreTables]
     mode: explicit
     dialect_coverage: [sqlite, postgres]
-    rationale: Configured external tables retain rows and indexes through real DB codegen and deterministic schema.sql generation; detailed FK and dev-schema coverage is in python/auto_schema/tests/external_tables_test.py.
+    rationale: Configured external tables retain rows and indexes through real DB codegen and deterministic schema.sql generation; detailed FK, pending migration, edge mutation, and dev-schema coverage is in python/auto_schema/tests/external_tables_test.py and external_mutations_test.py.
   - id: schema.nodes
     owns: [input.Schema.Nodes, input.Node.Fields]
     mode: explicit

--- a/testdata/codegen_matrix/features.yml
+++ b/testdata/codegen_matrix/features.yml
@@ -186,6 +186,7 @@ fixtures:
       - idempotence
     dialect: sqlite
     covers:
+      - codegen.ignore_tables
       - schema.nodes
       - node.table_name
       - node.actions
@@ -235,6 +236,7 @@ fixtures:
         runtime: bun
         postgresDriver: bun
     covers:
+      - codegen.ignore_tables
       - schema.nodes
       - node.table_name
       - node.actions
@@ -265,6 +267,11 @@ fixtures:
       - action.mutations
 
 features:
+  - id: codegen.ignore_tables
+    owns: [codegen.ignoreTables]
+    mode: explicit
+    dialect_coverage: [sqlite, postgres]
+    rationale: Configured external tables retain rows and indexes through real DB codegen and deterministic schema.sql generation; detailed FK and dev-schema coverage is in python/auto_schema/tests/external_tables_test.py.
   - id: schema.nodes
     owns: [input.Schema.Nodes, input.Node.Fields]
     mode: explicit

--- a/testdata/codegen_matrix/fixtures/db_schema_smoke/ent.yml
+++ b/testdata/codegen_matrix/fixtures/db_schema_smoke/ent.yml
@@ -1,4 +1,6 @@
 codegen:
+  ignoreTables: [external_accounts, main.external_sessions]
+  schemaSQLFilePath: src/schema/schema.sql
   relativeImports: true
   generatedHeader: "Codegen matrix DB fixture"
   fieldPrivacyEvaluated: on_demand

--- a/testdata/codegen_matrix/fixtures/postgres_schema_smoke/ent.yml
+++ b/testdata/codegen_matrix/fixtures/postgres_schema_smoke/ent.yml
@@ -1,4 +1,6 @@
 codegen:
+  ignoreTables: [external_accounts, public.external_sessions, auth.*]
+  schemaSQLFilePath: src/schema/schema.sql
   relativeImports: true
   generatedHeader: "Codegen matrix Postgres fixture"
   fieldPrivacyEvaluated: on_demand


### PR DESCRIPTION
Databases shared with auth providers or other services can contain tables that Ent must not manage. Add `codegen.ignoreTables` for exact default-schema names, exact `schema.table` names, and `schema.*` wildcards. Reject ambiguous prefix globs and collisions with Ent-generated tables.

Apply the ownership rules to reflection, migration autogeneration, custom comparisons, and generated SQL/squash-all artifacts. Preserve external rows, indexes, constraints, and existing foreign keys across the ownership boundary. Evaluate seed and edge mutations against the foreign keys active at that point in the pending migration, including additions, replacements, and removals. Reject indirect delete/update cascades, `SET NULL`/`SET DEFAULT` actions, and SQLite table drops that could change ignored rows. Protect the actual supporting PostgreSQL key while allowing unrelated unique-key removals and edge updates. Keep strict dev-schema isolation and existing migration-history/custom-SQL behavior.

Document the API and validate the Go and Python changes together in CI using the checkout's `auto_schema` package. Normalize the matrix's direct Python invocation to accept CI's PostgreSQL connection URL.

Validation:
- Full codegen matrix: Node/Bun, SQLite/PostgreSQL, generated TypeScript compilation, SQL artifacts, and idempotence; passed with CI's `postgres://` URL format.
- Full Python migration suite: 340 passed, one existing xfail/one xpass. Regression coverage includes pending FK changes, operation ordering, edge deletions/updates, combined FK-and-edge changes, dev-schema dependencies, SQLite implicit deletions, supporting keys, and unrelated managed changes.
- Go codegen, auto_schema, and DB package tests; Python type checks including the ownership guard; `git diff --check`.

Using the new option requires the updated Go and Python tools together. No package versions or release-image files are changed.
