### PR TITLE
Preserve parameter offsets in nested queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Fixed
 
+- preserve parameter offsets in nested queries so composing `JSONBKeyInList`
+  with other filters binds each value to the correct placeholder (#2031).
 - accept GraphQL literal input records in struct and union fields, including
   nested lists, and preserve validation errors for unprintable values (#2029).
 - avoid opening the Go codegen database pool until first use and close it when

--- a/ts/src/core/clause.test.ts
+++ b/ts/src/core/clause.test.ts
@@ -1065,6 +1065,51 @@ describe("postgres", () => {
   });
 
   describe("jsonb", () => {
+    test.each([
+      clause.JSONBKeyInList,
+      clause.JSONKeyInList,
+    ])("%p preserves offsets around multiple subqueries", (keyInList) => {
+      const owner = "9ed3cf20-cd13-4506-bf85-f3ba779f456a";
+      const tag = "O'Brien's friends";
+      const otherTag = "'); DROP TABLE contacts; -- $1";
+      const cls = clause.And(
+        clause.Eq("owner_id", owner),
+        keyInList("tags", "value", clause.sensitiveValue(tag), "c"),
+        clause.Or(
+          clause.Eq("favorite", true),
+          keyInList("tags", "value", otherTag, "c"),
+        ),
+        clause.Eq("archived", false),
+      );
+      const arrayFunction =
+        keyInList === clause.JSONBKeyInList
+          ? "jsonb_array_elements"
+          : "json_array_elements";
+      for (const idx of [1, 7]) {
+        expect(cls.clause(idx, "c")).toBe(
+          `c.owner_id = $${idx} AND EXISTS (SELECT 1 FROM ${arrayFunction}(c.tags) AS json_element WHERE json_element ? $${idx + 1} AND json_element->>'value' = $${idx + 2}) AND (c.favorite = $${idx + 3} OR EXISTS (SELECT 1 FROM ${arrayFunction}(c.tags) AS json_element WHERE json_element ? $${idx + 4} AND json_element->>'value' = $${idx + 5})) AND c.archived = $${idx + 6}`,
+        );
+      }
+      expect(cls.values()).toEqual([
+        owner,
+        "value",
+        tag,
+        true,
+        "value",
+        otherTag,
+        false,
+      ]);
+      expect(cls.logValues()).toEqual([
+        owner,
+        "value",
+        "*".repeat(tag.length),
+        true,
+        "value",
+        otherTag,
+        false,
+      ]);
+    });
+
     test("eq", () => {
       const cls = clause.JSONPathValuePredicate<JSONData>(
         "jsonb",

--- a/ts/src/core/clause.ts
+++ b/ts/src/core/clause.ts
@@ -136,7 +136,7 @@ class queryClause<T extends Data, K = keyof T> implements Clause<T, K> {
   ) {}
 
   clause(idx: number, alias?: string): string {
-    const q = buildQuery(this.dependentQueryOptions);
+    const q = buildQuery(this.dependentQueryOptions, idx);
 
     return `${this.prefix} (${q})`;
   }

--- a/ts/src/core/db_clause.test.ts
+++ b/ts/src/core/db_clause.test.ts
@@ -18,6 +18,7 @@ import { loadConfig } from "./config";
 import DB, { Dialect } from "./db";
 import { AssocEdge, loadEdges, loadRows, loadTwoWayEdges } from "./ent";
 import { setLogLevels } from "./logger";
+import { buildQueryData } from "./query_impl";
 
 const tableName = "contacts";
 const alias = "c";
@@ -581,6 +582,61 @@ test("jsonb key in list ", async () => {
     alias,
   );
   expect(uuid4Rows.length).toEqual(6);
+});
+
+test.each([
+  "O'Brien's friends",
+  "'); DROP TABLE contacts; -- $1",
+])("JSONBKeyInList binds composed tag queries: %s", async (tag) => {
+  const id = v1();
+  for (const contactID of [id, v1()]) {
+    await createRowForTest({
+      tableName,
+      fields: {
+        id: contactID,
+        first_name: "Jon",
+        last_name: "Snow",
+        emails: [],
+        phones: [],
+        foo: JSON.stringify([{ value: tag }, { value: "second tag" }]),
+      },
+    });
+  }
+  const options = {
+    tableName,
+    fields: ["id"],
+    alias,
+    clause: clause.And(
+      clause.Eq("id", id),
+      clause.JSONBKeyInList("foo", "value", tag, alias),
+      clause.JSONBKeyInList("foo", "value", "second tag", alias),
+      clause.Eq("last_name", "Snow"),
+    ),
+  };
+  expect(await loadRows(options)).toEqual([{ id }]);
+  const embedded = buildQueryData(options, 4);
+  const result = await tdb
+    .getPostgresClient()
+    .query(
+      `WITH prefix AS (SELECT $1::text, $2::boolean, $3::integer) ${embedded.query}`,
+      ["earlier value", true, 42, ...embedded.values],
+    );
+  expect(result.rows).toEqual([{ id }]);
+  expect(
+    await loadRows({
+      ...options,
+      clause: clause.And(options.clause, clause.Eq("first_name", "Ned")),
+    }),
+  ).toEqual([]);
+  expect(
+    await loadRows({
+      ...options,
+      clause: clause.And(
+        clause.Eq("id", id),
+        clause.JSONBKeyInList("foo", "value", `${tag} missing`, alias),
+      ),
+    }),
+  ).toEqual([]);
 });
 
 test("in clause", async () => {

--- a/ts/src/core/query_impl.test.ts
+++ b/ts/src/core/query_impl.test.ts
@@ -1,5 +1,8 @@
 import * as clause from "./clause";
-import { buildQueryData, getOrderByKey } from "./query_impl";
+import { QueryableDataOptions } from "./base";
+import { loadConfig } from "./config";
+import DB, { Dialect } from "./db";
+import { buildQuery, buildQueryData, getOrderByKey } from "./query_impl";
 
 function distanceExpression(key: string) {
   return clause.ParameterizedExpression(
@@ -15,7 +18,10 @@ describe("query_impl computed expressions", () => {
     const queryData = buildQueryData({
       tableName: "places",
       alias: "p",
-      fields: ["id", { alias: "distance", expression: distanceExpression("d") }],
+      fields: [
+        "id",
+        { alias: "distance", expression: distanceExpression("d") },
+      ],
       clause: clause.Eq("active", true),
       orderby: [
         {
@@ -70,5 +76,143 @@ describe("query_impl computed expressions", () => {
         },
       ]),
     );
+  });
+});
+
+describe.each([
+  Dialect.Postgres,
+  Dialect.SQLite,
+])("%s query offsets", (dialect) => {
+  beforeAll(() => {
+    loadConfig({
+      dbConnectionString:
+        dialect === Dialect.Postgres
+          ? "postgres://localhost/ent_test"
+          : "sqlite:///",
+    });
+  });
+
+  afterAll(async () => {
+    await DB.getInstance().endPool();
+  });
+
+  test.each([
+    1, 7,
+  ])("select, join, where, and order by start at %i", (startIdx) => {
+    const options: QueryableDataOptions = {
+      tableName: "contacts",
+      alias: "c",
+      fields: [
+        "id",
+        { alias: "selected", expression: clause.Eq("name", "selected name") },
+      ],
+      join: [
+        { tableName: "owners", alias: "o", clause: clause.Eq("id", 42, "o") },
+      ],
+      clause: clause.And(
+        clause.Eq("name", "O'Brien"),
+        clause.Eq("active", true),
+      ),
+      orderby: [
+        {
+          column: "name",
+          direction: "ASC",
+          expression: clause.Eq("name", clause.sensitiveValue("private")),
+        },
+      ],
+    };
+    const p = (offset: number) =>
+      dialect === Dialect.Postgres ? `$${startIdx + offset}` : "?";
+    const result = buildQueryData(options, startIdx);
+    expect(result.query).toBe(
+      `SELECT c.id, c.name = ${p(0)} AS selected FROM contacts AS c JOIN owners o ON o.id = ${p(1)} WHERE c.name = ${p(2)} AND c.active = ${p(3)} ORDER BY c.name = ${p(4)} ASC`,
+    );
+    expect(buildQuery(options, startIdx)).toBe(result.query);
+    expect(result.values).toEqual([
+      "selected name",
+      42,
+      "O'Brien",
+      true,
+      "private",
+    ]);
+    expect(result.logValues).toEqual([
+      "selected name",
+      42,
+      "O'Brien",
+      true,
+      "*******",
+    ]);
+  });
+
+  test.each([
+    1, 7,
+  ])("nested select subqueries start at %i", async (startIdx) => {
+    const subquery = (options: QueryableDataOptions) => {
+      const data = buildQueryData(options);
+      return clause.ParameterizedExpression(
+        "nested query",
+        (idx) => `(${buildQuery(options, idx)})`,
+        data.values,
+        data.logValues,
+      );
+    };
+    const inner = subquery({
+      tableName: "contacts",
+      alias: "i",
+      fields: [{ alias: "matches", expression: clause.Eq("name", "O'Brien") }],
+      clause: clause.Eq("id", 3),
+    });
+    const middle = subquery({
+      tableName: "contacts",
+      alias: "m",
+      fields: [{ alias: "matches", expression: inner }],
+      clause: clause.Eq("id", 2),
+    });
+    const options: QueryableDataOptions = {
+      tableName: "contacts",
+      alias: "c",
+      fields: [
+        { alias: "selected", expression: clause.Eq("name", "selected") },
+        { alias: "nested", expression: middle },
+        { alias: "sibling", expression: inner },
+      ],
+      clause: clause.Eq("id", 1),
+    };
+    const p = (offset: number) =>
+      dialect === Dialect.Postgres ? `$${startIdx + offset}` : "?";
+    const result = buildQueryData(options, startIdx);
+    expect(result.query).toBe(
+      `SELECT c.name = ${p(0)} AS selected, (SELECT (SELECT i.name = ${p(1)} AS matches FROM contacts AS i WHERE i.id = ${p(2)}) AS matches FROM contacts AS m WHERE m.id = ${p(3)}) AS nested, (SELECT i.name = ${p(4)} AS matches FROM contacts AS i WHERE i.id = ${p(5)}) AS sibling FROM contacts AS c WHERE c.id = ${p(6)}`,
+    );
+    expect(result.values).toEqual([
+      "selected",
+      "O'Brien",
+      3,
+      2,
+      "O'Brien",
+      3,
+      1,
+    ]);
+    expect(result.logValues).toEqual(result.values);
+    if (dialect === Dialect.SQLite) {
+      const pool = DB.getInstance().getSQLiteClient();
+      pool.execSync(
+        "CREATE TABLE IF NOT EXISTS contacts (id INTEGER PRIMARY KEY, name TEXT)",
+      );
+      pool.execSync("DELETE FROM contacts");
+      for (const [id, name] of [
+        [1, "selected"],
+        [2, "middle"],
+        [3, "O'Brien"],
+      ]) {
+        pool.execSync("INSERT INTO contacts (id, name) VALUES (?, ?)", [
+          id,
+          name,
+        ]);
+      }
+      expect((await pool.queryAll(result.query, result.values)).rows).toEqual([
+        { selected: 1, nested: 1, sibling: 1 },
+      ]);
+    }
   });
 });

--- a/ts/src/core/query_impl.ts
+++ b/ts/src/core/query_impl.ts
@@ -37,7 +37,9 @@ function getCacheKeyForExpression(expression: QueryExpression): string {
   return expression.instanceKey();
 }
 
-export function getSelectFieldsKey(fields: QueryableDataOptions["fields"]): string {
+export function getSelectFieldsKey(
+  fields: QueryableDataOptions["fields"],
+): string {
   return fields
     .map((field) => {
       if (typeof field === "string") {
@@ -224,18 +226,23 @@ export function getJoinInfo(
   };
 }
 
-export function buildQueryData(options: QueryableDataOptions): BuiltQueryData {
+// startIdx is the first placeholder number when embedding this query in another.
+// The returned values contain only this query's parameters.
+export function buildQueryData(
+  options: QueryableDataOptions,
+  startIdx = 1,
+): BuiltQueryData {
   const fieldsAlias = options.fieldsAlias ?? options.alias;
   const fieldInfo = getFieldsInfo(
     options.fields,
     fieldsAlias,
     options.disableFieldsAlias,
-    1,
+    startIdx,
   );
 
   const values = [...fieldInfo.values];
   const logValues = [...fieldInfo.logValues];
-  let clauseIdx = 1 + fieldInfo.valuesUsed;
+  let clauseIdx = startIdx + fieldInfo.valuesUsed;
 
   const parts: string[] = [];
   const tableName = options.alias
@@ -287,6 +294,9 @@ export function buildQueryData(options: QueryableDataOptions): BuiltQueryData {
   };
 }
 
-export function buildQuery(options: QueryableDataOptions): string {
-  return buildQueryData(options).query;
+export function buildQuery(
+  options: QueryableDataOptions,
+  startIdx = 1,
+): string {
+  return buildQueryData(options, startIdx).query;
 }


### PR DESCRIPTION
Composing a UUID owner filter with `JSONBKeyInList` reused `$1` inside its nested `EXISTS`, causing PostgreSQL to fail with `operator does not exist: jsonb ? uuid`. Nested query clauses now forward their incoming parameter index through `buildQuery` and `buildQueryData`, preserving the numbering of SELECT, JOIN, WHERE, and ORDER BY parameters while retaining the default starting index of 1.

Regressions cover preceding and following clauses, non-1 starting offsets, nested and sibling subqueries, aliases, quoted and SQL-like bound strings, sensitive log values, and placeholder/value correspondence. PostgreSQL tests reproduce the original error in disposable databases and verify the corrected queries; SQLite tests execute nested scalar queries in memory.

Validation on Node 24.12.0:

- Six focused clause, query-builder, custom-query, and query-loader suites: 386 tests passed.
- `npm run compile`, changed-file Biome checks, and `git diff --check` passed.
- Generated todo-sqlite custom GraphQL consumer suite: 2 tests passed against freshly compiled local Ent using a temporary Jest configuration; example `tsc --noEmit` passed.
- Full five-example matrix and codegen matrix were not rerun for this PR. No schema/codegen inputs changed.
