### PR TITLE
Keep core regression tests in their owning packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,38 @@
 # Internal agent guidance
 
-This file documents behavior expectations for dev branch schema support.
+This file documents repository-wide development and testing expectations.
 It is intended for contributors and automation working on this repo.
+
+## Test ownership and placement
+
+- Core functionality must have regression coverage in the package that owns the
+  implementation. Add or extend the nearby test suite first:
+  - TypeScript: colocated `ts/src/**/*.test.ts` (for example,
+    `ts/src/action/orchestrator.test.ts` and `transformed_orchestrator.test.ts`).
+  - Go: `*_test.go` in the implementing package, including generator/template
+    logic in its owning package.
+  - Python: the owning package's test directory, such as
+    `python/auto_schema/tests/` for migration comparison, rendering, and replay.
+- Runtime semantics such as defaults, validation, privacy, persistence,
+  transactions, inverse-edge ownership, and transformed operations must not be
+  tested only in codegen fixtures or example applications. Their regression
+  tests must run through the owning package's normal test command.
+- Keep fixture tests for generated output, generated consumer compatibility,
+  and integration across codegen/runtime/DB boundaries. Add a small
+  representative fixture test when that boundary matters; keep the core
+  behavior and edge-case coverage in the owning package. A generator-only
+  regression need not invent an unrelated runtime test.
+- Fixtures and shared test helpers may supply schemas, entities, or data to
+  package tests. This rule concerns ownership of test assertions, not a ban on
+  test fixtures. Package tests may use real databases where behavior requires
+  them; they should not require the full codegen matrix or an example app.
+- When fixing a core bug first reproduced in a fixture, add the regression to
+  the owning package and retain fixture coverage only for the distinct
+  integration contract. Do not keep expanding a fixture into the core suite
+  merely because it already has convenient setup.
+- During review, check test placement as well as passing results. Identify the
+  owning package regression and any additional fixture coverage in the handoff
+  or PR description. A passing matrix does not replace core package coverage.
 
 ## Local testing
 
@@ -22,6 +53,8 @@ Package-level commands:
 
 Codegen feature matrix:
 
+- The matrix supplements the package tests described above; it is not the home
+  for core runtime or migration regression suites.
 - `go test ./internal/codegenmatrix -count=1`
 - See `testdata/codegen_matrix/README.md` before adding schema/codegen options
   or generated-code regression coverage. New codegen inputs must be classified

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -1,5 +1,11 @@
 # Python workspace notes
 
+- Follow [the repository test ownership rules](../AGENTS.md#test-ownership-and-placement).
+  Core Python regressions belong in the owning package's tests. For
+  `auto_schema`, put comparison, normalization, rendering, operation ordering,
+  and upgrade/downgrade/replay coverage in `auto_schema/tests/`, using real DB
+  tests where needed. Codegen DB fixtures provide additional integration
+  coverage and must not be the only tests of migration behavior.
 - Preferred Python for this repo is 3.14.x when updating the Pipenv lockfile.
 - Use the helper script `python/scripts/refresh_pipenv_3_14.sh` to recreate the env, lock, install deps, and run tests.
 - If `pipenv` picks the wrong interpreter, prefer the pipx-managed binary and set `PIPENV_PYTHON` to the full 3.14 path.

--- a/python/auto_schema/CONTRIBUTING.MD
+++ b/python/auto_schema/CONTRIBUTING.MD
@@ -1,5 +1,13 @@
 # CONTRIBUTING
 
+Put core regression tests in this package's `tests/` directory, extending the
+suite for the affected implementation (for example, `runner_test.py`,
+`renderers_test.py`, or `ops_sql_test.py`). Migration comparison and replay
+tests may use real databases and shared fixtures; they must run through pytest
+without depending on the codegen matrix. Matrix fixtures add representative
+schema-to-DB integration checks, not the core migration test suite. See
+[the repository test ownership rules](../../AGENTS.md#test-ownership-and-placement).
+
 make changes to code and then run as following:
 
 * `pipenv shell` to get into virtual environment.

--- a/testdata/codegen_matrix/README.md
+++ b/testdata/codegen_matrix/README.md
@@ -4,6 +4,30 @@ The codegen matrix is the broad smoke suite for Ent schema features. It exists
 to catch generated TypeScript, GraphQL, import-order, DB schema, and
 idempotence regressions before they reach downstream apps.
 
+## Test Ownership
+
+Core functionality is tested in the package that implements it, following
+[AGENTS.md](../../AGENTS.md#test-ownership-and-placement). Put runtime regression
+and edge-case assertions in colocated `ts/src/**/*.test.ts`, generator logic
+tests in the owning Go package, and migration behavior tests in
+`python/auto_schema/tests/`. These tests must run with their package's normal
+test command, independently of this matrix.
+
+Fixture tests supplement those suites by checking actual generated output and
+integration boundaries. For example, inverse-edge ownership and default-reset
+semantics belong in the action package tests; a fixture can additionally prove
+that generated builders pass the right fields and ownership information to the
+runtime. Predicate comparison and migration replay belong in the Python tests;
+a DB fixture can additionally prove that schema input reaches generated DB
+output correctly.
+
+Keep fixture runtime tests small and representative. Do not accumulate the
+core behavior suite here because a fixture already provides convenient setup.
+Shared fixture data and helpers are fine in package tests; fixture-only
+assertions are insufficient coverage for a core behavior change.
+
+## Running The Matrix
+
 Run it with:
 
 ```sh
@@ -77,6 +101,9 @@ failure.
 
 The bar is:
 
+- Add the core regression in its owning package first. Add matrix assertions
+  for the distinct generation or integration contract, rather than moving the
+  package's core cases into a fixture.
 - Prefer one representative fixture interaction over a cartesian-product grid.
   A nullable boolean is usually not interesting; an id field with a foreign key,
   field edge, custom name, transform, or privacy policy often is.


### PR DESCRIPTION
Core runtime and migration regressions can accumulate in codegen fixtures, leaving the owning package test suites without coverage. Require core behavior and edge-case tests in the implementing package, with fixture tests focused on representative generated-output and integration contracts.

Update the root and Python agent guidance, Python contributor guide, and codegen matrix README. Shared fixtures and real database tests remain supported. No existing tests are relocated.

Validation: `git diff --check` passed and the guidance links resolve to the root policy. Documentation only; runtime tests were not run. No changelog entry because repository policy excludes internal workflow changes.
