### PR TITLE
Enforce control-flow braces with Biome linting

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -55,6 +55,7 @@ jobs:
         cache-dependency-path: ts/package-lock.json
 
     - run: npm ci 
+    - run: npm run lint
     - run: npm run build --if-present 
     - run: npm test -- --runInBand
       env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ When changing code in `ts/`, validate in this order:
 
 Package-level commands:
 
+- `cd ts && npm run lint`
 - `cd ts && npm test -- --runInBand`
 - `cd ts && npm test -- src/action/orchestrator.test.ts --runInBand`
 - `cd ts && npm test -- src/action/transformed_orchestrator.test.ts --runInBand`

--- a/ts/biome.json
+++ b/ts/biome.json
@@ -11,7 +11,13 @@
     "lineWidth": 80
   },
   "linter": {
-    "enabled": false
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "style": {
+        "useBlockStatements": "error"
+      }
+    }
   },
   "assist": {
     "enabled": false

--- a/ts/package.json
+++ b/ts/package.json
@@ -76,6 +76,8 @@
     "compile": "tsc",
     "test": "jest",
     "clean": "rm -rf dist",
+    "lint": "biome lint src",
+    "lint:fix": "biome lint --write --unsafe --only=style/useBlockStatements src",
     "format": "biome format --write biome.json package.json tsconfig.json jest.config.js src",
     "format:check": "biome check --diagnostic-level=error biome.json package.json tsconfig.json jest.config.js src",
     "prepare-code": "npm run clean && npm run compile && node src/setupPackage.js",

--- a/ts/src/testutils/db/temp_db.ts
+++ b/ts/src/testutils/db/temp_db.ts
@@ -729,12 +729,13 @@ export function setupSqlite(
       const client = await DB.getInstance().getNewClient();
       for (const [key, _] of tdb.__getTables()) {
         const query = `delete from ${key}`;
-        if (isSyncClient(client))
+        if (isSyncClient(client)) {
           if (client.execSync) {
             client.execSync(query);
           } else {
             await client.exec(query);
           }
+        }
       }
     });
   }


### PR DESCRIPTION
Control-flow bodies in `ts/src` could omit braces because Biome linting was disabled. Enable `style/useBlockStatements` as an error, add `lint` and a rule-scoped `lint:fix` command, and run lint in Node.js CI. Fix the existing violation in the SQLite test helper and list the lint command in `AGENTS.md`.

Validation:
- Full five-file diff reviewed; no actionable issues found.
- `npm run lint`: all 202 source files pass.
- Six smoke checks confirm unbraced `if`/`else` and loops fail while braced equivalents pass.
- Targeted database and helper suites: 24 tests pass with Node 22, matching the available SQLite native module.
- Biome checks for changed files and `git diff --check` pass.

The full `format:check` still reports pre-existing formatting issues in five unrelated files. No changelog entry is included because this is internal tooling, per repository guidance.
