### PR TITLE
Add PostgreSQL transaction scopes with final action validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ## [Unreleased]
 
+### Added
+
+- add PostgreSQL `withTransaction` scopes covering reads, action validation, and
+  writes, with isolation guards, retries, and post-commit observers (#2035).
+
 ### Fixed
 
 - update `uuid`, docs, test-helper, and standalone TypeScript package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Added
 
-- add PostgreSQL `withTransaction` scopes covering reads, action validation, and
-  writes, with isolation guards, retries, and post-commit observers (#2035).
+- Add PostgreSQL `withTransaction` scopes for reads, action preparation, and
+  writes, with isolation requirements, retries, and observers that run after commit (#2035).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ Changelog for the docker image are [here](/docker_CHANGELOG.md).
 
 ### Added
 
-- Add PostgreSQL `withTransaction` scopes for reads, action preparation, and
-  writes, with isolation requirements, retries, and observers that run after commit (#2035).
+- Add PostgreSQL `withTransactionScope` scopes for reads, action preparation, and
+  writes, with action-owned validation before commit, uncached final reads,
+  isolation requirements, retries, and observers that run after commit (#2035).
 
 ### Fixed
 

--- a/docs/docs/actions/action.md
+++ b/docs/docs/actions/action.md
@@ -37,7 +37,9 @@ We'll dive into each of these in the following sections.
 
 ## Transactions
 
-If you need to coordinate multiple actions at the call site, use a [Transaction](/docs/actions/transactions) to run them together. For work that belongs to an action, use [Triggers](/docs/actions/triggers) to queue changesets whose writes share the action's transaction. Trigger callbacks run before the ordinary write transaction. To include their reads and decisions in the transaction, call the action inside [`withTransaction`](/docs/actions/transactions#transaction-scoped-reads-and-actions).
+Use [Transaction](/docs/actions/transactions) to commit or roll back multiple actions' writes together. Use [triggers](/docs/actions/triggers) to add child changesets whose writes share an action's transaction.
+
+Trigger callbacks run before the ordinary write transaction. To include their reads and decisions in the transaction, call the action inside [`withTransaction`](/docs/actions/transactions#transaction-scoped-reads-and-actions).
 
 ## Default Privacy Policy
 

--- a/docs/docs/actions/action.md
+++ b/docs/docs/actions/action.md
@@ -37,7 +37,7 @@ We'll dive into each of these in the following sections.
 
 ## Transactions
 
-If you need to coordinate multiple actions at the call site, use a [Transaction](/docs/actions/transactions) to run them together. For action-internal work, use [Triggers](/docs/actions/triggers) since they run inside the action's own transaction.
+If you need to coordinate multiple actions at the call site, use a [Transaction](/docs/actions/transactions) to run them together. For work that belongs to an action, use [Triggers](/docs/actions/triggers) to queue changesets whose writes share the action's transaction. Trigger callbacks run before the ordinary write transaction. To include their reads and decisions in the transaction, call the action inside [`withTransaction`](/docs/actions/transactions#transaction-scoped-reads-and-actions).
 
 ## Default Privacy Policy
 

--- a/docs/docs/actions/action.md
+++ b/docs/docs/actions/action.md
@@ -39,7 +39,7 @@ We'll dive into each of these in the following sections.
 
 Use [Transaction](/docs/actions/transactions) to commit or roll back multiple actions' writes together. Use [triggers](/docs/actions/triggers) to add child changesets whose writes share an action's transaction.
 
-Trigger callbacks run before the ordinary write transaction. To include their reads and decisions in the transaction, call the action inside [`withTransaction`](/docs/actions/transactions#transaction-scoped-reads-and-actions).
+Trigger callbacks run before the ordinary write transaction. To include their reads and decisions in the transaction, call the action inside [`withTransactionScope`](/docs/actions/transactions#transaction-scoped-reads-and-actions).
 
 ## Default Privacy Policy
 

--- a/docs/docs/actions/transactions.md
+++ b/docs/docs/actions/transactions.md
@@ -116,6 +116,8 @@ Cached queries and loaders belong to the guarded-action generation in which you 
 
 Converting previously read rows to Ents preserves their original transaction and generation, including rows returned by `tx.query`, `tx.queryAll`, and `tx.exec`. Supplied Ents and `sourceEnt()` results used by edge-query privacy must belong to the current generation.
 
+`loadDerivedEnt()` and `loadDerivedEntX()` also preserve the input row's transaction and generation before running privacy checks. If the data has no recorded transaction provenance, the resulting Ent remains unscoped and can't be used in a guarded save. Load a tracked row inside the callback instead of copying or reusing untracked data.
+
 Standard Ent, object, count, query, and edge-metadata caches are isolated for each attempt. Transaction rows never populate request caches outside the scope. Commit invalidates participating request caches; rollback leaves them unchanged. SQL calls conservatively invalidate the attempt's caches, so raw writes and reads after acquiring locks see fresh data.
 
 #### Results

--- a/docs/docs/actions/transactions.md
+++ b/docs/docs/actions/transactions.md
@@ -4,17 +4,19 @@ sidebar_position: 16
 
 # Transactions
 
-Use `Transaction` when you need multiple actions' writes to succeed or fail together. Before writing, Ent computes field defaults and transformations, checks privacy policies, runs [triggers](/docs/actions/triggers), and validates the resulting input. These steps prepare the action and its child changesets. By default, they run before the write transaction; the queued writes then commit or roll back together. To include these steps and the reads they use in one PostgreSQL transaction, use `withTransaction`.
+Use `Transaction` to commit or roll back multiple actions' writes together. Before writing, Ent computes field defaults and transformations, checks privacy policies, runs [triggers](/docs/actions/triggers), and validates the resulting input. These steps prepare the action and its child changesets.
+
+By default, preparation runs before the write transaction. To include preparation and the reads it uses in one PostgreSQL transaction, wrap the operation in `withTransaction`.
 
 ## Transaction-scoped reads and actions
 
-`withTransaction` starts a transaction before calling its callback. Ent reads, privacy checks, validators, triggers, actions, edge writes, and audit changesets inside the callback use the same reserved connection. Other asynchronous requests use their own connections and caches. Outside this API, existing actions and `Transaction.run()` keep their default behavior.
+`withTransaction` starts a transaction before calling its callback. Ent loads, privacy checks, validators, triggers, actions, edge writes, and audit changesets in the callback use one reserved connection. Other asynchronous requests use their own connections and caches. Outside a scope, actions and `Transaction.run()` keep their existing behavior.
 
 ```ts
 import { withTransaction } from "@snowtop/ent/action";
 
 const result = await withTransaction(async () => {
-  // Reload and reconstruct on every attempt, including the first.
+  // Load the account and create the action on every attempt.
   const account = await Account.loadX(viewer, accountID);
   return EditAccountAction.create(viewer, account, {
     balance: account.balance - amount,
@@ -22,19 +24,57 @@ const result = await withTransaction(async () => {
 }, { maxRetries: 3 });
 ```
 
-This new API defaults to `serializable` because actions often read a value or count, validate a decision, and then write a result. At PostgreSQL's usual `read committed` isolation level, two concurrent actions can both pass validation using the same old state. Serializable isolation lets PostgreSQL detect conflicting decisions and abort an attempt instead of committing an inconsistent result. This can produce more transaction failures, so callers can opt into whole-callback retries.
+### Transaction lifecycle
 
-This default applies only when you call `withTransaction`. Ordinary action saves and `Transaction.run()` outside a scope still use their existing write transactions and the connection's configured isolation level. The API doesn't change PostgreSQL's default or the behavior of existing callers. Set `isolationLevel: "read committed"` when you use a compatible locking protocol, as described in [Explicit locks and composition](#explicit-locks-and-composition).
+An ordinary action starts its transaction after preparation:
 
-PostgreSQL rejects conflicting transactions with SQLSTATE `40001` and reports deadlocks with `40P01`. `maxRetries` defaults to zero. If you set `maxRetries` above zero, these errors cause the whole callback to retry with a new connection reservation, snapshot, loaders, and actions.
+```text
+Load → Prepare → BEGIN → Write → COMMIT → Load result → Observe
+```
 
-Every operation that enforces the invariant must follow a compatible serializable or locking protocol. This API doesn't automatically protect unrelated writers that use read committed isolation. For details, see [PostgreSQL transaction isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
+`withTransaction` starts earlier and owns the transaction until the callback finishes:
 
-If you enable retries, keep external side effects out of the callback and triggers. Send notifications through observers, or use an action to write an outbox record in the same transaction. Rollback doesn't undo sequence values or changes to external systems. If a connection fails during `COMMIT` and leaves the outcome unknown, `withTransaction` doesn't retry. Reconcile the outcome before retrying externally.
+```text
+Reserve connection → BEGIN
+                       │
+                       ▼
+             Run the callback
+             ├─ Load rows and create actions
+             ├─ Prepare defaults, transformations, privacy, triggers, and validation
+             ├─ Execute the action graph's writes
+             └─ Reload results and apply result privacy
+                       │
+                       ▼
+             Callback returns
+             ├─ Pending SQL or failed scope → ROLLBACK
+             └─ Successful scope → COMMIT
+                                      │
+                                      ▼
+                    Release connection → Invalidate request caches
+                                      → Run observers → Return result
+```
+
+The callback can save multiple actions. After a guarded save, reload the data for the next guarded action and prepare it from that data. All saves remain provisional until the outer `COMMIT` succeeds.
+
+If an attempt fails, Ent rolls it back, releases the connection, and discards its caches and observers. An eligible retry starts the whole callback again with fresh attempt state. A failure with no eligible retry rejects `withTransaction`.
+
+### Isolation and retries
+
+An invariant is an application rule that must remain true, such as requiring at least one account administrator. Actions often check an invariant by reading data, validating a decision, and writing a result.
+
+`withTransaction` defaults to `serializable` isolation. At PostgreSQL's usual `read committed` isolation level, concurrent actions can both pass validation using the same old state. Serializable isolation lets PostgreSQL detect conflicting decisions and abort an attempt. Callers can enable retries of the whole callback to handle these failures.
+
+This default applies only to `withTransaction`. Ordinary saves and `Transaction.run()` outside a scope use their existing write transactions and the connection's configured isolation level. Set `isolationLevel: "read committed"` when you use a compatible locking protocol, as described in [Explicit locks and composition](#explicit-locks-and-composition).
+
+PostgreSQL reports serialization failures with SQLSTATE `40001` and deadlocks with `40P01`. `maxRetries` defaults to zero. If you enable retries, either error can restart the callback with a new connection reservation, snapshot, and caches. Load Ents and construct actions again inside that callback.
+
+Every writer that can violate an invariant must follow a compatible serializable or locking protocol. This API doesn't protect unrelated writers that use read committed isolation. For details, see [PostgreSQL transaction isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
+
+If you enable retries, keep external side effects out of the callback and triggers. Send notifications through observers, or use an action to write an outbox record in the same transaction. Rollback doesn't undo sequence values or changes to external systems. If a connection failure during `COMMIT` leaves the outcome unknown, `withTransaction` doesn't retry. Determine the outcome before retrying externally. Connection cleanup failures also prevent retries; a failure after a successful commit cannot undo it.
 
 ### Require transactions for an action
 
-An action that enforces an invariant can require a transaction scope on every normal action save, builder save, or changeset entry point:
+An action can require a transaction for its normal action save, builder save, and changeset entry points:
 
 ```ts
 export default class RemoveAdminAction extends RemoveAdminActionBase {
@@ -49,25 +89,31 @@ await withTransaction(
 );
 ```
 
-Return `true` from `requiresTransaction()` to require either supported isolation level, or return `"serializable"` to reject weaker isolation. This guard runs before privacy checks, triggers, and validators. Apply it to every action that can violate the invariant, including generated GraphQL mutations and alternative edit or delete paths. Your application must protect raw SQL and custom actions that bypass the Ent orchestrator.
+Return `true` from `requiresTransaction()` to accept either supported isolation level, or return `"serializable"` to require serializable isolation. Ent checks this requirement before running action privacy checks, triggers, or validators. Apply it to every action that can violate the invariant, including generated GraphQL mutations and other edit or delete paths. Protect raw SQL and custom actions that bypass the Ent orchestrator in your application.
 
-Construct actions, builders, queries, and loaders inside the callback. Load `existingEnt` there too, and construct triggered changesets during that attempt. The runtime rejects builders, changesets, standard cached loaders, and preloaded Ents that don't belong to the current scope. Don't reuse a changeset or builder on another attempt.
+In this guide, a *guarded action* requires a transaction or declares invariant resources through `getTransactionResources()`.
 
-A GraphQL mutation wrapper must throw execution errors out of the callback. Returning an error-shaped result still counts as a successful return and requests a commit. An action save, executor assembly, or SQL failure marks the scope as failed even if you catch the error, so earlier writes roll back. Regenerated `saveXFromID` and `saveFromID` helpers include their initial load, construction, and edge setup in this failure boundary. Generated edge-group instance saves and changesets also include edge setup. During standalone validation, a child changeset can still report a correctable validation error without failing the transaction; SQL errors always fail it. A missing target returned by a nullable helper remains recoverable.
+Construct actions, builders, queries, and loaders inside the callback. Load `existingEnt` there too, and create triggered changesets during the same attempt. Ent rejects builders, changesets, standard cached loaders, and preloaded Ents that belong to another scope. Rebuild them for each retry.
+
+An action save, executor assembly, or SQL failure marks the scope as failed even if you catch the error. Earlier writes then roll back. Regenerated `saveXFromID` and `saveFromID` helpers include the initial load, construction, and edge setup in this failure handling. Generated edge-group instance saves and changesets also include edge setup. A missing target returned by a nullable helper remains recoverable.
+
+A GraphQL wrapper must throw execution errors out of the callback. Returning an object that contains an error still counts as a successful return and requests a commit, unless an action or SQL failure has already marked the scope as failed. During standalone validation, a child changeset can report a correctable validation error without failing the transaction. SQL errors always fail it.
 
 #### Prepare guarded root actions sequentially
 
-Prepare and save guarded root actions sequentially. Don't prebuild two guarded roots with `changeset()`, combine them in `Transaction`, or call their saves in `Promise.all`. These operations reject and roll back the scope even if the actions might be independent.
+Prepare and save one guarded root action at a time. Don't prebuild two guarded roots with `changeset()`, combine them in `Transaction`, or call their saves in `Promise.all`. These operations reject and roll back the scope even if the actions appear independent.
 
-After each guarded save, reconstruct queries and loaders and reload the Ents needed for the next action. Also reconstruct actions whose defaults or transforms were already prepared by validation or a getter. Each guarded save advances the transaction's generation, so prepared values can't carry over to the next save. Prebuilt changesets and assembled executors, including those for ordinary unguarded actions, also expire after a guarded save. They reject before fetching or writing data.
+Each guarded save advances the transaction's *generation*, which identifies the reads and prepared values that remain usable for the next action. After a guarded save, create fresh queries and loaders and reload the Ents needed by the next action. Reconstruct actions whose defaults or transformations were already prepared by validation or a getter.
 
-These checks prevent two root validators or rollups from preparing against the same old state within one transaction, where database isolation can't detect the dependency.
+Prebuilt changesets and assembled executors also expire after a guarded save, including those for ordinary unguarded actions. They reject before fetching or writing data. These checks prevent multiple root actions from making decisions against the same old state within one transaction, where database isolation can't detect the dependency.
 
 #### Compose guarded actions
 
-Return child changesets from triggers. Don't call a child's `save()` or `saveX()` method or execute child executors during preparation. Distinct guarded actions conflict by default. This includes ancestors, descendants, and actions separated by an unguarded wrapper. For example, a parent and child that remove different admin rows can both read the old count and violate the last-admin invariant. Their parent-child relationship doesn't establish independence.
+Return child changesets from triggers. Don't call a child's `save()` or `saveX()` method or execute its executor during preparation.
 
-If you have established that the actions are independent, implement `getTransactionResources()` on every participating guarded action, including the parent. Return the keys for the invariants that each action depends on:
+Distinct guarded actions conflict by default, including ancestors, descendants, and actions separated by an unguarded wrapper. For example, a parent and child that remove different administrators can both read the old administrator count and violate the requirement to keep one administrator. Their parent-child relationship doesn't establish independence.
+
+If the actions are independent, implement `getTransactionResources()` on every participating guarded action, including the parent. Return keys for the invariants that each action depends on:
 
 ```ts
 getTransactionResources(): readonly string[] {
@@ -76,29 +122,31 @@ getTransactionResources(): readonly string[] {
 }
 ```
 
-Use non-empty arrays of non-empty strings to declare explicit resources. The runtime takes a snapshot of these arrays. Only actions with disjoint resource keys can prepare together; ancestors and descendants must also have disjoint keys. Guarded roots must still run sequentially, even with explicit keys.
+Return a non-empty array of non-empty strings. Ent copies the array and permits actions to prepare together only when their resource keys don't overlap. This rule also applies to ancestors and descendants. Guarded roots must still run sequentially, even with explicit keys.
 
-The runtime reserves the guarded root before invoking `getTransactionResources()`, including when the hook returns a promise. Other guarded roots can't prepare while the hook resolves. The hook's reads and awaited work must stay within the same transaction generation.
+Ent reserves the guarded root before invoking `getTransactionResources()`. If the hook returns a promise, other guarded roots can't prepare while it resolves. The hook's reads and other awaited work must stay within one generation.
 
-If you omit the hook or return `undefined`, the action reserves a wildcard resource. This reservation conflicts with every other guarded action in the prepared graph, including actions with explicit keys. There is no special wildcard string. Defining the hook requires `withTransaction`, even without `requiresTransaction()`.
+If you omit the hook or return `undefined`, the action reserves a wildcard resource that conflicts with every other guarded action in the graph. There is no special wildcard string. Defining the hook requires `withTransaction`, even without `requiresTransaction()`.
 
-Declare every dependency that another action could invalidate, including aggregate predicates and privacy checks, rather than only the row being written. For example, a parent that changes account A's balance and a child that changes account B's balance can declare separate account keys if neither decision depends on the other account. Two actions that depend on the same admin count must share an invariant key and will be rejected. Consolidate their decisions into one action, or save sequentially and reload. Existing parent-child compositions that relied on ancestry alone must adopt this contract.
+Declare every dependency that another action could invalidate, including aggregate conditions and privacy checks. A row key alone is sufficient only when the action's decisions depend on that row alone. For example, a parent that changes account A's balance and a child that changes account B's balance can declare separate account keys if neither decision depends on the other account.
 
-During execution, the runtime also rejects known repeated updates or deletes of the same row through different builders in a guarded tree. Skipped conditional operations and changes limited to edges don't count as row mutations. Consolidate overlapping absolute updates into one child action. The runtime doesn't infer invariant keys from SQL dependencies; your application must declare all shared dependencies. Existing unguarded action batches keep their behavior.
+Actions that depend on the same administrator count must share an invariant key and cannot prepare together. Consolidate their decisions into one action, or save them sequentially and reload between saves. Parent-child compositions that relied on ancestry alone must adopt this contract.
+
+During execution, Ent also rejects known updates or deletes of the same row through different builders in a guarded graph. Skipped conditional operations and edge-only changes don't count as row mutations. Consolidate overlapping absolute updates into one child action. Ent doesn't infer invariant keys from SQL dependencies; your application must declare every shared dependency. Existing unguarded action batches keep their behavior.
 
 #### Validate without saving
 
-Standalone `valid()`, `validX()`, and `validWithErrors()` calls inside a scope use the same preparation guards. Their child changesets and resource reservations are temporary. After validation, the runtime discards them, including when validation reports errors. A subsequent save reruns validation and prepares a fresh child graph. Changesets captured during standalone validation can't execute. Cleanup also applies to retained children and grandchildren.
+Standalone `valid()`, `validX()`, and `validWithErrors()` calls inside a scope use the same preparation guards. Their child changesets and resource reservations are temporary. After validation, Ent discards them, including when validation reports an error. This cleanup includes retained children and grandchildren. A subsequent save reruns validation and prepares a fresh child graph. Changesets captured during standalone validation cannot execute.
 
-Before closing the validation scope, the runtime waits for participating SQL, Ent, privacy, and loader reads used to set up children. It waits even if another child has already failed and preserves the original validation error. A later SQL or composition failure still aborts the transaction.
+Before closing validation, Ent waits for participating SQL, Ent, privacy, and loader reads used to set up children. This includes pending privacy checks reused from an Ent cache. Ent waits even if another child has already failed and preserves the original validation error. A later SQL or composition failure still aborts the transaction.
 
-Field defaults and action or schema transformation results remain memoized. This preserves established builder IDs and applies transformed input only once. A transformation's `changeset` factory runs during each validation or save preparation in a scope and must build a fresh child changeset. Computing fields through a getter alone doesn't run the factory.
+Field defaults and action or schema transformation results remain memoized. This preserves builder IDs and applies transformed input once. A transformation's `changeset` factory runs during each validation or save preparation inside a scope and must create a fresh child changeset. Reading fields through a getter alone doesn't run the factory.
 
-Cleanup retains edges established by default-field `updateInput` and discards edges to children created during standalone validation. Validation can still change action fields through existing trigger behavior; it doesn't roll back application state in general. Await validation before building or saving the same action. You can inspect and correct normal validation errors. SQL failures and invalid transaction composition still fail the transaction.
+Cleanup preserves edges established by default-field `updateInput` and discards edges to children created during standalone validation. Validation can still change action fields through existing trigger behavior; it doesn't restore application state in general. Await validation before building or saving the same action. You can inspect and correct normal validation errors. SQL failures and invalid transaction composition still fail the transaction.
 
 ### Explicit locks and composition
 
-If you use read committed isolation, lock the invariant's stable owner row before reading data used for decisions. Every competing writer must acquire the same lock. Locking only rows about to be deleted can't protect an empty set or a last-admin count. Acquire multiple locks in a consistent order.
+If you use read committed isolation, lock a stable row that owns the invariant before reading data used for decisions. Every competing writer must acquire the same lock. Locking only rows about to be deleted cannot protect an empty set or the requirement to keep one administrator. Acquire multiple locks in a consistent order.
 
 ```ts
 await withTransaction(async (tx) => {
@@ -110,41 +158,51 @@ await withTransaction(async (tx) => {
 }, { isolationLevel: "read committed" });
 ```
 
-The callback receives `query`, `queryAll`, `exec`, `attempt` (zero-based), and `isolationLevel`. Use PostgreSQL placeholders to parameterize SQL. Low-level SQL doesn't apply Ent privacy or create audit actions. Use it for locks, then use Ent actions for mutations. Don't send SQL that controls the transaction, use DB handles captured before the callback, or change global DB configuration while a scope is active.
+The callback receives `query`, `queryAll`, `exec`, the zero-based `attempt` number, and `isolationLevel`. Use PostgreSQL placeholders to parameterize SQL. These SQL methods don't apply Ent privacy or create audit actions. Use them for locks, then use Ent actions for mutations.
 
-`withTransaction` rejects nested calls; it doesn't support savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` (exported from `@snowtop/ent/action`), check its `isolationLevel`, and call their implementation directly if an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope.
+While a scope is active, don't send SQL that controls the transaction, use DB handles captured before the callback, or change global DB configuration.
+
+`withTransaction` rejects nested calls and doesn't support savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` from `@snowtop/ent/action`, check its `isolationLevel`, and call their implementation directly when an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope.
 
 ### Caches, results, and observers
 
 #### Queries and caches
 
-Cached queries and loaders belong to the guarded-action generation in which you create them. Reusing them after a guarded save, or letting a pending read span that save, rejects and marks the scope as failed even if you catch the error. Await reads before saving, then create fresh readers for the next action. Reuse within the same generation and ordinary behavior outside a scope are unchanged.
+Cached queries and loaders belong to the generation in which you create them. Reusing them after a guarded save, or letting a pending read span that save, marks the scope as failed even if you catch the error. Await reads before saving, then create fresh readers for the next action. You can reuse readers within one generation. Their behavior outside a scope is unchanged.
 
-Converting previously read rows to Ents preserves their original transaction and generation, including rows returned by `tx.query`, `tx.queryAll`, and `tx.exec`. Supplied Ents and `sourceEnt()` results used by edge-query privacy must belong to the current generation.
+Rows retain the transaction and generation in which they were read, including rows returned by `tx.query`, `tx.queryAll`, and `tx.exec`. Converting a row to an Ent preserves that origin. Supplied Ents and `sourceEnt()` results used by edge-query privacy must belong to the current generation.
 
-`applyPrivacyPolicyForRow()`, `applyPrivacyPolicyForRows()`, `loadDerivedEnt()`, and `loadDerivedEntX()` preserve the input row's transaction and generation before running privacy checks. If the data has no recorded transaction provenance, the resulting Ent remains unscoped and can't be used in a guarded save. Load a tracked row inside the callback instead of copying or reusing untracked data.
+`applyPrivacyPolicyForRow()`, `applyPrivacyPolicyForRows()`, `loadDerivedEnt()`, and `loadDerivedEntX()` preserve the input row's transaction and generation before running privacy checks. If the row has no recorded transaction origin, the resulting Ent remains unscoped and cannot be used in a guarded save. Load a tracked row inside the callback instead of copying data or reusing untracked data.
 
-Standard Ent, object, count, query, and edge-metadata caches are isolated for each attempt. Transaction rows never populate request caches outside the scope. Commit invalidates participating request caches; rollback leaves them unchanged. Framework reads preserve cached results from other reads in the attempt. Raw SQL calls, including those made through `tx.query`, `tx.queryAll`, `tx.exec`, `DB.getPool()`, and `performRawQuery()`, conservatively invalidate caches for every participating viewer. Framework writes also invalidate these caches, so reads after writes or explicit locks see fresh data.
+Standard Ent, object, count, query, and edge metadata caches are isolated for each attempt. Transaction rows never populate request caches outside the scope. Commit invalidates participating request caches; rollback leaves them unchanged.
+
+Framework reads preserve other cached results in the attempt. Raw SQL calls conservatively invalidate caches for every participating viewer, including calls through `tx.query`, `tx.queryAll`, `tx.exec`, `DB.getPool()`, and `performRawQuery()`. Framework writes also invalidate these caches, so reads after writes or explicit locks see fresh data.
 
 #### Results
 
-`saveX()` results inside the callback are provisional. A thrown result-loading or post-fetch error marks the owning scope as failed, so all writes roll back even if you catch the error. This includes direct `editedEntX()` failures and exceptions from `viewerForEntLoad` or result privacy checks. Normal `null` results from nullable `save()` and `editedEnt()` calls don't fail the scope.
+Results from `saveX()` inside the callback are provisional. A result-loading or post-fetch error marks the owning scope as failed, so all writes roll back even if you catch the error. This includes direct `editedEntX()` failures and exceptions from `viewerForEntLoad` or result privacy checks. Normal `null` results from nullable `save()` and `editedEnt()` calls don't fail the scope.
 
-Direct result-loading errors from getters used after their owning commit can't undo that commit or fail a different transaction. Queries and actions that application privacy callbacks explicitly execute inside a later scope still follow that active scope's failure rules.
+A result getter used after its owning commit cannot undo that commit or fail a different transaction. Queries and actions that application privacy callbacks explicitly execute in a later scope still follow that scope's failure rules.
 
-Don't expose callback results until `withTransaction` resolves. After commit, returned Ent objects remain snapshots. Reload them inside a new scope to edit them again.
+Expose callback results only after `withTransaction` resolves. After commit, returned Ent objects remain snapshots. Reload them in a new scope before editing them again.
 
-Calling `editedEnt()` or `editedEntX()` again reads the action's retained result row and preserves that write's transaction and generation. Inspecting an old snapshot inside a later scope or after another guarded root saves doesn't make it a fresh mutation input. Immediate results of the latest completed action graph remain usable in that generation. Within a scope, standard actions reload their result rows after all graph writes and before result privacy checks. Results include changes made by other actions or raw changesets in that graph. The reload uses the stored row's primary key, including when an upsert matched an existing row. Edge-only actions and actions skipped by silent privacy checks also reload their result rows. After later guarded writes, reload from the database.
+Calling `editedEnt()` or `editedEntX()` again reads the action's retained result row and preserves that write's transaction and generation. Inspecting an old snapshot inside a later scope or after another guarded save doesn't make it a fresh mutation input. Results of the latest completed action graph remain usable in that generation.
+
+Inside a scope, standard actions reload their result rows after all graph writes and before result privacy checks. This adds one row reload per executed node operation that returns a row. Results include changes made by other actions or raw changesets in the graph. The reload uses the stored row's primary key, including when an upsert matched an existing row. Edge-only actions and actions skipped by silent privacy checks also reload their result rows. After later guarded writes, reload from the database.
 
 #### Observers and asynchronous work
 
-Action observers wait until the owning transaction commits. They then run outside its scope, after the connection is released. Rollback and failed retry attempts discard observers. Observer errors keep the existing best-effort policy and never cause committed work to retry. Observers can't roll back a commit and don't guarantee durable, exactly-once delivery.
+Action observers run after the owning transaction commits and releases its connection. They run outside that scope. Rollback and failed retry attempts discard observers.
 
-Await all work inside the callback. SQL still in progress when the callback returns causes rollback, and asynchronous work that inherits the scope can't use it after it closes. Detached jobs must start with their own request context.
+Observer errors follow the existing best-effort policy and never cause committed work to retry. Observers cannot roll back a commit and don't guarantee durable, exactly-once delivery.
+
+Await all work inside the callback. SQL still in progress when the callback returns causes rollback. Asynchronous work that inherits a scope cannot use it after it closes. Detached jobs must start with their own request context.
 
 ### Supported runtimes
 
-`withTransaction` supports PostgreSQL with Node's `pg` driver and Bun's `pg` or native Bun SQL driver. It rejects SQLite because the existing shared synchronous connection can't safely hold an asynchronous transaction scope across concurrent requests. It also rejects `repeatable read` and other isolation modes. Existing SQLite action transactions continue to work normally.
+`withTransaction` supports PostgreSQL with Node's `pg` driver and Bun's `pg` or native SQL driver. It rejects SQLite because the existing shared synchronous connection cannot safely hold an asynchronous transaction across concurrent requests. Existing SQLite action transactions continue to work normally.
+
+The supported isolation levels are `serializable` and `read committed`. Other levels, including `repeatable read`, are rejected.
 
 ## Basic usage
 

--- a/docs/docs/actions/transactions.md
+++ b/docs/docs/actions/transactions.md
@@ -4,7 +4,100 @@ sidebar_position: 16
 
 # Transactions
 
-Use `Transaction` when you need multiple actions to succeed or fail together in a single database transaction. This is different from [Triggers](/docs/actions/triggers): triggers are action-internal and already run inside the action's transaction. If any action fails (validation, privacy, or a database constraint), the entire transaction is rolled back.
+Use `Transaction` when you need multiple actions' writes to succeed or fail together. By default, action preparation, validators and [Triggers](/docs/actions/triggers) run before the write transaction; the changesets returned by triggers share its writes. To include reads and action preparation, use `withTransaction` on PostgreSQL.
+
+## Transaction-scoped reads and actions
+
+`withTransaction` starts a transaction before its callback. Ent reads, privacy checks, validators, triggers, actions, edge writes and audit changesets inside the callback use the same reserved connection. Other asynchronous requests keep their own connections and caches. Existing actions and `Transaction.run()` retain their default behavior outside this API.
+
+```ts
+import { withTransaction } from "@snowtop/ent";
+
+const result = await withTransaction(async () => {
+  // Reload and reconstruct on EVERY attempt, including the first.
+  const account = await Account.loadX(viewer, accountID);
+  return EditAccountAction.create(viewer, account, {
+    balance: account.balance - amount,
+  }).saveX();
+}, { maxRetries: 3 });
+```
+
+The default isolation level is `serializable`. PostgreSQL rejects conflicting transactions with SQLSTATE `40001`; deadlocks use `40P01`. `maxRetries` defaults to zero. Setting it retries the **whole callback** for those errors, with a new connection reservation, snapshot, loaders, and actions. Every operation enforcing the invariant must follow a compatible serializable or locking protocol; unrelated read-committed writers are not made safe automatically. See [PostgreSQL transaction isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
+
+Keep external side effects out of the callback and triggers when retrying. Send notifications through observers, or write an outbox record through an action in the same transaction. Sequence values and external systems are not rolled back. Unknown connection failures during `COMMIT` are not retried: the commit outcome may be unknown and must be reconciled before retrying externally.
+
+### Require transactions for an action
+
+An action with an invariant can fail closed on every normal action/builder save or changeset entrypoint:
+
+```ts
+export default class RemoveAdminAction extends RemoveAdminActionBase {
+  requiresTransaction() {
+    return "serializable" as const;
+  }
+}
+
+await withTransaction(
+  () => RemoveAdminAction.saveXFromID(viewer, fundID, { adminID }),
+  { maxRetries: 3 },
+);
+```
+
+`requiresTransaction()` may return `true` to require either supported isolation level, or `"serializable"` to reject weaker isolation. The guard runs before privacy, triggers and validators. Apply it to every action that can violate the invariant, including generated mutations exposed by GraphQL and alternative edit/delete paths. Raw SQL and custom action implementations that bypass the Ent orchestrator remain the application's responsibility.
+
+Construct actions, builders, queries and loaders inside the callback; construct triggered changesets during that attempt. Load `existingEnt` inside the callback too. The runtime rejects cross-scope builders, changesets, standard cached loaders and preloaded Ents. Do not reuse a changeset or builder for another attempt. A GraphQL mutation wrapper must throw execution errors back out of the callback rather than returning an error-shaped success result; the callback's successful return requests commit. An action save, executor assembly, or SQL failure marks the scope failed even if caught, so earlier writes roll back. Regenerated `saveXFromID`/`saveFromID` helpers include their initial load, construction, and edge setup in this failure boundary; nullable missing results remain recoverable.
+
+Guarded root actions must be prepared and saved **sequentially**. Do not prebuild two guarded roots with `changeset()`, put them together in `Transaction`, or call their saves in `Promise.all`; these modes reject and roll back the scope even when the actions might be independent. After each save, reconstruct queries and loaders and reload Ents needed for the next action. Reconstruct actions whose defaults or transforms have already been prepared by validation or a getter; those values cannot cross a guarded save. Prebuilt changesets and assembled executors, including ordinary unguarded actions, also expire after a guarded save and reject before pre-fetching or writing. This prevents two root validators or rollups from preparing against the same old state inside one transaction, where database isolation cannot detect the dependency.
+
+Return child changesets from triggers; do not call child `save()`/`saveX()` or execute child executors during preparation. Distinct guarded actions conflict by default, including ancestors and descendants and actions separated by an unguarded wrapper. A parent and child removing different admin rows can both read the old count and violate the last-admin invariant. Preparation ancestry does not establish independence.
+
+For actions whose independence is established, implement `getTransactionResources()` returning their invariant keys on every participating guarded action, including the parent:
+
+```ts
+getTransactionResources(): readonly string[] {
+  // Only appropriate when this action's decisions depend on this account alone.
+  return [`account:${this.builder.existingEnt.id}`];
+}
+```
+
+Omitting the hook or returning `undefined` means a wildcard reservation, which conflicts with every other guarded action in the prepared graph, including actions with explicit keys. Non-empty arrays of non-empty strings declare explicit resources; only disjoint keyed actions may prepare together. The runtime snapshots these arrays. Ancestors and descendants must have disjoint resources too, and guarded roots remain sequential even with keys. There is no special wildcard string. Resource declarations must cover every dependency that another action could invalidate, including aggregate predicates and privacy checks, not just the row being written. For example, a parent changing only account A's balance and a child changing only account B's balance can declare separate account keys when neither decision depends on the other account. Two actions that both depend on the same admin count must share an invariant key and will be rejected; consolidate their decisions into one action or save sequentially and reload. Existing parent/child compositions that relied on ancestry alone must adopt this contract. A hook itself requires `withTransaction`, even without `requiresTransaction()`.
+
+Standalone `valid()`, `validX()`, and `validWithErrors()` calls inside a scope use the same preparation guards. Their child changesets and reservations are temporary and are discarded after validation, including when validation reports errors. A subsequent save reruns validation and prepares a fresh child graph. Changesets captured from standalone validation cannot execute. This cleanup applies to retained children and grandchildren too. It waits for participating SQL, Ent/privacy, and loader reads used to set up children before closing the validation scope, even when another child has already failed. The original validation error is preserved; a late SQL or composition failure still aborts the transaction.
+
+Field defaults and action/schema transformation results remain memoized, preserving established builder IDs and applying transformed input only once. A transformation's `changeset` factory runs within each validation/save preparation in a scope and must build a fresh child changeset; computing fields through a getter alone does not execute that factory. Edges established by default-field `updateInput` are retained, while edges to probe-created children are discarded with the probe. Validation can still change action fields through existing trigger behavior; it is not a general rollback of application state. Await validation before building or saving the same action. Normal validation errors can be inspected and corrected; SQL failures and invalid transaction composition still fail the transaction.
+
+Known repeated row updates/deletes through different builders in a guarded tree are also rejected when executing; skipped conditional operations and edge-only changes do not count as row mutations. Consolidate overlapping absolute updates into one child action. Explicit resource declarations must include every shared invariant dependency: keys are an application contract, not inferred SQL dependencies. Existing unguarded action batches retain their behavior.
+
+### Explicit locks and composition
+
+For a read-committed workflow, lock the invariant's stable owner row **before** reading data used for decisions, and have every competing writer acquire that same lock. Locking only rows about to be deleted cannot protect an empty set or a last-admin count. Acquire multiple locks in a consistent order.
+
+```ts
+await withTransaction(async (tx) => {
+  await tx.query("SELECT id FROM accounts WHERE id = $1 FOR UPDATE", [accountID]);
+  const account = await Account.loadX(viewer, accountID);
+  await EditAccountAction.create(viewer, account, {
+    balance: account.balance - amount,
+  }).saveX();
+}, { isolationLevel: "read committed" });
+```
+
+The callback receives `query`, `queryAll`, `exec`, `attempt` (zero-based), and `isolationLevel`. SQL is parameterized using PostgreSQL placeholders. Low-level SQL does not apply Ent privacy or create audit actions; use it for locks and continue using Ent actions for mutations. Do not send transaction-control SQL, use DB handles captured before the callback, or change global DB configuration while a scope is active.
+
+Nested `withTransaction` calls are rejected; there are no savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` (exported from `@snowtop/ent`), check its `isolationLevel`, and call their implementation directly when an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope.
+
+### Caches, results, and observers
+
+- Cached queries and loaders belong to the guarded-action generation in which they were created. Reusing them after a guarded save, or letting a pending read span that save, rejects and marks the scope failed even if caught. Await reads before saving, then create fresh readers for the next action. Same-generation reuse and ordinary outside-scope behavior are unchanged. Turning previously read rows into Ents preserves their original transaction and generation, including rows returned by `tx.query`, `tx.queryAll`, and `tx.exec`. Supplied Ents and `sourceEnt()` results used by edge-query privacy must belong to the current generation.
+- Standard Ent, object, count, query and edge-metadata caches are isolated for each attempt. Transaction rows never populate outside request caches. Participating request caches are invalidated after commit; rollback leaves them untouched. SQL calls conservatively invalidate the attempt's caches, so raw writes and reads after acquiring locks see fresh data.
+- `saveX()` results inside the callback are provisional. A thrown result-loading or post-fetch error marks the owning scope failed, so all writes roll back even when the caller catches the error. This includes direct `editedEntX()` failures and exceptions from `viewerForEntLoad` or result privacy checks. Normal `null` results from nullable `save()`/`editedEnt()` do not fail the scope. Direct result-loading failures from getters used after their owning commit cannot undo it or fail a different transaction. Queries and actions explicitly executed by application privacy callbacks inside a later scope still follow that active scope's failure rules. Do not expose callback results until `withTransaction` resolves. After commit, already returned Ent objects remain snapshots; reload them inside a new scope to edit them again.
+- Calling `editedEnt()`/`editedEntX()` again reads the action's retained result row. It preserves that write's transaction and generation, so an old snapshot cannot become a fresh mutation input by being inspected inside a later scope or after another guarded root saves. Immediate results of the latest completed action graph remain usable in that generation; reload from the database after later guarded writes.
+- Action observers are queued until the owning commit, then run outside its scope after the connection is released. Rollback and failed retry attempts discard observers. Observer errors keep the existing best-effort policy and never retry committed work. Observers cannot roll back a commit and are not a durable exactly-once delivery mechanism.
+- Await all work inside the callback. Unawaited in-flight SQL causes rollback, and inherited asynchronous work cannot use a closed scope. Detached jobs must start from their own request context.
+
+### Supported runtimes
+
+PostgreSQL with Node's `pg` driver and Bun's `pg` or native Bun SQL driver is supported. SQLite is explicitly rejected: its existing shared synchronous connection cannot safely hold an asynchronous scoped transaction across concurrent requests. `repeatable read` and other isolation modes are rejected. Existing SQLite action transactions continue to work normally.
 
 ## Basic usage
 
@@ -64,5 +157,5 @@ const createdContact = await contactAction.editedEntX();
 ## Notes
 
 - All actions should be created with the same viewer type, and you usually pass the same viewer instance to `Transaction`.
-- If any action throws, nothing is committed.
+- Preparation failures prevent writes; write failures roll back the write transaction. Result loading or observers after commit cannot undo it.
 - When passing builders as input values, make sure your privacy policy allows builders (for example, `AllowIfBuilder`).

--- a/docs/docs/actions/transactions.md
+++ b/docs/docs/actions/transactions.md
@@ -4,17 +4,17 @@ sidebar_position: 16
 
 # Transactions
 
-Use `Transaction` when you need multiple actions' writes to succeed or fail together. By default, action preparation, validators and [Triggers](/docs/actions/triggers) run before the write transaction; the changesets returned by triggers share its writes. To include reads and action preparation, use `withTransaction` on PostgreSQL.
+Use `Transaction` when you need multiple actions' writes to succeed or fail together. By default, action preparation, validators, and [triggers](/docs/actions/triggers) run before the write transaction. The changesets that triggers return share that transaction's writes. To include reads and action preparation, use `withTransaction` on PostgreSQL.
 
 ## Transaction-scoped reads and actions
 
-`withTransaction` starts a transaction before its callback. Ent reads, privacy checks, validators, triggers, actions, edge writes and audit changesets inside the callback use the same reserved connection. Other asynchronous requests keep their own connections and caches. Existing actions and `Transaction.run()` retain their default behavior outside this API.
+`withTransaction` starts a transaction before calling its callback. Ent reads, privacy checks, validators, triggers, actions, edge writes, and audit changesets inside the callback use the same reserved connection. Other asynchronous requests use their own connections and caches. Outside this API, existing actions and `Transaction.run()` keep their default behavior.
 
 ```ts
 import { withTransaction } from "@snowtop/ent";
 
 const result = await withTransaction(async () => {
-  // Reload and reconstruct on EVERY attempt, including the first.
+  // Reload and reconstruct on every attempt, including the first.
   const account = await Account.loadX(viewer, accountID);
   return EditAccountAction.create(viewer, account, {
     balance: account.balance - amount,
@@ -22,13 +22,15 @@ const result = await withTransaction(async () => {
 }, { maxRetries: 3 });
 ```
 
-The default isolation level is `serializable`. PostgreSQL rejects conflicting transactions with SQLSTATE `40001`; deadlocks use `40P01`. `maxRetries` defaults to zero. Setting it retries the **whole callback** for those errors, with a new connection reservation, snapshot, loaders, and actions. Every operation enforcing the invariant must follow a compatible serializable or locking protocol; unrelated read-committed writers are not made safe automatically. See [PostgreSQL transaction isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
+The default isolation level is `serializable`. PostgreSQL rejects conflicting transactions with SQLSTATE `40001` and reports deadlocks with `40P01`. `maxRetries` defaults to zero. If you set `maxRetries` above zero, these errors cause the whole callback to retry with a new connection reservation, snapshot, loaders, and actions.
 
-Keep external side effects out of the callback and triggers when retrying. Send notifications through observers, or write an outbox record through an action in the same transaction. Sequence values and external systems are not rolled back. Unknown connection failures during `COMMIT` are not retried: the commit outcome may be unknown and must be reconciled before retrying externally.
+Every operation that enforces the invariant must follow a compatible serializable or locking protocol. This API doesn't automatically protect unrelated writers that use read committed isolation. For details, see [PostgreSQL transaction isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
+
+If you enable retries, keep external side effects out of the callback and triggers. Send notifications through observers, or use an action to write an outbox record in the same transaction. Rollback doesn't undo sequence values or changes to external systems. If a connection fails during `COMMIT` and leaves the outcome unknown, `withTransaction` doesn't retry. Reconcile the outcome before retrying externally.
 
 ### Require transactions for an action
 
-An action with an invariant can fail closed on every normal action/builder save or changeset entrypoint:
+An action that enforces an invariant can require a transaction scope on every normal action save, builder save, or changeset entry point:
 
 ```ts
 export default class RemoveAdminAction extends RemoveAdminActionBase {
@@ -43,34 +45,54 @@ await withTransaction(
 );
 ```
 
-`requiresTransaction()` may return `true` to require either supported isolation level, or `"serializable"` to reject weaker isolation. The guard runs before privacy, triggers and validators. Apply it to every action that can violate the invariant, including generated mutations exposed by GraphQL and alternative edit/delete paths. Raw SQL and custom action implementations that bypass the Ent orchestrator remain the application's responsibility.
+Return `true` from `requiresTransaction()` to require either supported isolation level, or return `"serializable"` to reject weaker isolation. This guard runs before privacy checks, triggers, and validators. Apply it to every action that can violate the invariant, including generated GraphQL mutations and alternative edit or delete paths. Your application must protect raw SQL and custom actions that bypass the Ent orchestrator.
 
-Construct actions, builders, queries and loaders inside the callback; construct triggered changesets during that attempt. Load `existingEnt` inside the callback too. The runtime rejects cross-scope builders, changesets, standard cached loaders and preloaded Ents. Do not reuse a changeset or builder for another attempt. A GraphQL mutation wrapper must throw execution errors back out of the callback rather than returning an error-shaped success result; the callback's successful return requests commit. An action save, executor assembly, or SQL failure marks the scope failed even if caught, so earlier writes roll back. Regenerated `saveXFromID`/`saveFromID` helpers include their initial load, construction, and edge setup in this failure boundary; nullable missing results remain recoverable.
+Construct actions, builders, queries, and loaders inside the callback. Load `existingEnt` there too, and construct triggered changesets during that attempt. The runtime rejects builders, changesets, standard cached loaders, and preloaded Ents that don't belong to the current scope. Don't reuse a changeset or builder on another attempt.
 
-Guarded root actions must be prepared and saved **sequentially**. Do not prebuild two guarded roots with `changeset()`, put them together in `Transaction`, or call their saves in `Promise.all`; these modes reject and roll back the scope even when the actions might be independent. After each save, reconstruct queries and loaders and reload Ents needed for the next action. Reconstruct actions whose defaults or transforms have already been prepared by validation or a getter; those values cannot cross a guarded save. Prebuilt changesets and assembled executors, including ordinary unguarded actions, also expire after a guarded save and reject before pre-fetching or writing. This prevents two root validators or rollups from preparing against the same old state inside one transaction, where database isolation cannot detect the dependency.
+A GraphQL mutation wrapper must throw execution errors out of the callback. Returning an error-shaped result still counts as a successful return and requests a commit. An action save, executor assembly, or SQL failure marks the scope as failed even if you catch the error, so earlier writes roll back. Regenerated `saveXFromID` and `saveFromID` helpers include their initial load, construction, and edge setup in this failure boundary. A missing target returned by a nullable helper remains recoverable.
 
-Return child changesets from triggers; do not call child `save()`/`saveX()` or execute child executors during preparation. Distinct guarded actions conflict by default, including ancestors and descendants and actions separated by an unguarded wrapper. A parent and child removing different admin rows can both read the old count and violate the last-admin invariant. Preparation ancestry does not establish independence.
+#### Prepare guarded root actions sequentially
 
-For actions whose independence is established, implement `getTransactionResources()` returning their invariant keys on every participating guarded action, including the parent:
+Prepare and save guarded root actions sequentially. Don't prebuild two guarded roots with `changeset()`, combine them in `Transaction`, or call their saves in `Promise.all`. These operations reject and roll back the scope even if the actions might be independent.
+
+After each guarded save, reconstruct queries and loaders and reload the Ents needed for the next action. Also reconstruct actions whose defaults or transforms were already prepared by validation or a getter. Each guarded save advances the transaction's generation, so prepared values can't carry over to the next save. Prebuilt changesets and assembled executors, including those for ordinary unguarded actions, also expire after a guarded save. They reject before fetching or writing data.
+
+These checks prevent two root validators or rollups from preparing against the same old state within one transaction, where database isolation can't detect the dependency.
+
+#### Compose guarded actions
+
+Return child changesets from triggers. Don't call a child's `save()` or `saveX()` method or execute child executors during preparation. Distinct guarded actions conflict by default. This includes ancestors, descendants, and actions separated by an unguarded wrapper. For example, a parent and child that remove different admin rows can both read the old count and violate the last-admin invariant. Their parent-child relationship doesn't establish independence.
+
+If you have established that the actions are independent, implement `getTransactionResources()` on every participating guarded action, including the parent. Return the keys for the invariants that each action depends on:
 
 ```ts
 getTransactionResources(): readonly string[] {
-  // Only appropriate when this action's decisions depend on this account alone.
+  // Use this key only if the action's decisions depend on this account alone.
   return [`account:${this.builder.existingEnt.id}`];
 }
 ```
 
-Omitting the hook or returning `undefined` means a wildcard reservation, which conflicts with every other guarded action in the prepared graph, including actions with explicit keys. Non-empty arrays of non-empty strings declare explicit resources; only disjoint keyed actions may prepare together. The runtime snapshots these arrays. Ancestors and descendants must have disjoint resources too, and guarded roots remain sequential even with keys. There is no special wildcard string. Resource declarations must cover every dependency that another action could invalidate, including aggregate predicates and privacy checks, not just the row being written. For example, a parent changing only account A's balance and a child changing only account B's balance can declare separate account keys when neither decision depends on the other account. Two actions that both depend on the same admin count must share an invariant key and will be rejected; consolidate their decisions into one action or save sequentially and reload. Existing parent/child compositions that relied on ancestry alone must adopt this contract. A hook itself requires `withTransaction`, even without `requiresTransaction()`.
+Use non-empty arrays of non-empty strings to declare explicit resources. The runtime takes a snapshot of these arrays. Only actions with disjoint resource keys can prepare together; ancestors and descendants must also have disjoint keys. Guarded roots must still run sequentially, even with explicit keys.
 
-Standalone `valid()`, `validX()`, and `validWithErrors()` calls inside a scope use the same preparation guards. Their child changesets and reservations are temporary and are discarded after validation, including when validation reports errors. A subsequent save reruns validation and prepares a fresh child graph. Changesets captured from standalone validation cannot execute. This cleanup applies to retained children and grandchildren too. It waits for participating SQL, Ent/privacy, and loader reads used to set up children before closing the validation scope, even when another child has already failed. The original validation error is preserved; a late SQL or composition failure still aborts the transaction.
+If you omit the hook or return `undefined`, the action reserves a wildcard resource. This reservation conflicts with every other guarded action in the prepared graph, including actions with explicit keys. There is no special wildcard string. Defining the hook requires `withTransaction`, even without `requiresTransaction()`.
 
-Field defaults and action/schema transformation results remain memoized, preserving established builder IDs and applying transformed input only once. A transformation's `changeset` factory runs within each validation/save preparation in a scope and must build a fresh child changeset; computing fields through a getter alone does not execute that factory. Edges established by default-field `updateInput` are retained, while edges to probe-created children are discarded with the probe. Validation can still change action fields through existing trigger behavior; it is not a general rollback of application state. Await validation before building or saving the same action. Normal validation errors can be inspected and corrected; SQL failures and invalid transaction composition still fail the transaction.
+Declare every dependency that another action could invalidate, including aggregate predicates and privacy checks, rather than only the row being written. For example, a parent that changes account A's balance and a child that changes account B's balance can declare separate account keys if neither decision depends on the other account. Two actions that depend on the same admin count must share an invariant key and will be rejected. Consolidate their decisions into one action, or save sequentially and reload. Existing parent-child compositions that relied on ancestry alone must adopt this contract.
 
-Known repeated row updates/deletes through different builders in a guarded tree are also rejected when executing; skipped conditional operations and edge-only changes do not count as row mutations. Consolidate overlapping absolute updates into one child action. Explicit resource declarations must include every shared invariant dependency: keys are an application contract, not inferred SQL dependencies. Existing unguarded action batches retain their behavior.
+During execution, the runtime also rejects known repeated updates or deletes of the same row through different builders in a guarded tree. Skipped conditional operations and changes limited to edges don't count as row mutations. Consolidate overlapping absolute updates into one child action. The runtime doesn't infer invariant keys from SQL dependencies; your application must declare all shared dependencies. Existing unguarded action batches keep their behavior.
+
+#### Validate without saving
+
+Standalone `valid()`, `validX()`, and `validWithErrors()` calls inside a scope use the same preparation guards. Their child changesets and resource reservations are temporary. After validation, the runtime discards them, including when validation reports errors. A subsequent save reruns validation and prepares a fresh child graph. Changesets captured during standalone validation can't execute. Cleanup also applies to retained children and grandchildren.
+
+Before closing the validation scope, the runtime waits for participating SQL, Ent, privacy, and loader reads used to set up children. It waits even if another child has already failed and preserves the original validation error. A later SQL or composition failure still aborts the transaction.
+
+Field defaults and action or schema transformation results remain memoized. This preserves established builder IDs and applies transformed input only once. A transformation's `changeset` factory runs during each validation or save preparation in a scope and must build a fresh child changeset. Computing fields through a getter alone doesn't run the factory.
+
+Cleanup retains edges established by default-field `updateInput` and discards edges to children created during standalone validation. Validation can still change action fields through existing trigger behavior; it doesn't roll back application state in general. Await validation before building or saving the same action. You can inspect and correct normal validation errors. SQL failures and invalid transaction composition still fail the transaction.
 
 ### Explicit locks and composition
 
-For a read-committed workflow, lock the invariant's stable owner row **before** reading data used for decisions, and have every competing writer acquire that same lock. Locking only rows about to be deleted cannot protect an empty set or a last-admin count. Acquire multiple locks in a consistent order.
+If you use read committed isolation, lock the invariant's stable owner row before reading data used for decisions. Every competing writer must acquire the same lock. Locking only rows about to be deleted can't protect an empty set or a last-admin count. Acquire multiple locks in a consistent order.
 
 ```ts
 await withTransaction(async (tx) => {
@@ -82,22 +104,39 @@ await withTransaction(async (tx) => {
 }, { isolationLevel: "read committed" });
 ```
 
-The callback receives `query`, `queryAll`, `exec`, `attempt` (zero-based), and `isolationLevel`. SQL is parameterized using PostgreSQL placeholders. Low-level SQL does not apply Ent privacy or create audit actions; use it for locks and continue using Ent actions for mutations. Do not send transaction-control SQL, use DB handles captured before the callback, or change global DB configuration while a scope is active.
+The callback receives `query`, `queryAll`, `exec`, `attempt` (zero-based), and `isolationLevel`. Use PostgreSQL placeholders to parameterize SQL. Low-level SQL doesn't apply Ent privacy or create audit actions. Use it for locks, then use Ent actions for mutations. Don't send SQL that controls the transaction, use DB handles captured before the callback, or change global DB configuration while a scope is active.
 
-Nested `withTransaction` calls are rejected; there are no savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` (exported from `@snowtop/ent`), check its `isolationLevel`, and call their implementation directly when an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope.
+`withTransaction` rejects nested calls; it doesn't support savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` (exported from `@snowtop/ent`), check its `isolationLevel`, and call their implementation directly if an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope.
 
 ### Caches, results, and observers
 
-- Cached queries and loaders belong to the guarded-action generation in which they were created. Reusing them after a guarded save, or letting a pending read span that save, rejects and marks the scope failed even if caught. Await reads before saving, then create fresh readers for the next action. Same-generation reuse and ordinary outside-scope behavior are unchanged. Turning previously read rows into Ents preserves their original transaction and generation, including rows returned by `tx.query`, `tx.queryAll`, and `tx.exec`. Supplied Ents and `sourceEnt()` results used by edge-query privacy must belong to the current generation.
-- Standard Ent, object, count, query and edge-metadata caches are isolated for each attempt. Transaction rows never populate outside request caches. Participating request caches are invalidated after commit; rollback leaves them untouched. SQL calls conservatively invalidate the attempt's caches, so raw writes and reads after acquiring locks see fresh data.
-- `saveX()` results inside the callback are provisional. A thrown result-loading or post-fetch error marks the owning scope failed, so all writes roll back even when the caller catches the error. This includes direct `editedEntX()` failures and exceptions from `viewerForEntLoad` or result privacy checks. Normal `null` results from nullable `save()`/`editedEnt()` do not fail the scope. Direct result-loading failures from getters used after their owning commit cannot undo it or fail a different transaction. Queries and actions explicitly executed by application privacy callbacks inside a later scope still follow that active scope's failure rules. Do not expose callback results until `withTransaction` resolves. After commit, already returned Ent objects remain snapshots; reload them inside a new scope to edit them again.
-- Calling `editedEnt()`/`editedEntX()` again reads the action's retained result row. It preserves that write's transaction and generation, so an old snapshot cannot become a fresh mutation input by being inspected inside a later scope or after another guarded root saves. Immediate results of the latest completed action graph remain usable in that generation; reload from the database after later guarded writes.
-- Action observers are queued until the owning commit, then run outside its scope after the connection is released. Rollback and failed retry attempts discard observers. Observer errors keep the existing best-effort policy and never retry committed work. Observers cannot roll back a commit and are not a durable exactly-once delivery mechanism.
-- Await all work inside the callback. Unawaited in-flight SQL causes rollback, and inherited asynchronous work cannot use a closed scope. Detached jobs must start from their own request context.
+#### Queries and caches
+
+Cached queries and loaders belong to the guarded-action generation in which you create them. Reusing them after a guarded save, or letting a pending read span that save, rejects and marks the scope as failed even if you catch the error. Await reads before saving, then create fresh readers for the next action. Reuse within the same generation and ordinary behavior outside a scope are unchanged.
+
+Converting previously read rows to Ents preserves their original transaction and generation, including rows returned by `tx.query`, `tx.queryAll`, and `tx.exec`. Supplied Ents and `sourceEnt()` results used by edge-query privacy must belong to the current generation.
+
+Standard Ent, object, count, query, and edge-metadata caches are isolated for each attempt. Transaction rows never populate request caches outside the scope. Commit invalidates participating request caches; rollback leaves them unchanged. SQL calls conservatively invalidate the attempt's caches, so raw writes and reads after acquiring locks see fresh data.
+
+#### Results
+
+`saveX()` results inside the callback are provisional. A thrown result-loading or post-fetch error marks the owning scope as failed, so all writes roll back even if you catch the error. This includes direct `editedEntX()` failures and exceptions from `viewerForEntLoad` or result privacy checks. Normal `null` results from nullable `save()` and `editedEnt()` calls don't fail the scope.
+
+Direct result-loading errors from getters used after their owning commit can't undo that commit or fail a different transaction. Queries and actions that application privacy callbacks explicitly execute inside a later scope still follow that active scope's failure rules.
+
+Don't expose callback results until `withTransaction` resolves. After commit, returned Ent objects remain snapshots. Reload them inside a new scope to edit them again.
+
+Calling `editedEnt()` or `editedEntX()` again reads the action's retained result row and preserves that write's transaction and generation. Inspecting an old snapshot inside a later scope or after another guarded root saves doesn't make it a fresh mutation input. Immediate results of the latest completed action graph remain usable in that generation. After later guarded writes, reload from the database.
+
+#### Observers and asynchronous work
+
+Action observers wait until the owning transaction commits. They then run outside its scope, after the connection is released. Rollback and failed retry attempts discard observers. Observer errors keep the existing best-effort policy and never cause committed work to retry. Observers can't roll back a commit and don't guarantee durable, exactly-once delivery.
+
+Await all work inside the callback. SQL still in progress when the callback returns causes rollback, and asynchronous work that inherits the scope can't use it after it closes. Detached jobs must start with their own request context.
 
 ### Supported runtimes
 
-PostgreSQL with Node's `pg` driver and Bun's `pg` or native Bun SQL driver is supported. SQLite is explicitly rejected: its existing shared synchronous connection cannot safely hold an asynchronous scoped transaction across concurrent requests. `repeatable read` and other isolation modes are rejected. Existing SQLite action transactions continue to work normally.
+`withTransaction` supports PostgreSQL with Node's `pg` driver and Bun's `pg` or native Bun SQL driver. It rejects SQLite because the existing shared synchronous connection can't safely hold an asynchronous transaction scope across concurrent requests. It also rejects `repeatable read` and other isolation modes. Existing SQLite action transactions continue to work normally.
 
 ## Basic usage
 

--- a/docs/docs/actions/transactions.md
+++ b/docs/docs/actions/transactions.md
@@ -6,16 +6,16 @@ sidebar_position: 16
 
 Use `Transaction` to commit or roll back multiple actions' writes together. Before writing, Ent computes field defaults and transformations, checks privacy policies, runs [triggers](/docs/actions/triggers), and validates the resulting input. These steps prepare the action and its child changesets.
 
-By default, preparation runs before the write transaction. To include preparation and the reads it uses in one PostgreSQL transaction, wrap the operation in `withTransaction`.
+By default, preparation runs before the write transaction. To include preparation and the reads it uses in one PostgreSQL transaction, wrap the operation in `withTransactionScope`.
 
 ## Transaction-scoped reads and actions
 
-`withTransaction` starts a transaction before calling its callback. Ent loads, privacy checks, validators, triggers, actions, edge writes, and audit changesets in the callback use one reserved connection. Other asynchronous requests use their own connections and caches. Outside a scope, actions and `Transaction.run()` keep their existing behavior.
+`withTransactionScope` starts a transaction before calling its callback. Ent loads, privacy checks, validators, triggers, actions, edge writes, and audit changesets in the callback use one reserved connection. Other asynchronous requests use their own connections and caches. Outside a scope, actions and `Transaction.run()` keep their existing behavior.
 
 ```ts
-import { withTransaction } from "@snowtop/ent/action";
+import { withTransactionScope } from "@snowtop/ent/action";
 
-const result = await withTransaction(async () => {
+const result = await withTransactionScope(async () => {
   // Load the account and create the action on every attempt.
   const account = await Account.loadX(viewer, accountID);
   return EditAccountAction.create(viewer, account, {
@@ -32,7 +32,7 @@ An ordinary action starts its transaction after preparation:
 Load → Prepare → BEGIN → Write → COMMIT → Load result → Observe
 ```
 
-`withTransaction` starts earlier and owns the transaction until the callback finishes:
+`withTransactionScope` starts earlier and owns the transaction through final validation and commit:
 
 ```text
 Reserve connection → BEGIN
@@ -46,52 +46,58 @@ Reserve connection → BEGIN
                        │
                        ▼
              Callback returns
-             ├─ Pending SQL or failed scope → ROLLBACK
-             └─ Successful scope → COMMIT
+             ├─ Pending work or failed scope → ROLLBACK
+             └─ Finish deferred database constraints and triggers
+                       │
+                       ▼
+             Run action validateBeforeCommit hooks
+             ├─ Read final state on the same connection, without caches
+             ├─ Failed check → ROLLBACK
+             └─ Successful checks → COMMIT
                                       │
                                       ▼
                     Release connection → Invalidate request caches
                                       → Run observers → Return result
 ```
 
-The callback can save multiple actions. After a guarded save, reload the data for the next guarded action and prepare it from that data. All saves remain provisional until the outer `COMMIT` succeeds.
+The callback can save multiple actions. After each save, reload the data for the next action and prepare it from that data. All saves remain provisional until the outer `COMMIT` succeeds.
 
-If an attempt fails, Ent rolls it back, releases the connection, and discards its caches and observers. An eligible retry starts the whole callback again with fresh attempt state. A failure with no eligible retry rejects `withTransaction`.
+If an attempt fails, Ent rolls it back, releases the connection, and discards its caches and observers. An eligible retry starts the whole callback again with fresh attempt state. A failure with no eligible retry rejects `withTransactionScope`.
 
 ### Isolation and retries
 
 An invariant is an application rule that must remain true, such as requiring at least one account administrator. Actions often check an invariant by reading data, validating a decision, and writing a result.
 
-`withTransaction` defaults to `serializable` isolation. At PostgreSQL's usual `read committed` isolation level, concurrent actions can both pass validation using the same old state. Serializable isolation lets PostgreSQL detect conflicting decisions and abort an attempt. Callers can enable retries of the whole callback to handle these failures.
+`withTransactionScope` defaults to `serializable` isolation. At PostgreSQL's usual `read committed` isolation level, concurrent actions can both pass validation using the same old state. Serializable isolation lets PostgreSQL detect conflicting decisions and abort an attempt. Callers can enable retries of the whole callback to handle these failures.
 
-This default applies only to `withTransaction`. Ordinary saves and `Transaction.run()` outside a scope use their existing write transactions and the connection's configured isolation level. Set `isolationLevel: "read committed"` when you use a compatible locking protocol, as described in [Explicit locks and composition](#explicit-locks-and-composition).
+This default applies only to `withTransactionScope`. Ordinary saves and `Transaction.run()` outside a scope use their existing write transactions and the connection's configured isolation level. Set `isolationLevel: "read committed"` when you use a compatible locking protocol, as described in [Explicit locks and composition](#explicit-locks-and-composition).
 
 PostgreSQL reports serialization failures with SQLSTATE `40001` and deadlocks with `40P01`. `maxRetries` defaults to zero. If you enable retries, either error can restart the callback with a new connection reservation, snapshot, and caches. Load Ents and construct actions again inside that callback.
 
 Every writer that can violate an invariant must follow a compatible serializable or locking protocol. This API doesn't protect unrelated writers that use read committed isolation. For details, see [PostgreSQL transaction isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
 
-If you enable retries, keep external side effects out of the callback and triggers. Send notifications through observers, or use an action to write an outbox record in the same transaction. Rollback doesn't undo sequence values or changes to external systems. If a connection failure during `COMMIT` leaves the outcome unknown, `withTransaction` doesn't retry. Determine the outcome before retrying externally. Connection cleanup failures also prevent retries; a failure after a successful commit cannot undo it.
+If you enable retries, keep external side effects out of the callback and triggers. Send notifications through observers, or use an action to write an outbox record in the same transaction. Rollback doesn't undo sequence values or changes to external systems. If a connection failure during `COMMIT` leaves the outcome unknown, `withTransactionScope` doesn't retry. Determine the outcome before retrying externally. Connection cleanup failures also prevent retries; a failure after a successful commit cannot undo it.
 
-### Require transactions for an action
+### Require a scope for an action
 
-An action can require a transaction for its normal action save, builder save, and changeset entry points:
+An action can require a scope for its action save, builder save, changeset, and standalone validation entry points:
 
 ```ts
 export default class RemoveAdminAction extends RemoveAdminActionBase {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return "serializable" as const;
   }
 }
 
-await withTransaction(
+await withTransactionScope(
   () => RemoveAdminAction.saveXFromID(viewer, fundID, { adminID }),
   { maxRetries: 3 },
 );
 ```
 
-Return `true` from `requiresTransaction()` to accept either supported isolation level, or return `"serializable"` to require serializable isolation. Ent checks this requirement before running action privacy checks, triggers, or validators. Apply it to every action that can violate the invariant, including generated GraphQL mutations and other edit or delete paths. Protect raw SQL and custom actions that bypass the Ent orchestrator in your application.
+Return `true` from `requiresTransactionScope()` to accept either supported isolation level, or return `"serializable"` to require serializable isolation. Ent checks this requirement before running action privacy checks, triggers, or validators. Apply it to every action that can violate the invariant, including generated GraphQL mutations and other edit or delete paths. Protect raw SQL and custom actions that bypass the Ent orchestrator in your application.
 
-In this guide, a *guarded action* requires a transaction or declares invariant resources through `getTransactionResources()`.
+`requiresTransactionScope()` checks a precondition. Every action inside a scope follows the same preparation and freshness rules, whether or not it declares this method. The method does not start a scope automatically.
 
 Construct actions, builders, queries, and loaders inside the callback. Load `existingEnt` there too, and create triggered changesets during the same attempt. Ent rejects builders, changesets, standard cached loaders, and preloaded Ents that belong to another scope. Rebuild them for each retry.
 
@@ -99,44 +105,77 @@ An action save, executor assembly, or SQL failure marks the scope as failed even
 
 A GraphQL wrapper must throw execution errors out of the callback. Returning an object that contains an error still counts as a successful return and requests a commit, unless an action or SQL failure has already marked the scope as failed. During standalone validation, a child changeset can report a correctable validation error without failing the transaction. SQL errors always fail it.
 
-#### Prepare guarded root actions sequentially
+#### Prepare root actions sequentially
 
-Prepare and save one guarded root action at a time. Don't prebuild two guarded roots with `changeset()`, combine them in `Transaction`, or call their saves in `Promise.all`. These operations reject and roll back the scope even if the actions appear independent.
-
-Each guarded save advances the transaction's *generation*, which identifies the reads and prepared values that remain usable for the next action. After a guarded save, create fresh queries and loaders and reload the Ents needed by the next action. Reconstruct actions whose defaults or transformations were already prepared by validation or a getter.
-
-Prebuilt changesets and assembled executors also expire after a guarded save, including those for ordinary unguarded actions. They reject before fetching or writing data. These checks prevent multiple root actions from making decisions against the same old state within one transaction, where database isolation can't detect the dependency.
-
-#### Compose guarded actions
-
-Return child changesets from triggers. Don't call a child's `save()` or `saveX()` method or execute its executor during preparation.
-
-Distinct guarded actions conflict by default, including ancestors, descendants, and actions separated by an unguarded wrapper. For example, a parent and child that remove different administrators can both read the old administrator count and violate the requirement to keep one administrator. Their parent-child relationship doesn't establish independence.
-
-If the actions are independent, implement `getTransactionResources()` on every participating guarded action, including the parent. Return keys for the invariants that each action depends on:
+A *root action* is an action the caller saves directly. Its triggers can return *child changesets*, which can have children of their own. Prepare and save one root at a time inside a scope. Don't prebuild multiple roots with `changeset()`, combine them in `Transaction`, or save them in `Promise.all`. These operations reject and roll back the scope.
 
 ```ts
-getTransactionResources(): readonly string[] {
-  // Use this key only if the action's decisions depend on this account alone.
-  return [`account:${this.builder.existingEnt.id}`];
+await withTransactionScope(async () => {
+  await RemoveAdminAction.saveXFromID(viewer, accountID, {
+    adminID: firstAdminID,
+  });
+
+  // Load and validate against the preceding action's writes.
+  await RemoveAdminAction.saveXFromID(viewer, accountID, {
+    adminID: secondAdminID,
+  });
+});
+```
+
+Each save advances the transaction's *generation*, which identifies the reads and prepared values that remain usable for the next action. After a save, create fresh queries and loaders and reload the Ents needed by the next action. Reconstruct actions whose defaults or transformations were already prepared by validation or a getter. Prebuilt changesets and assembled executors expire after a save and reject before fetching or writing data.
+
+#### Compose child actions
+
+Return child changesets from triggers. Don't call a child's `save()` or `saveX()` method or execute its executor during preparation. A parent and its children prepare as one graph before that graph's writes. Children don't automatically observe their siblings' writes during preparation.
+
+Use successive root saves when one decision must observe another action's writes. Use an action's final validation hook when a business rule depends on the completed operation's database state.
+
+Ent rejects known updates or deletes of the same row through different builders in one graph. Skipped conditional operations and edge-only changes don't count as row mutations. Consolidate overlapping absolute updates into one action. Final validation does not repair a lost calculation, such as two children both subtracting from the same original balance.
+
+#### Validate the final state before commit
+
+Define `validateBeforeCommit(context)` on an action to check a business rule after all writes in the scope. Ent registers the check automatically when the action executes, including when a trigger returns it as a child or grandchild.
+
+```ts
+import type { ScopeValidationContext } from "@snowtop/ent/action";
+
+export default class RemoveAdminAction extends RemoveAdminActionBase {
+  requiresTransactionScope() {
+    return "serializable" as const;
+  }
+
+  async validateBeforeCommit(context: ScopeValidationContext): Promise<void> {
+    const result = await context.query(
+      `SELECT count(*)::int AS count
+       FROM account_admins WHERE account_id = $1`,
+      [this.builder.existingEnt.id],
+    );
+    if (result.rows[0].count === 0) {
+      throw new Error("The account must have at least one administrator.");
+    }
+  }
 }
 ```
 
-Return a non-empty array of non-empty strings. Ent copies the array and permits actions to prepare together only when their resource keys don't overlap. This rule also applies to ancestors and descendants. Guarded roots must still run sequentially, even with explicit keys.
+After the callback returns, Ent finishes deferred database constraints and triggers, then runs every registered hook before committing. Each check sees all writes from the callback, including later root actions and database triggers. Throw an error to roll back the entire scope. Observers run only after a successful commit.
 
-Ent reserves the guarded root before invoking `getTransactionResources()`. If the hook returns a promise, other guarded roots can't prepare while it resolves. The hook's reads and other awaited work must stay within one generation.
+Declaring this hook requires a scope even without `requiresTransactionScope()`. An explicit isolation requirement still applies. The hook accepts either supported isolation level unless the action requires serializable isolation. A final check at read committed isolation still needs a compatible locking protocol to coordinate concurrent writers.
 
-If you omit the hook or return `undefined`, the action reserves a wildcard resource that conflicts with every other guarded action in the graph. There is no special wildcard string. Defining the hook requires `withTransaction`, even without `requiresTransaction()`.
+The context exposes `query`, `queryAll`, `attempt`, and `isolationLevel`. Its queries use the reserved transaction connection and accept one read statement: `SELECT`, a read-only `WITH` query, or `VALUES`. Parameterize values. Use parameters, dollar-quoted strings, or explicit PostgreSQL `E` strings for values containing backslashes. The context cannot save actions, issue writes, control the transaction, or be reused after final validation. PostgreSQL read-only mode also rejects persistent writes made by functions called from a validation query.
 
-Declare every dependency that another action could invalidate, including aggregate conditions and privacy checks. A row key alone is sufficient only when the action's decisions depend on that row alone. For example, a parent that changes account A's balance and a child that changes account B's balance can declare separate account keys if neither decision depends on the other account.
+Ent reads inside the hook bypass request caches, scope caches, loader caches, query/count caches, and cached privacy results. Applicable privacy checks still run. Create queries and loaders in the hook and query using identifiers. Previously loaded Ents, captured promises, and application memoization are not fresh database state. Direct SQL does not apply Ent privacy.
 
-Actions that depend on the same administrator count must share an invariant key and cannot prepare together. Consolidate their decisions into one action, or save them sequentially and reload between saves. Parent-child compositions that relied on ancestry alone must adopt this contract.
+An uncached read still follows PostgreSQL isolation rules. At serializable isolation, it sees the transaction snapshot and the transaction's own writes; it does not necessarily see other transactions' later commits.
 
-During execution, Ent also rejects known updates or deletes of the same row through different builders in a guarded graph. Skipped conditional operations and edge-only changes don't count as row mutations. Consolidate overlapping absolute updates into one child action. Ent doesn't infer invariant keys from SQL dependencies; your application must declare every shared dependency. Existing unguarded action batches keep their behavior.
+Checks run once for each executed action instance, including edge-only actions. Ent does not deduplicate rules across different actions or identifiers. Actions skipped by conditional execution or silent privacy failure do not register checks. Standalone validation and unexecuted changesets do not register checks. A retry rebuilds the actions and registrations for that attempt.
+
+For example, two children can each approve removing one of two administrators during preparation. Final validation then reads zero and rejects both removals. Replacing the only administrator can succeed if later writes restore a valid final state. Immediate validators and database constraints continue to apply; they do not become deferred automatically.
+
+Final validation supplements input validation, privacy, and correct calculations. Apply the rule to every relevant action and coordinate writers that bypass those actions. Ent does not infer missing business rules from SQL or automatically isolate children from each other.
 
 #### Validate without saving
 
-Standalone `valid()`, `validX()`, and `validWithErrors()` calls inside a scope use the same preparation guards. Their child changesets and resource reservations are temporary. After validation, Ent discards them, including when validation reports an error. This cleanup includes retained children and grandchildren. A subsequent save reruns validation and prepares a fresh child graph. Changesets captured during standalone validation cannot execute.
+Standalone `valid()`, `validX()`, and `validWithErrors()` calls inside a scope use the same preparation guards. Their child changesets and root preparation reservations are temporary. After validation, Ent discards them, including when validation reports an error. This cleanup includes retained children and grandchildren. A subsequent save reruns validation and prepares a fresh child graph. Changesets captured during standalone validation cannot execute.
 
 Before closing validation, Ent waits for participating SQL, Ent, privacy, and loader reads used to set up children. This includes pending privacy checks reused from an Ent cache. Ent waits even if another child has already failed and preserves the original validation error. A later SQL or composition failure still aborts the transaction.
 
@@ -149,7 +188,7 @@ Cleanup preserves edges established by default-field `updateInput` and discards 
 If you use read committed isolation, lock a stable row that owns the invariant before reading data used for decisions. Every competing writer must acquire the same lock. Locking only rows about to be deleted cannot protect an empty set or the requirement to keep one administrator. Acquire multiple locks in a consistent order.
 
 ```ts
-await withTransaction(async (tx) => {
+await withTransactionScope(async (tx) => {
   await tx.query("SELECT id FROM accounts WHERE id = $1 FOR UPDATE", [accountID]);
   const account = await Account.loadX(viewer, accountID);
   await EditAccountAction.create(viewer, account, {
@@ -162,17 +201,17 @@ The callback receives `query`, `queryAll`, `exec`, the zero-based `attempt` numb
 
 While a scope is active, don't send SQL that controls the transaction, use DB handles captured before the callback, or change global DB configuration.
 
-`withTransaction` rejects nested calls and doesn't support savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` from `@snowtop/ent/action`, check its `isolationLevel`, and call their implementation directly when an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope.
+`withTransactionScope` rejects nested calls and doesn't support savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` from `@snowtop/ent/action`, check its `isolationLevel`, and call their implementation directly when an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope, but cannot prepare multiple roots there. Use sequential saves or return child changesets from one root.
 
 ### Caches, results, and observers
 
 #### Queries and caches
 
-Cached queries and loaders belong to the generation in which you create them. Reusing them after a guarded save, or letting a pending read span that save, marks the scope as failed even if you catch the error. Await reads before saving, then create fresh readers for the next action. You can reuse readers within one generation. Their behavior outside a scope is unchanged.
+Cached queries and loaders belong to the generation in which you create them. Reusing them after a save, or letting a pending read span that save, marks the scope as failed even if you catch the error. Await reads before saving, then create fresh readers for the next action. You can reuse readers within one generation. Their behavior outside a scope is unchanged.
 
 Rows retain the transaction and generation in which they were read, including rows returned by `tx.query`, `tx.queryAll`, and `tx.exec`. Converting a row to an Ent preserves that origin. Supplied Ents and `sourceEnt()` results used by edge-query privacy must belong to the current generation.
 
-`applyPrivacyPolicyForRow()`, `applyPrivacyPolicyForRows()`, `loadDerivedEnt()`, and `loadDerivedEntX()` preserve the input row's transaction and generation before running privacy checks. If the row has no recorded transaction origin, the resulting Ent remains unscoped and cannot be used in a guarded save. Load a tracked row inside the callback instead of copying data or reusing untracked data.
+`applyPrivacyPolicyForRow()`, `applyPrivacyPolicyForRows()`, `loadDerivedEnt()`, and `loadDerivedEntX()` preserve the input row's transaction and generation before running privacy checks. If the row has no recorded transaction origin, the resulting Ent remains unscoped and cannot be used in a save inside a scope. Load a tracked row inside the callback instead of copying data or reusing untracked data.
 
 Standard Ent, object, count, query, and edge metadata caches are isolated for each attempt. Transaction rows never populate request caches outside the scope. Commit invalidates participating request caches; rollback leaves them unchanged.
 
@@ -184,11 +223,11 @@ Results from `saveX()` inside the callback are provisional. A result-loading or 
 
 A result getter used after its owning commit cannot undo that commit or fail a different transaction. Queries and actions that application privacy callbacks explicitly execute in a later scope still follow that scope's failure rules.
 
-Expose callback results only after `withTransaction` resolves. After commit, returned Ent objects remain snapshots. Reload them in a new scope before editing them again.
+Expose callback results only after `withTransactionScope` resolves. After commit, returned Ent objects remain snapshots. Reload them in a new scope before editing them again.
 
-Calling `editedEnt()` or `editedEntX()` again reads the action's retained result row and preserves that write's transaction and generation. Inspecting an old snapshot inside a later scope or after another guarded save doesn't make it a fresh mutation input. Results of the latest completed action graph remain usable in that generation.
+Calling `editedEnt()` or `editedEntX()` again reads the action's retained result row and preserves that write's transaction and generation. Inspecting an old snapshot inside a later scope or after another save doesn't make it a fresh mutation input. Results of the latest completed action graph remain usable in that generation.
 
-Inside a scope, standard actions reload their result rows after all graph writes and before result privacy checks. This adds one row reload per executed node operation that returns a row. Results include changes made by other actions or raw changesets in the graph. The reload uses the stored row's primary key, including when an upsert matched an existing row. Edge-only actions and actions skipped by silent privacy checks also reload their result rows. After later guarded writes, reload from the database.
+Inside a scope, standard actions reload their result rows after all graph writes and before result privacy checks. This adds one row reload per executed node operation that returns a row. Results include changes made by other actions or raw changesets in the graph. The reload uses the stored row's primary key, including when an upsert matched an existing row. Edge-only actions and actions skipped by silent privacy checks also reload their result rows. After later writes, reload from the database.
 
 #### Observers and asynchronous work
 
@@ -196,11 +235,11 @@ Action observers run after the owning transaction commits and releases its conne
 
 Observer errors follow the existing best-effort policy and never cause committed work to retry. Observers cannot roll back a commit and don't guarantee durable, exactly-once delivery.
 
-Await all work inside the callback. SQL still in progress when the callback returns causes rollback. Asynchronous work that inherits a scope cannot use it after it closes. Detached jobs must start with their own request context.
+Await all work inside the callback. Actions or SQL still in progress when the callback returns cause rollback. Final validation must also await all participating reads. Asynchronous work that inherits a scope cannot use it after it closes. Detached jobs must start with their own request context.
 
 ### Supported runtimes
 
-`withTransaction` supports PostgreSQL with Node's `pg` driver and Bun's `pg` or native SQL driver. It rejects SQLite because the existing shared synchronous connection cannot safely hold an asynchronous transaction across concurrent requests. Existing SQLite action transactions continue to work normally.
+`withTransactionScope` supports PostgreSQL with Node's `pg` driver and Bun's `pg` or native SQL driver. It rejects SQLite because the existing shared synchronous connection cannot safely hold an asynchronous transaction across concurrent requests. Existing SQLite action transactions continue to work normally.
 
 The supported isolation levels are `serializable` and `read committed`. Other levels, including `repeatable read`, are rejected.
 

--- a/docs/docs/actions/transactions.md
+++ b/docs/docs/actions/transactions.md
@@ -74,6 +74,8 @@ getTransactionResources(): readonly string[] {
 
 Use non-empty arrays of non-empty strings to declare explicit resources. The runtime takes a snapshot of these arrays. Only actions with disjoint resource keys can prepare together; ancestors and descendants must also have disjoint keys. Guarded roots must still run sequentially, even with explicit keys.
 
+The runtime reserves the guarded root before invoking `getTransactionResources()`, including when the hook returns a promise. Other guarded roots can't prepare while the hook resolves. The hook's reads and awaited work must stay within the same transaction generation.
+
 If you omit the hook or return `undefined`, the action reserves a wildcard resource. This reservation conflicts with every other guarded action in the prepared graph, including actions with explicit keys. There is no special wildcard string. Defining the hook requires `withTransaction`, even without `requiresTransaction()`.
 
 Declare every dependency that another action could invalidate, including aggregate predicates and privacy checks, rather than only the row being written. For example, a parent that changes account A's balance and a child that changes account B's balance can declare separate account keys if neither decision depends on the other account. Two actions that depend on the same admin count must share an invariant key and will be rejected. Consolidate their decisions into one action, or save sequentially and reload. Existing parent-child compositions that relied on ancestry alone must adopt this contract.

--- a/docs/docs/actions/transactions.md
+++ b/docs/docs/actions/transactions.md
@@ -4,14 +4,14 @@ sidebar_position: 16
 
 # Transactions
 
-Use `Transaction` when you need multiple actions' writes to succeed or fail together. By default, action preparation, validators, and [triggers](/docs/actions/triggers) run before the write transaction. The changesets that triggers return share that transaction's writes. To include reads and action preparation, use `withTransaction` on PostgreSQL.
+Use `Transaction` when you need multiple actions' writes to succeed or fail together. Before writing, Ent computes field defaults and transformations, checks privacy policies, runs [triggers](/docs/actions/triggers), and validates the resulting input. These steps prepare the action and its child changesets. By default, they run before the write transaction; the queued writes then commit or roll back together. To include these steps and the reads they use in one PostgreSQL transaction, use `withTransaction`.
 
 ## Transaction-scoped reads and actions
 
 `withTransaction` starts a transaction before calling its callback. Ent reads, privacy checks, validators, triggers, actions, edge writes, and audit changesets inside the callback use the same reserved connection. Other asynchronous requests use their own connections and caches. Outside this API, existing actions and `Transaction.run()` keep their default behavior.
 
 ```ts
-import { withTransaction } from "@snowtop/ent";
+import { withTransaction } from "@snowtop/ent/action";
 
 const result = await withTransaction(async () => {
   // Reload and reconstruct on every attempt, including the first.
@@ -22,7 +22,11 @@ const result = await withTransaction(async () => {
 }, { maxRetries: 3 });
 ```
 
-The default isolation level is `serializable`. PostgreSQL rejects conflicting transactions with SQLSTATE `40001` and reports deadlocks with `40P01`. `maxRetries` defaults to zero. If you set `maxRetries` above zero, these errors cause the whole callback to retry with a new connection reservation, snapshot, loaders, and actions.
+This new API defaults to `serializable` because actions often read a value or count, validate a decision, and then write a result. At PostgreSQL's usual `read committed` isolation level, two concurrent actions can both pass validation using the same old state. Serializable isolation lets PostgreSQL detect conflicting decisions and abort an attempt instead of committing an inconsistent result. This can produce more transaction failures, so callers can opt into whole-callback retries.
+
+This default applies only when you call `withTransaction`. Ordinary action saves and `Transaction.run()` outside a scope still use their existing write transactions and the connection's configured isolation level. The API doesn't change PostgreSQL's default or the behavior of existing callers. Set `isolationLevel: "read committed"` when you use a compatible locking protocol, as described in [Explicit locks and composition](#explicit-locks-and-composition).
+
+PostgreSQL rejects conflicting transactions with SQLSTATE `40001` and reports deadlocks with `40P01`. `maxRetries` defaults to zero. If you set `maxRetries` above zero, these errors cause the whole callback to retry with a new connection reservation, snapshot, loaders, and actions.
 
 Every operation that enforces the invariant must follow a compatible serializable or locking protocol. This API doesn't automatically protect unrelated writers that use read committed isolation. For details, see [PostgreSQL transaction isolation](https://www.postgresql.org/docs/current/transaction-iso.html).
 
@@ -49,7 +53,7 @@ Return `true` from `requiresTransaction()` to require either supported isolation
 
 Construct actions, builders, queries, and loaders inside the callback. Load `existingEnt` there too, and construct triggered changesets during that attempt. The runtime rejects builders, changesets, standard cached loaders, and preloaded Ents that don't belong to the current scope. Don't reuse a changeset or builder on another attempt.
 
-A GraphQL mutation wrapper must throw execution errors out of the callback. Returning an error-shaped result still counts as a successful return and requests a commit. An action save, executor assembly, or SQL failure marks the scope as failed even if you catch the error, so earlier writes roll back. Regenerated `saveXFromID` and `saveFromID` helpers include their initial load, construction, and edge setup in this failure boundary. A missing target returned by a nullable helper remains recoverable.
+A GraphQL mutation wrapper must throw execution errors out of the callback. Returning an error-shaped result still counts as a successful return and requests a commit. An action save, executor assembly, or SQL failure marks the scope as failed even if you catch the error, so earlier writes roll back. Regenerated `saveXFromID` and `saveFromID` helpers include their initial load, construction, and edge setup in this failure boundary. Generated edge-group instance saves and changesets also include edge setup. During standalone validation, a child changeset can still report a correctable validation error without failing the transaction; SQL errors always fail it. A missing target returned by a nullable helper remains recoverable.
 
 #### Prepare guarded root actions sequentially
 
@@ -108,7 +112,7 @@ await withTransaction(async (tx) => {
 
 The callback receives `query`, `queryAll`, `exec`, `attempt` (zero-based), and `isolationLevel`. Use PostgreSQL placeholders to parameterize SQL. Low-level SQL doesn't apply Ent privacy or create audit actions. Use it for locks, then use Ent actions for mutations. Don't send SQL that controls the transaction, use DB handles captured before the callback, or change global DB configuration while a scope is active.
 
-`withTransaction` rejects nested calls; it doesn't support savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` (exported from `@snowtop/ent`), check its `isolationLevel`, and call their implementation directly if an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope.
+`withTransaction` rejects nested calls; it doesn't support savepoints or independent inner commits. Composed services can inspect `getTransactionScope()` (exported from `@snowtop/ent/action`), check its `isolationLevel`, and call their implementation directly if an appropriate scope already exists. `new Transaction(viewer, actions).run()` joins the current scope.
 
 ### Caches, results, and observers
 
@@ -118,9 +122,9 @@ Cached queries and loaders belong to the guarded-action generation in which you 
 
 Converting previously read rows to Ents preserves their original transaction and generation, including rows returned by `tx.query`, `tx.queryAll`, and `tx.exec`. Supplied Ents and `sourceEnt()` results used by edge-query privacy must belong to the current generation.
 
-`loadDerivedEnt()` and `loadDerivedEntX()` also preserve the input row's transaction and generation before running privacy checks. If the data has no recorded transaction provenance, the resulting Ent remains unscoped and can't be used in a guarded save. Load a tracked row inside the callback instead of copying or reusing untracked data.
+`applyPrivacyPolicyForRow()`, `applyPrivacyPolicyForRows()`, `loadDerivedEnt()`, and `loadDerivedEntX()` preserve the input row's transaction and generation before running privacy checks. If the data has no recorded transaction provenance, the resulting Ent remains unscoped and can't be used in a guarded save. Load a tracked row inside the callback instead of copying or reusing untracked data.
 
-Standard Ent, object, count, query, and edge-metadata caches are isolated for each attempt. Transaction rows never populate request caches outside the scope. Commit invalidates participating request caches; rollback leaves them unchanged. SQL calls conservatively invalidate the attempt's caches, so raw writes and reads after acquiring locks see fresh data.
+Standard Ent, object, count, query, and edge-metadata caches are isolated for each attempt. Transaction rows never populate request caches outside the scope. Commit invalidates participating request caches; rollback leaves them unchanged. Framework reads preserve cached results from other reads in the attempt. Raw SQL calls, including those made through `tx.query`, `tx.queryAll`, `tx.exec`, `DB.getPool()`, and `performRawQuery()`, conservatively invalidate caches for every participating viewer. Framework writes also invalidate these caches, so reads after writes or explicit locks see fresh data.
 
 #### Results
 
@@ -130,7 +134,7 @@ Direct result-loading errors from getters used after their owning commit can't u
 
 Don't expose callback results until `withTransaction` resolves. After commit, returned Ent objects remain snapshots. Reload them inside a new scope to edit them again.
 
-Calling `editedEnt()` or `editedEntX()` again reads the action's retained result row and preserves that write's transaction and generation. Inspecting an old snapshot inside a later scope or after another guarded root saves doesn't make it a fresh mutation input. Immediate results of the latest completed action graph remain usable in that generation. After later guarded writes, reload from the database.
+Calling `editedEnt()` or `editedEntX()` again reads the action's retained result row and preserves that write's transaction and generation. Inspecting an old snapshot inside a later scope or after another guarded root saves doesn't make it a fresh mutation input. Immediate results of the latest completed action graph remain usable in that generation. Within a scope, standard actions reload their result rows after all graph writes and before result privacy checks. Results include changes made by other actions or raw changesets in that graph. The reload uses the stored row's primary key, including when an upsert matched an existing row. Edge-only actions and actions skipped by silent privacy checks also reload their result rows. After later guarded writes, reload from the database.
 
 #### Observers and asynchronous work
 

--- a/examples/ent-local-guide/src/ent/generated/place/actions/delete_place_action_base.ts
+++ b/examples/ent-local-guide/src/ent/generated/place/actions/delete_place_action_base.ts
@@ -11,7 +11,7 @@ import type {
 } from "@snowtop/ent/action";
 import type { PlaceInput } from "./place_builder";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation } from "@snowtop/ent/action";
+import { WriteOperation, runActionExecution } from "@snowtop/ent/action";
 import { Place } from "../../..";
 import { PlaceBuilder } from "./place_builder";
 
@@ -120,7 +120,9 @@ export class DeletePlaceActionBase
     viewer: Viewer,
     id: ID,
   ): Promise<void> {
-    const place = await Place.loadX(viewer, id);
-    return new this(viewer, place).saveX();
+    return runActionExecution(async () => {
+      const place = await Place.loadX(viewer, id);
+      return new this(viewer, place).saveX();
+    });
   }
 }

--- a/examples/ent-local-guide/src/ent/generated/place/actions/edit_place_action_base.ts
+++ b/examples/ent-local-guide/src/ent/generated/place/actions/edit_place_action_base.ts
@@ -12,7 +12,7 @@ import type {
   Validator,
 } from "@snowtop/ent/action";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation } from "@snowtop/ent/action";
+import { WriteOperation, runActionExecution } from "@snowtop/ent/action";
 import { Place, User } from "../../..";
 import { PlaceBuilder } from "./place_builder";
 import { PlaceCategory } from "../../types";
@@ -158,7 +158,9 @@ export class EditPlaceActionBase
     id: ID,
     input: PlaceEditInput,
   ): Promise<Place> {
-    const place = await Place.loadX(viewer, id);
-    return new this(viewer, place, input).saveX();
+    return runActionExecution(async () => {
+      const place = await Place.loadX(viewer, id);
+      return new this(viewer, place, input).saveX();
+    });
   }
 }

--- a/examples/ent-local-guide/src/ent/generated/place_review/actions/delete_place_review_action_base.ts
+++ b/examples/ent-local-guide/src/ent/generated/place_review/actions/delete_place_review_action_base.ts
@@ -11,7 +11,7 @@ import type {
 } from "@snowtop/ent/action";
 import type { PlaceReviewInput } from "./place_review_builder";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation } from "@snowtop/ent/action";
+import { WriteOperation, runActionExecution } from "@snowtop/ent/action";
 import { PlaceReview } from "../../..";
 import { PlaceReviewBuilder } from "./place_review_builder";
 
@@ -138,7 +138,9 @@ export class DeletePlaceReviewActionBase
     viewer: Viewer,
     id: ID,
   ): Promise<void> {
-    const placeReview = await PlaceReview.loadX(viewer, id);
-    return new this(viewer, placeReview).saveX();
+    return runActionExecution(async () => {
+      const placeReview = await PlaceReview.loadX(viewer, id);
+      return new this(viewer, placeReview).saveX();
+    });
   }
 }

--- a/examples/ent-local-guide/src/ent/generated/place_review/actions/edit_place_review_action_base.ts
+++ b/examples/ent-local-guide/src/ent/generated/place_review/actions/edit_place_review_action_base.ts
@@ -15,6 +15,7 @@ import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
 import {
   WriteOperation,
   maybeConvertRelativeInputPlusExpressions,
+  runActionExecution,
 } from "@snowtop/ent/action";
 import { Place, PlaceReview, User } from "../../..";
 import { PlaceReviewBuilder } from "./place_review_builder";
@@ -180,7 +181,9 @@ export class EditPlaceReviewActionBase
     id: ID,
     input: PlaceReviewEditInput,
   ): Promise<PlaceReview> {
-    const placeReview = await PlaceReview.loadX(viewer, id);
-    return new this(viewer, placeReview, input).saveX();
+    return runActionExecution(async () => {
+      const placeReview = await PlaceReview.loadX(viewer, id);
+      return new this(viewer, placeReview, input).saveX();
+    });
   }
 }

--- a/examples/ent-local-guide/src/ent/generated/user/actions/delete_user_action_base.ts
+++ b/examples/ent-local-guide/src/ent/generated/user/actions/delete_user_action_base.ts
@@ -11,7 +11,7 @@ import type {
 } from "@snowtop/ent/action";
 import type { UserInput } from "./user_builder";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation } from "@snowtop/ent/action";
+import { WriteOperation, runActionExecution } from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder } from "./user_builder";
 
@@ -119,7 +119,9 @@ export class DeleteUserActionBase
     viewer: Viewer,
     id: ID,
   ): Promise<void> {
-    const user = await User.loadX(viewer, id);
-    return new this(viewer, user).saveX();
+    return runActionExecution(async () => {
+      const user = await User.loadX(viewer, id);
+      return new this(viewer, user).saveX();
+    });
   }
 }

--- a/examples/ent-local-guide/src/ent/generated/user/actions/edit_user_action_base.ts
+++ b/examples/ent-local-guide/src/ent/generated/user/actions/edit_user_action_base.ts
@@ -10,7 +10,7 @@ import type {
   Validator,
 } from "@snowtop/ent/action";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation } from "@snowtop/ent/action";
+import { WriteOperation, runActionExecution } from "@snowtop/ent/action";
 import { User } from "../../..";
 import { UserBuilder } from "./user_builder";
 
@@ -139,7 +139,9 @@ export class EditUserActionBase
     id: ID,
     input: UserEditInput,
   ): Promise<User> {
-    const user = await User.loadX(viewer, id);
-    return new this(viewer, user, input).saveX();
+    return runActionExecution(async () => {
+      const user = await User.loadX(viewer, id);
+      return new this(viewer, user, input).saveX();
+    });
   }
 }

--- a/examples/ent-local-guide/src/ent/generated/user/actions/favorite_place_base.ts
+++ b/examples/ent-local-guide/src/ent/generated/user/actions/favorite_place_base.ts
@@ -17,7 +17,7 @@ import type {
 } from "@snowtop/ent/action";
 import type { UserInput } from "./user_builder";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation } from "@snowtop/ent/action";
+import { WriteOperation, runActionExecution } from "@snowtop/ent/action";
 import { Place, User } from "../../..";
 import { UserBuilder } from "./user_builder";
 
@@ -140,7 +140,9 @@ export class FavoritePlaceBase
     id: ID,
     favoritePlaceId: ID,
   ): Promise<User> {
-    const user = await User.loadX(viewer, id);
-    return new this(viewer, user).addFavoritePlace(favoritePlaceId).saveX();
+    return runActionExecution(async () => {
+      const user = await User.loadX(viewer, id);
+      return new this(viewer, user).addFavoritePlace(favoritePlaceId).saveX();
+    });
   }
 }

--- a/examples/ent-local-guide/src/ent/generated/user/actions/unfavorite_place_base.ts
+++ b/examples/ent-local-guide/src/ent/generated/user/actions/unfavorite_place_base.ts
@@ -11,7 +11,7 @@ import type {
 } from "@snowtop/ent/action";
 import type { UserInput } from "./user_builder";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation } from "@snowtop/ent/action";
+import { WriteOperation, runActionExecution } from "@snowtop/ent/action";
 import { Place, User } from "../../..";
 import { UserBuilder } from "./user_builder";
 
@@ -126,7 +126,11 @@ export class UnfavoritePlaceBase
     id: ID,
     favoritePlaceId: ID,
   ): Promise<User> {
-    const user = await User.loadX(viewer, id);
-    return new this(viewer, user).removeFavoritePlace(favoritePlaceId).saveX();
+    return runActionExecution(async () => {
+      const user = await User.loadX(viewer, id);
+      return new this(viewer, user)
+        .removeFavoritePlace(favoritePlaceId)
+        .saveX();
+    });
   }
 }

--- a/examples/ent-local-guide/src/ent/user/actions/transaction.test.ts
+++ b/examples/ent-local-guide/src/ent/user/actions/transaction.test.ts
@@ -1,20 +1,12 @@
-import { Dialect } from "@snowtop/ent/core/db";
+import { randomUUID } from "crypto";
 import { DB, IDViewer, withTransaction } from "@snowtop/ent";
-import { getBuilderSchemaFromFields } from "@snowtop/ent/testutils/builder";
-import {
-  getSchemaTable,
-  setupPostgres,
-} from "@snowtop/ent/testutils/db/temp_db";
 import { User } from "src/ent";
-import UserSchema from "src/schema/user_schema";
 import { CreateUserActionBase } from "../../generated/user/actions/create_user_action_base";
 import DeleteUserAction from "./delete_user_action";
 import EditUserAction from "./edit_user_action";
 import FavoritePlace from "./favorite_place";
 
-const id = "e408025d-bffd-4c09-8219-727d2f4a1b83";
-const missing = "80aed407-1c09-4453-9457-ff0a029c61f8";
-const viewer = new IDViewer(id);
+const dbTest = process.env.POSTGRES_TEST_DB ? test : test.skip;
 const failure = new Error("generated helper setup failed");
 class BrokenDelete extends DeleteUserAction {
   constructor(...args: ConstructorParameters<typeof DeleteUserAction>) {
@@ -38,22 +30,33 @@ class GuardedCreate extends CreateUserActionBase {
 }
 
 describe("generated save helpers in a scoped transaction", () => {
-  setupPostgres(() => [
-    getSchemaTable(
-      getBuilderSchemaFromFields(UserSchema.fields, User),
-      Dialect.Postgres,
-    ),
-  ]);
+  let id: string;
+  let missing: string;
+  let viewer: IDViewer;
+  let createdSlug: string;
+
   beforeEach(async () => {
+    id = randomUUID();
+    missing = randomUUID();
+    viewer = new IDViewer(id);
+    createdSlug = `transaction-created-${id}`;
     await DB.getInstance()
       .getPool()
       .query(
-        "INSERT INTO users (id, created_at, updated_at, name, slug) VALUES ($1, now(), now(), 'Before', 'scoped-user')",
-        [id],
+        "INSERT INTO users (id, created_at, updated_at, name, slug) VALUES ($1, now(), now(), 'Before', $2)",
+        [id, `transaction-${id}`],
+      );
+  });
+  afterEach(async () => {
+    await DB.getInstance()
+      .getPool()
+      .query(
+        "DELETE FROM users WHERE id = $1 OR slug = $2",
+        [id, createdSlug],
       );
   });
   const name = async () => (await User.loadX(viewer, id)).name;
-  test.each([
+  dbTest.each([
     ["delete load", () => DeleteUserAction.saveXFromID(viewer, missing)],
     [
       "edit load",
@@ -87,14 +90,14 @@ describe("generated save helpers in a scoped transaction", () => {
       expect(await name()).toBe("Before");
     },
   );
-  test("successful generated edit commits and returns the saved Ent", async () => {
+  dbTest("successful generated edit commits and returns the saved Ent", async () => {
     const result = await withTransaction(() =>
       EditUserAction.saveXFromID(viewer, id, { name: "After" }),
     );
     expect(result.name).toBe("After");
     expect(await name()).toBe("After");
   });
-  test("outside-scope helper failure does not undo earlier committed work", async () => {
+  dbTest("outside-scope helper failure does not undo earlier committed work", async () => {
     await DB.getInstance()
       .getPool()
       .query("UPDATE users SET name = 'Committed' WHERE id = $1", [id]);
@@ -103,11 +106,11 @@ describe("generated save helpers in a scoped transaction", () => {
     ).rejects.toThrow();
     expect(await name()).toBe("Committed");
   });
-  test("generated guarded create exposes its ID during and after result loading", async () => {
+  dbTest("generated guarded create exposes its ID during and after result loading", async () => {
     await withTransaction(async () => {
       const action = new GuardedCreate(viewer, {
         name: "Created",
-        slug: "created-in-scope",
+        slug: createdSlug,
       });
       const result = await action.saveX();
       expect(await action.builder.getEntID()).toBe(result.id);

--- a/examples/ent-local-guide/src/ent/user/actions/transaction.test.ts
+++ b/examples/ent-local-guide/src/ent/user/actions/transaction.test.ts
@@ -1,0 +1,117 @@
+import { Dialect } from "@snowtop/ent/core/db";
+import { DB, IDViewer, withTransaction } from "@snowtop/ent";
+import { getBuilderSchemaFromFields } from "@snowtop/ent/testutils/builder";
+import {
+  getSchemaTable,
+  setupPostgres,
+} from "@snowtop/ent/testutils/db/temp_db";
+import { User } from "src/ent";
+import UserSchema from "src/schema/user_schema";
+import { CreateUserActionBase } from "../../generated/user/actions/create_user_action_base";
+import DeleteUserAction from "./delete_user_action";
+import EditUserAction from "./edit_user_action";
+import FavoritePlace from "./favorite_place";
+
+const id = "e408025d-bffd-4c09-8219-727d2f4a1b83";
+const missing = "80aed407-1c09-4453-9457-ff0a029c61f8";
+const viewer = new IDViewer(id);
+const failure = new Error("generated helper setup failed");
+class BrokenDelete extends DeleteUserAction {
+  constructor(...args: ConstructorParameters<typeof DeleteUserAction>) {
+    super(...args);
+    throw failure;
+  }
+}
+class BrokenFavorite extends FavoritePlace {
+  addFavoritePlace(): this {
+    throw failure;
+  }
+}
+
+class GuardedCreate extends CreateUserActionBase {
+  requiresTransaction() {
+    return true;
+  }
+  async viewerForEntLoad() {
+    return new IDViewer(await this.builder.getEntID());
+  }
+}
+
+describe("generated save helpers in a scoped transaction", () => {
+  setupPostgres(() => [
+    getSchemaTable(
+      getBuilderSchemaFromFields(UserSchema.fields, User),
+      Dialect.Postgres,
+    ),
+  ]);
+  beforeEach(async () => {
+    await DB.getInstance()
+      .getPool()
+      .query(
+        "INSERT INTO users (id, created_at, updated_at, name, slug) VALUES ($1, now(), now(), 'Before', 'scoped-user')",
+        [id],
+      );
+  });
+  const name = async () => (await User.loadX(viewer, id)).name;
+  test.each([
+    ["delete load", () => DeleteUserAction.saveXFromID(viewer, missing)],
+    [
+      "edit load",
+      () => EditUserAction.saveXFromID(viewer, missing, { name: "Never" }),
+    ],
+    ["edge load", () => FavoritePlace.saveXFromID(viewer, missing, id)],
+    ["constructor", () => BrokenDelete.saveXFromID(viewer, id)],
+    ["edge setup", () => BrokenFavorite.saveXFromID(viewer, id, missing)],
+  ] as const)(
+    "caught %s failure rolls back earlier writes",
+    async (_label, save) => {
+      let caught: unknown;
+      let outer: unknown;
+      try {
+        await withTransaction(async (tx) => {
+          await tx.exec(
+            "UPDATE users SET name = 'Earlier write' WHERE id = $1",
+            [id],
+          );
+          try {
+            await save();
+          } catch (error) {
+            caught = error;
+          }
+        });
+      } catch (error) {
+        outer = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(outer).toBe(caught);
+      expect(await name()).toBe("Before");
+    },
+  );
+  test("successful generated edit commits and returns the saved Ent", async () => {
+    const result = await withTransaction(() =>
+      EditUserAction.saveXFromID(viewer, id, { name: "After" }),
+    );
+    expect(result.name).toBe("After");
+    expect(await name()).toBe("After");
+  });
+  test("outside-scope helper failure does not undo earlier committed work", async () => {
+    await DB.getInstance()
+      .getPool()
+      .query("UPDATE users SET name = 'Committed' WHERE id = $1", [id]);
+    await expect(
+      DeleteUserAction.saveXFromID(viewer, missing),
+    ).rejects.toThrow();
+    expect(await name()).toBe("Committed");
+  });
+  test("generated guarded create exposes its ID during and after result loading", async () => {
+    await withTransaction(async () => {
+      const action = new GuardedCreate(viewer, {
+        name: "Created",
+        slug: "created-in-scope",
+      });
+      const result = await action.saveX();
+      expect(await action.builder.getEntID()).toBe(result.id);
+      expect(result.name).toBe("Created");
+    });
+  });
+});

--- a/examples/ent-local-guide/src/ent/user/actions/transaction.test.ts
+++ b/examples/ent-local-guide/src/ent/user/actions/transaction.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { DB, IDViewer } from "@snowtop/ent";
-import { withTransaction } from "@snowtop/ent/action";
+import { ScopeValidationContext, withTransactionScope } from "@snowtop/ent/action";
 import { User } from "src/ent";
 import { CreateUserActionBase } from "../../generated/user/actions/create_user_action_base";
 import DeleteUserAction from "./delete_user_action";
@@ -21,8 +21,8 @@ class BrokenFavorite extends FavoritePlace {
   }
 }
 
-class GuardedCreate extends CreateUserActionBase {
-  requiresTransaction() {
+class ScopedCreate extends CreateUserActionBase {
+  requiresTransactionScope() {
     return true;
   }
   async viewerForEntLoad() {
@@ -69,7 +69,7 @@ describe("generated save helpers in a scoped transaction", () => {
       let caught: unknown;
       let outer: unknown;
       try {
-        await withTransaction(async (tx) => {
+        await withTransactionScope(async (tx) => {
           await tx.exec(
             "UPDATE users SET name = 'Earlier write' WHERE id = $1",
             [id],
@@ -91,7 +91,7 @@ describe("generated save helpers in a scoped transaction", () => {
   dbTest(
     "successful generated edit commits and returns the saved Ent",
     async () => {
-      const result = await withTransaction(() =>
+      const result = await withTransactionScope(() =>
         EditUserAction.saveXFromID(viewer, id, { name: "After" }),
       );
       expect(result.name).toBe("After");
@@ -111,10 +111,10 @@ describe("generated save helpers in a scoped transaction", () => {
     },
   );
   dbTest(
-    "generated guarded create exposes its ID during and after result loading",
+    "generated scoped create exposes its ID during and after result loading",
     async () => {
-      await withTransaction(async () => {
-        const action = new GuardedCreate(viewer, {
+      await withTransactionScope(async () => {
+        const action = new ScopedCreate(viewer, {
           name: "Created",
           slug: createdSlug,
         });
@@ -128,19 +128,14 @@ describe("generated save helpers in a scoped transaction", () => {
   dbTest.each(["root", "child"] as const)(
     "generated %s without row writes returns fields updated by its graph",
     async (position) => {
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const owner = await User.loadX(viewer, id);
         const noWrite = Object.assign(FavoritePlace.create(viewer, owner), {
-          requiresTransaction: () => true,
-          getTransactionResources: () => ["favorite-places"],
-        });
+          requiresTransactionScope: () => true});
         const writer = Object.assign(
           EditUserAction.create(viewer, owner, { name: "After" }),
           {
-            requiresTransaction: () => true,
-            getTransactionResources: () => ["user-name"],
-          },
-        );
+            requiresTransactionScope: () => true});
         const parent = position === "root" ? noWrite : writer;
         const child = position === "root" ? writer : noWrite;
         parent.getTriggers = () => [{ changeset: () => child.changeset() }];
@@ -153,11 +148,33 @@ describe("generated save helpers in a scoped transaction", () => {
             name: `${refreshed.name} again`,
           }),
           {
-            requiresTransaction: () => true,
+            requiresTransactionScope: () => true,
           },
         ).saveX();
       });
       expect(await name()).toBe("After again");
     },
   );
+});
+class CheckedEdit extends EditUserAction {
+  async validateBeforeCommit(context: ScopeValidationContext) {
+    const result = await context.query("SELECT name FROM users WHERE id = $1", [this.builder.existingEnt.id]);
+    if (result.rows[0]?.name === "Invalid") {
+      throw new Error("invalid final user name");
+    }
+  }
+}
+
+dbTest("generated saveXFromID registers final validation without caller setup", async () => {
+  const id = randomUUID();
+  const viewer = new IDViewer(id);
+  await DB.getInstance().getPool().query("INSERT INTO users (id, created_at, updated_at, name, slug) VALUES ($1, now(), now(), 'Before', $2)", [id, `final-validation-${id}`]);
+  try {
+    await expect(withTransactionScope(() => CheckedEdit.saveXFromID(viewer, id, { name: "Invalid" }))).rejects.toThrow("invalid final user name");
+    expect((await User.loadX(viewer, id)).name).toBe("Before");
+    await withTransactionScope(() => CheckedEdit.saveXFromID(viewer, id, { name: "Valid" }));
+    expect((await User.loadX(viewer, id)).name).toBe("Valid");
+  } finally {
+    await DB.getInstance().getPool().query("DELETE FROM users WHERE id = $1", [id]);
+  }
 });

--- a/examples/ent-local-guide/src/ent/user/actions/transaction.test.ts
+++ b/examples/ent-local-guide/src/ent/user/actions/transaction.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
-import { DB, IDViewer, withTransaction } from "@snowtop/ent";
+import { DB, IDViewer } from "@snowtop/ent";
+import { withTransaction } from "@snowtop/ent/action";
 import { User } from "src/ent";
 import { CreateUserActionBase } from "../../generated/user/actions/create_user_action_base";
 import DeleteUserAction from "./delete_user_action";
@@ -50,10 +51,7 @@ describe("generated save helpers in a scoped transaction", () => {
   afterEach(async () => {
     await DB.getInstance()
       .getPool()
-      .query(
-        "DELETE FROM users WHERE id = $1 OR slug = $2",
-        [id, createdSlug],
-      );
+      .query("DELETE FROM users WHERE id = $1 OR slug = $2", [id, createdSlug]);
   });
   const name = async () => (await User.loadX(viewer, id)).name;
   dbTest.each([
@@ -90,31 +88,76 @@ describe("generated save helpers in a scoped transaction", () => {
       expect(await name()).toBe("Before");
     },
   );
-  dbTest("successful generated edit commits and returns the saved Ent", async () => {
-    const result = await withTransaction(() =>
-      EditUserAction.saveXFromID(viewer, id, { name: "After" }),
-    );
-    expect(result.name).toBe("After");
-    expect(await name()).toBe("After");
-  });
-  dbTest("outside-scope helper failure does not undo earlier committed work", async () => {
-    await DB.getInstance()
-      .getPool()
-      .query("UPDATE users SET name = 'Committed' WHERE id = $1", [id]);
-    await expect(
-      DeleteUserAction.saveXFromID(viewer, missing),
-    ).rejects.toThrow();
-    expect(await name()).toBe("Committed");
-  });
-  dbTest("generated guarded create exposes its ID during and after result loading", async () => {
-    await withTransaction(async () => {
-      const action = new GuardedCreate(viewer, {
-        name: "Created",
-        slug: createdSlug,
+  dbTest(
+    "successful generated edit commits and returns the saved Ent",
+    async () => {
+      const result = await withTransaction(() =>
+        EditUserAction.saveXFromID(viewer, id, { name: "After" }),
+      );
+      expect(result.name).toBe("After");
+      expect(await name()).toBe("After");
+    },
+  );
+  dbTest(
+    "outside-scope helper failure does not undo earlier committed work",
+    async () => {
+      await DB.getInstance()
+        .getPool()
+        .query("UPDATE users SET name = 'Committed' WHERE id = $1", [id]);
+      await expect(
+        DeleteUserAction.saveXFromID(viewer, missing),
+      ).rejects.toThrow();
+      expect(await name()).toBe("Committed");
+    },
+  );
+  dbTest(
+    "generated guarded create exposes its ID during and after result loading",
+    async () => {
+      await withTransaction(async () => {
+        const action = new GuardedCreate(viewer, {
+          name: "Created",
+          slug: createdSlug,
+        });
+        const result = await action.saveX();
+        expect(await action.builder.getEntID()).toBe(result.id);
+        expect(result.name).toBe("Created");
       });
-      const result = await action.saveX();
-      expect(await action.builder.getEntID()).toBe(result.id);
-      expect(result.name).toBe("Created");
-    });
-  });
+    },
+  );
+
+  dbTest.each(["root", "child"] as const)(
+    "generated %s without row writes returns fields updated by its graph",
+    async (position) => {
+      await withTransaction(async () => {
+        const owner = await User.loadX(viewer, id);
+        const noWrite = Object.assign(FavoritePlace.create(viewer, owner), {
+          requiresTransaction: () => true,
+          getTransactionResources: () => ["favorite-places"],
+        });
+        const writer = Object.assign(
+          EditUserAction.create(viewer, owner, { name: "After" }),
+          {
+            requiresTransaction: () => true,
+            getTransactionResources: () => ["user-name"],
+          },
+        );
+        const parent = position === "root" ? noWrite : writer;
+        const child = position === "root" ? writer : noWrite;
+        parent.getTriggers = () => [{ changeset: () => child.changeset() }];
+        const result = await parent.saveX();
+        const refreshed =
+          position === "root" ? result! : await noWrite.builder.editedEntX();
+        expect(refreshed.name).toBe("After");
+        await Object.assign(
+          EditUserAction.create(viewer, refreshed, {
+            name: `${refreshed.name} again`,
+          }),
+          {
+            requiresTransaction: () => true,
+          },
+        ).saveX();
+      });
+      expect(await name()).toBe("After again");
+    },
+  );
 });

--- a/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/edit_event_activity_rsvp_status_action_base.ts
+++ b/examples/ent-rsvp/backend/src/ent/generated/event_activity/actions/edit_event_activity_rsvp_status_action_base.ts
@@ -10,7 +10,12 @@ import type {
   Validator,
 } from "@snowtop/ent/action";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation, setEdgeTypeInGroup } from "@snowtop/ent/action";
+import {
+  WriteOperation,
+  runActionChangeset,
+  runActionExecution,
+  setEdgeTypeInGroup,
+} from "@snowtop/ent/action";
 import { EventActivity } from "src/ent/";
 import { EventActivityBuilder } from "src/ent/generated/event_activity/actions/event_activity_builder";
 import { NodeType } from "src/ent/generated/types";
@@ -152,15 +157,19 @@ export class EditEventActivityRsvpStatusActionBase
   }
 
   async changeset(): Promise<Changeset> {
-    await this.setEdgeType();
-    return this.builder.build();
+    return runActionChangeset(async () => {
+      await this.setEdgeType();
+      return this.builder.build();
+    });
   }
 
   async changesetWithOptions_BETA(
     options: ChangesetOptions,
   ): Promise<Changeset> {
-    await this.setEdgeType();
-    return this.builder.buildWithOptions_BETA(options);
+    return runActionChangeset(async () => {
+      await this.setEdgeType();
+      return this.builder.buildWithOptions_BETA(options);
+    });
   }
 
   private async setEdgeType() {
@@ -185,15 +194,19 @@ export class EditEventActivityRsvpStatusActionBase
   }
 
   async save(): Promise<EventActivity | null> {
-    await this.setEdgeType();
-    await this.builder.save();
-    return this.builder.editedEnt();
+    return runActionExecution(async () => {
+      await this.setEdgeType();
+      await this.builder.save();
+      return this.builder.editedEnt();
+    });
   }
 
   async saveX(): Promise<EventActivity> {
-    await this.setEdgeType();
-    await this.builder.saveX();
-    return this.builder.editedEntX();
+    return runActionExecution(async () => {
+      await this.setEdgeType();
+      await this.builder.saveX();
+      return this.builder.editedEntX();
+    });
   }
 
   static create<T extends EditEventActivityRsvpStatusActionBase>(
@@ -219,7 +232,9 @@ export class EditEventActivityRsvpStatusActionBase
     id: ID,
     input: EditEventActivityRsvpStatusInput,
   ): Promise<EventActivity> {
-    const eventActivity = await EventActivity.loadX(viewer, id);
-    return new this(viewer, eventActivity, input).saveX();
+    return runActionExecution(async () => {
+      const eventActivity = await EventActivity.loadX(viewer, id);
+      return new this(viewer, eventActivity, input).saveX();
+    });
   }
 }

--- a/examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts
+++ b/examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts
@@ -13,7 +13,12 @@ import type {
   Validator,
 } from "@snowtop/ent/action";
 import type { ExampleViewer as ExampleViewerAlias } from "../../../../viewer/viewer";
-import { WriteOperation, setEdgeTypeInGroup } from "@snowtop/ent/action";
+import {
+  WriteOperation,
+  runActionChangeset,
+  runActionExecution,
+  setEdgeTypeInGroup,
+} from "@snowtop/ent/action";
 import { Event } from "../../..";
 import { EventBuilder } from "./event_builder";
 import { NodeType } from "../../types";
@@ -160,15 +165,19 @@ export class EditEventRsvpStatusActionBase
   }
 
   async changeset(): Promise<Changeset> {
-    await this.setEdgeType();
-    return this.builder.build();
+    return runActionChangeset(async () => {
+      await this.setEdgeType();
+      return this.builder.build();
+    });
   }
 
   async changesetWithOptions_BETA(
     options: ChangesetOptions,
   ): Promise<Changeset> {
-    await this.setEdgeType();
-    return this.builder.buildWithOptions_BETA(options);
+    return runActionChangeset(async () => {
+      await this.setEdgeType();
+      return this.builder.buildWithOptions_BETA(options);
+    });
   }
 
   private async setEdgeType() {
@@ -193,15 +202,19 @@ export class EditEventRsvpStatusActionBase
   }
 
   async save(): Promise<Event | null> {
-    await this.setEdgeType();
-    await this.builder.save();
-    return this.builder.editedEnt();
+    return runActionExecution(async () => {
+      await this.setEdgeType();
+      await this.builder.save();
+      return this.builder.editedEnt();
+    });
   }
 
   async saveX(): Promise<Event> {
-    await this.setEdgeType();
-    await this.builder.saveX();
-    return this.builder.editedEntX();
+    return runActionExecution(async () => {
+      await this.setEdgeType();
+      await this.builder.saveX();
+      return this.builder.editedEntX();
+    });
   }
 
   static create<T extends EditEventRsvpStatusActionBase>(
@@ -227,7 +240,9 @@ export class EditEventRsvpStatusActionBase
     id: ID,
     input: EditEventRsvpStatusInput,
   ): Promise<Event> {
-    const event = await Event.loadX(viewer, id);
-    return new this(viewer, event, input).saveX();
+    return runActionExecution(async () => {
+      const event = await Event.loadX(viewer, id);
+      return new this(viewer, event, input).saveX();
+    });
   }
 }

--- a/examples/todo-sqlite/src/ent/generated/account/actions/edit_account_todo_status_action_base.ts
+++ b/examples/todo-sqlite/src/ent/generated/account/actions/edit_account_todo_status_action_base.ts
@@ -10,7 +10,12 @@ import type {
   Validator,
 } from "@snowtop/ent/action";
 import { AllowIfViewerHasIdentityPrivacyPolicy } from "@snowtop/ent";
-import { WriteOperation, setEdgeTypeInGroup } from "@snowtop/ent/action";
+import {
+  WriteOperation,
+  runActionChangeset,
+  runActionExecution,
+  setEdgeTypeInGroup,
+} from "@snowtop/ent/action";
 import { Account } from "src/ent/";
 import { AccountBuilder } from "src/ent/generated/account/actions/account_builder";
 import { NodeType } from "src/ent/generated/types";
@@ -148,15 +153,19 @@ export class EditAccountTodoStatusActionBase
   }
 
   async changeset(): Promise<Changeset> {
-    await this.setEdgeType();
-    return this.builder.build();
+    return runActionChangeset(async () => {
+      await this.setEdgeType();
+      return this.builder.build();
+    });
   }
 
   async changesetWithOptions_BETA(
     options: ChangesetOptions,
   ): Promise<Changeset> {
-    await this.setEdgeType();
-    return this.builder.buildWithOptions_BETA(options);
+    return runActionChangeset(async () => {
+      await this.setEdgeType();
+      return this.builder.buildWithOptions_BETA(options);
+    });
   }
 
   private async setEdgeType() {
@@ -181,15 +190,19 @@ export class EditAccountTodoStatusActionBase
   }
 
   async save(): Promise<Account | null> {
-    await this.setEdgeType();
-    await this.builder.save();
-    return this.builder.editedEnt();
+    return runActionExecution(async () => {
+      await this.setEdgeType();
+      await this.builder.save();
+      return this.builder.editedEnt();
+    });
   }
 
   async saveX(): Promise<Account> {
-    await this.setEdgeType();
-    await this.builder.saveX();
-    return this.builder.editedEntX();
+    return runActionExecution(async () => {
+      await this.setEdgeType();
+      await this.builder.saveX();
+      return this.builder.editedEntX();
+    });
   }
 
   static create<T extends EditAccountTodoStatusActionBase>(
@@ -215,7 +228,9 @@ export class EditAccountTodoStatusActionBase
     id: ID,
     input: EditAccountTodoStatusInput,
   ): Promise<Account> {
-    const account = await Account.loadX(viewer, id);
-    return new this(viewer, account, input).saveX();
+    return runActionExecution(async () => {
+      const account = await Account.loadX(viewer, id);
+      return new this(viewer, account, input).saveX();
+    });
   }
 }

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -1,4 +1,4 @@
-{{ reserveImport .Package.ActionPackagePath "WriteOperation" "setEdgeTypeInGroup" "convertRelativeInput" "maybeConvertRelativeInputPlusExpressions"}}
+{{ reserveImport .Package.ActionPackagePath "WriteOperation" "setEdgeTypeInGroup" "convertRelativeInput" "maybeConvertRelativeInputPlusExpressions" "runActionExecution"}}
 {{ reserveTypeImport .Package.ActionPackagePath "Action" "Builder" "Changeset" "Trigger" "Observer" "Validator" "ChangesetOptions"}}
 {{ reserveTypeImport .Package.PackagePath "ID" "Ent" "AssocEdgeInputOptions" "PrivacyPolicy" "Clause" "CreateRowOptions"}}
 {{ reserveImport .Package.TypesImportPath "NodeType"}}
@@ -421,6 +421,7 @@ export class {{$actionName}} implements {{useTypeImport "Action"}}<{{$node}}, {{
         input: {{$inputName}},
       {{ end -}}
       ): Promise<{{$returnType}}> {
+      return {{useImport "runActionExecution"}}(async () => {
       {{ if $action.CanFail -}}
         const {{$instance}} = await {{$node}}.load(viewer, id);
         if ({{$instance}} === null) {
@@ -459,6 +460,7 @@ export class {{$actionName}} implements {{useTypeImport "Action"}}<{{$node}}, {{
           return new this(viewer, {{$instance}}).saveX();
         {{end -}}
       {{end -}}
+      });
     } 
   {{end -}}
 }

--- a/internal/tscode/action_base.tmpl
+++ b/internal/tscode/action_base.tmpl
@@ -1,4 +1,4 @@
-{{ reserveImport .Package.ActionPackagePath "WriteOperation" "setEdgeTypeInGroup" "convertRelativeInput" "maybeConvertRelativeInputPlusExpressions" "runActionExecution"}}
+{{ reserveImport .Package.ActionPackagePath "WriteOperation" "setEdgeTypeInGroup" "convertRelativeInput" "maybeConvertRelativeInputPlusExpressions" "runActionExecution" "runActionChangeset"}}
 {{ reserveTypeImport .Package.ActionPackagePath "Action" "Builder" "Changeset" "Trigger" "Observer" "Validator" "ChangesetOptions"}}
 {{ reserveTypeImport .Package.PackagePath "ID" "Ent" "AssocEdgeInputOptions" "PrivacyPolicy" "Clause" "CreateRowOptions"}}
 {{ reserveImport .Package.TypesImportPath "NodeType"}}
@@ -269,16 +269,24 @@ export class {{$actionName}} implements {{useTypeImport "Action"}}<{{$node}}, {{
 
   async changeset(): Promise<{{useTypeImport "Changeset"}}> {
     {{if edgeGroupAction $action }}
-      await this.setEdgeType();
-    {{ end -}}
-    return this.builder.build();
+      return {{useImport "runActionChangeset"}}(async () => {
+        await this.setEdgeType();
+        return this.builder.build();
+      });
+    {{else}}
+      return this.builder.build();
+    {{end -}}
   }
 
   async changesetWithOptions_BETA(options: {{useTypeImport "ChangesetOptions"}}): Promise<{{useTypeImport "Changeset"}}> {
     {{if edgeGroupAction $action }}
-      await this.setEdgeType();
-    {{ end -}}
-    return this.builder.buildWithOptions_BETA(options);
+      return {{useImport "runActionChangeset"}}(async () => {
+        await this.setEdgeType();
+        return this.builder.buildWithOptions_BETA(options);
+      });
+    {{else}}
+      return this.builder.buildWithOptions_BETA(options);
+    {{end -}}
   }
 
   {{ if edgeGroupAction $action -}}
@@ -315,10 +323,15 @@ export class {{$actionName}} implements {{useTypeImport "Action"}}<{{$node}}, {{
   {{ else -}}
     async save(): Promise<{{$node}} | null> {
       {{ if edgeGroupAction $action }}
-        await this.setEdgeType();
-      {{ end -}}
-      await this.builder.save();
-      return this.builder.editedEnt();
+        return {{useImport "runActionExecution"}}(async () => {
+          await this.setEdgeType();
+          await this.builder.save();
+          return this.builder.editedEnt();
+        });
+      {{else}}
+        await this.builder.save();
+        return this.builder.editedEnt();
+      {{end -}}
   {{ end -}}
   }
 
@@ -328,10 +341,15 @@ export class {{$actionName}} implements {{useTypeImport "Action"}}<{{$node}}, {{
   {{ else -}}
     async saveX(): Promise<{{$node}}> {
       {{ if edgeGroupAction $action }}
-        await this.setEdgeType();
-      {{ end -}}
-      await this.builder.saveX();
-      return this.builder.editedEntX();
+        return {{useImport "runActionExecution"}}(async () => {
+          await this.setEdgeType();
+          await this.builder.saveX();
+          return this.builder.editedEntX();
+        });
+      {{else}}
+        await this.builder.saveX();
+        return this.builder.editedEntX();
+      {{end -}}
   {{ end -}}
   }
 

--- a/internal/tscode/action_base_test.go
+++ b/internal/tscode/action_base_test.go
@@ -1,0 +1,51 @@
+package tscode
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/lolopinto/ent/ent"
+	"github.com/lolopinto/ent/internal/codegen"
+	"github.com/lolopinto/ent/internal/codegen/codegenapi"
+	"github.com/lolopinto/ent/internal/schema"
+	"github.com/lolopinto/ent/internal/schema/base"
+	"github.com/lolopinto/ent/internal/schema/input"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEdgeGroupActionSetupUsesTransactionFailureBoundary(t *testing.T) {
+	s, err := schema.ParseFromInputSchema(&codegenapi.DummyConfig{}, &input.Schema{
+		Nodes: map[string]*input.Node{
+			"User": {
+				Fields: []*input.Field{{Name: "id", Type: &input.FieldType{DBType: input.UUID}, PrimaryKey: true}},
+				AssocEdgeGroups: []*input.AssocEdgeGroup{{
+					Name: "Friendships", GroupStatusName: "FriendshipStatus",
+					AssocEdges: []*input.AssocEdge{{Name: "Friends", SchemaName: "User", Symmetric: true}},
+					EdgeAction: &input.EdgeAction{Operation: ent.EdgeGroupAction, CustomActionName: "EditFriendshipAction"},
+				}},
+			},
+		},
+	}, base.TypeScript)
+	require.NoError(t, err)
+	rootDir := t.TempDir()
+	processor, err := codegen.NewTestCodegenProcessor(filepath.Join(rootDir, "src/schema"), s, &codegen.CodegenConfig{})
+	require.NoError(t, err)
+	require.NoError(t, processor.Run([]codegen.Step{new(Step)}, "", codegen.DisablePrompts(), codegen.DisableFormat(), codegen.FromTest()))
+	output, err := os.ReadFile(filepath.Join(rootDir, "src/ent/generated/user/actions/edit_friendship_action_base.ts"))
+	require.NoError(t, err)
+	for _, method := range []string{"save", "saveX", "changeset", "changesetWithOptions_BETA"} {
+		t.Run(method, func(t *testing.T) {
+			boundary := "runActionExecution"
+			if method == "changeset" || method == "changesetWithOptions_BETA" {
+				boundary = "runActionChangeset"
+			}
+			pattern := `(?s)async ` + method + `\([^\n]*\).*?\{\s*return ` + boundary + `\(async \(\) => \{\s*await this\.setEdgeType\(\);`
+			require.Regexp(t, regexp.MustCompile(pattern), string(output))
+		})
+	}
+	for _, method := range []string{"valid", "validX"} {
+		require.Regexp(t, regexp.MustCompile(`async `+method+`\(\)[^{]*\{\s*await this\.setEdgeType\(\);`), string(output))
+	}
+}

--- a/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
+++ b/testdata/codegen_matrix/fixtures/feature_stress/codegen_matrix_assertions.yml
@@ -1,4 +1,14 @@
 contains:
+  - path: src/ent/generated/user/actions/edit_user_action_base.ts
+    text: "return runActionExecution(async () => {"
+  - path: src/ent/generated/user/actions/delete_user_action_base.ts
+    text: "return runActionExecution(async () => {"
+  - path: src/ent/generated/payment/actions/edit_payment_action_base.ts
+    text: "return runActionExecution(async () => {"
+  - path: src/ent/generated/payment/actions/add_payment_watcher_action_base.ts
+    text: "return runActionExecution(async () => {"
+  - path: src/ent/generated/payment/actions/touch_matrix_payment_action_base.ts
+    text: "return runActionExecution(async () => {"
   - path: src/graphql/generated/resolvers/decorated_runtime_ready_query_type.ts
     text: "return r.runtimeReady();"
   - path: src/graphql/generated/mutations/payment/create_matrix_payment_type.ts

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -150,11 +150,15 @@ export interface Action<
   TExistingEnt extends TMaybleNullableEnt<TEnt> = MaybeNull<TEnt>,
 > {
   readonly viewer: Viewer;
-  /** Require a transaction scope, optionally with serializable isolation. */
+  /**
+   * Return `true` to require a transaction scope, or `"serializable"` to require
+   * serializable isolation. Ent checks this requirement before preparing the action.
+   */
   requiresTransaction?(): boolean | "serializable";
   /**
-   * Declare invariant keys for independent actions, including parents and children.
-   * Root actions must still run sequentially.
+   * Declare the invariant keys this action depends on. Guarded actions in the
+   * same graph must have disjoint keys, including parents and children.
+   * Prepare and save guarded root actions sequentially.
    */
   getTransactionResources?():
     | readonly string[]
@@ -251,7 +255,6 @@ async function saveBuilderImpl<
       if (throwErr) {
         throw e;
       } else {
-        // expected...
         return;
       }
     }
@@ -262,8 +265,7 @@ async function saveBuilderImpl<
       try {
         return executor.execute();
       } catch (e) {
-        // Preserve synchronous error suppression for non-X saves
-        // and abort the scope.
+        // Suppress synchronous errors for non-X saves, but fail the scope.
         const transaction = getTransactionState();
         if (transaction) {
           failTransaction(transaction, e);

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -150,9 +150,12 @@ export interface Action<
   TExistingEnt extends TMaybleNullableEnt<TEnt> = MaybeNull<TEnt>,
 > {
   readonly viewer: Viewer;
-  /** Require a scoped transaction, or require serializable isolation specifically. */
+  /** Require a transaction scope, optionally with serializable isolation. */
   requiresTransaction?(): boolean | "serializable";
-  /** Invariant keys for proven independent actions, including parent/child pairs; roots remain sequential. */
+  /**
+   * Declare invariant keys for independent actions, including parents and children.
+   * Root actions must still run sequentially.
+   */
   getTransactionResources?():
     | readonly string[]
     | undefined
@@ -259,7 +262,8 @@ async function saveBuilderImpl<
       try {
         return executor.execute();
       } catch (e) {
-        // Preserve non-X synchronous-error suppression, but abort its scope.
+        // Preserve synchronous error suppression for non-X saves and abort the
+        // scope.
         const transaction = getTransactionState();
         if (transaction) {
           failTransaction(transaction, e);

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -12,6 +12,12 @@ import { loadEdgeForID2, AssocEdge } from "../core/ent";
 import { DataOperation, AssocEdgeInputOptions } from "./operations";
 import { Queryer } from "../core/db";
 import { log } from "../core/logger";
+import {
+  failTransaction,
+  getTransactionState,
+  assertIndependentActionSave,
+  runActionExecution,
+} from "../core/transaction_context";
 import { TransformedUpdateOperation, UpdateOperation } from "../schema";
 import { FieldInfoMap } from "../schema/schema";
 
@@ -144,6 +150,13 @@ export interface Action<
   TExistingEnt extends TMaybleNullableEnt<TEnt> = MaybeNull<TEnt>,
 > {
   readonly viewer: Viewer;
+  /** Require a scoped transaction, or require serializable isolation specifically. */
+  requiresTransaction?(): boolean | "serializable";
+  /** Invariant keys for proven independent actions, including parent/child pairs; roots remain sequential. */
+  getTransactionResources?():
+    | readonly string[]
+    | undefined
+    | Promise<readonly string[] | undefined>;
   changeset(): Promise<Changeset>;
   changesetWithOptions_BETA?(options: ChangesetOptions): Promise<Changeset>;
   builder: TBuilder;
@@ -221,28 +234,35 @@ async function saveBuilderImpl<
   TEnt extends Ent<TViewer>,
   TViewer extends Viewer,
 >(builder: Builder<TEnt, TViewer>, throwErr: boolean): Promise<void> {
-  let changeset: Changeset;
-  try {
-    changeset = await builder.build();
-  } catch (e) {
-    log("error", e);
-    if (throwErr) {
-      throw e;
-    } else {
-      // expected...
-      return;
-    }
-  }
-  const executor = changeset.executor();
-  if (throwErr) {
-    return executor.execute();
-  } else {
+  return runActionExecution(async () => {
+    let changeset: Changeset;
     try {
-      return executor.execute();
+      assertIndependentActionSave();
+      changeset = await builder.build();
     } catch (e) {
-      // it's already caught and logged upstream
+      const transaction = getTransactionState();
+      if (transaction) failTransaction(transaction, e);
+      log("error", e);
+      if (throwErr) {
+        throw e;
+      } else {
+        // expected...
+        return;
+      }
     }
-  }
+    const executor = changeset.executor();
+    if (throwErr) {
+      return executor.execute();
+    } else {
+      try {
+        return executor.execute();
+      } catch (e) {
+        // Preserve non-X synchronous-error suppression, but abort its scope.
+        const transaction = getTransactionState();
+        if (transaction) failTransaction(transaction, e);
+      }
+    }
+  });
 }
 
 // Orchestrator in orchestrator.ts in generated Builders

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -20,6 +20,7 @@ import {
 } from "../core/transaction_context";
 import { TransformedUpdateOperation, UpdateOperation } from "../schema";
 import { FieldInfoMap } from "../schema/schema";
+import type { ScopeValidationContext } from "../core/transaction";
 
 export { WriteOperation };
 
@@ -154,16 +155,14 @@ export interface Action<
    * Return `true` to require a transaction scope, or `"serializable"` to require
    * serializable isolation. Ent checks this requirement before preparing the action.
    */
-  requiresTransaction?(): boolean | "serializable";
+  requiresTransactionScope?(): boolean | "serializable";
   /**
-   * Declare the invariant keys this action depends on. Guarded actions in the
-   * same graph must have disjoint keys, including parents and children.
-   * Prepare and save guarded root actions sequentially.
+   * Check the transaction's final state after all action writes and before commit.
+   * Declaring this hook requires a transaction scope. Read through the context or
+   * create fresh Ent queries in the hook; final validation bypasses result caches.
+   * Throw to roll back the scope. Actions cannot prepare or write in this phase.
    */
-  getTransactionResources?():
-    | readonly string[]
-    | undefined
-    | Promise<readonly string[] | undefined>;
+  validateBeforeCommit?(context: ScopeValidationContext): void | Promise<void>;
   changeset(): Promise<Changeset>;
   changesetWithOptions_BETA?(options: ChangesetOptions): Promise<Changeset>;
   builder: TBuilder;

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -241,7 +241,9 @@ async function saveBuilderImpl<
       changeset = await builder.build();
     } catch (e) {
       const transaction = getTransactionState();
-      if (transaction) failTransaction(transaction, e);
+      if (transaction) {
+        failTransaction(transaction, e);
+      }
       log("error", e);
       if (throwErr) {
         throw e;
@@ -259,7 +261,9 @@ async function saveBuilderImpl<
       } catch (e) {
         // Preserve non-X synchronous-error suppression, but abort its scope.
         const transaction = getTransactionState();
-        if (transaction) failTransaction(transaction, e);
+        if (transaction) {
+          failTransaction(transaction, e);
+        }
       }
     }
   });

--- a/ts/src/action/action.ts
+++ b/ts/src/action/action.ts
@@ -262,8 +262,8 @@ async function saveBuilderImpl<
       try {
         return executor.execute();
       } catch (e) {
-        // Preserve synchronous error suppression for non-X saves and abort the
-        // scope.
+        // Preserve synchronous error suppression for non-X saves
+        // and abort the scope.
         const transaction = getTransactionState();
         if (transaction) {
           failTransaction(transaction, e);

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -432,8 +432,8 @@ export async function executeOperations(
         }
         await operation.performWrite(transaction.queryer, context);
       }
-      // Result loads are provisional; a failure can still roll back the owning
-      // scope.
+      // Result loads are provisional; a failure can still roll
+      // back the owning scope.
       await executor.postFetch?.(transaction.queryer, context);
       completeGuardedPreparation(transaction, executor);
       transaction.receipts.push(() => {

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -432,7 +432,8 @@ export async function executeOperations(
         }
         await operation.performWrite(transaction.queryer, context);
       }
-      // Result loads are still provisional and can roll back the owning scope.
+      // Result loads are provisional; a failure can still roll back the owning
+      // scope.
       await executor.postFetch?.(transaction.queryer, context);
       completeGuardedPreparation(transaction, executor);
       transaction.receipts.push(() => {

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -197,7 +197,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
         graph.addNode(c.placeholderID.toString());
         if (c.dependencies) {
           for (let [_, builder] of c.dependencies) {
-            // dependency should go first...
+            // Execute dependencies before the changeset that uses them.
             graph.addEdge(
               builder.placeholderID.toString(),
               c.placeholderID.toString(),
@@ -214,7 +214,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
       let localChangesets = new Map<ID, Changeset>();
       changesets.forEach((c) => localChangesets.set(c.placeholderID, c));
 
-      // create a new changeset representing the source changeset with the simple executor
+      // Represent the root operations as a changeset with a list executor.
       impl({
         viewer: this.viewer,
         placeholderID: this.placeholderID,
@@ -230,8 +230,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
         },
       });
 
-      // use a set to handle repeated ops because of how the executor logic currently works
-      // TODO: can this logic be rewritten to not have a set yet avoid duplicates?
+      // Deduplicate operations that appear in more than one executor.
       let nodeOps: Set<DataOperation<Ent>> = new Set();
       let remainOps: Set<DataOperation<Ent>> = new Set();
 
@@ -240,9 +239,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
         let c = changesetMap.get(node);
 
         if (!c) {
-          // phew. expect it to be handled somewhere else
-          // we can just skip it and expect the resolver to handle this correctly
-          // this means it's not a changeset that was created by this ent and can/will be handled elsewhere
+          // Leave dependencies outside this changeset graph to the resolver.
           if (dependencies.has(node)) {
             return;
           }
@@ -251,7 +248,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
           );
         }
 
-        // get ordered list of ops
+        // Read operations in dependency order.
         let executor = c.executor();
         for (let op of executor) {
           if (op.createdEnt) {
@@ -261,8 +258,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
           }
         }
 
-        // only add executors that are part of the changeset to what should be tracked here
-        // or self.
+        // Track the root executor and executors for its direct child changesets.
         if (
           localChangesets.has(c.placeholderID) ||
           c.placeholderID === placeholderID
@@ -270,7 +266,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
           this.executors.push(executor);
         }
       });
-      // get all the operations and put node operations first
+      // Run node operations before the remaining operations.
       this.allOperations = [...nodeOps, ...remainOps];
       setExecutorBuilders(
         this,
@@ -432,8 +428,7 @@ export async function executeOperations(
         }
         await operation.performWrite(transaction.queryer, context);
       }
-      // Result loads are provisional; a failure can still roll
-      // back the owning scope.
+      // Load results before commit so a failure can roll back the owning scope.
       await executor.postFetch?.(transaction.queryer, context);
       completeGuardedPreparation(transaction, executor);
       transaction.receipts.push(() => {

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -279,7 +279,9 @@ export class ComplexExecutor<T extends Ent> implements Executor {
         ]),
       );
     } catch (error) {
-      if (this.transaction) failTransaction(this.transaction, error);
+      if (this.transaction) {
+        failTransaction(this.transaction, error);
+      }
       throw error;
     }
   }
@@ -409,8 +411,12 @@ export async function executeOperations(
         await executor.preFetch(transaction.queryer, context);
       }
       for (const operation of executor) {
-        if (operation.shortCircuit?.(executor)) continue;
-        if (trackOps) operations.push(operation);
+        if (operation.shortCircuit?.(executor)) {
+          continue;
+        }
+        if (trackOps) {
+          operations.push(operation);
+        }
         operation.resolve?.(executor);
         const target =
           transaction.guardedRoot && operation.transactionWriteTarget?.();

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -13,7 +13,9 @@ import {
   getTransactionState,
   getExecutorBuilders,
   setExecutorBuilders,
-  completeGuardedPreparation,
+  completeActionPreparation,
+  getExecutorScopeValidators,
+  setExecutorScopeValidators,
   assertIndependentActionSave,
   runActionExecution,
 } from "../core/transaction_context";
@@ -38,6 +40,15 @@ export class ListBasedExecutor<T extends Ent> implements Executor {
   ) {
     this.builder = options?.builder;
     setExecutorBuilders(this, this.builder ? [this.builder] : []);
+    const action = options?.action;
+    if (options && action?.validateBeforeCommit) {
+      setExecutorScopeValidators(this, [
+        {
+          builder: options.builder,
+          validate: (context) => action.validateBeforeCommit!(context),
+        },
+      ]);
+    }
   }
   private lastOp: DataOperation<T> | undefined;
   private createdEnt: T | null = null;
@@ -274,6 +285,12 @@ export class ComplexExecutor<T extends Ent> implements Executor {
           ...getExecutorBuilders(executor),
         ]),
       );
+      setExecutorScopeValidators(
+        this,
+        this.executors.flatMap((executor) => [
+          ...getExecutorScopeValidators(executor),
+        ]),
+      );
     } catch (error) {
       if (this.transaction) {
         failTransaction(this.transaction, error);
@@ -400,9 +417,18 @@ export async function executeOperations(
   if (transaction) {
     const operations: DataOperation<Ent>[] = [];
     const writeTargets = new Map<string, Builder<Ent>>();
+    const executedBuilders = new Set<Builder<Ent>>();
     try {
       assertExecutorTransaction(executor);
       assertIndependentActionSave();
+      if (
+        transaction.preparingRoot &&
+        !getExecutorBuilders(executor).includes(transaction.preparingRoot)
+      ) {
+        throw new Error(
+          "execute the complete prepared root action before starting another save",
+        );
+      }
       if (executor.preFetch) {
         await executor.preFetch(transaction.queryer, context);
       }
@@ -414,23 +440,32 @@ export async function executeOperations(
           operations.push(operation);
         }
         operation.resolve?.(executor);
-        const target =
-          transaction.guardedRoot && operation.transactionWriteTarget?.();
+        const target = operation.transactionWriteTarget?.();
         if (target) {
           const key = JSON.stringify(target);
           const previous = writeTargets.get(key);
           if (previous && previous !== operation.builder) {
             throw new Error(
-              "guarded changesets cannot mutate the same Ent through multiple builders; consolidate dependent writes into one action",
+              "scoped changesets cannot mutate the same Ent through multiple builders; consolidate dependent writes into one action",
             );
           }
           writeTargets.set(key, operation.builder);
         }
         await operation.performWrite(transaction.queryer, context);
+        if (!operation.skipScopeValidation) {
+          executedBuilders.add(operation.builder);
+        }
       }
       // Load results before commit so a failure can roll back the owning scope.
       await executor.postFetch?.(transaction.queryer, context);
-      completeGuardedPreparation(transaction, executor);
+      completeActionPreparation(transaction, executor);
+      for (const { builder, validate } of getExecutorScopeValidators(
+        executor,
+      )) {
+        if (executedBuilders.has(builder as Builder<Ent>)) {
+          transaction.validators.set(builder, validate);
+        }
+      }
       transaction.receipts.push(() => {
         (
           executor as Executor & { transactionCommitted?(): void }

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -403,7 +403,7 @@ export async function executeOperations(
   const transaction = getTransactionState();
   if (transaction) {
     const operations: DataOperation<Ent>[] = [];
-    const writeTargets = new Map<string, object>();
+    const writeTargets = new Map<string, Builder<Ent>>();
     try {
       assertExecutorTransaction(executor);
       assertIndependentActionSave();

--- a/ts/src/action/executor.ts
+++ b/ts/src/action/executor.ts
@@ -5,6 +5,18 @@ import { Builder, WriteOperation } from "../action";
 import { OrchestratorOptions } from "./orchestrator";
 import DB, { Client, Queryer, SyncClient } from "../core/db";
 import { log } from "../core/logger";
+import {
+  assertTransactionRead,
+  assertExecutorTransaction,
+  getTransactionReadState,
+  failTransaction,
+  getTransactionState,
+  getExecutorBuilders,
+  setExecutorBuilders,
+  completeGuardedPreparation,
+  assertIndependentActionSave,
+  runActionExecution,
+} from "../core/transaction_context";
 import { TopologicalGraph } from "./topological_sort";
 import {
   ConditionalNodeOperation,
@@ -14,6 +26,7 @@ import {
 
 // private to ent
 export class ListBasedExecutor<T extends Ent> implements Executor {
+  private transactionRead = getTransactionReadState();
   private idx: number = 0;
   public builder?: Builder<Ent> | undefined;
   constructor(
@@ -24,6 +37,7 @@ export class ListBasedExecutor<T extends Ent> implements Executor {
     private complexOptions?: ComplexExecutorOptions,
   ) {
     this.builder = options?.builder;
+    setExecutorBuilders(this, this.builder ? [this.builder] : []);
   }
   private lastOp: DataOperation<T> | undefined;
   private createdEnt: T | null = null;
@@ -48,6 +62,7 @@ export class ListBasedExecutor<T extends Ent> implements Executor {
 
   // returns true and null|undefined when done
   next(): IteratorResult<DataOperation<T>> {
+    assertTransactionRead(this.transactionRead);
     let createdEnt = getCreatedEnt(this.viewer, this.lastOp);
     if (createdEnt) {
       this.createdEnt = createdEnt;
@@ -91,7 +106,9 @@ export class ListBasedExecutor<T extends Ent> implements Executor {
   }
 
   async execute(): Promise<void> {
-    await executeOperations(this, this.viewer.context);
+    await runActionExecution(() =>
+      executeOperations(this, this.viewer.context),
+    );
   }
 
   async preFetch?(queryer: Queryer, context: Context): Promise<void> {
@@ -148,6 +165,8 @@ interface ComplexExecutorOptions {
 }
 
 export class ComplexExecutor<T extends Ent> implements Executor {
+  private transaction = getTransactionState();
+  private transactionRead = getTransactionReadState();
   private idx: number = 0;
   private mapper: Map<ID, Ent> = new Map();
   private lastOp: DataOperation<Ent> | undefined;
@@ -165,93 +184,104 @@ export class ComplexExecutor<T extends Ent> implements Executor {
     options?: OrchestratorOptions<T, Data, Viewer>,
     private complexOptions?: ComplexExecutorOptions,
   ) {
-    this.builder = options?.builder;
+    try {
+      this.builder = options?.builder;
 
-    const graph = new TopologicalGraph();
+      const graph = new TopologicalGraph();
 
-    const changesetMap: Map<string, Changeset> = new Map();
+      const changesetMap: Map<string, Changeset> = new Map();
 
-    const impl = (c: Changeset) => {
-      changesetMap.set(c.placeholderID.toString(), c);
+      const impl = (c: Changeset) => {
+        changesetMap.set(c.placeholderID.toString(), c);
 
-      graph.addNode(c.placeholderID.toString());
-      if (c.dependencies) {
-        for (let [_, builder] of c.dependencies) {
-          // dependency should go first...
-          graph.addEdge(
-            builder.placeholderID.toString(),
-            c.placeholderID.toString(),
+        graph.addNode(c.placeholderID.toString());
+        if (c.dependencies) {
+          for (let [_, builder] of c.dependencies) {
+            // dependency should go first...
+            graph.addEdge(
+              builder.placeholderID.toString(),
+              c.placeholderID.toString(),
+            );
+          }
+        }
+
+        if (c.changesets) {
+          c.changesets.forEach((c2) => {
+            impl(c2);
+          });
+        }
+      };
+      let localChangesets = new Map<ID, Changeset>();
+      changesets.forEach((c) => localChangesets.set(c.placeholderID, c));
+
+      // create a new changeset representing the source changeset with the simple executor
+      impl({
+        viewer: this.viewer,
+        placeholderID: this.placeholderID,
+        changesets: changesets,
+        dependencies: dependencies,
+        executor: () => {
+          return new ListBasedExecutor(
+            this.viewer,
+            this.placeholderID,
+            operations,
+            options,
+          );
+        },
+      });
+
+      // use a set to handle repeated ops because of how the executor logic currently works
+      // TODO: can this logic be rewritten to not have a set yet avoid duplicates?
+      let nodeOps: Set<DataOperation<Ent>> = new Set();
+      let remainOps: Set<DataOperation<Ent>> = new Set();
+
+      const sorted = graph.topologicalSort();
+      sorted.forEach((node) => {
+        let c = changesetMap.get(node);
+
+        if (!c) {
+          // phew. expect it to be handled somewhere else
+          // we can just skip it and expect the resolver to handle this correctly
+          // this means it's not a changeset that was created by this ent and can/will be handled elsewhere
+          if (dependencies.has(node)) {
+            return;
+          }
+          throw new Error(
+            `trying to do a write with incomplete mutation data ${node}. current node: ${placeholderID}`,
           );
         }
-      }
 
-      if (c.changesets) {
-        c.changesets.forEach((c2) => {
-          impl(c2);
-        });
-      }
-    };
-    let localChangesets = new Map<ID, Changeset>();
-    changesets.forEach((c) => localChangesets.set(c.placeholderID, c));
-
-    // create a new changeset representing the source changeset with the simple executor
-    impl({
-      viewer: this.viewer,
-      placeholderID: this.placeholderID,
-      changesets: changesets,
-      dependencies: dependencies,
-      executor: () => {
-        return new ListBasedExecutor(
-          this.viewer,
-          this.placeholderID,
-          operations,
-          options,
-        );
-      },
-    });
-
-    // use a set to handle repeated ops because of how the executor logic currently works
-    // TODO: can this logic be rewritten to not have a set yet avoid duplicates?
-    let nodeOps: Set<DataOperation<Ent>> = new Set();
-    let remainOps: Set<DataOperation<Ent>> = new Set();
-
-    const sorted = graph.topologicalSort();
-    sorted.forEach((node) => {
-      let c = changesetMap.get(node);
-
-      if (!c) {
-        // phew. expect it to be handled somewhere else
-        // we can just skip it and expect the resolver to handle this correctly
-        // this means it's not a changeset that was created by this ent and can/will be handled elsewhere
-        if (dependencies.has(node)) {
-          return;
+        // get ordered list of ops
+        let executor = c.executor();
+        for (let op of executor) {
+          if (op.createdEnt) {
+            nodeOps.add(op);
+          } else {
+            remainOps.add(op);
+          }
         }
-        throw new Error(
-          `trying to do a write with incomplete mutation data ${node}. current node: ${placeholderID}`,
-        );
-      }
 
-      // get ordered list of ops
-      let executor = c.executor();
-      for (let op of executor) {
-        if (op.createdEnt) {
-          nodeOps.add(op);
-        } else {
-          remainOps.add(op);
+        // only add executors that are part of the changeset to what should be tracked here
+        // or self.
+        if (
+          localChangesets.has(c.placeholderID) ||
+          c.placeholderID === placeholderID
+        ) {
+          this.executors.push(executor);
         }
-      }
-
-      // only add executors that are part of the changeset to what should be tracked here
-      // or self.
-      if (
-        localChangesets.has(c.placeholderID) ||
-        c.placeholderID === placeholderID
-      ) {
-        this.executors.push(executor);
-      }
-    });
-    // get all the operations and put node operations first
-    this.allOperations = [...nodeOps, ...remainOps];
+      });
+      // get all the operations and put node operations first
+      this.allOperations = [...nodeOps, ...remainOps];
+      setExecutorBuilders(
+        this,
+        this.executors.flatMap((executor) => [
+          ...getExecutorBuilders(executor),
+        ]),
+      );
+    } catch (error) {
+      if (this.transaction) failTransaction(this.transaction, error);
+      throw error;
+    }
   }
 
   [Symbol.iterator]() {
@@ -277,6 +307,7 @@ export class ComplexExecutor<T extends Ent> implements Executor {
   }
 
   next(): IteratorResult<DataOperation<Ent>> {
+    assertTransactionRead(this.transactionRead);
     this.handleCreatedEnt();
     maybeFlagOpOperationAsChanged(this.lastOp, this.changedOps);
 
@@ -330,7 +361,9 @@ export class ComplexExecutor<T extends Ent> implements Executor {
   }
 
   async execute(): Promise<void> {
-    await executeOperations(this, this.viewer.context);
+    await runActionExecution(() =>
+      executeOperations(this, this.viewer.context),
+    );
   }
 
   async preFetch?(queryer: Queryer, context: Context): Promise<void> {
@@ -365,6 +398,52 @@ export async function executeOperations(
   context?: Context,
   trackOps?: true,
 ) {
+  const transaction = getTransactionState();
+  if (transaction) {
+    const operations: DataOperation<Ent>[] = [];
+    const writeTargets = new Map<string, object>();
+    try {
+      assertExecutorTransaction(executor);
+      assertIndependentActionSave();
+      if (executor.preFetch) {
+        await executor.preFetch(transaction.queryer, context);
+      }
+      for (const operation of executor) {
+        if (operation.shortCircuit?.(executor)) continue;
+        if (trackOps) operations.push(operation);
+        operation.resolve?.(executor);
+        const target =
+          transaction.guardedRoot && operation.transactionWriteTarget?.();
+        if (target) {
+          const key = JSON.stringify(target);
+          const previous = writeTargets.get(key);
+          if (previous && previous !== operation.builder) {
+            throw new Error(
+              "guarded changesets cannot mutate the same Ent through multiple builders; consolidate dependent writes into one action",
+            );
+          }
+          writeTargets.set(key, operation.builder);
+        }
+        await operation.performWrite(transaction.queryer, context);
+      }
+      // Result loads are still provisional and can roll back the owning scope.
+      await executor.postFetch?.(transaction.queryer, context);
+      completeGuardedPreparation(transaction, executor);
+      transaction.receipts.push(() => {
+        (
+          executor as Executor & { transactionCommitted?(): void }
+        ).transactionCommitted?.();
+      });
+      if (executor.executeObservers) {
+        transaction.observers.push(() => executor.executeObservers!());
+      }
+      return operations;
+    } catch (error) {
+      failTransaction(transaction, error);
+      throw error;
+    }
+  }
+  assertExecutorTransaction(executor);
   const client = await DB.getInstance().getNewClient();
 
   const operations: DataOperation<Ent>[] = [];

--- a/ts/src/action/generated_edge_group.test.ts
+++ b/ts/src/action/generated_edge_group.test.ts
@@ -4,7 +4,7 @@ import vm from "vm";
 import ts from "typescript";
 import DB from "../core/db";
 import * as actionRuntime from "./index";
-import { withTransaction } from "./index";
+import { withTransactionScope } from "./index";
 import {
   setupPostgres,
   assoc_edge_config_table,
@@ -91,7 +91,7 @@ test.each([
 ] as const)("caught generated %s edge setup failure rolls back earlier writes", async (method) => {
   let caught: unknown;
   await expect(
-    withTransaction(async (tx) => {
+    withTransactionScope(async (tx) => {
       await tx.exec("INSERT INTO generated_setup_marker VALUES (1)");
       try {
         await action()[method]();
@@ -109,7 +109,7 @@ test.each([
   "valid",
   "validX",
 ] as const)("generated %s setup failure keeps standalone validation recoverable", async (method) => {
-  await withTransaction(async (tx) => {
+  await withTransactionScope(async (tx) => {
     await tx.exec("INSERT INTO generated_setup_marker VALUES (1)");
     await expect(action()[method]()).rejects.toThrow("error loading edge data");
   });

--- a/ts/src/action/generated_edge_group.test.ts
+++ b/ts/src/action/generated_edge_group.test.ts
@@ -1,0 +1,128 @@
+import fs from "fs";
+import path from "path";
+import vm from "vm";
+import ts from "typescript";
+import DB from "../core/db";
+import * as actionRuntime from "./index";
+import { withTransaction } from "./index";
+import {
+  setupPostgres,
+  assoc_edge_config_table,
+} from "../testutils/db/temp_db";
+import { TestContext } from "../testutils/context/test_context";
+
+type GeneratedMethod = (...args: unknown[]) => Promise<unknown>;
+interface GeneratedEdgeGroup {
+  save: GeneratedMethod;
+  saveX: GeneratedMethod;
+  changeset: GeneratedMethod;
+  changesetWithOptions_BETA: GeneratedMethod;
+  valid: GeneratedMethod;
+  validX: GeneratedMethod;
+}
+
+// Load the generated methods as a consumer fixture without starting the example.
+// Their edge setup and transaction boundaries call the local package runtime.
+const source = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "../../../examples/simple/src/ent/generated/event/actions/edit_event_rsvp_status_action_base.ts",
+  ),
+  "utf8",
+);
+const emitted = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+  },
+}).outputText;
+const generated = {} as {
+  EditEventRsvpStatusActionBase: { prototype: GeneratedEdgeGroup };
+};
+vm.runInNewContext(emitted, {
+  exports: generated,
+  require: (name: string) =>
+    name === "@snowtop/ent/action"
+      ? actionRuntime
+      : name.endsWith("/types")
+        ? { NodeType: { User: "User" } }
+        : {},
+});
+
+function action(): GeneratedEdgeGroup {
+  return Object.assign(
+    Object.create(generated.EditEventRsvpStatusActionBase.prototype),
+    {
+      builder: { orchestrator: { viewer: new TestContext().getViewer() } },
+      input: {
+        rsvpStatus: "attending",
+        userId: "f4a78b60-ddc3-43e2-b34d-a4e540f60680",
+      },
+      event: {
+        id: "e1cddfe5-39c5-4bdc-8ea1-296efb0e41c15",
+        getEventRsvpStatusMap: () =>
+          new Map([["attending", "a9d4f039-9e3b-4571-8fc1-0bd1ac531cf7"]]),
+      },
+    },
+  );
+}
+
+setupPostgres(() => [assoc_edge_config_table()]);
+beforeEach(async () => {
+  await DB.getInstance()
+    .getPool()
+    .query("CREATE TABLE generated_setup_marker (id integer)");
+});
+afterEach(async () => {
+  await DB.getInstance().getPool().query("DROP TABLE generated_setup_marker");
+});
+const rows = async () =>
+  (
+    await DB.getInstance()
+      .getPool()
+      .query("SELECT * FROM generated_setup_marker")
+  ).rows;
+
+test.each([
+  "save",
+  "saveX",
+  "changeset",
+  "changesetWithOptions_BETA",
+] as const)("caught generated %s edge setup failure rolls back earlier writes", async (method) => {
+  let caught: unknown;
+  await expect(
+    withTransaction(async (tx) => {
+      await tx.exec("INSERT INTO generated_setup_marker VALUES (1)");
+      try {
+        await action()[method]();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain("error loading edge data");
+    }),
+  ).rejects.toThrow("error loading edge data");
+  expect(await rows()).toEqual([]);
+});
+
+test.each([
+  "valid",
+  "validX",
+] as const)("generated %s setup failure keeps standalone validation recoverable", async (method) => {
+  await withTransaction(async (tx) => {
+    await tx.exec("INSERT INTO generated_setup_marker VALUES (1)");
+    await expect(action()[method]()).rejects.toThrow("error loading edge data");
+  });
+  expect(await rows()).toEqual([{ id: 1 }]);
+});
+
+test.each([
+  "save",
+  "saveX",
+] as const)("unscoped %s failure preserves earlier committed work", async (method) => {
+  await DB.getInstance()
+    .getPool()
+    .exec("INSERT INTO generated_setup_marker VALUES (1)");
+  await expect(action()[method]()).rejects.toThrow("error loading edge data");
+  expect(await rows()).toEqual([{ id: 1 }]);
+});

--- a/ts/src/action/index.ts
+++ b/ts/src/action/index.ts
@@ -36,5 +36,9 @@ export {
 } from "../core/transaction_context";
 export type { AssocEdgeOptions } from "./operations";
 
-export { withTransaction, getTransactionScope } from "../core/transaction";
-export type { TransactionOptions, TransactionScope } from "../core/transaction";
+export { withTransactionScope, getTransactionScope } from "../core/transaction";
+export type {
+  TransactionOptions,
+  TransactionScope,
+  ScopeValidationContext,
+} from "../core/transaction";

--- a/ts/src/action/index.ts
+++ b/ts/src/action/index.ts
@@ -28,8 +28,8 @@ export type {
   RelativeNumberValue,
 } from "./relative_value";
 export { Transaction } from "./transaction";
-// Internal entry point for generated saves. Handle
-// load and construction failures.
+// Internal entry points that handle load, construction, and setup failures
+// in generated actions.
 export {
   runActionExecution,
   runActionChangeset,

--- a/ts/src/action/index.ts
+++ b/ts/src/action/index.ts
@@ -28,4 +28,6 @@ export type {
   RelativeNumberValue,
 } from "./relative_value";
 export { Transaction } from "./transaction";
+// Internal generated save entrypoint: includes loads and construction in failure handling.
+export { runActionExecution } from "../core/transaction_context";
 export type { AssocEdgeOptions } from "./operations";

--- a/ts/src/action/index.ts
+++ b/ts/src/action/index.ts
@@ -28,7 +28,7 @@ export type {
   RelativeNumberValue,
 } from "./relative_value";
 export { Transaction } from "./transaction";
-// Internal entry point for generated saves. Handle load and construction
-// failures.
+// Internal entry point for generated saves. Handle
+// load and construction failures.
 export { runActionExecution } from "../core/transaction_context";
 export type { AssocEdgeOptions } from "./operations";

--- a/ts/src/action/index.ts
+++ b/ts/src/action/index.ts
@@ -28,6 +28,7 @@ export type {
   RelativeNumberValue,
 } from "./relative_value";
 export { Transaction } from "./transaction";
-// Internal generated save entrypoint: includes loads and construction in failure handling.
+// Internal entry point for generated saves. Handle load and construction
+// failures.
 export { runActionExecution } from "../core/transaction_context";
 export type { AssocEdgeOptions } from "./operations";

--- a/ts/src/action/index.ts
+++ b/ts/src/action/index.ts
@@ -30,5 +30,11 @@ export type {
 export { Transaction } from "./transaction";
 // Internal entry point for generated saves. Handle
 // load and construction failures.
-export { runActionExecution } from "../core/transaction_context";
+export {
+  runActionExecution,
+  runActionChangeset,
+} from "../core/transaction_context";
 export type { AssocEdgeOptions } from "./operations";
+
+export { withTransaction, getTransactionScope } from "../core/transaction";
+export type { TransactionOptions, TransactionScope } from "../core/transaction";

--- a/ts/src/action/operations.ts
+++ b/ts/src/action/operations.ts
@@ -27,6 +27,7 @@ import {
 } from "../core/ent";
 import { __getGlobalSchema } from "../core/global_schema";
 import { ObjectLoader } from "../core/loaders";
+import { getTransactionState } from "../core/transaction_context";
 import { buildQuery } from "../core/query_impl";
 import {
   SQLStatementOperation,
@@ -120,10 +121,10 @@ export class RawQueryOperation<
     for (const q of this.queries) {
       if (typeof q === "string") {
         logQuery(q, []);
-        await queryer.query(q);
+        await queryer.exec(q);
       } else {
         logQuery(q.query, q.logValues || []);
-        await queryer.query(q.query, q.values);
+        await queryer.exec(q.query, q.values);
       }
     }
   }
@@ -152,21 +153,53 @@ export interface EditNodeOptions<
   builder: Builder<TEnt, TViewer>;
 }
 
+interface ResultRowOptions {
+  tableName: string;
+  key: string;
+  fields: LoadEntOptions<Ent>["fields"];
+}
+
+async function reloadScopedResult(
+  queryer: Queryer,
+  options: ResultRowOptions,
+  id: ID,
+): Promise<Data | null> {
+  const cls = clause.Eq(options.key, id);
+  const query = buildQuery({
+    tableName: options.tableName,
+    fields: options.fields.length ? options.fields : ["*"],
+    clause: cls,
+  });
+  logQuery(query, cls.logValues());
+  const result = await queryer.query(query, cls.values());
+  return result.rows[0] ?? null;
+}
+
 export class NoOperation<
   TEnt extends Ent<TViewer>,
   TViewer extends Viewer = Viewer,
 > implements DataOperation<TEnt, TViewer>
 {
   private row: Data | null = null;
+  private executed = false;
   constructor(
     public builder: Builder<TEnt, TViewer>,
-    existingEnt: Ent | null = null,
+    private existingEnt: Ent | null,
+    private resultOptions: ResultRowOptions,
   ) {
     // @ts-ignore
     this.row = existingEnt?.data;
   }
 
-  async performWrite(queryer: Queryer, context?: Context) {}
+  async performWrite(queryer: Queryer, context?: Context) {
+    this.executed = true;
+  }
+
+  async postFetch(queryer: Queryer) {
+    if (getTransactionState() && this.executed && this.existingEnt) {
+      this.row = await reloadScopedResult(queryer, this.resultOptions, this.existingEnt.id);
+    }
+  }
 
   performWriteSync(queryer: SyncQueryer, context?: Context): void {}
 
@@ -291,6 +324,18 @@ export class EditNodeOperation<
           operation: WriteOperation.Edit,
         };
       }
+    }
+  }
+
+  async postFetch(queryer: Queryer) {
+    if (getTransactionState() && this.row) {
+      // Other graph operations can change fields after this operation returns.
+      // Use the stored row's key, including when an upsert found an existing row.
+      this.row = await reloadScopedResult(queryer, {
+        tableName: this.options.tableName,
+        key: this.options.key,
+        fields: this.options.loadEntOptions.fields,
+      }, this.row[this.options.key]);
     }
   }
 

--- a/ts/src/action/operations.ts
+++ b/ts/src/action/operations.ts
@@ -70,6 +70,8 @@ export interface DataOperation<
   // Check known row mutations after resolving placeholders and skipping
   // writes that don't apply.
   transactionWriteTarget?(): readonly [string, ID] | undefined;
+  // A skipped action must not register final validation through an operation wrapper.
+  readonly skipScopeValidation?: boolean;
 
   // any data that needs to be fetched asynchronously post write|post transaction
   postFetch?(queryer: Queryer, context?: Context): Promise<void>;
@@ -180,6 +182,7 @@ export class NoOperation<
   TViewer extends Viewer = Viewer,
 > implements DataOperation<TEnt, TViewer>
 {
+  readonly skipScopeValidation = true;
   private row: Data | null = null;
   private executed = false;
   constructor(
@@ -197,7 +200,11 @@ export class NoOperation<
 
   async postFetch(queryer: Queryer) {
     if (getTransactionState() && this.executed && this.existingEnt) {
-      this.row = await reloadScopedResult(queryer, this.resultOptions, this.existingEnt.id);
+      this.row = await reloadScopedResult(
+        queryer,
+        this.resultOptions,
+        this.existingEnt.id,
+      );
     }
   }
 
@@ -331,11 +338,15 @@ export class EditNodeOperation<
     if (getTransactionState() && this.row) {
       // Other graph operations can change fields after this operation returns.
       // Use the stored row's key, including when an upsert found an existing row.
-      this.row = await reloadScopedResult(queryer, {
-        tableName: this.options.tableName,
-        key: this.options.key,
-        fields: this.options.loadEntOptions.fields,
-      }, this.row[this.options.key]);
+      this.row = await reloadScopedResult(
+        queryer,
+        {
+          tableName: this.options.tableName,
+          key: this.options.key,
+          fields: this.options.loadEntOptions.fields,
+        },
+        this.row[this.options.key],
+      );
     }
   }
 
@@ -1021,6 +1032,10 @@ export class ConditionalOperation<
   ) {
     this.builder = op.builder;
     this.placeholderID = op.placeholderID;
+  }
+
+  get skipScopeValidation(): boolean {
+    return this.op.skipScopeValidation === true;
   }
 
   shortCircuit(executor: Executor): boolean {

--- a/ts/src/action/operations.ts
+++ b/ts/src/action/operations.ts
@@ -66,7 +66,8 @@ export interface DataOperation<
   shortCircuit?(executor: Executor): boolean;
   updatedOperation?(): UpdatedOperation<TEnt, TViewer> | null;
   resolve?(executor: Executor): void; //throws?
-  // Known row mutations, checked after conditional skips and placeholder resolution.
+  // Check known row mutations after resolving placeholders and skipping
+  // writes that don't apply.
   transactionWriteTarget?(): readonly [string, ID] | undefined;
 
   // any data that needs to be fetched asynchronously post write|post transaction

--- a/ts/src/action/operations.ts
+++ b/ts/src/action/operations.ts
@@ -66,6 +66,8 @@ export interface DataOperation<
   shortCircuit?(executor: Executor): boolean;
   updatedOperation?(): UpdatedOperation<TEnt, TViewer> | null;
   resolve?(executor: Executor): void; //throws?
+  // Known row mutations, checked after conditional skips and placeholder resolution.
+  transactionWriteTarget?(): readonly [string, ID] | undefined;
 
   // any data that needs to be fetched asynchronously post write|post transaction
   postFetch?(queryer: Queryer, context?: Context): Promise<void>;
@@ -81,6 +83,10 @@ export class DeleteNodeOperation<
     public readonly builder: Builder<TEnt, TViewer>,
     private options: DataOptions,
   ) {}
+
+  transactionWriteTarget(): readonly [string, ID] {
+    return [this.options.tableName, this.id];
+  }
 
   async performWrite(queryer: Queryer, context?: Context): Promise<void> {
     let options = {
@@ -221,6 +227,13 @@ export class EditNodeOperation<
       return true;
     }
     return false;
+  }
+
+  transactionWriteTarget(): readonly [string, ID] | undefined {
+    if (this.existingEnt && this.hasData(this.options.fields)) {
+      return [this.options.tableName, this.existingEnt.id];
+    }
+    return undefined;
   }
 
   private buildOnConflictQuery(options: EditNodeOptions<TEnt, TViewer>) {
@@ -967,6 +980,10 @@ export class ConditionalOperation<
   shortCircuit(executor: Executor): boolean {
     this.shortCircuited = executor.builderOpChanged(this.conditionalBuilder);
     return this.shortCircuited;
+  }
+
+  transactionWriteTarget(): readonly [string, ID] | undefined {
+    return this.op.transactionWriteTarget?.();
   }
 
   async preFetch(

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -10,7 +10,7 @@ import {
 } from "../core/base";
 import {
   loadEdgeDatas,
-  applyPrivacyPolicyForRow,
+  applyPrivacyPolicyForActionResult,
   parameterizedQueryOptions,
   loadEdgeData,
 } from "../core/ent";
@@ -52,8 +52,29 @@ import { Trigger } from "./action";
 import * as clause from "../core/clause";
 import { isPromise } from "util/types";
 import { RawQueryOperation } from "./operations";
+import {
+  awaitActionPreparations,
+  assertEntTransaction,
+  assertLoaderTransaction,
+  assertTransactionRead,
+  failTransaction,
+  getTransactionReadState,
+  getTransactionState,
+  claimGuardedPreparation,
+  runInActionPreparation,
+  isPreparingAction,
+  isValidationPreparation,
+  recordActionResultTransaction,
+  hasActionResultTransaction,
+  recordPreparedEntTransaction,
+  TransactionReadState,
+} from "../core/transaction_context";
 
 type MaybeNull<T extends Ent> = T | null;
+// Expected validator/privacy failures from child builds remain recoverable
+// during a standalone validation probe. SQL and composition failures still
+// poison the owning transaction.
+const validationFailures = new WeakSet<Error>();
 type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
 
 export interface OrchestratorOptions<
@@ -257,6 +278,13 @@ export class Orchestrator<
   private disableTransformations: boolean;
   private onConflict: CreateRowOptions["onConflict"] | undefined;
   private memoizedGetFields: () => Promise<fieldsInfo>;
+  private fieldPreparationRead?: TransactionReadState;
+  private transformedChangeset?: TransformedUpdateOperation<
+    TEnt,
+    TViewer
+  >["changeset"];
+  private transaction = getTransactionState();
+  private preparationInProgress = false;
 
   constructor(
     private options: OrchestratorOptions<TEnt, TInput, TViewer, TExistingEnt>,
@@ -264,7 +292,30 @@ export class Orchestrator<
     this.viewer = options.viewer;
     this.actualOperation = this.options.operation;
     this.existingEnt = this.options.builder.existingEnt;
-    this.memoizedGetFields = memoizeNoArgs(this.getFieldsInfo.bind(this));
+    let prepared = false;
+    const fields = memoizeNoArgs(() => {
+      prepared = true;
+      this.fieldPreparationRead = getTransactionReadState();
+      return this.getFieldsInfo();
+    });
+    this.memoizedGetFields = async () => {
+      // Defaults and transformations may depend on reads, even for inserts.
+      // Keep stable IDs within an attempt, but never reuse a prior generation.
+      // Committed actions can still expose their retained data outside a scope.
+      if (
+        getTransactionState() &&
+        prepared &&
+        !hasActionResultTransaction(this.options.builder)
+      )
+        assertTransactionRead(this.fieldPreparationRead);
+      const result = await fields();
+      if (
+        getTransactionState() &&
+        !hasActionResultTransaction(this.options.builder)
+      )
+        assertTransactionRead(this.fieldPreparationRead);
+      return result;
+    };
   }
 
   // don't type this because we don't care
@@ -644,6 +695,7 @@ export class Orchestrator<
     viewerToUse: TViewer,
     rowToUse?: Data,
   ): Promise<TEnt> {
+    if (getTransactionState()) assertTransactionRead(this.fieldPreparationRead);
     if (this.actualOperation !== WriteOperation.Insert) {
       return this.existingEnt!;
     }
@@ -656,7 +708,10 @@ export class Orchestrator<
     }
 
     // we create an unsafe ent to be used for privacy policies
-    return new this.options.builder.ent(viewerToUse, rowToUse);
+    if (getTransactionState()) assertTransactionRead(this.fieldPreparationRead);
+    const ent = new this.options.builder.ent(viewerToUse, rowToUse);
+    recordPreparedEntTransaction(ent, this.fieldPreparationRead);
+    return ent;
   }
 
   private getSQLStatementOperation(): SQLStatementOperation {
@@ -769,6 +824,29 @@ export class Orchestrator<
   }
 
   private async validate(): Promise<Error[]> {
+    if (!getTransactionState() || isPreparingAction(this.options.builder)) {
+      return this.validateImpl();
+    }
+    return this.prepareAction(() => this.validateImpl(), true);
+  }
+
+  private async prepareFields(): Promise<fieldsInfo> {
+    const requirement = this.options.action?.requiresTransaction?.();
+    if (requirement && !getTransactionState()) {
+      throw new Error(
+        "this action requires withTransaction; construct and save the action inside its callback",
+      );
+    }
+    if (
+      requirement === "serializable" &&
+      getTransactionState()?.isolationLevel !== "serializable"
+    ) {
+      throw new Error(
+        "this action requires a serializable withTransaction scope",
+      );
+    }
+    assertLoaderTransaction(this.transaction);
+    if (this.existingEnt) assertEntTransaction(this.existingEnt);
     // existing ent required for edit or delete operations
     switch (this.actualOperation) {
       case WriteOperation.Delete:
@@ -780,8 +858,21 @@ export class Orchestrator<
         }
     }
 
+    const fields = await this.memoizedGetFields();
+    // A completed action can expose stable snapshot fields/IDs, but those
+    // retained values never become fresh preparation for another save.
+    if (getTransactionState()) assertTransactionRead(this.fieldPreparationRead);
+    // A schema transform may replace the original mutation target.
+    if (this.existingEnt) assertEntTransaction(this.existingEnt);
+    return fields;
+  }
+
+  private async validateImpl(): Promise<Error[]> {
     const { schemaFields, editedData, userDefinedKeys, editPrivacyFields } =
-      await this.memoizedGetFields();
+      await this.prepareFields();
+    if (this.transformedChangeset) {
+      this.changesets.push(await this.transformedChangeset());
+    }
     const action = this.options.action;
     const builder = this.options.builder;
 
@@ -843,7 +934,7 @@ export class Orchestrator<
           })(),
         );
       }
-      await Promise.all(promises);
+      await awaitActionPreparations(promises);
     }
 
     // privacy or field errors should return first so it's less confusing
@@ -866,7 +957,7 @@ export class Orchestrator<
     // not ideal we're calling this twice. fix...
     // needed for now. may need to rewrite some of this?
     const editedFields2 = await this.options.editedFields();
-    const [errs2, errs3] = await Promise.all([
+    const [errs2, errs3] = await awaitActionPreparations([
       this.formatAndValidateFields(schemaFields, editedFields2),
       this.validators(validators, action!, builder),
     ]);
@@ -907,11 +998,11 @@ export class Orchestrator<
     }
 
     for (const triggers of groups) {
-      await Promise.all(
+      await awaitActionPreparations(
         triggers.map(async (trigger) => {
           let ret = await trigger.changeset(builder, action.getInput());
           if (Array.isArray(ret)) {
-            ret = await Promise.all(ret);
+            ret = await awaitActionPreparations(ret);
           }
 
           if (Array.isArray(ret)) {
@@ -934,7 +1025,7 @@ export class Orchestrator<
     builder: Builder<TEnt, TViewer>,
   ): Promise<Error[]> {
     const errors: Error[] = [];
-    await Promise.all(
+    await awaitActionPreparations(
       validators.map(async (v) => {
         try {
           const r = await v.validate(builder, action.getInput());
@@ -1032,8 +1123,14 @@ export class Orchestrator<
         }
       }
       if (transformed.changeset) {
-        const changeset = await transformed.changeset();
-        this.changesets.push(changeset);
+        if (this.transaction) {
+          // Keep transformed fields/defaults stable, but rebuild child graphs
+          // inside each preparation. A standalone validation discards its graph.
+          this.transformedChangeset = transformed.changeset.bind(transformed);
+        } else {
+          const changeset = await transformed.changeset();
+          this.changesets.push(changeset);
+        }
       }
       this.actualOperation = this.getWriteOpForSQLStamentOp(transformed.op);
       if (transformed.existingEnt) {
@@ -1298,6 +1395,9 @@ export class Orchestrator<
   async validX(): Promise<void> {
     const errors = await this.validate();
     if (errors.length) {
+      if (isValidationPreparation() && errors[0] instanceof Error) {
+        validationFailures.add(errors[0]);
+      }
       // just throw the first one...
       // TODO we should ideally throw all of them
       throw errors[0];
@@ -1315,7 +1415,101 @@ export class Orchestrator<
     return this.validate();
   }
 
+  private snapshotPreparation(): () => void {
+    const saved = {
+      changesets: this.changesets,
+      dependencies: this.dependencies,
+      fieldsToResolve: this.fieldsToResolve,
+      mainOp: this.mainOp,
+      edges: this.edges,
+      conditionalEdges: this.conditionalEdges,
+      edgeSet: this.edgeSet,
+    };
+    const copyEdges = (edges: EdgeMap<TViewer>): EdgeMap<TViewer> =>
+      new Map(
+        [...edges].map(([type, operations]) => [
+          type,
+          new Map([...operations].map(([op, ids]) => [op, new Map(ids)])),
+        ]),
+      );
+    this.changesets = [...saved.changesets];
+    this.dependencies = new Map(saved.dependencies);
+    this.fieldsToResolve = [...saved.fieldsToResolve];
+    this.edges = copyEdges(saved.edges);
+    this.conditionalEdges = copyEdges(saved.conditionalEdges);
+    this.edgeSet = new Set(saved.edgeSet);
+    return () => {
+      Object.assign(this, saved);
+    };
+  }
+
+  private async prepareAction<T>(
+    prepare: () => Promise<T>,
+    validationOnly = false,
+  ): Promise<T> {
+    const state = getTransactionState();
+    if (state && this.preparationInProgress) {
+      const error = new Error(
+        "action preparation is already in progress; await validation before building or saving",
+      );
+      failTransaction(state, error);
+      throw error;
+    }
+    if (state) this.preparationInProgress = true;
+    // A public validation probe must discard each participant's child graph,
+    // including retained children that are rebuilt during the later save.
+    const probing = state && (validationOnly || isValidationPreparation());
+    let restore: (() => void) | undefined;
+    try {
+      return await runInActionPreparation(
+        this.options.builder,
+        async () => {
+          const action = this.options.action;
+          if (action?.getTransactionResources) {
+            claimGuardedPreparation(await action.getTransactionResources());
+          } else if (action?.requiresTransaction?.() && getTransactionState()) {
+            claimGuardedPreparation();
+          }
+          if (probing) {
+            // Defaults and transformed inputs are memoized once, including any
+            // inverse edges set by updateInput. Snapshot only after those are
+            // established so they survive probes without being applied twice.
+            await this.prepareFields();
+            restore = this.snapshotPreparation();
+          }
+          return prepare();
+        },
+        validationOnly,
+      );
+    } catch (error) {
+      if (
+        state &&
+        !(probing && error instanceof Error && validationFailures.has(error))
+      )
+        failTransaction(state, error);
+      throw error;
+    } finally {
+      if (state) this.preparationInProgress = false;
+      restore?.();
+    }
+  }
+
   private async buildPlusChangeset(
+    conditionalBuilder: Builder<TEnt, TViewer>,
+    conditionalOverride: boolean,
+  ): Promise<EntChangeset<TEnt>> {
+    return this.prepareAction(() => {
+      if (conditionalOverride) {
+        this.dependencies.set(
+          conditionalBuilder.placeholderID,
+          conditionalBuilder,
+        );
+      }
+      return this.buildChangeset(conditionalBuilder, conditionalOverride);
+    });
+  }
+
+  private async buildChangeset(
     conditionalBuilder: Builder<TEnt, TViewer>,
     conditionalOverride: boolean,
   ): Promise<EntChangeset<TEnt>> {
@@ -1352,6 +1546,7 @@ export class Orchestrator<
     // TODO test actualOperation value
     // observers is fine since they're run after and we have the actualOperation value...
 
+    if (getTransactionState()) assertTransactionRead(this.fieldPreparationRead);
     return new EntChangeset(
       this.options.viewer,
       this.options.builder,
@@ -1371,11 +1566,6 @@ export class Orchestrator<
   async buildWithOptions_BETA(
     options: ChangesetOptions,
   ): Promise<EntChangeset<TEnt>> {
-    // set as dependency so that we do the right order of operations
-    this.dependencies.set(
-      options.conditionalBuilder.placeholderID,
-      options.conditionalBuilder,
-    );
     return this.buildPlusChangeset(options.conditionalBuilder, true);
   }
 
@@ -1394,35 +1584,66 @@ export class Orchestrator<
     return null;
   }
 
-  async editedEnt(): Promise<TEnt | null> {
-    const row = await this.returnedRow();
-    if (!row) {
-      return null;
+  private async loadResult<T extends TEnt | null>(
+    load: () => Promise<T>,
+  ): Promise<T> {
+    const transaction = getTransactionState();
+    try {
+      const result = await load();
+      if (result) {
+        recordActionResultTransaction(result, this.options.builder);
+      }
+      return result;
+    } catch (error) {
+      // Generated saves load their result after executeOperations returns.
+      // Caught result failures must still roll back the active owning scope;
+      // direct getter failures belong only to their originating scope.
+      if (transaction?.active && transaction === this.transaction) {
+        failTransaction(transaction, error);
+      }
+      throw error;
     }
-    const viewer = await this.viewerForEntLoad(row);
-    return applyPrivacyPolicyForRow(viewer, this.options.loaderOptions, row);
+  }
+
+  async editedEnt(): Promise<TEnt | null> {
+    return this.loadResult(async () => {
+      const row = await this.returnedRow();
+      if (!row) {
+        return null;
+      }
+      const viewer = await this.viewerForEntLoad(row);
+      return applyPrivacyPolicyForActionResult(
+        viewer,
+        this.options.loaderOptions,
+        row,
+        this.options.builder,
+      );
+    });
   }
 
   async editedEntX(): Promise<TEnt> {
-    const row = await this.returnedRow();
-    if (!row) {
-      throw new Error(`ent was not created`);
-    }
-    const viewer = await this.viewerForEntLoad(row);
-    const ent = await applyPrivacyPolicyForRow(
-      viewer,
-      this.options.loaderOptions,
-      row,
-    );
-
-    if (!ent) {
-      if (this.actualOperation == WriteOperation.Insert) {
-        throw new Error(`was able to create ent but not load it`);
-      } else {
-        throw new Error(`was able to edit ent but not load it`);
+    return this.loadResult(async () => {
+      const row = await this.returnedRow();
+      if (!row) {
+        throw new Error(`ent was not created`);
       }
-    }
-    return ent;
+      const viewer = await this.viewerForEntLoad(row);
+      const ent = await applyPrivacyPolicyForActionResult(
+        viewer,
+        this.options.loaderOptions,
+        row,
+        this.options.builder,
+      );
+
+      if (!ent) {
+        if (this.actualOperation == WriteOperation.Insert) {
+          throw new Error(`was able to create ent but not load it`);
+        } else {
+          throw new Error(`was able to edit ent but not load it`);
+        }
+      }
+      return ent;
+    });
   }
 }
 
@@ -1440,6 +1661,8 @@ export class EntChangeset<
 > implements Changeset
 {
   private _executor: Executor | null;
+  private transactionRead = getTransactionReadState();
+  private validationOnly = isValidationPreparation();
   constructor(
     public viewer: Viewer,
     private builder: Builder<TEnt, TViewer>,
@@ -1485,7 +1708,9 @@ export class EntChangeset<
     op: EdgeOperation<TViewer>,
     edgeType: string,
   ) {
+    const read = getTransactionReadState();
     const edgeData = await loadEdgeData(edgeType);
+    assertTransactionRead(read);
     const ops: DataOperation<TEnt, TViewer>[] = [op];
     if (!edgeData) {
       throw new Error(`could not load edge data for '${edgeType}'`);
@@ -1568,6 +1793,12 @@ export class EntChangeset<
   }
 
   executor(): Executor {
+    assertTransactionRead(this.transactionRead);
+    if (this.validationOnly) {
+      throw new Error(
+        "changesets prepared by public validation cannot execute; rebuild them when saving",
+      );
+    }
     if (this._executor) {
       return this._executor;
     }

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -324,9 +324,8 @@ export class Orchestrator<
     });
     this.memoizedGetFields = async () => {
       // Defaults and transformations may depend on reads, even for inserts.
-      // Keep IDs stable within an attempt, but never reuse a previous
-      // generation. Committed actions can still expose their retained data
-      // outside a scope.
+      // Keep IDs stable within an attempt, but reject prepared values from an
+      // earlier generation. Committed actions can expose retained data outside a scope.
       if (
         getTransactionState() &&
         prepared &&
@@ -1271,9 +1270,8 @@ export class Orchestrator<
       }
       if (transformed.changeset) {
         if (this.transaction) {
-          // Keep transformed fields and defaults stable, but rebuild child
-          // graphs for each preparation. Standalone
-          // validation discards its graph.
+          // Preserve transformed fields and defaults. Rebuild the child graph
+          // for each preparation because standalone validation discards it.
           this.transformedChangeset = transformed.changeset.bind(transformed);
         } else {
           const changeset = await transformed.changeset();
@@ -1659,10 +1657,9 @@ export class Orchestrator<
             claimGuardedPreparation();
           }
           if (probing) {
-            // Defaults and transformed inputs are memoized once, including
-            // inverse edges set by updateInput. Take the snapshot after setting
-            // those edges so validation preserves them
-            // without applying them twice.
+            // Memoize defaults and transformed inputs, including inverse edges
+            // set by updateInput. Snapshot those edges so validation preserves
+            // them without applying them twice.
             await this.prepareFields();
             restore = this.snapshotPreparation();
           }
@@ -2006,10 +2003,8 @@ export class EntChangeset<
       }
 
       if (!this.changesets?.length) {
-        // if we have dependencies but no changesets, we just need a simple
-        // executor and depend on something else in the stack to handle this correctly
-        // ComplexExecutor which could be a parent of this should make sure the dependency
-        // is resolved beforehand
+        // Without child changesets, use a list executor. The parent complex
+        // executor resolves any dependencies before running these operations.
         return (this._executor = new ListBasedExecutor(
           this.viewer,
           this.placeholderID,

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -1687,17 +1687,19 @@ export class Orchestrator<
   }
 
   private async buildPlusChangeset(
-    conditionalBuilder: Builder<TEnt, TViewer>,
-    conditionalOverride: boolean,
+    options?: ChangesetOptions,
   ): Promise<EntChangeset<TEnt>> {
     return this.prepareAction(() => {
-      if (conditionalOverride) {
+      if (options) {
         this.dependencies.set(
-          conditionalBuilder.placeholderID,
-          conditionalBuilder,
+          options.conditionalBuilder.placeholderID,
+          options.conditionalBuilder,
         );
       }
-      return this.buildChangeset(conditionalBuilder, conditionalOverride);
+      return this.buildChangeset(
+        options?.conditionalBuilder ?? this.options.builder,
+        options !== undefined,
+      );
     });
   }
 
@@ -1714,7 +1716,11 @@ export class Orchestrator<
       const res = await this.valid();
       if (!res) {
         processOps = false;
-        const op = new NoOperation(this.options.builder, this.existingEnt);
+        const op = new NoOperation(this.options.builder, this.existingEnt, {
+          tableName: this.options.tableName,
+          key: this.options.key,
+          fields: this.options.loaderOptions.fields,
+        });
         this.mainOp = op;
         ops = [op];
 
@@ -1754,13 +1760,13 @@ export class Orchestrator<
   }
 
   async build(): Promise<EntChangeset<TEnt>> {
-    return this.buildPlusChangeset(this.options.builder, false);
+    return this.buildPlusChangeset();
   }
 
   async buildWithOptions_BETA(
     options: ChangesetOptions,
   ): Promise<EntChangeset<TEnt>> {
-    return this.buildPlusChangeset(options.conditionalBuilder, true);
+    return this.buildPlusChangeset(options);
   }
 
   private async viewerForEntLoad(data: Data) {
@@ -1987,44 +1993,52 @@ export class EntChangeset<
   }
 
   executor(): Executor {
-    assertTransactionRead(this.transactionRead);
-    if (this.validationOnly) {
-      throw new Error(
-        "changesets prepared by public validation cannot execute; rebuild them when saving",
-      );
-    }
-    if (this._executor) {
-      return this._executor;
-    }
+    const transaction = getTransactionState();
+    try {
+      assertTransactionRead(this.transactionRead);
+      if (this.validationOnly) {
+        throw new Error(
+          "changesets prepared by public validation cannot execute; rebuild them when saving",
+        );
+      }
+      if (this._executor) {
+        return this._executor;
+      }
 
-    if (!this.changesets?.length) {
-      // if we have dependencies but no changesets, we just need a simple
-      // executor and depend on something else in the stack to handle this correctly
-      // ComplexExecutor which could be a parent of this should make sure the dependency
-      // is resolved beforehand
-      return (this._executor = new ListBasedExecutor(
+      if (!this.changesets?.length) {
+        // if we have dependencies but no changesets, we just need a simple
+        // executor and depend on something else in the stack to handle this correctly
+        // ComplexExecutor which could be a parent of this should make sure the dependency
+        // is resolved beforehand
+        return (this._executor = new ListBasedExecutor(
+          this.viewer,
+          this.placeholderID,
+          this.operations,
+          this.options,
+          {
+            conditionalOverride: this.conditionalOverride,
+            builder: this.builder,
+          },
+        ));
+      }
+
+      return (this._executor = new ComplexExecutor(
         this.viewer,
         this.placeholderID,
         this.operations,
+        this.dependencies || new Map(),
+        this.changesets || [],
         this.options,
         {
           conditionalOverride: this.conditionalOverride,
           builder: this.builder,
         },
       ));
+    } catch (error) {
+      if (transaction) {
+        failTransaction(transaction, error);
+      }
+      throw error;
     }
-
-    return (this._executor = new ComplexExecutor(
-      this.viewer,
-      this.placeholderID,
-      this.operations,
-      this.dependencies || new Map(),
-      this.changesets || [],
-      this.options,
-      {
-        conditionalOverride: this.conditionalOverride,
-        builder: this.builder,
-      },
-    ));
   }
 }

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -325,8 +325,8 @@ export class Orchestrator<
     this.memoizedGetFields = async () => {
       // Defaults and transformations may depend on reads, even for inserts.
       // Keep IDs stable within an attempt, but never reuse a previous
-      // generation.
-      // Committed actions can still expose their retained data outside a scope.
+      // generation. Committed actions can still expose their retained data
+      // outside a scope.
       if (
         getTransactionState() &&
         prepared &&
@@ -1272,8 +1272,8 @@ export class Orchestrator<
       if (transformed.changeset) {
         if (this.transaction) {
           // Keep transformed fields and defaults stable, but rebuild child
-          // graphs
-          // for each preparation. Standalone validation discards its graph.
+          // graphs for each preparation. Standalone
+          // validation discards its graph.
           this.transformedChangeset = transformed.changeset.bind(transformed);
         } else {
           const changeset = await transformed.changeset();
@@ -1660,10 +1660,9 @@ export class Orchestrator<
           }
           if (probing) {
             // Defaults and transformed inputs are memoized once, including
-            // inverse
-            // edges set by updateInput. Take the snapshot after setting those
-            // edges
-            // so validation preserves them without applying them twice.
+            // inverse edges set by updateInput. Take the snapshot after setting
+            // those edges so validation preserves them
+            // without applying them twice.
             await this.prepareFields();
             restore = this.snapshotPreparation();
           }

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -306,14 +306,16 @@ export class Orchestrator<
         getTransactionState() &&
         prepared &&
         !hasActionResultTransaction(this.options.builder)
-      )
+      ) {
         assertTransactionRead(this.fieldPreparationRead);
+      }
       const result = await fields();
       if (
         getTransactionState() &&
         !hasActionResultTransaction(this.options.builder)
-      )
+      ) {
         assertTransactionRead(this.fieldPreparationRead);
+      }
       return result;
     };
   }
@@ -695,7 +697,9 @@ export class Orchestrator<
     viewerToUse: TViewer,
     rowToUse?: Data,
   ): Promise<TEnt> {
-    if (getTransactionState()) assertTransactionRead(this.fieldPreparationRead);
+    if (getTransactionState()) {
+      assertTransactionRead(this.fieldPreparationRead);
+    }
     if (this.actualOperation !== WriteOperation.Insert) {
       return this.existingEnt!;
     }
@@ -708,7 +712,9 @@ export class Orchestrator<
     }
 
     // we create an unsafe ent to be used for privacy policies
-    if (getTransactionState()) assertTransactionRead(this.fieldPreparationRead);
+    if (getTransactionState()) {
+      assertTransactionRead(this.fieldPreparationRead);
+    }
     const ent = new this.options.builder.ent(viewerToUse, rowToUse);
     recordPreparedEntTransaction(ent, this.fieldPreparationRead);
     return ent;
@@ -846,7 +852,9 @@ export class Orchestrator<
       );
     }
     assertLoaderTransaction(this.transaction);
-    if (this.existingEnt) assertEntTransaction(this.existingEnt);
+    if (this.existingEnt) {
+      assertEntTransaction(this.existingEnt);
+    }
     // existing ent required for edit or delete operations
     switch (this.actualOperation) {
       case WriteOperation.Delete:
@@ -861,9 +869,13 @@ export class Orchestrator<
     const fields = await this.memoizedGetFields();
     // A completed action can expose stable snapshot fields/IDs, but those
     // retained values never become fresh preparation for another save.
-    if (getTransactionState()) assertTransactionRead(this.fieldPreparationRead);
+    if (getTransactionState()) {
+      assertTransactionRead(this.fieldPreparationRead);
+    }
     // A schema transform may replace the original mutation target.
-    if (this.existingEnt) assertEntTransaction(this.existingEnt);
+    if (this.existingEnt) {
+      assertEntTransaction(this.existingEnt);
+    }
     return fields;
   }
 
@@ -1455,7 +1467,9 @@ export class Orchestrator<
       failTransaction(state, error);
       throw error;
     }
-    if (state) this.preparationInProgress = true;
+    if (state) {
+      this.preparationInProgress = true;
+    }
     // A public validation probe must discard each participant's child graph,
     // including retained children that are rebuilt during the later save.
     const probing = state && (validationOnly || isValidationPreparation());
@@ -1485,11 +1499,14 @@ export class Orchestrator<
       if (
         state &&
         !(probing && error instanceof Error && validationFailures.has(error))
-      )
+      ) {
         failTransaction(state, error);
+      }
       throw error;
     } finally {
-      if (state) this.preparationInProgress = false;
+      if (state) {
+        this.preparationInProgress = false;
+      }
       restore?.();
     }
   }
@@ -1546,7 +1563,9 @@ export class Orchestrator<
     // TODO test actualOperation value
     // observers is fine since they're run after and we have the actualOperation value...
 
-    if (getTransactionState()) assertTransactionRead(this.fieldPreparationRead);
+    if (getTransactionState()) {
+      assertTransactionRead(this.fieldPreparationRead);
+    }
     return new EntChangeset(
       this.options.viewer,
       this.options.builder,

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -62,6 +62,7 @@ import {
   getTransactionReadState,
   getTransactionState,
   claimGuardedPreparation,
+  reserveGuardedPreparation,
   runInActionPreparation,
   isPreparingAction,
   isValidationPreparation,
@@ -1650,7 +1651,10 @@ export class Orchestrator<
         async () => {
           const action = this.options.action;
           if (action?.getTransactionResources) {
-            claimGuardedPreparation(await action.getTransactionResources());
+            const resourceRead = reserveGuardedPreparation();
+            const resources = await action.getTransactionResources();
+            assertTransactionRead(resourceRead);
+            claimGuardedPreparation(resources);
           } else if (action?.requiresTransaction?.() && getTransactionState()) {
             claimGuardedPreparation();
           }

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -71,9 +71,9 @@ import {
 } from "../core/transaction_context";
 
 type MaybeNull<T extends Ent> = T | null;
-// Expected validator/privacy failures from child builds remain recoverable
-// during a standalone validation probe. SQL and composition failures still
-// poison the owning transaction.
+// Expected validation and privacy failures in child builds remain recoverable
+// during standalone validation. SQL and composition failures still abort the
+// owning transaction.
 const validationFailures = new WeakSet<Error>();
 type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
 
@@ -300,7 +300,8 @@ export class Orchestrator<
     });
     this.memoizedGetFields = async () => {
       // Defaults and transformations may depend on reads, even for inserts.
-      // Keep stable IDs within an attempt, but never reuse a prior generation.
+      // Keep IDs stable within an attempt, but never reuse a previous
+      // generation.
       // Committed actions can still expose their retained data outside a scope.
       if (
         getTransactionState() &&
@@ -867,8 +868,8 @@ export class Orchestrator<
     }
 
     const fields = await this.memoizedGetFields();
-    // A completed action can expose stable snapshot fields/IDs, but those
-    // retained values never become fresh preparation for another save.
+    // A completed action can expose fields and IDs from its saved snapshot.
+    // Another save must not use those values as fresh preparation.
     if (getTransactionState()) {
       assertTransactionRead(this.fieldPreparationRead);
     }
@@ -1136,8 +1137,9 @@ export class Orchestrator<
       }
       if (transformed.changeset) {
         if (this.transaction) {
-          // Keep transformed fields/defaults stable, but rebuild child graphs
-          // inside each preparation. A standalone validation discards its graph.
+          // Keep transformed fields and defaults stable, but rebuild child
+          // graphs
+          // for each preparation. Standalone validation discards its graph.
           this.transformedChangeset = transformed.changeset.bind(transformed);
         } else {
           const changeset = await transformed.changeset();
@@ -1470,8 +1472,8 @@ export class Orchestrator<
     if (state) {
       this.preparationInProgress = true;
     }
-    // A public validation probe must discard each participant's child graph,
-    // including retained children that are rebuilt during the later save.
+    // Standalone validation must discard each participant's child graph,
+    // including retained children that a later save rebuilds.
     const probing = state && (validationOnly || isValidationPreparation());
     let restore: (() => void) | undefined;
     try {
@@ -1485,9 +1487,11 @@ export class Orchestrator<
             claimGuardedPreparation();
           }
           if (probing) {
-            // Defaults and transformed inputs are memoized once, including any
-            // inverse edges set by updateInput. Snapshot only after those are
-            // established so they survive probes without being applied twice.
+            // Defaults and transformed inputs are memoized once, including
+            // inverse
+            // edges set by updateInput. Take the snapshot after setting those
+            // edges
+            // so validation preserves them without applying them twice.
             await this.prepareFields();
             restore = this.snapshotPreparation();
           }
@@ -1615,8 +1619,8 @@ export class Orchestrator<
       return result;
     } catch (error) {
       // Generated saves load their result after executeOperations returns.
-      // Caught result failures must still roll back the active owning scope;
-      // direct getter failures belong only to their originating scope.
+      // Result failures must roll back the active owning scope even if caught.
+      // Direct getter failures affect only the scope that created the result.
       if (transaction?.active && transaction === this.transaction) {
         failTransaction(transaction, error);
       }

--- a/ts/src/action/orchestrator.ts
+++ b/ts/src/action/orchestrator.ts
@@ -55,14 +55,14 @@ import { isPromise } from "util/types";
 import { RawQueryOperation } from "./operations";
 import {
   awaitActionPreparations,
+  trackValidationRead,
   assertEntTransaction,
   assertLoaderTransaction,
   assertTransactionRead,
   failTransaction,
   getTransactionReadState,
   getTransactionState,
-  claimGuardedPreparation,
-  reserveGuardedPreparation,
+  assertActionPreparationAllowed,
   runInActionPreparation,
   isPreparingAction,
   isValidationPreparation,
@@ -975,10 +975,14 @@ export class Orchestrator<
   }
 
   private async prepareFields(): Promise<fieldsInfo> {
-    const requirement = this.options.action?.requiresTransaction?.();
-    if (requirement && !getTransactionState()) {
+    assertActionPreparationAllowed();
+    const requirement = this.options.action?.requiresTransactionScope?.();
+    if (
+      (requirement || this.options.action?.validateBeforeCommit) &&
+      !getTransactionState()
+    ) {
       throw new Error(
-        "this action requires withTransaction; construct and save the action inside its callback",
+        "this action requires withTransactionScope; construct and save the action inside its callback",
       );
     }
     if (
@@ -986,7 +990,7 @@ export class Orchestrator<
       getTransactionState()?.isolationLevel !== "serializable"
     ) {
       throw new Error(
-        "this action requires a serializable withTransaction scope",
+        "this action requires a serializable withTransactionScope scope",
       );
     }
     assertLoaderTransaction(this.transaction);
@@ -1647,15 +1651,6 @@ export class Orchestrator<
       return await runInActionPreparation(
         this.options.builder,
         async () => {
-          const action = this.options.action;
-          if (action?.getTransactionResources) {
-            const resourceRead = reserveGuardedPreparation();
-            const resources = await action.getTransactionResources();
-            assertTransactionRead(resourceRead);
-            claimGuardedPreparation(resources);
-          } else if (action?.requiresTransaction?.() && getTransactionState()) {
-            claimGuardedPreparation();
-          }
           if (probing) {
             // Memoize defaults and transformed inputs, including inverse edges
             // set by updateInput. Snapshot those edges so validation preserves
@@ -1785,8 +1780,13 @@ export class Orchestrator<
     load: () => Promise<T>,
   ): Promise<T> {
     const transaction = getTransactionState();
+    let pending: Promise<T> | undefined;
     try {
-      const result = await load();
+      pending = trackValidationRead(load());
+      if (transaction === this.transaction) {
+        transaction?.pendingActions.add(pending);
+      }
+      const result = await pending;
       if (result) {
         recordActionResultTransaction(result, this.options.builder);
       }
@@ -1799,6 +1799,10 @@ export class Orchestrator<
         failTransaction(transaction, error);
       }
       throw error;
+    } finally {
+      if (pending && transaction === this.transaction) {
+        transaction?.pendingActions.delete(pending);
+      }
     }
   }
 

--- a/ts/src/action/transaction.ts
+++ b/ts/src/action/transaction.ts
@@ -2,6 +2,10 @@ import { Ent, Viewer, Data } from "../core/base";
 import { Action, Changeset } from "./action";
 import { ComplexExecutor } from "./executor";
 import { EntBuilder } from "./experimental_action";
+import {
+  assertIndependentActionSave,
+  runActionExecution,
+} from "../core/transaction_context";
 
 type MaybeNull<T extends Ent> = T | null;
 type TMaybleNullableEnt<T extends Ent> = T | MaybeNull<T>;
@@ -27,21 +31,24 @@ export class Transaction<TViewer extends Viewer = Viewer> {
   ) {}
 
   async run() {
-    const changesets: Changeset[] = [];
-    await Promise.all(
-      this.actions.map(async (action) => {
-        const c = await action.changeset();
-        changesets.push(c);
-      }),
-    );
+    return runActionExecution(async () => {
+      assertIndependentActionSave();
+      const changesets: Changeset[] = [];
+      await Promise.all(
+        this.actions.map(async (action) => {
+          const c = await action.changeset();
+          changesets.push(c);
+        }),
+      );
 
-    const executor = new ComplexExecutor(
-      this.viewer,
-      "", // no placeholder, no opers
-      [],
-      new Map(),
-      changesets,
-    );
-    await executor.execute();
+      const executor = new ComplexExecutor(
+        this.viewer,
+        "", // no placeholder, no opers
+        [],
+        new Map(),
+        changesets,
+      );
+      await executor.execute();
+    });
   }
 }

--- a/ts/src/action/transaction.ts
+++ b/ts/src/action/transaction.ts
@@ -43,7 +43,7 @@ export class Transaction<TViewer extends Viewer = Viewer> {
 
       const executor = new ComplexExecutor(
         this.viewer,
-        "", // no placeholder, no opers
+        "", // No root placeholder or operations; execute the child changesets.
         [],
         new Map(),
         changesets,

--- a/ts/src/action/transaction_upsert.test.ts
+++ b/ts/src/action/transaction_upsert.test.ts
@@ -3,7 +3,7 @@ import { Allow, Deny, ID } from "../core/base";
 import { Dialect } from "../core/db";
 import { loadEnt, loadEntX } from "../core/ent";
 import { ObjectLoaderFactory } from "../core/loaders";
-import { withTransaction } from "../core/transaction";
+import { withTransactionScope } from "../core/transaction";
 import { BooleanType, IntegerType, StringType } from "../schema";
 import {
   BaseEnt,
@@ -55,7 +55,7 @@ const context = new TestContext();
 const viewer = context.getViewer();
 const load = (id: ID) => loadEntX(viewer, id, options);
 class Guarded extends SimpleAction<UpsertAccount> {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return true;
   }
 }
@@ -85,20 +85,17 @@ function conflict(
   update = false,
 ) {
   const attemptedID = key === "id" ? owner.id : randomUUID();
-  const action = Object.assign(
-    new Guarded(
-      viewer,
-      schema,
-      new Map<string, unknown>([
-        ["id", attemptedID],
-        ["accountKey", owner.data.account_key],
-        ["balance", 100],
-        ["admin", true],
-      ]),
-      WriteOperation.Insert,
-      null,
-    ),
-    { getTransactionResources: () => ["identity"] },
+  const action = new Guarded(
+    viewer,
+    schema,
+    new Map<string, unknown>([
+      ["id", attemptedID],
+      ["accountKey", owner.data.account_key],
+      ["balance", 100],
+      ["admin", true],
+    ]),
+    WriteOperation.Insert,
+    null,
   );
   action.builder.orchestrator.setOnConflictOptions({
     onConflictCols: [key],
@@ -128,12 +125,10 @@ describe.each([
     ["account_key", true],
   ] as const)("conflict on %s with result privacy %s sees final graph writes", async (key, privacy) => {
     const owner = await create();
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const current = await load(owner.id);
       const { action: upsert, attemptedID } = conflict(current, key, update);
-      const writer = Object.assign(edit(current, 80), {
-        getTransactionResources: () => ["balance"],
-      });
+      const writer = edit(current, 80);
       const parent = position === "root" ? upsert : writer;
       const child = position === "root" ? writer : upsert;
       parent.getTriggers = () => [{ changeset: () => child.changeset() }];
@@ -159,7 +154,7 @@ test.each([
 ])("conflict result deleted later in the graph, strict getter %s", async (strict) => {
   const owner = await create();
   let resultFailure: unknown;
-  const transaction = withTransaction(async () => {
+  const transaction = withTransactionScope(async () => {
     const current = await load(owner.id);
     const { action: upsert } = conflict(current, "account_key");
     const parent = new SimpleAction(
@@ -197,7 +192,7 @@ test.each([
   true,
 ])("new row result includes later graph writes, upsert %s", async (upsert) => {
   const id = randomUUID();
-  await withTransaction(async () => {
+  await withTransactionScope(async () => {
     const action = new Guarded(
       viewer,
       schema,
@@ -240,21 +235,14 @@ test.each([
 ])("ordinary child result reflects a later raw sibling write, privacy %s", async (privacy) => {
   const parentOwner = await create();
   const childOwner = await create();
-  await withTransaction(async () => {
-    const parent = Object.assign(edit(await load(parentOwner.id), 80), {
-      getTransactionResources: () => ["parent", "balance"],
-    });
-    const child = Object.assign(
-      new Guarded(
-        viewer,
-        schema,
-        new Map([["admin", true]]),
-        WriteOperation.Edit,
-        await load(childOwner.id),
-      ),
-      {
-        getTransactionResources: () => ["identity"],
-      },
+  await withTransactionScope(async () => {
+    const parent = edit(await load(parentOwner.id), 80);
+    const child = new Guarded(
+      viewer,
+      schema,
+      new Map([["admin", true]]),
+      WriteOperation.Edit,
+      await load(childOwner.id),
     );
     parent.getTriggers = () => [
       {

--- a/ts/src/action/transaction_upsert.test.ts
+++ b/ts/src/action/transaction_upsert.test.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from "crypto";
+import { Allow, Deny, ID } from "../core/base";
+import { Dialect } from "../core/db";
+import { loadEnt, loadEntX } from "../core/ent";
+import { ObjectLoaderFactory } from "../core/loaders";
+import { withTransaction } from "../core/transaction";
+import { BooleanType, IntegerType, StringType } from "../schema";
+import {
+  BaseEnt,
+  SimpleAction,
+  getBuilderSchemaFromFields,
+  getDbFields,
+} from "../testutils/builder";
+import { TestContext } from "../testutils/context/test_context";
+import { getSchemaTable, setupPostgres } from "../testutils/db/temp_db";
+import { WriteOperation } from "./action";
+import { EntChangeset } from "./orchestrator";
+
+let requiredBalance: number | undefined;
+class UpsertAccount extends BaseEnt {
+  nodeType = "UpsertAccount";
+  getPrivacyPolicy() {
+    return {
+      rules: [
+        {
+          apply: async () =>
+            requiredBalance === undefined ||
+            this.data.balance === requiredBalance
+              ? Allow()
+              : Deny(),
+        },
+      ],
+    };
+  }
+}
+const schema = getBuilderSchemaFromFields(
+  {
+    balance: IntegerType(),
+    admin: BooleanType(),
+    accountKey: StringType({ unique: true }),
+  },
+  UpsertAccount,
+);
+const loader = {
+  tableName: "upsert_accounts",
+  fields: getDbFields(schema),
+  key: "id",
+};
+const options = {
+  ...loader,
+  ent: UpsertAccount,
+  loaderFactory: new ObjectLoaderFactory(loader),
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+const load = (id: ID) => loadEntX(viewer, id, options);
+class Guarded extends SimpleAction<UpsertAccount> {
+  requiresTransaction() {
+    return true;
+  }
+}
+const create = () =>
+  new SimpleAction(
+    viewer,
+    schema,
+    new Map<string, unknown>([
+      ["balance", 100],
+      ["admin", false],
+      ["accountKey", randomUUID()],
+    ]),
+    WriteOperation.Insert,
+    null,
+  ).saveX();
+const edit = (ent: UpsertAccount, balance: number) =>
+  new Guarded(
+    viewer,
+    schema,
+    new Map([["balance", balance]]),
+    WriteOperation.Edit,
+    ent,
+  );
+function conflict(
+  owner: UpsertAccount,
+  key: "id" | "account_key",
+  update = false,
+) {
+  const attemptedID = key === "id" ? owner.id : randomUUID();
+  const action = Object.assign(
+    new Guarded(
+      viewer,
+      schema,
+      new Map<string, unknown>([
+        ["id", attemptedID],
+        ["accountKey", owner.data.account_key],
+        ["balance", 100],
+        ["admin", true],
+      ]),
+      WriteOperation.Insert,
+      null,
+    ),
+    { getTransactionResources: () => ["identity"] },
+  );
+  action.builder.orchestrator.setOnConflictOptions({
+    onConflictCols: [key],
+    updateCols: update ? ["admin"] : undefined,
+  });
+  return { action, attemptedID };
+}
+setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
+beforeEach(() => {
+  context.cache.reset();
+  requiredBalance = undefined;
+});
+afterEach(() => {
+  requiredBalance = undefined;
+});
+
+describe.each([
+  ["root", false],
+  ["child", false],
+  ["root", true],
+  ["child", true],
+] as const)("upsert %s result with update %s", (position, update) => {
+  test.each([
+    ["id", false],
+    ["id", true],
+    ["account_key", false],
+    ["account_key", true],
+  ] as const)("conflict on %s with result privacy %s sees final graph writes", async (key, privacy) => {
+    const owner = await create();
+    await withTransaction(async () => {
+      const current = await load(owner.id);
+      const { action: upsert, attemptedID } = conflict(current, key, update);
+      const writer = Object.assign(edit(current, 80), {
+        getTransactionResources: () => ["balance"],
+      });
+      const parent = position === "root" ? upsert : writer;
+      const child = position === "root" ? writer : upsert;
+      parent.getTriggers = () => [{ changeset: () => child.changeset() }];
+      requiredBalance = privacy ? 80 : undefined;
+      await parent.saveX();
+      const result = await upsert.editedEntX();
+      expect(result.id).toBe(owner.id);
+      if (key === "account_key") {
+        expect(result.id).not.toBe(attemptedID);
+      }
+      expect(result.data.balance).toBe(80);
+      expect(result.data.admin).toBe(update);
+      requiredBalance = undefined;
+      await edit(result, result.data.balance - 30).saveX();
+    });
+    expect((await load(owner.id)).data.balance).toBe(50);
+  });
+});
+
+test.each([
+  false,
+  true,
+])("conflict result deleted later in the graph, strict getter %s", async (strict) => {
+  const owner = await create();
+  let resultFailure: unknown;
+  const transaction = withTransaction(async () => {
+    const current = await load(owner.id);
+    const { action: upsert } = conflict(current, "account_key");
+    const parent = new SimpleAction(
+      viewer,
+      schema,
+      new Map(),
+      WriteOperation.Delete,
+      current,
+    );
+    parent.getTriggers = () => [{ changeset: () => upsert.changeset() }];
+    await parent.save();
+    expect(await loadEnt(viewer, owner.id, options)).toBeNull();
+    if (strict) {
+      await upsert.editedEntX().catch((error) => {
+        resultFailure = error;
+      });
+      expect(resultFailure).toBeInstanceOf(Error);
+    } else {
+      expect(await upsert.editedEnt()).toBeNull();
+    }
+  });
+  if (strict) {
+    const transactionFailure = await transaction.catch((error) => error);
+    expect(resultFailure).toBeInstanceOf(Error);
+    expect(transactionFailure).toBe(resultFailure);
+    expect((await load(owner.id)).data.balance).toBe(100);
+  } else {
+    await transaction;
+    expect(await loadEnt(viewer, owner.id, options)).toBeNull();
+  }
+});
+
+test.each([
+  false,
+  true,
+])("new row result includes later graph writes, upsert %s", async (upsert) => {
+  const id = randomUUID();
+  await withTransaction(async () => {
+    const action = new Guarded(
+      viewer,
+      schema,
+      new Map<string, unknown>([
+        ["id", id],
+        ["accountKey", randomUUID()],
+        ["balance", 100],
+        ["admin", false],
+      ]),
+      WriteOperation.Insert,
+      null,
+    );
+    if (upsert) {
+      action.builder.orchestrator.setOnConflictOptions({
+        onConflictCols: ["account_key"],
+      });
+    }
+    action.getTriggers = () => [
+      {
+        changeset: async () =>
+          EntChangeset.changesetFromQueries(action.builder, [
+            {
+              query: "UPDATE upsert_accounts SET balance = $1 WHERE id = $2",
+              values: [80, id],
+            },
+          ]),
+      },
+    ];
+    const result = await action.saveX();
+    expect(result.id).toBe(id);
+    expect(result.data.balance).toBe(80);
+    await edit(result, result.data.balance - 30).saveX();
+  });
+  expect((await load(id)).data.balance).toBe(50);
+});
+
+test.each([
+  false,
+  true,
+])("ordinary child result reflects a later raw sibling write, privacy %s", async (privacy) => {
+  const parentOwner = await create();
+  const childOwner = await create();
+  await withTransaction(async () => {
+    const parent = Object.assign(edit(await load(parentOwner.id), 80), {
+      getTransactionResources: () => ["parent", "balance"],
+    });
+    const child = Object.assign(
+      new Guarded(
+        viewer,
+        schema,
+        new Map([["admin", true]]),
+        WriteOperation.Edit,
+        await load(childOwner.id),
+      ),
+      {
+        getTransactionResources: () => ["identity"],
+      },
+    );
+    parent.getTriggers = () => [
+      {
+        changeset: async () => [
+          await child.changeset(),
+          EntChangeset.changesetFromQueries(parent.builder, [
+            {
+              query: "UPDATE upsert_accounts SET balance = $1 WHERE id = $2",
+              values: [80, childOwner.id],
+            },
+          ]),
+        ],
+      },
+    ];
+    requiredBalance = privacy ? 80 : undefined;
+    await parent.saveX();
+    const result = await child.editedEntX();
+    expect(result.data.balance).toBe(80);
+    expect(result.data.admin).toBe(true);
+    requiredBalance = undefined;
+    await edit(result, result.data.balance - 30).saveX();
+  });
+  expect((await load(childOwner.id)).data.balance).toBe(50);
+});

--- a/ts/src/core/context.ts
+++ b/ts/src/core/context.ts
@@ -20,7 +20,9 @@ export function getContextCache(context?: Context): Context["cache"] {
     scoped = new ContextCache();
     state.caches.set(cache, scoped);
   }
-  return scoped;
+  // Retain cache participation for invalidation after commit, even when final
+  // validation is the first phase to read through this request context.
+  return state.validating ? undefined : scoped;
 }
 
 const DEFAULT_MAX_DISCARDED_LOADERS = 1000;

--- a/ts/src/core/context.ts
+++ b/ts/src/core/context.ts
@@ -6,6 +6,22 @@ import { log } from "./logger";
 import { stableStringify } from "./cache_utils";
 import { getOnQueryCacheHit } from "./metrics";
 import { getOrderByKey, getSelectFieldsKey } from "./query_impl";
+import { getTransactionState } from "./transaction_context";
+
+/** Internal cache boundary shared by all Ent reads and loader factories. */
+export function getContextCache(context?: Context): Context["cache"] {
+  const state = getTransactionState();
+  const cache = context?.cache;
+  if (!state || !cache) {
+    return cache;
+  }
+  let scoped = state.caches.get(cache);
+  if (!scoped) {
+    scoped = new ContextCache();
+    state.caches.set(cache, scoped);
+  }
+  return scoped;
+}
 
 const DEFAULT_MAX_DISCARDED_LOADERS = 1000;
 let maxDiscardedLoaders = DEFAULT_MAX_DISCARDED_LOADERS;

--- a/ts/src/core/db.ts
+++ b/ts/src/core/db.ts
@@ -3,6 +3,7 @@ import { load } from "js-yaml";
 import { DateTime } from "luxon";
 import pg, { Pool, PoolClient, PoolConfig } from "pg";
 import { log } from "./logger";
+import { getTransactionState } from "./transaction_context";
 import type {
   PostgresDriver,
   RuntimeDBExtension,
@@ -497,17 +498,27 @@ export default class DB {
   }
 
   getConnection(): Connection {
+    if (getTransactionState()) {
+      throw new Error(
+        "use getPool() inside withTransaction; raw connections cannot join the scope",
+      );
+    }
     return this.q;
   }
 
   // TODO rename all these...
   getPool(): Queryer {
-    return this.q.self();
+    return getTransactionState()?.queryer ?? this.q.self();
   }
 
   // TODO rename
   // expect to release client as needed
   async getNewClient(): Promise<Client> {
+    if (getTransactionState()) {
+      throw new Error(
+        "use getPool() inside withTransaction; a new client would escape the transaction",
+      );
+    }
     return this.q.newClient();
   }
 

--- a/ts/src/core/db.ts
+++ b/ts/src/core/db.ts
@@ -500,7 +500,7 @@ export default class DB {
   getConnection(): Connection {
     if (getTransactionState()) {
       throw new Error(
-        "use getPool() inside withTransaction; raw connections cannot join the scope",
+        "use getPool() inside withTransactionScope; raw connections cannot join the scope",
       );
     }
     return this.q;
@@ -516,7 +516,7 @@ export default class DB {
   async getNewClient(): Promise<Client> {
     if (getTransactionState()) {
       throw new Error(
-        "use getPool() inside withTransaction; a new client would escape the transaction",
+        "use getPool() inside withTransactionScope; a new client would escape the transaction",
       );
     }
     return this.q.newClient();

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -941,7 +941,9 @@ export async function performRawQuery(
   return performQuery(DB.getInstance().getPool(), query, values, logValues);
 }
 
-/** @internal Execute SQL constructed by framework read loaders without evicting their caches. */
+/**
+ * @internal Execute SQL from framework read loaders and preserve their caches.
+ */
 export async function performReadQuery(
   query: string,
   values: Parameters<Queryer["queryAll"]>[1],

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -40,7 +40,9 @@ import {
   copyEntTransaction,
   getTransactionState,
   recordEntTransaction,
+  recordDerivedEntTransaction,
   recordActionResultTransaction,
+  runTransactionRead,
   trackValidationRead,
 } from "./transaction_context";
 
@@ -744,14 +746,14 @@ export async function loadDerivedEnt<
   data: Data,
   loader: new (viewer: TViewer, data: Data) => TEnt,
 ): Promise<TEnt | null> {
-  const ent = new loader(viewer, data);
-  const r = await applyPrivacyPolicyForEnt(viewer, ent, data, {
-    ent: loader,
+  return runTransactionRead(getTransactionReadState(), async () => {
+    const ent = new loader(viewer, data);
+    recordDerivedEntTransaction(ent, data);
+    const r = await applyPrivacyPolicyForEnt(viewer, ent, data, {
+      ent: loader,
+    });
+    return rowIsError(r) ? null : (r as TEnt | null);
   });
-  if (rowIsError(r)) {
-    return null;
-  }
-  return r as TEnt | null;
 }
 
 // won't have caching yet either
@@ -763,8 +765,11 @@ export async function loadDerivedEntX<
   data: Data,
   loader: new (viewer: TViewer, data: Data) => TEnt,
 ): Promise<TEnt> {
-  const ent = new loader(viewer, data);
-  return applyPrivacyPolicyForEntX(viewer, ent, data, { ent: loader });
+  return runTransactionRead(getTransactionReadState(), async () => {
+    const ent = new loader(viewer, data);
+    recordDerivedEntTransaction(ent, data);
+    return applyPrivacyPolicyForEntX(viewer, ent, data, { ent: loader });
+  });
 }
 
 interface FieldPrivacyOptions<

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -32,6 +32,17 @@ import DB, {
 
 import { applyPrivacyPolicy, applyPrivacyPolicyImpl } from "./privacy";
 import { mapWithConcurrency } from "./async_utils";
+import { getContextCache } from "./context";
+import {
+  assertTransactionRead,
+  getTransactionReadState,
+  recordRowTransaction,
+  copyEntTransaction,
+  getTransactionState,
+  recordEntTransaction,
+  recordActionResultTransaction,
+  trackValidationRead,
+} from "./transaction_context";
 
 import DataLoader from "dataloader";
 import * as clause from "./clause";
@@ -258,14 +269,15 @@ export function getEntLoader<TViewer extends Viewer, TEnt extends Ent<TViewer>>(
   viewer: TViewer,
   options: LoadEntOptions<TEnt, TViewer>,
 ): EntLoader<TViewer, TEnt> {
-  if (!viewer.context?.cache) {
+  const cache = getContextCache(viewer.context);
+  if (!cache) {
     return new EntLoader(viewer, options);
   }
   const name = `ent-loader:${viewer.instanceKey()}:${
     options.loaderFactory.name
   }`;
 
-  return viewer.context.cache.getLoaderWithLoadMany(
+  return cache.getLoaderWithLoadMany(
     name,
     () => new EntLoader(viewer, options),
   ) as EntLoader<TViewer, TEnt>;
@@ -842,9 +854,10 @@ async function doFieldPrivacy<
   await Promise.all(promises);
   if (somethingChanged) {
     // have to create new instance
-    const ent = new options.ent(viewer, clone);
-    ent.__setRawDBData(origData);
-    return ent;
+    const redacted = new options.ent(viewer, clone);
+    copyEntTransaction(ent, redacted);
+    redacted.__setRawDBData(origData);
+    return redacted;
   }
   ent.__setRawDBData(origData);
   return ent;
@@ -875,7 +888,8 @@ export async function loadRowX(options: LoadRowOptions): Promise<Data> {
 
 // primitive data fetching. called by loaders
 export async function loadRow(options: LoadRowOptions): Promise<Data | null> {
-  let cache = options.context?.cache;
+  const read = getTransactionReadState();
+  let cache = getContextCache(options.context);
   if (cache) {
     let row = cache.getCachedRow(options);
     if (row !== null) {
@@ -888,6 +902,8 @@ export async function loadRow(options: LoadRowOptions): Promise<Data | null> {
   const pool = DB.getInstance().getPool();
 
   const res = await pool.query(queryData.query, queryData.values);
+  assertTransactionRead(read);
+  for (const row of res.rows) recordRowTransaction(row, read);
   if (res.rowCount != 1) {
     if (res.rowCount > 1) {
       log("error", "got more than one row for query " + queryData.query);
@@ -915,11 +931,14 @@ export async function performRawQuery(
   values: any[],
   logValues?: any[],
 ): Promise<Data[]> {
+  const read = getTransactionReadState();
   const pool = DB.getInstance().getPool();
 
   logQuery(query, logValues || []);
   try {
     const res = await pool.queryAll(query, values);
+    assertTransactionRead(read);
+    for (const row of res.rows) recordRowTransaction(row, read);
     return res.rows;
   } catch (e) {
     if (_logQueryWithError) {
@@ -934,7 +953,8 @@ export async function performRawQuery(
 
 // TODO this should throw, we can't be hiding errors here
 export async function loadRows(options: LoadRowsOptions): Promise<Data[]> {
-  let cache = options.context?.cache;
+  const read = getTransactionReadState();
+  let cache = getContextCache(options.context);
   if (cache) {
     let rows = cache.getCachedRows(options);
     if (rows !== null) {
@@ -948,6 +968,7 @@ export async function loadRows(options: LoadRowsOptions): Promise<Data[]> {
     queryData.values,
     queryData.logValues,
   );
+  assertTransactionRead(read);
   if (cache) {
     // put the rows in the cache...
     cache.primeCache(options, r);
@@ -1028,7 +1049,7 @@ async function mutateRow(
 ) {
   logQuery(query, logValues);
 
-  let cache = options.context?.cache;
+  let cache = getContextCache(options.context);
   let res: QueryResult<QueryResultRow>;
   try {
     if (isSyncQueryer(queryer)) {
@@ -1058,7 +1079,7 @@ function mutateRowSync(
 ) {
   logQuery(query, logValues);
 
-  let cache = options.context?.cache;
+  let cache = getContextCache(options.context);
   try {
     const res = queryer.execSync(query, values);
     if (cache) {
@@ -1329,7 +1350,6 @@ export function decodeCursorPayload(encoded: string): string {
   return Buffer.from(encoded, "base64").toString("utf8");
 }
 
-
 // TODO eventually update this for sortCol time unique keys
 export function getCursor(opts: cursorOptions) {
   const { row, cursorKeys, rowKeys } = opts;
@@ -1382,13 +1402,31 @@ export const assocEdgeLoader = createAssocEdgeConfigLoader({
   keyType: "uuid",
 });
 
+function getAssocEdgeConfigLoader() {
+  const state = getTransactionState();
+  if (!state) return assocEdgeLoader;
+  let loader = state.resources.get(assocEdgeLoader) as
+    | typeof assocEdgeLoader
+    | undefined;
+  if (!loader) {
+    loader = createAssocEdgeConfigLoader({
+      tableName: "assoc_edge_config",
+      fields: assocEdgeFields,
+      key: "edge_type",
+      keyType: "uuid",
+    });
+    state.resources.set(assocEdgeLoader, loader);
+  }
+  return loader;
+}
+
 // we don't expect assoc_edge_config information to change
 // so not using ContextCache but just caching it as needed once per server
 
 export async function loadEdgeData(
   edgeType: string,
 ): Promise<AssocEdgeData | null> {
-  const row = await assocEdgeLoader.load(edgeType);
+  const row = await getAssocEdgeConfigLoader().load(edgeType);
   if (!row) {
     return null;
   }
@@ -1402,7 +1440,7 @@ export async function loadEdgeDatas(
     return new Map();
   }
 
-  const rows = await assocEdgeLoader.loadMany(edgeTypes);
+  const rows = await getAssocEdgeConfigLoader().loadMany(edgeTypes);
   const m = new Map<string, AssocEdgeData>();
   rows.forEach((row) => {
     if (!row) {
@@ -1695,6 +1733,20 @@ export async function applyPrivacyPolicyForRow<
   return rowIsError(r) ? null : r;
 }
 
+/** @internal Materialize a write result with its originating builder's provenance. */
+export async function applyPrivacyPolicyForActionResult<
+  TEnt extends Ent<TViewer>,
+  TViewer extends Viewer,
+>(
+  viewer: TViewer,
+  options: LoadEntOptions<TEnt, TViewer>,
+  row: Data,
+  builder: object,
+): Promise<TEnt | null> {
+  const r = await applyPrivacyPolicyForRowImpl(viewer, options, row, builder);
+  return rowIsError(r) ? null : r;
+}
+
 async function applyPrivacyPolicyForRowImpl<
   TEnt extends Ent<TViewer>,
   TViewer extends Viewer,
@@ -1702,9 +1754,14 @@ async function applyPrivacyPolicyForRowImpl<
   viewer: TViewer,
   options: LoadEntOptions<TEnt, TViewer>,
   row: Data,
+  resultBuilder?: object,
 ): Promise<TEnt | Error> {
   const ent = new options.ent(viewer, row);
-  return applyPrivacyPolicyForEnt(viewer, ent, row, options);
+  if (resultBuilder) recordActionResultTransaction(ent, resultBuilder);
+  else recordEntTransaction(ent, row);
+  return trackValidationRead(
+    applyPrivacyPolicyForEnt(viewer, ent, row, options),
+  );
 }
 
 async function applyPrivacyPolicyForRowX<
@@ -1716,7 +1773,10 @@ async function applyPrivacyPolicyForRowX<
   row: Data,
 ): Promise<TEnt> {
   const ent = new options.ent(viewer, row);
-  return applyPrivacyPolicyForEntX(viewer, ent, row, options);
+  recordEntTransaction(ent, row);
+  return trackValidationRead(
+    applyPrivacyPolicyForEntX(viewer, ent, row, options),
+  );
 }
 
 // deprecated. doesn't use entcache

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -903,7 +903,9 @@ export async function loadRow(options: LoadRowOptions): Promise<Data | null> {
 
   const res = await pool.query(queryData.query, queryData.values);
   assertTransactionRead(read);
-  for (const row of res.rows) recordRowTransaction(row, read);
+  for (const row of res.rows) {
+    recordRowTransaction(row, read);
+  }
   if (res.rowCount != 1) {
     if (res.rowCount > 1) {
       log("error", "got more than one row for query " + queryData.query);
@@ -938,7 +940,9 @@ export async function performRawQuery(
   try {
     const res = await pool.queryAll(query, values);
     assertTransactionRead(read);
-    for (const row of res.rows) recordRowTransaction(row, read);
+    for (const row of res.rows) {
+      recordRowTransaction(row, read);
+    }
     return res.rows;
   } catch (e) {
     if (_logQueryWithError) {
@@ -1404,7 +1408,9 @@ export const assocEdgeLoader = createAssocEdgeConfigLoader({
 
 function getAssocEdgeConfigLoader() {
   const state = getTransactionState();
-  if (!state) return assocEdgeLoader;
+  if (!state) {
+    return assocEdgeLoader;
+  }
   let loader = state.resources.get(assocEdgeLoader) as
     | typeof assocEdgeLoader
     | undefined;
@@ -1757,8 +1763,11 @@ async function applyPrivacyPolicyForRowImpl<
   resultBuilder?: object,
 ): Promise<TEnt | Error> {
   const ent = new options.ent(viewer, row);
-  if (resultBuilder) recordActionResultTransaction(ent, resultBuilder);
-  else recordEntTransaction(ent, row);
+  if (resultBuilder) {
+    recordActionResultTransaction(ent, resultBuilder);
+  } else {
+    recordEntTransaction(ent, row);
+  }
   return trackValidationRead(
     applyPrivacyPolicyForEnt(viewer, ent, row, options),
   );

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -1739,7 +1739,10 @@ export async function applyPrivacyPolicyForRow<
   return rowIsError(r) ? null : r;
 }
 
-/** @internal Materialize a write result with its originating builder's provenance. */
+/**
+ * @internal Create an Ent from a write result using its builder's transaction
+ * and generation.
+ */
 export async function applyPrivacyPolicyForActionResult<
   TEnt extends Ent<TViewer>,
   TViewer extends Viewer,

--- a/ts/src/core/ent.ts
+++ b/ts/src/core/ent.ts
@@ -1,3 +1,4 @@
+import type { Builder } from "../action/action";
 import {
   Context,
   CreateRowOptions,
@@ -40,7 +41,6 @@ import {
   copyEntTransaction,
   getTransactionState,
   recordEntTransaction,
-  recordDerivedEntTransaction,
   recordActionResultTransaction,
   runTransactionRead,
   trackValidationRead,
@@ -333,7 +333,7 @@ async function applyPrivacyPolicyForRowAndStoreInEntLoader<
   // TODO hmm... we eventually need a custom data-loader for this too so that it's all done correctly if there's a complicated fetch deep down in graphql
   const result = loader.getMap().get(id);
   if (result !== undefined) {
-    return result;
+    return runTransactionRead(getTransactionReadState(), async () => result);
   }
 
   const r = await applyPrivacyPolicyForRowImpl(viewer, options, row);
@@ -748,7 +748,7 @@ export async function loadDerivedEnt<
 ): Promise<TEnt | null> {
   return runTransactionRead(getTransactionReadState(), async () => {
     const ent = new loader(viewer, data);
-    recordDerivedEntTransaction(ent, data);
+    recordEntTransaction(ent, data);
     const r = await applyPrivacyPolicyForEnt(viewer, ent, data, {
       ent: loader,
     });
@@ -767,7 +767,7 @@ export async function loadDerivedEntX<
 ): Promise<TEnt> {
   return runTransactionRead(getTransactionReadState(), async () => {
     const ent = new loader(viewer, data);
-    recordDerivedEntTransaction(ent, data);
+    recordEntTransaction(ent, data);
     return applyPrivacyPolicyForEntX(viewer, ent, data, { ent: loader });
   });
 }
@@ -904,7 +904,7 @@ export async function loadRow(options: LoadRowOptions): Promise<Data | null> {
 
   const queryData = buildQueryData(options);
   logQuery(queryData.query, queryData.logValues);
-  const pool = DB.getInstance().getPool();
+  const pool = getTransactionState()?.readQueryer ?? DB.getInstance().getPool();
 
   const res = await pool.query(queryData.query, queryData.values);
   assertTransactionRead(read);
@@ -938,9 +938,26 @@ export async function performRawQuery(
   values: any[],
   logValues?: any[],
 ): Promise<Data[]> {
-  const read = getTransactionReadState();
-  const pool = DB.getInstance().getPool();
+  return performQuery(DB.getInstance().getPool(), query, values, logValues);
+}
 
+/** @internal Execute SQL constructed by framework read loaders without evicting their caches. */
+export async function performReadQuery(
+  query: string,
+  values: Parameters<Queryer["queryAll"]>[1],
+  logValues?: Parameters<Queryer["queryAll"]>[1],
+): Promise<Data[]> {
+  const pool = getTransactionState()?.readQueryer ?? DB.getInstance().getPool();
+  return performQuery(pool, query, values, logValues);
+}
+
+async function performQuery(
+  pool: Pick<Queryer, "queryAll">,
+  query: string,
+  values: Parameters<Queryer["queryAll"]>[1],
+  logValues?: Parameters<Queryer["queryAll"]>[1],
+): Promise<Data[]> {
+  const read = getTransactionReadState();
   logQuery(query, logValues || []);
   try {
     const res = await pool.queryAll(query, values);
@@ -972,7 +989,7 @@ export async function loadRows(options: LoadRowsOptions): Promise<Data[]> {
   }
 
   const queryData = buildQueryData(options);
-  const r = await performRawQuery(
+  const r = await performReadQuery(
     queryData.query,
     queryData.values,
     queryData.logValues,
@@ -1416,9 +1433,7 @@ function getAssocEdgeConfigLoader() {
   if (!state) {
     return assocEdgeLoader;
   }
-  let loader = state.resources.get(assocEdgeLoader) as
-    | typeof assocEdgeLoader
-    | undefined;
+  let loader = state.edgeMetadataLoader;
   if (!loader) {
     loader = createAssocEdgeConfigLoader({
       tableName: "assoc_edge_config",
@@ -1426,7 +1441,7 @@ function getAssocEdgeConfigLoader() {
       key: "edge_type",
       keyType: "uuid",
     });
-    state.resources.set(assocEdgeLoader, loader);
+    state.edgeMetadataLoader = loader;
   }
   return loader;
 }
@@ -1755,7 +1770,7 @@ export async function applyPrivacyPolicyForActionResult<
   viewer: TViewer,
   options: LoadEntOptions<TEnt, TViewer>,
   row: Data,
-  builder: object,
+  builder: Builder<TEnt, TViewer>,
 ): Promise<TEnt | null> {
   const r = await applyPrivacyPolicyForRowImpl(viewer, options, row, builder);
   return rowIsError(r) ? null : r;
@@ -1768,17 +1783,22 @@ async function applyPrivacyPolicyForRowImpl<
   viewer: TViewer,
   options: LoadEntOptions<TEnt, TViewer>,
   row: Data,
-  resultBuilder?: object,
+  resultBuilder?: Builder<TEnt, TViewer>,
 ): Promise<TEnt | Error> {
-  const ent = new options.ent(viewer, row);
-  if (resultBuilder) {
-    recordActionResultTransaction(ent, resultBuilder);
-  } else {
-    recordEntTransaction(ent, row);
-  }
-  return trackValidationRead(
-    applyPrivacyPolicyForEnt(viewer, ent, row, options),
-  );
+  const materialize = async () => {
+    const ent = new options.ent(viewer, row);
+    if (resultBuilder) {
+      recordActionResultTransaction(ent, resultBuilder);
+    } else {
+      recordEntTransaction(ent, row);
+    }
+    return applyPrivacyPolicyForEnt(viewer, ent, row, options);
+  };
+  // Saved results retain their owning write's provenance, including when a
+  // caller inspects them after commit. Normal row conversions are scoped reads.
+  return resultBuilder
+    ? trackValidationRead(materialize())
+    : runTransactionRead(getTransactionReadState(), materialize);
 }
 
 async function applyPrivacyPolicyForRowX<
@@ -1789,11 +1809,11 @@ async function applyPrivacyPolicyForRowX<
   options: LoadEntOptions<TEnt, TViewer>,
   row: Data,
 ): Promise<TEnt> {
-  const ent = new options.ent(viewer, row);
-  recordEntTransaction(ent, row);
-  return trackValidationRead(
-    applyPrivacyPolicyForEntX(viewer, ent, row, options),
-  );
+  return runTransactionRead(getTransactionReadState(), async () => {
+    const ent = new options.ent(viewer, row);
+    recordEntTransaction(ent, row);
+    return applyPrivacyPolicyForEntX(viewer, ent, row, options);
+  });
 }
 
 // deprecated. doesn't use entcache

--- a/ts/src/core/loaders/assoc_count_loader.ts
+++ b/ts/src/core/loaders/assoc_count_loader.ts
@@ -1,3 +1,7 @@
+import {
+  getTransactionReadState,
+  runTransactionRead,
+} from "../transaction_context";
 import DataLoader from "dataloader";
 import {
   ID,
@@ -14,9 +18,10 @@ import {
 import * as clause from "../clause";
 import { getCustomLoader, getLoader } from "./loader";
 import { createCountDataLoader } from "./raw_count_loader";
-import { memoizeNoArgs } from "../memoize";
+import { memoizeInTransaction as memoizeNoArgs } from "../memoize";
 
 export class AssocEdgeCountLoader implements Loader<ID, number> {
+  private transactionRead = getTransactionReadState();
   private loaderFn: () => Promise<DataLoader<ID, number>>;
   private loader: DataLoader<ID, number> | undefined;
 
@@ -54,15 +59,17 @@ export class AssocEdgeCountLoader implements Loader<ID, number> {
   }
 
   async load(id: ID): Promise<number> {
-    if (!this.loaderFn) {
-      return loadRawEdgeCountX({
-        id1: id,
-        edgeType: this.edgeType,
-        queryOptions: this.options,
-      });
-    }
-    const loader = await this.loaderFn();
-    return loader.load(id);
+    return runTransactionRead(this.transactionRead, async () => {
+      if (!this.loaderFn) {
+        return loadRawEdgeCountX({
+          id1: id,
+          edgeType: this.edgeType,
+          queryOptions: this.options,
+        });
+      }
+      const loader = await this.loaderFn();
+      return loader.load(id);
+    });
   }
 
   clearAll() {

--- a/ts/src/core/loaders/assoc_edge_loader.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.ts
@@ -22,7 +22,7 @@ import {
   loadEdgeData,
   loadEdgeForID2,
   loadTwoWayEdges,
-  performRawQuery,
+  performReadQuery,
 } from "../ent";
 import { stableStringify } from "../cache_utils";
 import { memoizeInTransaction as memoizeNoArgs } from "../memoize";
@@ -114,7 +114,7 @@ function createLoader<T extends AssocEdge>(
         clause: cls1,
       });
 
-      const rows = await performRawQuery(query, cls.values(), cls.logValues());
+      const rows = await performReadQuery(query, cls.values(), cls.logValues());
       for (const row of rows) {
         const srcID = row.id1;
         const idx = m.get(srcID);

--- a/ts/src/core/loaders/assoc_edge_loader.ts
+++ b/ts/src/core/loaders/assoc_edge_loader.ts
@@ -1,3 +1,7 @@
+import {
+  getTransactionReadState,
+  runTransactionRead,
+} from "../transaction_context";
 import DataLoader from "dataloader";
 import {
   Context,
@@ -21,7 +25,7 @@ import {
   performRawQuery,
 } from "../ent";
 import { stableStringify } from "../cache_utils";
-import { memoizeNoArgs } from "../memoize";
+import { memoizeInTransaction as memoizeNoArgs } from "../memoize";
 import { getOrderByKey, OrderBy } from "../query_impl";
 import {
   createLoaderCacheMap,
@@ -136,6 +140,7 @@ export interface AssocLoader<T extends AssocEdge> extends Loader<ID, T[]> {
 }
 
 export class AssocEdgeLoader<T extends AssocEdge> implements Loader<ID, T[]> {
+  private transactionRead = getTransactionReadState();
   private loaderFn: () => Promise<DataLoader<ID, T[]>>;
   private loader: DataLoader<ID, T[]> | undefined;
   constructor(
@@ -163,29 +168,35 @@ export class AssocEdgeLoader<T extends AssocEdge> implements Loader<ID, T[]> {
   }
 
   async load(id: ID): Promise<T[]> {
-    const loader = await this.loaderFn();
-    return loader.load(id);
+    return runTransactionRead(this.transactionRead, async () => {
+      const loader = await this.loaderFn();
+      return loader.load(id);
+    });
   }
 
   async loadTwoWay(id: ID): Promise<T[]> {
-    return loadTwoWayEdges({
-      ctr: this.edgeCtr,
-      id1: id,
-      edgeType: this.edgeType,
-      context: this.context,
-      queryOptions: this.options,
+    return runTransactionRead(this.transactionRead, async () => {
+      return loadTwoWayEdges({
+        ctr: this.edgeCtr,
+        id1: id,
+        edgeType: this.edgeType,
+        context: this.context,
+        queryOptions: this.options,
+      });
     });
   }
 
   // maybe eventually optimize this
   async loadEdgeForID2(id: ID, id2: ID) {
-    return loadEdgeForID2({
-      id1: id,
-      edgeType: this.edgeType,
-      id2,
-      context: this.context,
-      ctr: this.edgeCtr,
-      queryOptions: this.options,
+    return runTransactionRead(this.transactionRead, async () => {
+      return loadEdgeForID2({
+        id1: id,
+        edgeType: this.edgeType,
+        id2,
+        context: this.context,
+        ctr: this.edgeCtr,
+        queryOptions: this.options,
+      });
     });
   }
 
@@ -197,6 +208,7 @@ export class AssocEdgeLoader<T extends AssocEdge> implements Loader<ID, T[]> {
 export class AssocDirectEdgeLoader<T extends AssocEdge>
   implements Loader<ID, T[]>
 {
+  private transactionRead = getTransactionReadState();
   private loader: DataLoader<ID, T[]> | undefined;
   private loaderFn: (() => Promise<DataLoader<ID, T[]>>) | undefined;
   constructor(
@@ -246,37 +258,43 @@ export class AssocDirectEdgeLoader<T extends AssocEdge>
   }
 
   async load(id: ID) {
-    if (this.loaderFn) {
-      const loader = await this.loaderFn();
-      return loader.load(id);
-    }
-    return loadCustomEdges({
-      id1: id,
-      edgeType: this.edgeType,
-      context: this.context,
-      queryOptions: this.options,
-      ctr: this.edgeCtr,
+    return runTransactionRead(this.transactionRead, async () => {
+      if (this.loaderFn) {
+        const loader = await this.loaderFn();
+        return loader.load(id);
+      }
+      return loadCustomEdges({
+        id1: id,
+        edgeType: this.edgeType,
+        context: this.context,
+        queryOptions: this.options,
+        ctr: this.edgeCtr,
+      });
     });
   }
 
   async loadTwoWay(id: ID): Promise<T[]> {
-    return loadTwoWayEdges({
-      ctr: this.edgeCtr,
-      id1: id,
-      edgeType: this.edgeType,
-      context: this.context,
-      queryOptions: this.options,
+    return runTransactionRead(this.transactionRead, async () => {
+      return loadTwoWayEdges({
+        ctr: this.edgeCtr,
+        id1: id,
+        edgeType: this.edgeType,
+        context: this.context,
+        queryOptions: this.options,
+      });
     });
   }
 
   async loadEdgeForID2(id: ID, id2: ID) {
-    return loadEdgeForID2({
-      id1: id,
-      edgeType: this.edgeType,
-      id2,
-      context: this.context,
-      queryOptions: this.options,
-      ctr: this.edgeCtr,
+    return runTransactionRead(this.transactionRead, async () => {
+      return loadEdgeForID2({
+        id1: id,
+        edgeType: this.edgeType,
+        id2,
+        context: this.context,
+        queryOptions: this.options,
+        ctr: this.edgeCtr,
+      });
     });
   }
 

--- a/ts/src/core/loaders/loader.ts
+++ b/ts/src/core/loaders/loader.ts
@@ -134,7 +134,9 @@ export class InstrumentedDataLoader<K, V> extends DataLoader<K, V> {
   load(key: K): Promise<V> {
     assertTransactionRead(this.transaction);
     const result = super.load(key);
-    if (!this.transaction) return result;
+    if (!this.transaction) {
+      return result;
+    }
     return trackValidationRead(
       result.then((value) => {
         assertTransactionRead(this.transaction);
@@ -146,7 +148,9 @@ export class InstrumentedDataLoader<K, V> extends DataLoader<K, V> {
   loadMany(keys: ArrayLike<K>): Promise<(V | Error)[]> {
     assertTransactionRead(this.transaction);
     const result = super.loadMany(keys);
-    if (!this.transaction) return result;
+    if (!this.transaction) {
+      return result;
+    }
     return trackValidationRead(
       result.then((value) => {
         assertTransactionRead(this.transaction);

--- a/ts/src/core/loaders/loader.ts
+++ b/ts/src/core/loaders/loader.ts
@@ -7,6 +7,7 @@ import {
   assertTransactionRead,
   getTransactionReadState,
   trackValidationRead,
+  isFinalScopeValidation,
 } from "../transaction_context";
 
 const DEFAULT_MAX_BATCH_SIZE = 1000;
@@ -191,7 +192,12 @@ export class InstrumentedDataLoader<K, V> extends DataLoader<K, V> {
     );
     const loaderOptions =
       cacheMap === options.cacheMap ? options : { ...options, cacheMap };
-    super(wrappedBatchFn, loaderOptions);
+    super(
+      wrappedBatchFn,
+      isFinalScopeValidation()
+        ? { ...loaderOptions, cache: false }
+        : loaderOptions,
+    );
   }
 }
 

--- a/ts/src/core/loaders/loader.ts
+++ b/ts/src/core/loaders/loader.ts
@@ -2,6 +2,12 @@ import DataLoader from "dataloader";
 import { Loader, LoaderFactory, Context, DataOptions } from "../base";
 import { log, logEnabled } from "../logger";
 import { getOnDataLoaderBatch, getOnDataLoaderCacheHit } from "../metrics";
+import { getContextCache } from "../context";
+import {
+  assertTransactionRead,
+  getTransactionReadState,
+  trackValidationRead,
+} from "../transaction_context";
 
 const DEFAULT_MAX_BATCH_SIZE = 1000;
 let loaderMaxBatchSize = DEFAULT_MAX_BATCH_SIZE;
@@ -48,13 +54,14 @@ export function getLoader<K, V>(
   context?: Context,
 ): Loader<K, V> {
   // just create a new one every time if no context cache
-  if (!context?.cache) {
+  const cache = getContextCache(context);
+  if (!cache) {
     log("debug", `new loader created for ${factory.name}`);
     return create();
   }
 
   // g|set from context cache
-  return context.cache.getLoader(factory.name, create);
+  return cache.getLoader(factory.name, create);
 }
 
 export function getCustomLoader<K, V>(
@@ -63,13 +70,14 @@ export function getCustomLoader<K, V>(
   context?: Context,
 ): Loader<K, V> {
   // just create a new one every time if no context cache
-  if (!context?.cache) {
+  const cache = getContextCache(context);
+  if (!cache) {
     log("debug", `new loader created for ${key}`);
     return create();
   }
 
   // g|set from context cache
-  return context.cache.getLoader(key, create);
+  return cache.getLoader(key, create);
 }
 
 export type CacheMapLike<K, V> = {
@@ -121,6 +129,37 @@ function instrumentCacheMap<K, V>(
 }
 
 export class InstrumentedDataLoader<K, V> extends DataLoader<K, V> {
+  private transaction = getTransactionReadState();
+
+  load(key: K): Promise<V> {
+    assertTransactionRead(this.transaction);
+    const result = super.load(key);
+    if (!this.transaction) return result;
+    return trackValidationRead(
+      result.then((value) => {
+        assertTransactionRead(this.transaction);
+        return value;
+      }),
+    );
+  }
+
+  loadMany(keys: ArrayLike<K>): Promise<(V | Error)[]> {
+    assertTransactionRead(this.transaction);
+    const result = super.loadMany(keys);
+    if (!this.transaction) return result;
+    return trackValidationRead(
+      result.then((value) => {
+        assertTransactionRead(this.transaction);
+        return value;
+      }),
+    );
+  }
+
+  prime(key: K, value: V | PromiseLike<V> | Error): this {
+    assertTransactionRead(this.transaction);
+    return super.prime(key, value);
+  }
+
   constructor(
     loaderName: string,
     batchLoadFn: BatchLoadFn<K, V>,

--- a/ts/src/core/loaders/object_loader.ts
+++ b/ts/src/core/loaders/object_loader.ts
@@ -1,3 +1,7 @@
+import {
+  getTransactionReadState,
+  runTransactionRead,
+} from "../transaction_context";
 import DataLoader from "dataloader";
 import {
   LoadRowOptions,
@@ -24,7 +28,7 @@ import {
   getCustomLoader,
   getLoaderMaxBatchSize,
 } from "./loader";
-import { memoizeNoArgs } from "../memoize";
+import { memoizeInTransaction as memoizeNoArgs } from "../memoize";
 
 const DEFAULT_CLAUSE_LOADER_CONCURRENCY = 10;
 let clauseLoaderConcurrency = DEFAULT_CLAUSE_LOADER_CONCURRENCY;
@@ -273,6 +277,7 @@ export class ObjectLoader<
     Loader<ID, TResultData | null>,
     Loader<clause.Clause<TQueryData, K>, TResultData[] | null>
 {
+  private transactionRead = getTransactionReadState();
   private idLoader: DataLoader<ID, TResultData> | undefined;
   private clauseLoader: DataLoader<
     clause.Clause<TQueryData, K>,
@@ -324,11 +329,13 @@ export class ObjectLoader<
   async load(
     key: clause.Clause<TQueryData, K> | ID,
   ): Promise<TResultData | TResultData[] | null> {
-    if (typeof key === "string" || typeof key === "number") {
-      return this.loadID(key);
-    }
+    return runTransactionRead(this.transactionRead, async () => {
+      if (typeof key === "string" || typeof key === "number") {
+        return this.loadID(key);
+      }
 
-    return this.loadClause(key);
+      return this.loadClause(key);
+    });
   }
 
   private async loadID(key: ID): Promise<TResultData | null> {
@@ -381,15 +388,17 @@ export class ObjectLoader<
   async loadMany(
     keys: ID[] | clause.Clause<TQueryData, K>[],
   ): Promise<Array<TResultData | TResultData[] | null>> {
-    if (!keys.length) {
-      return [];
-    }
+    return runTransactionRead(this.transactionRead, async () => {
+      if (!keys.length) {
+        return [];
+      }
 
-    if (typeof keys[0] === "string" || typeof keys[0] === "number") {
-      return this.loadIDMany(keys as ID[]);
-    }
+      if (typeof keys[0] === "string" || typeof keys[0] === "number") {
+        return this.loadIDMany(keys as ID[]);
+      }
 
-    return this.loadClauseMany(keys as clause.Clause<TQueryData, K>[]);
+      return this.loadClauseMany(keys as clause.Clause<TQueryData, K>[]);
+    });
   }
 
   private loadIDMany(keys: ID[]): Promise<Array<TResultData | null>> {
@@ -444,6 +453,7 @@ export class ObjectLoader<
 export class ObjectCountLoader<V extends Data = Data, K = keyof V>
   implements Loader<clause.Clause<V, K>, number>
 {
+  private transactionRead = getTransactionReadState();
   private loader: DataLoader<clause.Clause<V, K>, number> | null;
 
   constructor(
@@ -460,10 +470,12 @@ export class ObjectCountLoader<V extends Data = Data, K = keyof V>
   }
 
   async load(key: clause.Clause<V, K>): Promise<number> {
-    if (this.loader) {
-      return this.loader.load(key);
-    }
-    return loadCountForClauseLoader(this.options, key, this.context);
+    return runTransactionRead(this.transactionRead, async () => {
+      if (this.loader) {
+        return this.loader.load(key);
+      }
+      return loadCountForClauseLoader(this.options, key, this.context);
+    });
   }
 
   clearAll() {
@@ -471,16 +483,21 @@ export class ObjectCountLoader<V extends Data = Data, K = keyof V>
   }
 
   async loadMany(keys: clause.Clause<V, K>[]): Promise<Array<number>> {
-    if (!keys.length) {
-      return [];
-    }
-    if (this.loader) {
-      // @ts-expect-error
-      return this.loader.loadMany(keys);
-    }
+    return runTransactionRead(
+      this.transactionRead,
+      async (): Promise<number[]> => {
+        if (!keys.length) {
+          return [];
+        }
+        if (this.loader) {
+          // @ts-expect-error
+          return this.loader.loadMany(keys);
+        }
 
-    return mapWithConcurrency(keys, clauseLoaderConcurrency, (key) =>
-      loadCountForClauseLoader(this.options, key, this.context),
+        return mapWithConcurrency(keys, clauseLoaderConcurrency, (key) =>
+          loadCountForClauseLoader(this.options, key, this.context),
+        );
+      },
     );
   }
 }

--- a/ts/src/core/loaders/query_loader.ts
+++ b/ts/src/core/loaders/query_loader.ts
@@ -17,7 +17,7 @@ import {
   buildGroupQuery,
   getDefaultLimit,
   loadRows,
-  performRawQuery,
+  performReadQuery,
 } from "../ent";
 import { stableStringify } from "../cache_utils";
 import { memoizeInTransaction as memoizeNoArgs } from "../memoize";
@@ -140,7 +140,7 @@ function createLoader<K extends any>(
         clause: extraClause,
       });
 
-      const rows = await performRawQuery(
+      const rows = await performReadQuery(
         query,
         cls2.values(),
         cls2.logValues(),

--- a/ts/src/core/loaders/query_loader.ts
+++ b/ts/src/core/loaders/query_loader.ts
@@ -1,3 +1,7 @@
+import {
+  getTransactionReadState,
+  runTransactionRead,
+} from "../transaction_context";
 import DataLoader from "dataloader";
 import {
   Context,
@@ -16,7 +20,7 @@ import {
   performRawQuery,
 } from "../ent";
 import { stableStringify } from "../cache_utils";
-import { memoizeNoArgs } from "../memoize";
+import { memoizeInTransaction as memoizeNoArgs } from "../memoize";
 import { getOrderByKey, OrderBy, orderByHasExpressions } from "../query_impl";
 import {
   createLoaderCacheMap,
@@ -81,8 +85,8 @@ function createLoader<K extends any>(
   const loaderName = options.groupCol
     ? `queryLoader:${options.tableName}:${options.groupCol}`
     : options.clause
-      ? `queryLoader:${options.tableName}:${options.clause.instanceKey()}`
-      : `queryLoader:${options.tableName}`;
+    ? `queryLoader:${options.tableName}:${options.clause.instanceKey()}`
+    : `queryLoader:${options.tableName}`;
   const loaderOptions: DataLoader.Options<K, Data[]> = {
     maxBatchSize: getLoaderMaxBatchSize(),
     cacheMap: createLoaderCacheMap(options),
@@ -160,6 +164,7 @@ function createLoader<K extends any>(
 }
 
 class QueryDirectLoader<K extends any> implements Loader<K, Data[]> {
+  private transactionRead = getTransactionReadState();
   private memoizedInitPrime: () => void;
   private primedLoaders:
     | Map<string, PrimableLoader<any, Data | null>>
@@ -188,26 +193,28 @@ class QueryDirectLoader<K extends any> implements Loader<K, Data[]> {
   }
 
   async load(id: K): Promise<Data[]> {
-    const rows = await simpleCase(
-      this.options,
-      id,
-      this.queryOptions,
-      this.context,
-    );
-    if (this.context) {
-      this.memoizedInitPrime();
-      if (this.primedLoaders) {
-        for (const row of rows) {
-          for (const [key, loader] of this.primedLoaders) {
-            const value = row[key];
-            if (value !== undefined) {
-              loader.prime(row);
+    return runTransactionRead(this.transactionRead, async () => {
+      const rows = await simpleCase(
+        this.options,
+        id,
+        this.queryOptions,
+        this.context,
+      );
+      if (this.context) {
+        this.memoizedInitPrime();
+        if (this.primedLoaders) {
+          for (const row of rows) {
+            for (const [key, loader] of this.primedLoaders) {
+              const value = row[key];
+              if (value !== undefined) {
+                loader.prime(row);
+              }
             }
           }
         }
       }
-    }
-    return rows;
+      return rows;
+    });
   }
 
   clearAll() {}
@@ -216,6 +223,7 @@ class QueryDirectLoader<K extends any> implements Loader<K, Data[]> {
 // note, you should never call this directly
 // there's scenarios where QueryDirectLoader is needed instead of this...
 class QueryLoader<K extends any> implements Loader<K, Data[]> {
+  private transactionRead = getTransactionReadState();
   private loader: DataLoader<K, Data[]> | undefined;
   private primedLoaders:
     | Map<string, PrimableLoader<any, Data | null>>
@@ -248,23 +256,25 @@ class QueryLoader<K extends any> implements Loader<K, Data[]> {
   }
 
   async load(id: K): Promise<Data[]> {
-    if (this.loader) {
-      this.memoizedInitPrime();
-      const rows = await this.loader.load(id);
-      if (this.primedLoaders) {
-        for (const row of rows) {
-          for (const [key, loader] of this.primedLoaders) {
-            const value = row[key];
-            if (value !== undefined) {
-              loader.prime(row);
+    return runTransactionRead(this.transactionRead, async () => {
+      if (this.loader) {
+        this.memoizedInitPrime();
+        const rows = await this.loader.load(id);
+        if (this.primedLoaders) {
+          for (const row of rows) {
+            for (const [key, loader] of this.primedLoaders) {
+              const value = row[key];
+              if (value !== undefined) {
+                loader.prime(row);
+              }
             }
           }
         }
+        return rows;
       }
-      return rows;
-    }
 
-    return simpleCase(this.options, id, this.queryOptions, this.context);
+      return simpleCase(this.options, id, this.queryOptions, this.context);
+    });
   }
 
   clearAll() {

--- a/ts/src/core/loaders/raw_count_loader.ts
+++ b/ts/src/core/loaders/raw_count_loader.ts
@@ -1,3 +1,7 @@
+import {
+  getTransactionReadState,
+  runTransactionRead,
+} from "../transaction_context";
 import DataLoader from "dataloader";
 import {
   LoadRowOptions,
@@ -63,8 +67,8 @@ export function createCountDataLoader<K extends any>(
   const loaderName = options.groupCol
     ? `rawCountLoader:${options.tableName}:${options.groupCol}`
     : options.clause
-      ? `rawCountLoader:${options.tableName}:${options.clause.instanceKey()}`
-      : `rawCountLoader:${options.tableName}`;
+    ? `rawCountLoader:${options.tableName}:${options.clause.instanceKey()}`
+    : `rawCountLoader:${options.tableName}`;
   const loaderOptions: DataLoader.Options<K, number> = {
     maxBatchSize: getLoaderMaxBatchSize(),
     cacheMap: createLoaderCacheMap(options),
@@ -126,6 +130,7 @@ export function createCountDataLoader<K extends any>(
 // for now this only works for single column counts
 // e.g. foreign key count
 export class RawCountLoader<K extends any> implements Loader<K, number> {
+  private transactionRead = getTransactionReadState();
   private loader: DataLoader<K, number> | undefined;
   // tableName, columns
   constructor(
@@ -138,12 +143,14 @@ export class RawCountLoader<K extends any> implements Loader<K, number> {
   }
 
   async load(id: K): Promise<number> {
-    if (this.loader) {
-      return this.loader.load(id);
-    }
+    return runTransactionRead(this.transactionRead, async () => {
+      if (this.loader) {
+        return this.loader.load(id);
+      }
 
-    const rows = await simpleCase(this.options, id, this.context);
-    return rows[0];
+      const rows = await simpleCase(this.options, id, this.context);
+      return rows[0];
+    });
   }
 
   clearAll() {

--- a/ts/src/core/memoize.ts
+++ b/ts/src/core/memoize.ts
@@ -1,3 +1,9 @@
+import { isPromise } from "util/types";
+import {
+  assertTransactionRead,
+  getTransactionReadState,
+} from "./transaction_context";
+
 export function memoizeNoArgs<T>(fn: () => T): () => T {
   let called = false;
   let value: T;
@@ -9,5 +15,23 @@ export function memoizeNoArgs<T>(fn: () => T): () => T {
     value = fn();
     called = true;
     return value;
+  };
+}
+
+// Cached query/loader state cannot cross scopes. Ordinary builder field
+// memoization remains readable by post-commit observers and result callers.
+export function memoizeInTransaction<T>(fn: () => T): () => T {
+  const transaction = getTransactionReadState();
+  const memoized = memoizeNoArgs(fn);
+  return () => {
+    assertTransactionRead(transaction);
+    const result = memoized();
+    if (transaction && isPromise(result)) {
+      return result.then((value) => {
+        assertTransactionRead(transaction);
+        return value;
+      }) as T;
+    }
+    return result;
   };
 }

--- a/ts/src/core/memoize.ts
+++ b/ts/src/core/memoize.ts
@@ -2,6 +2,7 @@ import { isPromise } from "util/types";
 import {
   assertTransactionRead,
   getTransactionReadState,
+  isFinalScopeValidation,
 } from "./transaction_context";
 
 export function memoizeNoArgs<T>(fn: () => T): () => T {
@@ -25,7 +26,7 @@ export function memoizeInTransaction<T>(fn: () => T): () => T {
   const memoized = memoizeNoArgs(fn);
   return () => {
     assertTransactionRead(transaction);
-    const result = memoized();
+    const result = isFinalScopeValidation() ? fn() : memoized();
     if (transaction && isPromise(result)) {
       return result.then((value) => {
         assertTransactionRead(transaction);

--- a/ts/src/core/memoize.ts
+++ b/ts/src/core/memoize.ts
@@ -18,8 +18,8 @@ export function memoizeNoArgs<T>(fn: () => T): () => T {
   };
 }
 
-// Cached query/loader state cannot cross scopes. Ordinary builder field
-// memoization remains readable by post-commit observers and result callers.
+// Cached query and loader state cannot cross scopes. Observers and result
+// callers can still read memoized builder fields after commit.
 export function memoizeInTransaction<T>(fn: () => T): () => T {
   const transaction = getTransactionReadState();
   const memoized = memoizeNoArgs(fn);

--- a/ts/src/core/query/assoc_query.ts
+++ b/ts/src/core/query/assoc_query.ts
@@ -96,35 +96,39 @@ export abstract class AssocEdgeQueryBase<
 
   // doesn't work with filters...
   async queryRawCount(): Promise<number> {
-    const info = await this.getSingleID();
-    if (info.invalidated) {
-      return 0;
-    }
+    return this.readInTransaction(async () => {
+      const info = await this.getSingleID();
+      if (info.invalidated) {
+        return 0;
+      }
 
-    return this.countLoaderFactory
-      .createConfigurableLoader(
-        this.getDefaultEdgeQueryOptions() ?? {},
-        this.viewer.context,
-      )
-      .load(info.id);
+      return this.countLoaderFactory
+        .createConfigurableLoader(
+          this.getDefaultEdgeQueryOptions() ?? {},
+          this.viewer.context,
+        )
+        .load(info.id);
+    });
   }
 
   async queryAllRawCount(): Promise<Map<ID, number>> {
-    let results: Map<ID, number> = new Map();
-    const infos = await this.genIDInfosToFetch();
+    return this.readInTransaction(async () => {
+      let results: Map<ID, number> = new Map();
+      const infos = await this.genIDInfosToFetch();
 
-    const loader = this.countLoaderFactory.createLoader(this.viewer.context);
-    await Promise.all(
-      infos.map(async (info) => {
-        if (info.invalidated) {
-          results.set(info.id, 0);
-          return;
-        }
-        const count = await loader.load(info.id);
-        results.set(info.id, count);
-      }),
-    );
-    return results;
+      const loader = this.countLoaderFactory.createLoader(this.viewer.context);
+      await Promise.all(
+        infos.map(async (info) => {
+          if (info.invalidated) {
+            results.set(info.id, 0);
+            return;
+          }
+          const count = await loader.load(info.id);
+          results.set(info.id, count);
+        }),
+      );
+      return results;
+    });
   }
 
   protected async loadEntsFromEdges(
@@ -214,33 +218,37 @@ export abstract class AssocEdgeQueryBase<
   }
 
   async queryID2(id2: ID): Promise<TEdge | undefined> {
-    const info = await this.getSingleID();
-    if (info.invalidated) {
-      return;
-    }
+    return this.readInTransaction(async () => {
+      const info = await this.getSingleID();
+      if (info.invalidated) {
+        return;
+      }
 
-    const loader = this.dataLoaderFactory.createLoader(this.viewer.context);
-    return loader.loadEdgeForID2(info.id, id2);
+      const loader = this.dataLoaderFactory.createLoader(this.viewer.context);
+      return loader.loadEdgeForID2(info.id, id2);
+    });
   }
 
   async queryAllID2(id2: ID): Promise<Map<ID, TEdge>> {
-    const infos = await this.genIDInfosToFetch();
+    return this.readInTransaction(async () => {
+      const infos = await this.genIDInfosToFetch();
 
-    const loader = this.dataLoaderFactory.createLoader(this.viewer.context);
+      const loader = this.dataLoaderFactory.createLoader(this.viewer.context);
 
-    const m = new Map<ID, TEdge>();
-    await Promise.all(
-      infos.map(async (info) => {
-        if (info.invalidated) {
-          return;
-        }
-        const edge = await loader.loadEdgeForID2(info.id, id2);
-        if (edge) {
-          m.set(info.id, edge);
-        }
-      }),
-    );
-    return m;
+      const m = new Map<ID, TEdge>();
+      await Promise.all(
+        infos.map(async (info) => {
+          if (info.invalidated) {
+            return;
+          }
+          const edge = await loader.loadEdgeForID2(info.id, id2);
+          if (edge) {
+            m.set(info.id, edge);
+          }
+        }),
+      );
+      return m;
+    });
   }
 
   __beforeBETA(time: Date) {
@@ -310,10 +318,11 @@ export interface EdgeQueryCtr<
   TDest extends Ent,
   TEdge extends AssocEdge,
 > {
-  new (
-    viewer: Viewer,
-    src: EdgeQuerySource<TSource>,
-  ): EdgeQuery<TSource, TDest, TEdge>;
+  new (viewer: Viewer, src: EdgeQuerySource<TSource>): EdgeQuery<
+    TSource,
+    TDest,
+    TEdge
+  >;
 }
 
 class BeforeFilter implements EdgeQueryFilter<AssocEdge> {
@@ -341,10 +350,7 @@ class AfterFilter implements EdgeQueryFilter<AssocEdge> {
 }
 
 class WithinFilter implements EdgeQueryFilter<AssocEdge> {
-  constructor(
-    private start: Date,
-    private end: Date,
-  ) {}
+  constructor(private start: Date, private end: Date) {}
 
   query(options: EdgeQueryableDataOptions): EdgeQueryableDataOptions {
     const cls = clause.And(

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -142,7 +142,7 @@ export class CustomClauseQuery<
 
   async queryRawCount(): Promise<number> {
     return this.readInTransaction(async () => {
-      // sqlite needs as count otherwise it returns count(1)
+      // Alias the count column; SQLite otherwise names it count(1).
       let fields: SelectBaseDataOptions["fields"] = ["count(1) as count"];
       if (this.options.joinBETA) {
         const firstRequestedField = this.options.loadEntOptions.fields[0];

--- a/ts/src/core/query/custom_clause_query.ts
+++ b/ts/src/core/query/custom_clause_query.ts
@@ -141,37 +141,39 @@ export class CustomClauseQuery<
   }
 
   async queryRawCount(): Promise<number> {
-    // sqlite needs as count otherwise it returns count(1)
-    let fields: SelectBaseDataOptions["fields"] = ["count(1) as count"];
-    if (this.options.joinBETA) {
-      const firstRequestedField = this.options.loadEntOptions.fields[0];
-      const alias =
-        this.options.loadEntOptions.fieldsAlias ??
-        this.options.loadEntOptions.alias;
-      const fieldString =
-        typeof firstRequestedField === "object"
-          ? "expression" in firstRequestedField
-            ? (() => {
-                throw new Error(
-                  "join-backed raw counts do not support computed select expressions",
-                );
-              })()
-            : `${firstRequestedField.alias}.${firstRequestedField.column}`
-          : alias
+    return this.readInTransaction(async () => {
+      // sqlite needs as count otherwise it returns count(1)
+      let fields: SelectBaseDataOptions["fields"] = ["count(1) as count"];
+      if (this.options.joinBETA) {
+        const firstRequestedField = this.options.loadEntOptions.fields[0];
+        const alias =
+          this.options.loadEntOptions.fieldsAlias ??
+          this.options.loadEntOptions.alias;
+        const fieldString =
+          typeof firstRequestedField === "object"
+            ? "expression" in firstRequestedField
+              ? (() => {
+                  throw new Error(
+                    "join-backed raw counts do not support computed select expressions",
+                  );
+                })()
+              : `${firstRequestedField.alias}.${firstRequestedField.column}`
+            : alias
             ? `${alias}.${firstRequestedField}`
             : firstRequestedField;
-      fields = [`count(distinct ${fieldString}) as count`];
-    }
-    const row = await loadRow({
-      ...this.options.loadEntOptions,
-      tableName: this.options.loadEntOptions.tableName,
-      fields,
-      clause: this.clause,
-      context: this.viewer.context,
-      join: this.options.joinBETA,
-      disableFieldsAlias: true,
+        fields = [`count(distinct ${fieldString}) as count`];
+      }
+      const row = await loadRow({
+        ...this.options.loadEntOptions,
+        tableName: this.options.loadEntOptions.tableName,
+        fields,
+        clause: this.clause,
+        context: this.viewer.context,
+        join: this.options.joinBETA,
+        disableFieldsAlias: true,
+      });
+      return parseInt(row?.count, 10) || 0;
     });
-    return parseInt(row?.count, 10) || 0;
   }
 
   async queryAllRawCount(): Promise<Map<ID, number>> {

--- a/ts/src/core/query/custom_query.ts
+++ b/ts/src/core/query/custom_query.ts
@@ -1,3 +1,4 @@
+import { getContextCache } from "../context";
 import {
   ConfigurableLoaderFactory,
   Data,
@@ -77,7 +78,8 @@ function getRawCountLoader<
   TDest extends Ent<TViewer>,
   TViewer extends Viewer = Viewer,
 >(viewer: TViewer, opts: CustomEdgeQueryOptions<TSource, TDest, TViewer>) {
-  if (!viewer.context?.cache) {
+  const cache = getContextCache(viewer.context);
+  if (!cache) {
     return new RawCountLoader({
       tableName: opts.loadEntOptions.tableName,
       groupCol: opts.groupCol,
@@ -85,7 +87,7 @@ function getRawCountLoader<
     });
   }
   const name = `custom_query_count_loader:${opts.name}`;
-  return viewer.context.cache.getLoader(
+  return cache.getLoader(
     name,
     () =>
       new RawCountLoader({
@@ -236,21 +238,25 @@ export abstract class CustomEdgeQueryBase<
   }
 
   async queryRawCount(): Promise<number> {
-    const idVisible = await this.idVisible();
-    if (!idVisible) {
-      return 0;
-    }
+    return this.readInTransaction(async () => {
+      const idVisible = await this.idVisible();
+      if (!idVisible) {
+        return 0;
+      }
 
-    return this.getCountLoader().load(this.id);
+      return this.getCountLoader().load(this.id);
+    });
   }
 
   async queryAllRawCount(): Promise<Map<ID, number>> {
-    let count = 0;
-    const idVisible = await this.idVisible();
-    if (idVisible) {
-      count = await this.queryRawCount();
-    }
-    return new Map<ID, number>([[this.id, count]]);
+    return this.readInTransaction(async () => {
+      let count = 0;
+      const idVisible = await this.idVisible();
+      if (idVisible) {
+        count = await this.queryRawCount();
+      }
+      return new Map<ID, number>([[this.id, count]]);
+    });
   }
 
   protected async loadRawIDs(

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -577,7 +577,7 @@ export abstract class BaseEdgeQuery<
 
   readonly queryAllEnts = async (): Promise<Map<ID, TDest[]>> => {
     return this.readInTransaction(async () => {
-      // applies filters and then gets things after
+      // Apply edge filters before loading the corresponding Ents.
       const edges = await this.memoizedloadEdges();
       let promises: Promise<void>[] = [];
       const results: Map<ID, TDest[]> = new Map();

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -397,8 +397,6 @@ export abstract class BaseEdgeQuery<
   private pagination: Map<ID, PaginationInfo> = new Map();
   private memoizedloadEdges: () => Promise<Map<ID, TEdge[]>>;
   protected genIDInfosToFetch: () => Promise<IDInfo[]>;
-  private idMap: Map<ID, TSource> = new Map();
-  private idsToFetch: ID[] = [];
 
   // if the column we're sorting by is not unique e.g. created_at, we add a secondary sort column which is used in the cursor
   // to break ties and ensure that we can paginate correctly
@@ -407,7 +405,10 @@ export abstract class BaseEdgeQuery<
   private limitAdded = false;
   private cursorKeys: string[] = [];
 
-  constructor(public viewer: Viewer, options: EdgeQueryOptions) {
+  constructor(
+    public viewer: Viewer,
+    options: EdgeQueryOptions,
+  ) {
     // we also sort cursor col in same direction. (direction doesn't matter)
     const orderBy = [...options.orderby];
     if (
@@ -423,7 +424,7 @@ export abstract class BaseEdgeQuery<
         o.alias ??
         (options.fieldOptions?.disableFieldsAlias
           ? undefined
-          : options.fieldOptions?.fieldsAlias ?? options.fieldOptions?.alias);
+          : (options.fieldOptions?.fieldsAlias ?? options.fieldOptions?.alias));
     });
     this.edgeQueryOptions = { ...options, orderby: orderBy };
     this.cursorCol = options.cursorCol;
@@ -626,27 +627,23 @@ export abstract class BaseEdgeQuery<
     options: EdgeQueryableDataOptions,
   ): Promise<void>;
 
-  private addID(id: ID | TSource) {
-    if (typeof id === "object") {
-      assertEntTransaction(id);
-      this.idMap.set(id.id, id);
-      this.idsToFetch.push(id.id);
-    } else {
-      this.idsToFetch.push(id);
-    }
-  }
-
   abstract getTableName(): string | Promise<string>;
 
   protected async genIDInfosToFetchImpl() {
-    await this.loadRawIDs(this.addID.bind(this));
-
-    return applyPrivacyPolicyForEdgeQ(
-      this.viewer,
-      this,
-      this.idsToFetch,
-      this.idMap,
-    );
+    // Final validation can repeat this read without memoization. Keep source
+    // identifiers local so repeated and concurrent reads do not accumulate IDs.
+    const ids: ID[] = [];
+    const ents = new Map<ID, TSource>();
+    await this.loadRawIDs((source) => {
+      if (typeof source === "object") {
+        assertEntTransaction(source);
+        ents.set(source.id, source);
+        ids.push(source.id);
+      } else {
+        ids.push(source);
+      }
+    });
+    return applyPrivacyPolicyForEdgeQ(this.viewer, this, ids, ents);
   }
 
   private _defaultEdgeQueryableOptions: EdgeQueryableDataOptions | undefined;

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -771,7 +771,9 @@ async function applyPrivacyPolicyForEdgeQ<
       if (!ent) {
         ent = await edgeQ.sourceEnt(id);
       }
-      if (ent) assertEntTransaction(ent);
+      if (ent) {
+        assertEntTransaction(ent);
+      }
       const r = await applyPrivacyPolicy(
         viewer,
         edgeQ.getPrivacyPolicy(),

--- a/ts/src/core/query/query.ts
+++ b/ts/src/core/query/query.ts
@@ -1,3 +1,9 @@
+import {
+  assertEntTransaction,
+  assertTransactionRead,
+  getTransactionReadState,
+  runTransactionRead,
+} from "../transaction_context";
 import { isPromise } from "util/types";
 import {
   Data,
@@ -13,7 +19,7 @@ import {
 import * as clause from "../clause";
 import { decodeCursorPayload, getCursor, getDefaultLimit } from "../ent";
 import { AlwaysAllowPrivacyPolicy, applyPrivacyPolicy } from "../privacy";
-import { memoizeNoArgs } from "../memoize";
+import { memoizeInTransaction as memoizeNoArgs } from "../memoize";
 import { OrderBy, orderByHasExpressions, reverseOrderBy } from "../query_impl";
 
 export interface EdgeQuery<
@@ -379,6 +385,12 @@ export abstract class BaseEdgeQuery<
   TEdge extends Data,
 > implements EdgeQuery<TSource, TDest, TEdge>
 {
+  private transactionRead = getTransactionReadState();
+
+  protected readInTransaction<T>(read: () => Promise<T>): Promise<T> {
+    return runTransactionRead(this.transactionRead, read);
+  }
+
   private filters: EdgeQueryFilter<TEdge>[] = [];
   private queryDispatched: boolean;
   protected edges: Map<ID, TEdge[]> = new Map();
@@ -395,10 +407,7 @@ export abstract class BaseEdgeQuery<
   private limitAdded = false;
   private cursorKeys: string[] = [];
 
-  constructor(
-    public viewer: Viewer,
-    options: EdgeQueryOptions,
-  ) {
+  constructor(public viewer: Viewer, options: EdgeQueryOptions) {
     // we also sort cursor col in same direction. (direction doesn't matter)
     const orderBy = [...options.orderby];
     if (
@@ -414,7 +423,7 @@ export abstract class BaseEdgeQuery<
         o.alias ??
         (options.fieldOptions?.disableFieldsAlias
           ? undefined
-          : (options.fieldOptions?.fieldsAlias ?? options.fieldOptions?.alias));
+          : options.fieldOptions?.fieldsAlias ?? options.fieldOptions?.alias);
     });
     this.edgeQueryOptions = { ...options, orderby: orderBy };
     this.cursorCol = options.cursorCol;
@@ -498,7 +507,9 @@ export abstract class BaseEdgeQuery<
 
   // this is basically just raw rows
   readonly queryEdges = async (): Promise<TEdge[]> => {
-    return this.querySingleEdge("queryEdges");
+    return this.readInTransaction(async () => {
+      return this.querySingleEdge("queryEdges");
+    });
   };
 
   abstract queryRawCount(): Promise<number>;
@@ -506,40 +517,50 @@ export abstract class BaseEdgeQuery<
   abstract queryAllRawCount(): Promise<Map<ID, number>>;
 
   readonly queryAllEdges = async (): Promise<Map<ID, TEdge[]>> => {
-    return this.memoizedloadEdges();
+    return this.readInTransaction(async () => {
+      return this.memoizedloadEdges();
+    });
   };
 
   abstract dataToID(edge: TEdge): ID;
 
   readonly queryIDs = async (): Promise<ID[]> => {
-    const edges = await this.querySingleEdge("queryIDs");
-    return edges.map((edge) => this.dataToID(edge));
+    return this.readInTransaction(async () => {
+      const edges = await this.querySingleEdge("queryIDs");
+      return edges.map((edge) => this.dataToID(edge));
+    });
   };
 
   readonly queryAllIDs = async (): Promise<Map<ID, ID[]>> => {
-    const edges = await this.memoizedloadEdges();
-    let results: Map<ID, ID[]> = new Map();
-    for (const [id, edge_data] of edges) {
-      results.set(
-        id,
-        edge_data.map((edge) => this.dataToID(edge)),
-      );
-    }
-    return results;
+    return this.readInTransaction(async () => {
+      const edges = await this.memoizedloadEdges();
+      let results: Map<ID, ID[]> = new Map();
+      for (const [id, edge_data] of edges) {
+        results.set(
+          id,
+          edge_data.map((edge) => this.dataToID(edge)),
+        );
+      }
+      return results;
+    });
   };
 
   readonly queryCount = async (): Promise<number> => {
-    const edges = await this.querySingleEdge("queryCount");
-    return edges.length;
+    return this.readInTransaction(async () => {
+      const edges = await this.querySingleEdge("queryCount");
+      return edges.length;
+    });
   };
 
   readonly queryAllCount = async (): Promise<Map<ID, number>> => {
-    let results: Map<ID, number> = new Map();
-    const edges = await this.memoizedloadEdges();
-    edges.forEach((list, id) => {
-      results.set(id, list.length);
+    return this.readInTransaction(async () => {
+      let results: Map<ID, number> = new Map();
+      const edges = await this.memoizedloadEdges();
+      edges.forEach((list, id) => {
+        results.set(id, list.length);
+      });
+      return results;
     });
-    return results;
   };
 
   protected abstract loadEntsFromEdges(
@@ -548,29 +569,34 @@ export abstract class BaseEdgeQuery<
   ): Promise<TDest[]>;
 
   readonly queryEnts = async (): Promise<TDest[]> => {
-    const edges = await this.querySingleEdge("queryEnts");
-    return this.loadEntsFromEdges("id", edges);
+    return this.readInTransaction(async () => {
+      const edges = await this.querySingleEdge("queryEnts");
+      return this.loadEntsFromEdges("id", edges);
+    });
   };
 
   readonly queryAllEnts = async (): Promise<Map<ID, TDest[]>> => {
-    // applies filters and then gets things after
-    const edges = await this.memoizedloadEdges();
-    let promises: Promise<void>[] = [];
-    const results: Map<ID, TDest[]> = new Map();
+    return this.readInTransaction(async () => {
+      // applies filters and then gets things after
+      const edges = await this.memoizedloadEdges();
+      let promises: Promise<void>[] = [];
+      const results: Map<ID, TDest[]> = new Map();
 
-    const loadEntsForID = async (id: ID, edges: TEdge[]) => {
-      const ents = await this.loadEntsFromEdges(id, edges);
-      results.set(id, ents);
-    };
-    for (const [id, edgesList] of edges) {
-      promises.push(loadEntsForID(id, edgesList));
-    }
+      const loadEntsForID = async (id: ID, edges: TEdge[]) => {
+        const ents = await this.loadEntsFromEdges(id, edges);
+        results.set(id, ents);
+      };
+      for (const [id, edgesList] of edges) {
+        promises.push(loadEntsForID(id, edgesList));
+      }
 
-    await Promise.all(promises);
-    return results;
+      await Promise.all(promises);
+      return results;
+    });
   };
 
   paginationInfo(): Map<ID, PaginationInfo> {
+    assertTransactionRead(this.transactionRead);
     this.assertQueryDispatched("paginationInfo");
     return this.pagination;
   }
@@ -602,6 +628,7 @@ export abstract class BaseEdgeQuery<
 
   private addID(id: ID | TSource) {
     if (typeof id === "object") {
+      assertEntTransaction(id);
       this.idMap.set(id.id, id);
       this.idsToFetch.push(id.id);
     } else {
@@ -744,6 +771,7 @@ async function applyPrivacyPolicyForEdgeQ<
       if (!ent) {
         ent = await edgeQ.sourceEnt(id);
       }
+      if (ent) assertEntTransaction(ent);
       const r = await applyPrivacyPolicy(
         viewer,
         edgeQ.getPrivacyPolicy(),

--- a/ts/src/core/transaction.test.ts
+++ b/ts/src/core/transaction.test.ts
@@ -1,5 +1,5 @@
 import DB, { Dialect } from "./db";
-import { withTransaction, TransactionScope } from "./transaction";
+import { withTransactionScope, TransactionScope } from "./transaction";
 import { getTransactionState } from "./transaction_context";
 import {
   loadEnt,
@@ -92,16 +92,9 @@ function barrier(n: number) {
 }
 
 class GuardedEdit extends SimpleAction<ScopedAccount> {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return true;
   }
-}
-
-function independent<T extends SimpleAction<ScopedAccount>>(
-  action: T,
-  resource: string,
-): T {
-  return Object.assign(action, { getTransactionResources: () => [resource] });
 }
 
 describe("transaction-scoped actions (disposable Postgres database)", () => {
@@ -190,7 +183,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       const owner = await create();
       const observe = jest.fn();
       let caught: unknown;
-      const outcome = withTransaction(async () => {
+      const outcome = withTransactionScope(async () => {
         const first = edit(await load(owner.id as string), 75);
         first.getObservers = () => [{ observe }];
         await first.saveX();
@@ -271,7 +264,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           const failure = new Error(stage);
           const observe = jest.fn();
           await expect(
-            withTransaction(async () => {
+            withTransactionScope(async () => {
               const first = edit(await load(owner.id as string), 75);
               first.getObservers = () => [{ observe }];
               await first.saveX();
@@ -320,7 +313,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       const failure = new Error("custom changeset preparation");
       const observe = jest.fn();
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           const first = edit(await load(owner.id as string), 75);
           first.getObservers = () => [{ observe }];
           await first.saveX();
@@ -344,7 +337,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       const failure = new Error("execution context unavailable");
       const observe = jest.fn();
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           const first = edit(await load(owner.id as string), 75);
           first.getObservers = () => [{ observe }];
           await first.saveX();
@@ -435,10 +428,10 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   };
 
   test.each(privacyReadPaths)(
-    "fresh field-redacted %s reads remain valid guarded action inputs",
+    "fresh field-redacted %s reads remain valid scoped action inputs",
     async (path) => {
       const owner = await create();
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const redacted = await loadWithFieldPrivacy(path, owner.id as string);
         expect(redacted!.data.admin).toBeNull();
         await edit(redacted!, 75).saveX();
@@ -468,7 +461,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         ],
       };
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           const pending = loadWithFieldPrivacy(
             path,
             owner.id as string,
@@ -505,7 +498,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     });
     await started.promise;
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         try {
           await edit(await load(owner.id as string), 75).saveX();
         } finally {
@@ -536,7 +529,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         });
       let caught: unknown;
       try {
-        const failure = await withTransaction(async () => {
+        const failure = await withTransactionScope(async () => {
           for (const [account, balance] of [
             [earlier, 75],
             [target, 12],
@@ -626,7 +619,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           });
         try {
           await expect(
-            withTransaction(async () => {
+            withTransactionScope(async () => {
               const action = edit(await load(owner.id as string), 12);
               if (source === "viewer throw") {
                 action.viewerForEntLoad = () => {
@@ -660,7 +653,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           : original.call(this);
       });
     try {
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const action = edit(await load(owner.id as string), 12);
         action.getObservers = () => [{ observe }];
         action.getTriggers = () => [
@@ -694,7 +687,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     async (method) => {
       const owner = await create();
       let caught: unknown;
-      const failure = await withTransaction(async () => {
+      const failure = await withTransactionScope(async () => {
         await edit(await load(owner.id as string), 75).saveX();
         const candidate = edit(await load(owner.id as string), 12);
         try {
@@ -766,7 +759,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     async (method) => {
       const owner = await create();
       let previous!: GuardedEdit;
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         previous = edit(await load(owner.id as string), 75);
         await previous.saveX();
       });
@@ -775,7 +768,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         throw error;
       };
       await expect(previous[method]()).rejects.toBe(error);
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         await edit(await load(owner.id as string), 50).saveX();
         await expect(previous[method]()).rejects.toBe(error);
       });
@@ -791,7 +784,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     ["unscoped", "editedEnt"],
     ["unscoped", "editedEntX"],
   ] as const)(
-    "%s %s snapshots cannot become fresh inputs to a guarded mutation",
+    "%s %s snapshots cannot become fresh inputs to a scoped mutation",
     async (origin, method) => {
       const owner = await create();
       let previous!: SimpleAction<ScopedAccount>;
@@ -800,7 +793,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         await previous.saveX();
       };
       if (origin === "previous scope") {
-        await withTransaction(savePrevious);
+        await withTransactionScope(savePrevious);
       } else if (origin === "unscoped") {
         previous = new SimpleAction(
           viewer,
@@ -812,7 +805,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         await previous.saveX();
       }
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           if (origin === "same scope") {
             await savePrevious();
           }
@@ -836,7 +829,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     "fresh %s results retain the completed write's current provenance",
     async (source) => {
       const [owner, target] = await Promise.all([create(), create()]);
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const parent = edit(await load(owner.id as string), 90);
         let child!: SimpleAction<ScopedAccount>;
         parent.getTriggers = () => [
@@ -871,7 +864,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     const account = await create();
     const observed: number[] = [];
     let scopedPid = 0;
-    await withTransaction(async (tx) => {
+    await withTransactionScope(async (tx) => {
       scopedPid = (await tx.query("SELECT pg_backend_pid() AS pid")).rows[0]
         .pid;
       const action = edit(await load(account.id as string), 75);
@@ -933,7 +926,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     const outside = await load(account.id as string);
     const observe = jest.fn();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const action = edit(await load(account.id as string), 30);
         action.getTriggers = () => [
           {
@@ -961,7 +954,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   test("observers and callers can read committed builder IDs without rerunning preparation", async () => {
     const effects: string[] = [];
     let action!: SimpleAction<ScopedAccount>;
-    const result = await withTransaction(async () => {
+    const result = await withTransactionScope(async () => {
       action = new SimpleAction(
         viewer,
         accountSchema,
@@ -995,7 +988,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     const account = await create();
     const written = deferred();
     const release = deferred();
-    const worker = withTransaction(async () => {
+    const worker = withTransactionScope(async () => {
       await edit(await load(account.id as string), 9).saveX();
       written.resolve();
       await release.promise;
@@ -1004,7 +997,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     await written.promise;
     try {
       expect((await load(account.id as string)).data.balance).toBe(100);
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         expect((await load(account.id as string)).data.balance).toBe(100);
       });
     } finally {
@@ -1020,7 +1013,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     const attempts: number[] = [];
     let observers = 0;
     const sell = (amount: number) =>
-      withTransaction(
+      withTransactionScope(
         async (tx) => {
           attempts.push(tx.attempt);
           const current = await load(account.id as string);
@@ -1062,7 +1055,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     const accounts = await Promise.all([create(), create()]);
     const meet = barrier(2);
     const removeAdmin = (account: ScopedAccount) =>
-      withTransaction(
+      withTransactionScope(
         async (tx) => {
           const current = await load(account.id as string);
           const action = new GuardedEdit(
@@ -1122,7 +1115,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     const account = await create();
     const locked = deferred();
     const release = deferred();
-    const first = withTransaction(
+    const first = withTransactionScope(
       async (tx) => {
         await tx.query(
           "SELECT id FROM scoped_accounts WHERE id = $1 FOR UPDATE",
@@ -1137,7 +1130,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     );
     await locked.promise;
     const secondStarted = deferred();
-    const second = withTransaction(
+    const second = withTransactionScope(
       async (tx) => {
         // This cached value must be invalidated by the explicit lock query.
         expect((await load(account.id as string)).data.balance).toBe(100);
@@ -1159,26 +1152,26 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     expect((await load(account.id as string)).data.balance).toBe(50);
   });
 
-  test("guarded direct saves/builders/changesets fail closed and stale Ents cannot cross scopes", async () => {
+  test("scoped direct saves/builders/changesets fail closed and stale Ents cannot cross scopes", async () => {
     const account = await create();
     await expect(edit(account, 1).saveX()).rejects.toThrow(
-      "requires withTransaction",
+      "requires withTransactionScope",
     );
     await expect(edit(account, 1).builder.saveX()).rejects.toThrow(
-      "requires withTransaction",
+      "requires withTransactionScope",
     );
     await expect(edit(account, 1).changeset()).rejects.toThrow(
-      "requires withTransaction",
+      "requires withTransactionScope",
     );
     await expect(
-      withTransaction(async () => edit(account, 1).saveX()),
+      withTransactionScope(async () => edit(account, 1).saveX()),
     ).rejects.toThrow("reload existingEnt");
     const oldAction = edit(account, 1);
     await expect(
-      withTransaction(async () => oldAction.saveX()),
+      withTransactionScope(async () => oldAction.saveX()),
     ).rejects.toThrow("cannot cross transaction scopes");
     let oldChangeset: Awaited<ReturnType<GuardedEdit["changeset"]>>;
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       oldChangeset = await edit(
         await load(account.id as string),
         1,
@@ -1191,7 +1184,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   test("privacy denial rolls back earlier actions; legacy action Transaction groups join outer scope", async () => {
     const account = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         await new Transaction(viewer, [
           edit(await load(account.id as string), 50),
         ]).run();
@@ -1206,7 +1199,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   test("caught SQL errors still abort and borrowed clients/nested scopes are rejected", async () => {
     const account = await create();
     await expect(
-      withTransaction(async (tx) => {
+      withTransactionScope(async (tx) => {
         await edit(await load(account.id as string), 1).saveX();
         await tx
           .query("SELECT no_such_column FROM scoped_accounts")
@@ -1214,8 +1207,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       }),
     ).rejects.toThrow("no_such_column");
     expect((await load(account.id as string)).data.balance).toBe(100);
-    await withTransaction(async () => {
-      await expect(withTransaction(async () => {})).rejects.toThrow("nested");
+    await withTransactionScope(async () => {
+      await expect(withTransactionScope(async () => {})).rejects.toThrow("nested");
       await expect(DB.getInstance().getNewClient()).rejects.toThrow("escape");
       expect(() => DB.getInstance().getConnection()).toThrow("raw connections");
     });
@@ -1225,10 +1218,10 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     const account = await create();
     const trigger = jest.fn();
     await expect(
-      withTransaction(
+      withTransactionScope(
         async () => {
           const action = edit(await load(account.id as string), 0);
-          Object.assign(action, { requiresTransaction: () => "serializable" });
+          Object.assign(action, { requiresTransactionScope: () => "serializable" });
           action.getTriggers = () => [{ changeset: trigger }];
           await action.saveX();
         },
@@ -1241,7 +1234,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   test("a swallowed non-X validation failure still rolls back earlier writes", async () => {
     const account = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         await edit(await load(account.id as string), 50).saveX();
         const invalid = edit(await load(account.id as string), 0);
         invalid.getValidators = () => [
@@ -1260,7 +1253,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   test("caught changeset preparation failure still aborts the owning scope", async () => {
     const account = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         await edit(await load(account.id as string), 50).saveX();
         const invalid = edit(await load(account.id as string), 0);
         invalid.getValidators = () => [
@@ -1284,7 +1277,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     let closedQuery!: () => Promise<unknown>;
     const gate = deferred();
     let detached!: Promise<unknown>;
-    await withTransaction(async (tx) => {
+    await withTransactionScope(async (tx) => {
       scope = tx;
       await expect(outsideLoader.load(account.id)).rejects.toThrow(
         "cannot cross transaction scopes",
@@ -1305,7 +1298,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   test("raw writes invalidate all transaction viewers' caches", async () => {
     const account = await create();
     const other = new TestContext();
-    await withTransaction(async (tx) => {
+    await withTransactionScope(async (tx) => {
       expect((await load(account.id as string)).data.balance).toBe(100);
       expect(
         (await loadEntX(other.getViewer(), account.id, options)).data.balance,
@@ -1330,7 +1323,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       );
     const [owner, target] = await Promise.all([create(), create()]);
     const readEdges = () => loadEdges({ id1: owner.id, edgeType, context });
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const action = edit(await load(owner.id as string), 100);
       action.builder.orchestrator.addOutboundEdge(
         target.id,
@@ -1340,7 +1333,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       await action.saveX();
     });
     expect((await readEdges()).length).toBe(1);
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       expect((await readEdges()).length).toBe(1);
       const action = edit(await load(owner.id as string), 100);
       action.builder.orchestrator.removeOutboundEdge(target.id, edgeType);
@@ -1350,24 +1343,24 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     expect(await readEdges()).toEqual([]);
   });
 
-  test("prebuilt guarded sale roots in one Transaction fail before losing an absolute balance update", async () => {
+  test("prebuilt scoped sale roots in one Transaction fail before losing an absolute balance update", async () => {
     const account = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const current = await load(account.id as string);
         await new Transaction(viewer, [
           edit(current, 80),
           edit(current, 70),
         ]).run();
       }),
-    ).rejects.toThrow("guarded root actions");
+    ).rejects.toThrow("root actions");
     expect((await load(account.id as string)).data.balance).toBe(100);
   });
 
-  test("prebuilt guarded admin roots cannot both validate against the old count", async () => {
+  test("prebuilt scoped admin roots cannot both validate against the old count", async () => {
     const accounts = await Promise.all([create(), create()]);
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const actions = await Promise.all(
           accounts.map(async (account) => {
             const action = new GuardedEdit(
@@ -1396,26 +1389,26 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         );
         await new Transaction(viewer, actions).run();
       }),
-    ).rejects.toThrow("guarded root actions");
+    ).rejects.toThrow("root actions");
     expect(
       (await loadRows({ ...options, clause: Eq("admin", true), context }))
         .length,
     ).toBe(2);
   });
 
-  test("parallel guarded root saves roll back, while sequential saves reload fresh state", async () => {
+  test("parallel scoped root saves roll back, while sequential saves reload fresh state", async () => {
     const account = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const current = await load(account.id as string);
         await Promise.all([
           edit(current, 80).saveX(),
           edit(current, 70).saveX(),
         ]);
       }),
-    ).rejects.toThrow("guarded root actions");
+    ).rejects.toThrow("root actions");
     expect((await load(account.id as string)).data.balance).toBe(100);
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       await edit(await load(account.id as string), 80).saveX();
       const fresh = await load(account.id as string);
       await edit(fresh, fresh.data.balance - 30).saveX();
@@ -1423,10 +1416,10 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     expect((await load(account.id as string)).data.balance).toBe(50);
   });
 
-  test("an Ent loaded before a previous guarded save cannot feed the next root", async () => {
+  test("an Ent loaded before a previous scoped save cannot feed the next root", async () => {
     const account = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const old = await load(account.id as string);
         await edit(old, 80).saveX();
         await edit(old, 70).saveX();
@@ -1435,27 +1428,18 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     expect((await load(account.id as string)).data.balance).toBe(100);
   });
 
-  test("guarded root permits distinct trigger child changesets and releases the complete tree", async () => {
+  test("scoped root permits distinct trigger child changesets and releases the complete tree", async () => {
     const accounts = await Promise.all([create(), create(), create()]);
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const current = await Promise.all(
         accounts.map((account) => load(account.id as string)),
       );
-      const parent = independent(
-        edit(current[0], 90),
-        `account:${current[0].id}`,
-      );
+      const parent = edit(current[0], 90);
       parent.getTriggers = () => [
         {
           changeset: async () => [
-            await independent(
-              edit(current[1], 80),
-              `account:${current[1].id}`,
-            ).changeset(),
-            await independent(
-              edit(current[2], 70),
-              `account:${current[2].id}`,
-            ).changeset(),
+            await edit(current[1], 80).changeset(),
+            await edit(current[2], 70).changeset(),
           ],
         },
       ];
@@ -1472,7 +1456,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   test("nested trigger saves and sibling child writes to one Ent fail closed", async () => {
     const [owner, target] = await Promise.all([create(), create()]);
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const parent = edit(await load(owner.id as string), 90);
         parent.getTriggers = () => [
           {
@@ -1489,8 +1473,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       }),
     ).rejects.toThrow("nested action saves");
     await expect(
-      withTransaction(async () => {
-        // An unguarded wrapper must not let guarded sibling children bypass checks.
+      withTransactionScope(async () => {
+        // An ordinary wrapper must not let scoped sibling children bypass checks.
         const parent = new SimpleAction(
           viewer,
           accountSchema,
@@ -1503,9 +1487,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
             async changeset() {
               const current = await load(target.id as string);
               return [
-                // Reject known duplicate row writes even with incorrect resource keys.
-                await independent(edit(current, 80), "first").changeset(),
-                await independent(edit(current, 70), "second").changeset(),
+                // Reject writes to the same row through different builders.
+                await edit(current, 80).changeset(),
+                await edit(current, 70).changeset(),
               ];
             },
           },
@@ -1530,17 +1514,14 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       create(),
       create(),
     ]);
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const current = await load(owner.id as string);
-      const parent = independent(
-        new GuardedEdit(
-          viewer,
-          accountSchema,
-          new Map(),
-          WriteOperation.Edit,
-          current,
-        ),
-        `edge:${owner.id}:${first.id}`,
+      const parent = new GuardedEdit(
+        viewer,
+        accountSchema,
+        new Map(),
+        WriteOperation.Edit,
+        current,
       );
       parent.builder.orchestrator.addOutboundEdge(
         first.id,
@@ -1550,15 +1531,12 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       parent.getTriggers = () => [
         {
           async changeset() {
-            const child = independent(
-              new GuardedEdit(
-                viewer,
-                accountSchema,
-                new Map(),
-                WriteOperation.Edit,
-                current,
-              ),
-              `edge:${owner.id}:${second.id}`,
+            const child = new GuardedEdit(
+              viewer,
+              accountSchema,
+              new Map(),
+              WriteOperation.Edit,
+              current,
             );
             child.builder.orchestrator.addOutboundEdge(
               second.id,
@@ -1580,7 +1558,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
 
   test("skipped child writes do not conflict and distinct nested deletions remain supported", async () => {
     const accounts = await Promise.all([create(), create(), create()]);
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const current = await load(accounts[0].id as string);
       const parent = edit(current, 80);
       parent.getTriggers = () => [
@@ -1602,19 +1580,16 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       await parent.saveX();
     });
     expect((await load(accounts[0].id as string)).data.balance).toBe(80);
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const current = await Promise.all(
         accounts.map((account) => load(account.id as string)),
       );
-      const parent = independent(
-        new GuardedEdit(
-          viewer,
-          accountSchema,
-          new Map(),
-          WriteOperation.Delete,
-          current[0],
-        ),
-        `account:${current[0].id}`,
+      const parent = new GuardedEdit(
+        viewer,
+        accountSchema,
+        new Map(),
+        WriteOperation.Delete,
+        current[0],
       );
       parent.getTriggers = () => [
         {
@@ -1623,15 +1598,12 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
               current
                 .slice(1)
                 .map((account) =>
-                  independent(
-                    new GuardedEdit(
-                      viewer,
-                      accountSchema,
-                      new Map(),
-                      WriteOperation.Delete,
-                      account,
-                    ),
-                    `account:${account.id}`,
+                  new GuardedEdit(
+                    viewer,
+                    accountSchema,
+                    new Map(),
+                    WriteOperation.Delete,
+                    account,
                   ).changeset(),
                 ),
             ),
@@ -1645,10 +1617,10 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     ).toBe(0);
   });
 
-  test("unguarded wrapper cannot combine guarded last-admin removals of distinct rows", async () => {
+  test("a wrapper checks the final state after removing administrators in child actions", async () => {
     const accounts = await Promise.all([create(), create()]);
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const parent = new SimpleAction(
           viewer,
           auditSchema,
@@ -1668,6 +1640,21 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
                     WriteOperation.Edit,
                     await load(account.id as string),
                   );
+                  Object.assign(child, {
+                    validateBeforeCommit: async () => {
+                      if (
+                        !(
+                          await loadRows({
+                            ...options,
+                            clause: Eq("admin", true),
+                            context,
+                          })
+                        ).length
+                      ) {
+                        throw new Error("last admin");
+                      }
+                    },
+                  });
                   child.getValidators = () => [
                     {
                       async validate() {
@@ -1690,7 +1677,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         ];
         await parent.saveX();
       }),
-    ).rejects.toThrow("overlapping guarded action preparation branches");
+    ).rejects.toThrow("last admin");
     expect(
       (await loadRows({ ...options, clause: Eq("admin", true), context }))
         .length,
@@ -1699,170 +1686,154 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
   });
 
   test.each([
-    [undefined, undefined, false],
-    ["admins", "admins", false],
-    [undefined, "admins", false],
-    ["admins", undefined, false],
-    [undefined, undefined, true],
-  ] as const)(
-    "ancestor and descendant cannot independently decide the last-admin invariant (%s, %s, wrapper=%s)",
-    async (parentKey, childKey, wrapper) => {
-      const accounts = await Promise.all([create(), create()]);
-      const remove = async (id: string, key: string | undefined) => {
-        const action = new GuardedEdit(
-          viewer,
-          accountSchema,
-          new Map([["admin", false]]),
-          WriteOperation.Edit,
-          await load(id),
-        );
-        if (key) {
-          independent(action, key);
-        }
-        action.getValidators = () => [
-          {
-            async validate() {
-              const rows = await loadRows({
-                ...options,
-                clause: Eq("admin", true),
-                context,
-              });
-              if (rows.length <= 1) {
-                throw new Error("last admin");
-              }
-            },
+    false,
+    true,
+  ])("final validation checks ancestor and descendant administrator removals (wrapper=%s)", async (wrapper) => {
+    const accounts = await Promise.all([create(), create()]);
+    const remove = async (id: string) => {
+      const action = new GuardedEdit(
+        viewer,
+        accountSchema,
+        new Map([["admin", false]]),
+        WriteOperation.Edit,
+        await load(id),
+      );
+      Object.assign(action, {
+        validateBeforeCommit: async () => {
+          if (
+            !(
+              await loadRows({ ...options, clause: Eq("admin", true), context })
+            ).length
+          ) {
+            throw new Error("last admin");
+          }
+        },
+      });
+      action.getValidators = () => [
+        {
+          async validate() {
+            const rows = await loadRows({
+              ...options,
+              clause: Eq("admin", true),
+              context,
+            });
+            if (rows.length <= 1) {
+              throw new Error("last admin");
+            }
           },
-        ];
-        return action;
-      };
-      await expect(
-        withTransaction(async () => {
-          const parent = await remove(accounts[0].id as string, parentKey);
-          const child = async () =>
-            (await remove(accounts[1].id as string, childKey)).changeset();
-          parent.getTriggers = () => [
-            {
-              async changeset() {
-                if (!wrapper) {
-                  return child();
-                }
-                const intermediate = new SimpleAction(
-                  viewer,
-                  auditSchema,
-                  new Map([["message", "remove admins"]]),
-                  WriteOperation.Insert,
-                  null,
-                );
-                intermediate.getTriggers = () => [{ changeset: child }];
-                return intermediate.changeset();
-              },
-            },
-          ];
-          await parent.saveX();
-        }),
-      ).rejects.toThrow("overlapping guarded action preparation branches");
-      expect(
-        (await loadRows({ ...options, clause: Eq("admin", true), context }))
-          .length,
-      ).toBe(2);
-      expect((await audits()).rowCount).toBe(0);
-    },
-  );
-
-  test.each(["valid", "validX", "validWithErrors"] as const)(
-    "%s then save rebuilds independent child changesets and writes each once",
-    async (method) => {
-      const [owner, target] = await Promise.all([create(), create()]);
-      const observe = jest.fn();
-      await withTransaction(async () => {
-        const parent = independent(
-          edit(await load(owner.id as string), 90),
-          `account:${owner.id}`,
-        );
+        },
+      ];
+      return action;
+    };
+    await expect(
+      withTransactionScope(async () => {
+        const parent = await remove(accounts[0].id as string);
+        const child = async () =>
+          (await remove(accounts[1].id as string)).changeset();
         parent.getTriggers = () => [
           {
             async changeset() {
-              const child = independent(
-                edit(await load(target.id as string), 80),
-                `account:${target.id}`,
+              if (!wrapper) {
+                return child();
+              }
+              const intermediate = new SimpleAction(
+                viewer,
+                auditSchema,
+                new Map([["message", "remove admins"]]),
+                WriteOperation.Insert,
+                null,
               );
-              child.getObservers = () => [{ observe }];
-              child.getTriggers = () => [
-                {
-                  changeset: () =>
-                    new SimpleAction(
-                      viewer,
-                      auditSchema,
-                      new Map([["message", "child write"]]),
-                      WriteOperation.Insert,
-                      null,
-                    ).changeset(),
-                },
-              ];
-              return child.changeset();
+              intermediate.getTriggers = () => [{ changeset: child }];
+              return intermediate.changeset();
             },
           },
         ];
-        const result = await parent[method]();
-        expect(result).toEqual(
-          method === "valid" ? true : method === "validX" ? undefined : [],
-        );
-        expect((await load(target.id as string)).data.balance).toBe(100);
-        expect((await audits()).rowCount).toBe(0);
         await parent.saveX();
-        expect((await audits()).rowCount).toBe(1);
-        expect(observe).not.toHaveBeenCalled();
-      });
-      expect((await load(owner.id as string)).data.balance).toBe(90);
-      expect((await load(target.id as string)).data.balance).toBe(80);
-      expect(observe).toHaveBeenCalledTimes(1);
-    },
-  );
+      }),
+    ).rejects.toThrow("last admin");
+    expect(
+      (await loadRows({ ...options, clause: Eq("admin", true), context }))
+        .length,
+    ).toBe(2);
+    expect((await audits()).rowCount).toBe(0);
+  });
 
-  test.each(["valid", "validX", "validWithErrors"] as const)(
-    "failed %s discards its child graph before a corrected save",
-    async (method) => {
-      const [owner, oldTarget, newTarget] = await Promise.all([
-        create(),
-        create(),
-        create(),
-      ]);
-      await withTransaction(async () => {
-        const parent = independent(
-          edit(await load(owner.id as string), 90),
-          `account:${owner.id}`,
-        );
-        let target = oldTarget;
-        let invalid = true;
-        const error = new Error("invalid candidate");
-        parent.getValidators = () => [
-          { validate: async () => (invalid ? error : undefined) },
-        ];
-        parent.getTriggers = () => [
-          {
-            changeset: async () =>
-              independent(
-                edit(await load(target.id as string), 80),
-                `account:${target.id}`,
-              ).changeset(),
+  test.each(["valid", "validX", "validWithErrors"] as const)("%s then save rebuilds independent child changesets and writes each once", async (method) => {
+    const [owner, target] = await Promise.all([create(), create()]);
+    const observe = jest.fn();
+    await withTransactionScope(async () => {
+      const parent = edit(await load(owner.id as string), 90);
+      parent.getTriggers = () => [
+        {
+          async changeset() {
+            const child = edit(await load(target.id as string), 80);
+            child.getObservers = () => [{ observe }];
+            child.getTriggers = () => [
+              {
+                changeset: () =>
+                  new SimpleAction(
+                    viewer,
+                    auditSchema,
+                    new Map([["message", "child write"]]),
+                    WriteOperation.Insert,
+                    null,
+                  ).changeset(),
+              },
+            ];
+            return child.changeset();
           },
-        ];
-        if (method === "validX") {
-          await expect(parent.validX()).rejects.toBe(error);
-        } else {
-          expect(await parent[method]()).toEqual(
-            method === "valid" ? false : [error],
-          );
-        }
-        target = newTarget;
-        invalid = false;
-        await parent.saveX();
-      });
-      expect((await load(owner.id as string)).data.balance).toBe(90);
-      expect((await load(oldTarget.id as string)).data.balance).toBe(100);
-      expect((await load(newTarget.id as string)).data.balance).toBe(80);
-    },
-  );
+        },
+      ];
+      const result = await parent[method]();
+      expect(result).toEqual(
+        method === "valid" ? true : method === "validX" ? undefined : [],
+      );
+      expect((await load(target.id as string)).data.balance).toBe(100);
+      expect((await audits()).rowCount).toBe(0);
+      await parent.saveX();
+      expect((await audits()).rowCount).toBe(1);
+      expect(observe).not.toHaveBeenCalled();
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(90);
+    expect((await load(target.id as string)).data.balance).toBe(80);
+    expect(observe).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["valid", "validX", "validWithErrors"] as const)("failed %s discards its child graph before a corrected save", async (method) => {
+    const [owner, oldTarget, newTarget] = await Promise.all([
+      create(),
+      create(),
+      create(),
+    ]);
+    await withTransactionScope(async () => {
+      const parent = edit(await load(owner.id as string), 90);
+      let target = oldTarget;
+      let invalid = true;
+      const error = new Error("invalid candidate");
+      parent.getValidators = () => [
+        { validate: async () => (invalid ? error : undefined) },
+      ];
+      parent.getTriggers = () => [
+        {
+          changeset: async () =>
+            edit(await load(target.id as string), 80).changeset(),
+        },
+      ];
+      if (method === "validX") {
+        await expect(parent.validX()).rejects.toBe(error);
+      } else {
+        expect(await parent[method]()).toEqual(
+          method === "valid" ? false : [error],
+        );
+      }
+      target = newTarget;
+      invalid = false;
+      await parent.saveX();
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(90);
+    expect((await load(oldTarget.id as string)).data.balance).toBe(100);
+    expect((await load(newTarget.id as string)).data.balance).toBe(80);
+  });
 
   describe.each([
     "siblings",
@@ -1871,185 +1842,160 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     "user Promise.all",
   ] as const)("parallel validation with %s", (shape) => {
     describe.each([false, true])("nested grandchildren %s", (nested) => {
-      test.each(["valid", "validX", "validWithErrors"] as const)(
-        "%s drains children before reporting a recoverable error and supports a corrected save",
-        async (method) => {
-          const accounts = await Promise.all(
-            Array.from({ length: 5 }, () => create()),
+      test.each(["valid", "validX", "validWithErrors"] as const)("%s drains children before reporting a recoverable error and supports a corrected save", async (method) => {
+        const accounts = await Promise.all(
+          Array.from({ length: 5 }, () => create()),
+        );
+        const observe = jest.fn();
+        await withTransactionScope(async () => {
+          const actions = await Promise.all(
+            accounts.map(async (account, index) =>
+              edit(await load(account.id as string), 90 - index * 10),
+            ),
           );
-          const observe = jest.fn();
-          await withTransaction(async () => {
-            const actions = await Promise.all(
-              accounts.map(async (account, index) =>
-                independent(
-                  edit(await load(account.id as string), 90 - index * 10),
-                  `account:${account.id}`,
-                ),
-              ),
-            );
-            const [parent, invalidChild, slowChild, fastBranch, slowBranch] =
-              actions;
-            let invalid = true;
-            const error = new Error("first invalid child");
-            invalidChild.getValidators = () => [
-              { validate: async () => (invalid ? error : undefined) },
-            ];
-            const started = deferred();
-            const finish = deferred();
-            slowChild.getObservers = () => [{ observe }];
-            slowChild.getTriggers = () => [
-              {
-                changeset: async () => {
-                  started.resolve();
-                  await finish.promise;
-                  return new SimpleAction(
-                    viewer,
-                    auditSchema,
-                    new Map([["message", "drained child"]]),
-                    WriteOperation.Insert,
-                    null,
-                  ).changeset();
-                },
-              },
-            ];
-            fastBranch.getTriggers = () => [
-              { changeset: () => invalidChild.changeset() },
-            ];
-            slowBranch.getTriggers = () => [
-              { changeset: () => slowChild.changeset() },
-            ];
-            const fast = nested ? fastBranch : invalidChild;
-            const slow = nested ? slowBranch : slowChild;
-            let pendingSlow!: Promise<unknown>;
-            const prepareSlow = () => {
-              const pending = slow.changeset();
-              pendingSlow = pending;
-              return pending;
-            };
-            if (shape === "siblings") {
-              parent.getTriggers = () => [
-                { changeset: () => fast.changeset() },
-                { changeset: prepareSlow },
-              ];
-            } else if (shape === "trigger group") {
-              parent.getTriggers = () => [
-                [
-                  { changeset: () => fast.changeset() },
-                  { changeset: prepareSlow },
-                ],
-              ];
-            } else if (shape === "child array") {
-              parent.getTriggers = () => [
-                { changeset: () => [fast.changeset(), prepareSlow()] },
-              ];
-            } else {
-              parent.getTriggers = () => [
-                {
-                  changeset: () =>
-                    Promise.all([fast.changeset(), prepareSlow()]),
-                },
-              ];
-            }
-            let settled = false;
-            const validation = parent[method]().then(
-              (value) => {
-                settled = true;
-                return { value };
-              },
-              (error) => {
-                settled = true;
-                return { error };
-              },
-            );
-            await started.promise;
-            // Release independently of validation so the test completes whether
-            // validation rejects early or waits for pending work.
-            await new Promise((resolve) => setImmediate(resolve));
-            const settledBeforeRelease = settled;
-            finish.resolve();
-            expect(await validation).toEqual({ error });
-            await expect(pendingSlow).resolves.toBeDefined();
-            expect(settledBeforeRelease).toBe(false);
-            expect(getTransactionState()!.failed).toBe(false);
-            expect((await audits()).rowCount).toBe(0);
-            invalid = false;
-            await parent.saveX();
-            expect((await audits()).rowCount).toBe(1);
-            expect(observe).not.toHaveBeenCalled();
-          });
-          expect((await load(accounts[0].id as string)).data.balance).toBe(90);
-          expect((await load(accounts[1].id as string)).data.balance).toBe(80);
-          expect((await load(accounts[2].id as string)).data.balance).toBe(70);
-          expect((await audits()).rowCount).toBe(1);
-          expect(observe).toHaveBeenCalledTimes(1);
-        },
-      );
-    });
-  });
-
-  test.each(["sql", "composition"] as const)(
-    "late %s failures remain fatal while parallel validation preserves its first normal error",
-    async (failure) => {
-      const [owner, one, two] = await Promise.all([
-        create(),
-        create(),
-        create(),
-      ]);
-      const firstError = new Error("first ordinary validation error");
-      const started = deferred();
-      const finish = deferred();
-      await expect(
-        withTransaction(async () => {
-          await edit(await load(owner.id as string), 75).saveX();
-          const parent = independent(
-            edit(await load(owner.id as string), 90),
-            `account:${owner.id}`,
-          );
-          const invalid = independent(
-            edit(await load(one.id as string), 80),
-            `account:${one.id}`,
-          );
-          invalid.getValidators = () => [{ validate: async () => firstError }];
-          const slow = independent(
-            edit(await load(two.id as string), 70),
-            `account:${two.id}`,
-          );
-          slow.getTriggers = () => [
+          const [parent, invalidChild, slowChild, fastBranch, slowBranch] =
+            actions;
+          let invalid = true;
+          const error = new Error("first invalid child");
+          invalidChild.getValidators = () => [
+            { validate: async () => (invalid ? error : undefined) },
+          ];
+          const started = deferred();
+          const finish = deferred();
+          slowChild.getObservers = () => [{ observe }];
+          slowChild.getTriggers = () => [
             {
               changeset: async () => {
                 started.resolve();
                 await finish.promise;
-                if (failure === "sql") {
-                  await DB.getInstance()
-                    .getPool()
-                    .query("SELECT * FROM missing_parallel_validation_table");
-                } else {
-                  return independent(
-                    edit(await load(owner.id as string), 60),
-                    `account:${owner.id}`,
-                  ).changeset();
-                }
+                return new SimpleAction(
+                  viewer,
+                  auditSchema,
+                  new Map([["message", "drained child"]]),
+                  WriteOperation.Insert,
+                  null,
+                ).changeset();
               },
             },
           ];
-          parent.getTriggers = () => [
-            { changeset: () => invalid.changeset() },
-            { changeset: () => slow.changeset() },
+          fastBranch.getTriggers = () => [
+            { changeset: () => invalidChild.changeset() },
           ];
-          const validation = expect(parent.validX()).rejects.toBe(firstError);
+          slowBranch.getTriggers = () => [
+            { changeset: () => slowChild.changeset() },
+          ];
+          const fast = nested ? fastBranch : invalidChild;
+          const slow = nested ? slowBranch : slowChild;
+          let pendingSlow!: Promise<unknown>;
+          const prepareSlow = () => {
+            const pending = slow.changeset();
+            pendingSlow = pending;
+            return pending;
+          };
+          if (shape === "siblings") {
+            parent.getTriggers = () => [
+              { changeset: () => fast.changeset() },
+              { changeset: prepareSlow },
+            ];
+          } else if (shape === "trigger group") {
+            parent.getTriggers = () => [
+              [
+                { changeset: () => fast.changeset() },
+                { changeset: prepareSlow },
+              ],
+            ];
+          } else if (shape === "child array") {
+            parent.getTriggers = () => [
+              { changeset: () => [fast.changeset(), prepareSlow()] },
+            ];
+          } else {
+            parent.getTriggers = () => [
+              {
+                changeset: () => Promise.all([fast.changeset(), prepareSlow()]),
+              },
+            ];
+          }
+          let settled = false;
+          const validation = parent[method]().then(
+            (value) => {
+              settled = true;
+              return { value };
+            },
+            (error) => {
+              settled = true;
+              return { error };
+            },
+          );
           await started.promise;
+          // Release independently of validation so the test completes whether
+          // validation rejects early or waits for pending work.
           await new Promise((resolve) => setImmediate(resolve));
+          const settledBeforeRelease = settled;
           finish.resolve();
-          await validation;
-        }),
-      ).rejects.toThrow(
-        failure === "sql"
-          ? "missing_parallel_validation_table"
-          : "overlapping guarded action preparation branches",
-      );
-      expect((await load(owner.id as string)).data.balance).toBe(100);
-    },
-  );
+          expect(await validation).toEqual({ error });
+          await expect(pendingSlow).resolves.toBeDefined();
+          expect(settledBeforeRelease).toBe(false);
+          expect(getTransactionState()!.failed).toBe(false);
+          expect((await audits()).rowCount).toBe(0);
+          invalid = false;
+          await parent.saveX();
+          expect((await audits()).rowCount).toBe(1);
+          expect(observe).not.toHaveBeenCalled();
+        });
+        expect((await load(accounts[0].id as string)).data.balance).toBe(90);
+        expect((await load(accounts[1].id as string)).data.balance).toBe(80);
+        expect((await load(accounts[2].id as string)).data.balance).toBe(70);
+        expect((await audits()).rowCount).toBe(1);
+        expect(observe).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  test.each(["sql", "composition"] as const)("late %s failures remain fatal while parallel validation preserves its first normal error", async (failure) => {
+    const [owner, one, two] = await Promise.all([create(), create(), create()]);
+    const firstError = new Error("first ordinary validation error");
+    const started = deferred();
+    const finish = deferred();
+    await expect(
+      withTransactionScope(async () => {
+        await edit(await load(owner.id as string), 75).saveX();
+        const parent = edit(await load(owner.id as string), 90);
+        const invalid = edit(await load(one.id as string), 80);
+        invalid.getValidators = () => [{ validate: async () => firstError }];
+        const slow = edit(await load(two.id as string), 70);
+        slow.getTriggers = () => [
+          {
+            changeset: async () => {
+              started.resolve();
+              await finish.promise;
+              if (failure === "sql") {
+                await DB.getInstance()
+                  .getPool()
+                  .query("SELECT * FROM missing_parallel_validation_table");
+              } else {
+                await edit(await load(owner.id as string), 60).saveX();
+                return;
+              }
+            },
+          },
+        ];
+        parent.getTriggers = () => [
+          { changeset: () => invalid.changeset() },
+          { changeset: () => slow.changeset() },
+        ];
+        const validation = expect(parent.validX()).rejects.toBe(firstError);
+        await started.promise;
+        await new Promise((resolve) => setImmediate(resolve));
+        finish.resolve();
+        await validation;
+      }),
+    ).rejects.toThrow(
+      failure === "sql"
+        ? "missing_parallel_validation_table"
+        : "nested action saves",
+    );
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+  });
 
   test("outside a transaction parallel child validation retains fail-fast behavior", async () => {
     const [owner, one, two] = await Promise.all([create(), create(), create()]);
@@ -2101,135 +2047,108 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     expect(settledBeforeRelease).toBe(true);
   });
 
-  test.each(["valid", "validX", "validWithErrors"] as const)(
-    "%s releases successful and failed validation reservations for another root",
-    async (method) => {
-      const [owner, target] = await Promise.all([create(), create()]);
-      await withTransaction(async () => {
-        const parent = independent(
-          edit(await load(owner.id as string), 90),
-          `account:${owner.id}`,
-        );
-        parent.getTriggers = () => [
-          {
-            changeset: async () =>
-              independent(
-                edit(await load(target.id as string), 80),
-                `account:${target.id}`,
-              ).changeset(),
-          },
-        ];
-        await parent[method]();
-        const candidate = edit(await load(owner.id as string), 50);
-        const error = new Error("invalid candidate");
-        candidate.getValidators = () => [{ validate: async () => error }];
-        if (method === "validX") {
-          await expect(candidate.validX()).rejects.toBe(error);
-        } else {
-          await candidate[method]();
-        }
-        await edit(await load(target.id as string), 60).saveX();
-      });
-      expect((await load(owner.id as string)).data.balance).toBe(100);
-      expect((await load(target.id as string)).data.balance).toBe(60);
-    },
-  );
+  test.each(["valid", "validX", "validWithErrors"] as const)("%s releases successful and failed validation reservations for another root", async (method) => {
+    const [owner, target] = await Promise.all([create(), create()]);
+    await withTransactionScope(async () => {
+      const parent = edit(await load(owner.id as string), 90);
+      parent.getTriggers = () => [
+        {
+          changeset: async () =>
+            edit(await load(target.id as string), 80).changeset(),
+        },
+      ];
+      await parent[method]();
+      const candidate = edit(await load(owner.id as string), 50);
+      const error = new Error("invalid candidate");
+      candidate.getValidators = () => [{ validate: async () => error }];
+      if (method === "validX") {
+        await expect(candidate.validX()).rejects.toBe(error);
+      } else {
+        await candidate[method]();
+      }
+      await edit(await load(target.id as string), 60).saveX();
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+    expect((await load(target.id as string)).data.balance).toBe(60);
+  });
 
-  test.each(["valid", "validX", "validWithErrors"] as const)(
-    "%s discards probe graphs from retained children and their grandchildren",
-    async (method) => {
-      const [owner, childTarget, grandchildTarget] = await Promise.all([
-        create(),
-        create(),
-        create(),
-      ]);
-      const observe = jest.fn();
-      await withTransaction(async () => {
-        const parent = independent(
-          edit(await load(owner.id as string), 90),
-          `account:${owner.id}`,
-        );
-        const child = independent(
-          edit(await load(childTarget.id as string), 80),
-          `account:${childTarget.id}`,
-        );
-        child.getTriggers = () => [
-          {
-            async changeset() {
-              const grandchild = independent(
-                edit(await load(grandchildTarget.id as string), 70),
-                `account:${grandchildTarget.id}`,
-              );
-              grandchild.getObservers = () => [{ observe }];
-              grandchild.getTriggers = () => [
-                {
-                  changeset: () =>
-                    new SimpleAction(
-                      viewer,
-                      auditSchema,
-                      new Map([["message", "grandchild write"]]),
-                      WriteOperation.Insert,
-                      null,
-                    ).changeset(),
-                },
-              ];
-              return grandchild.changeset();
-            },
+  test.each(["valid", "validX", "validWithErrors"] as const)("%s discards probe graphs from retained children and their grandchildren", async (method) => {
+    const [owner, childTarget, grandchildTarget] = await Promise.all([
+      create(),
+      create(),
+      create(),
+    ]);
+    const observe = jest.fn();
+    await withTransactionScope(async () => {
+      const parent = edit(await load(owner.id as string), 90);
+      const child = edit(await load(childTarget.id as string), 80);
+      child.getTriggers = () => [
+        {
+          async changeset() {
+            const grandchild = edit(
+              await load(grandchildTarget.id as string),
+              70,
+            );
+            grandchild.getObservers = () => [{ observe }];
+            grandchild.getTriggers = () => [
+              {
+                changeset: () =>
+                  new SimpleAction(
+                    viewer,
+                    auditSchema,
+                    new Map([["message", "grandchild write"]]),
+                    WriteOperation.Insert,
+                    null,
+                  ).changeset(),
+              },
+            ];
+            return grandchild.changeset();
           },
-        ];
-        parent.getTriggers = () => [{ changeset: () => child.changeset() }];
-        let invalid = true;
-        const error = new Error("invalid parent");
-        parent.getValidators = () => [
-          { validate: async () => (invalid ? error : undefined) },
-        ];
-        if (method === "validX") {
-          await expect(parent.validX()).rejects.toBe(error);
-        } else {
-          expect(await parent[method]()).toEqual(
-            method === "valid" ? false : [error],
-          );
-        }
-        invalid = false;
-        await parent[method]();
-        await parent.saveX();
-      });
-      expect((await load(owner.id as string)).data.balance).toBe(90);
-      expect((await load(childTarget.id as string)).data.balance).toBe(80);
-      expect((await load(grandchildTarget.id as string)).data.balance).toBe(70);
-      expect((await audits()).rowCount).toBe(1);
-      expect(observe).toHaveBeenCalledTimes(1);
-    },
-  );
+        },
+      ];
+      parent.getTriggers = () => [{ changeset: () => child.changeset() }];
+      let invalid = true;
+      const error = new Error("invalid parent");
+      parent.getValidators = () => [
+        { validate: async () => (invalid ? error : undefined) },
+      ];
+      if (method === "validX") {
+        await expect(parent.validX()).rejects.toBe(error);
+      } else {
+        expect(await parent[method]()).toEqual(
+          method === "valid" ? false : [error],
+        );
+      }
+      invalid = false;
+      await parent[method]();
+      await parent.saveX();
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(90);
+    expect((await load(childTarget.id as string)).data.balance).toBe(80);
+    expect((await load(grandchildTarget.id as string)).data.balance).toBe(70);
+    expect((await audits()).rowCount).toBe(1);
+    expect(observe).toHaveBeenCalledTimes(1);
+  });
 
-  test.each(["valid", "validX", "validWithErrors"] as const)(
-    "%s permits correcting an invalid retained child before saving",
-    async (method) => {
-      const [owner, target] = await Promise.all([create(), create()]);
-      await withTransaction(async () => {
-        const parent = independent(
-          edit(await load(owner.id as string), 90),
-          `account:${owner.id}`,
-        );
-        const child = independent(
-          edit(await load(target.id as string), 80),
-          `account:${target.id}`,
-        );
-        let invalid = true;
-        const error = new Error("invalid child");
-        child.getValidators = () => [
-          { validate: async () => (invalid ? error : undefined) },
-        ];
-        parent.getTriggers = () => [{ changeset: () => child.changeset() }];
-        // Trigger changeset failures propagate from valid and validWithErrors too.
-        await expect(parent[method]()).rejects.toBe(error);
-        invalid = false;
-        await parent.saveX();
-      });
-      expect((await load(owner.id as string)).data.balance).toBe(90);
-      expect((await load(target.id as string)).data.balance).toBe(80);
-    },
-  );
+  test.each(["valid", "validX", "validWithErrors"] as const)("%s permits correcting an invalid retained child before saving", async (method) => {
+    const [owner, target] = await Promise.all([create(), create()]);
+    await withTransactionScope(async () => {
+      const parent = edit(await load(owner.id as string), 90);
+      const child = edit(await load(target.id as string), 80);
+      let invalid = true;
+      const error = new Error("invalid child");
+      child.getValidators = () => [
+        { validate: async () => (invalid ? error : undefined) },
+      ];
+      parent.getTriggers = () => [{ changeset: () => child.changeset() }];
+      // Trigger changeset failures propagate from valid and validWithErrors too.
+      await expect(parent[method]()).rejects.toBe(error);
+      invalid = false;
+      await parent.saveX();
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(90);
+    expect((await load(target.id as string)).data.balance).toBe(80);
+  });
 
   test.each([
     ["action", "valid"],
@@ -2242,7 +2161,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     "%s transform children survive failed and repeated %s probes",
     async (source, method) => {
       const owner = await create();
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         let message = "probe";
         const transform = ({ op }: { op: SQLStatementOperation }) => {
           if (op !== SQLStatementOperation.Delete) {
@@ -2317,7 +2236,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
 
   test("public validation restores an insert transformed into an existing target update", async () => {
     const owner = await create();
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const parent = new GuardedEdit(
         viewer,
         accountSchema,
@@ -2368,7 +2287,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         "INSERT INTO assoc_edge_config (edge_type, edge_name, edge_table, symmetric_edge, inverse_edge_type, created_at, updated_at) VALUES ($1, 'probe child', 'scoped_account_edges', false, NULL, now(), now())",
         [edgeType],
       );
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const parent = edit(await load(owner.id as string), 90);
       parent.getTriggers = () => [
         {
@@ -2409,7 +2328,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     "%s does not transform already-transformed action input twice",
     async (method) => {
       const owner = await create();
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const parent = edit(await load(owner.id as string), 90);
         Object.assign(parent, {
           transformWrite: ({
@@ -2445,7 +2364,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       },
       ScopedAccount,
     );
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const action = new GuardedEdit(
         viewer,
         schema,
@@ -2473,7 +2392,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         [edgeType],
       );
     let owner!: ScopedAccount;
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const schema = getBuilderSchemaFromFields(
         {
           balance: IntegerType({ defaultValueOnCreate: () => 42 }),
@@ -2509,7 +2428,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
 
   test("scoped transform factories preserve their receiver and synchronous changesets", async () => {
     const owner = await create();
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const parent = edit(await load(owner.id as string), 90);
       Object.assign(parent, {
         transformWrite: ({ op }: { op: SQLStatementOperation }) => ({
@@ -2534,9 +2453,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     ]);
   });
 
-  test("public validation preserves an unguarded parent's ancestry", async () => {
+  test("public validation preserves an ordinary parent's ancestry", async () => {
     const [owner, target] = await Promise.all([create(), create()]);
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const parent = new SimpleAction(
         viewer,
         accountSchema,
@@ -2557,33 +2476,27 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     expect((await load(target.id as string)).data.balance).toBe(80);
   });
 
-  test.each(["valid", "validX", "validWithErrors"] as const)(
-    "%s applies the ancestor conflict guard before preparing overlapping children",
-    async (method) => {
-      const [owner, target] = await Promise.all([create(), create()]);
-      await expect(
-        withTransaction(async () => {
-          const parent = edit(await load(owner.id as string), 90);
-          parent.getTriggers = () => [
-            {
-              changeset: async () =>
-                edit(await load(target.id as string), 80).changeset(),
-            },
-          ];
-          await expect(parent[method]()).rejects.toThrow(
-            "overlapping guarded action preparation branches",
-          );
-        }),
-      ).rejects.toThrow("overlapping guarded action preparation branches");
-      expect((await load(owner.id as string)).data.balance).toBe(100);
-      expect((await load(target.id as string)).data.balance).toBe(100);
-    },
-  );
+  test.each(["valid", "validX", "validWithErrors"] as const)("%s prepares descendants and allows saving them afterward", async (method) => {
+    const [owner, target] = await Promise.all([create(), create()]);
+    await withTransactionScope(async () => {
+      const parent = edit(await load(owner.id as string), 90);
+      parent.getTriggers = () => [
+        {
+          changeset: async () =>
+            edit(await load(target.id as string), 80).changeset(),
+        },
+      ];
+      await parent[method]();
+      await parent.saveX();
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(90);
+    expect((await load(target.id as string)).data.balance).toBe(80);
+  });
 
   test("saving while public validation is pending fails closed", async () => {
     const owner = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const parent = edit(await load(owner.id as string), 90);
         const started = deferred();
         const finish = deferred();
@@ -2610,43 +2523,35 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     expect((await load(owner.id as string)).data.balance).toBe(100);
   });
 
-  test.each([true, false])(
-    "default wildcard conflicts with keyed sibling regardless preparation order (%s)",
-    async (keyedFirst) => {
-      const accounts = await Promise.all([create(), create(), create()]);
-      await expect(
-        withTransaction(async () => {
-          const current = await Promise.all(
-            accounts.map((account) => load(account.id as string)),
-          );
-          const parent = new SimpleAction(
-            viewer,
-            accountSchema,
-            new Map([["balance", 90]]),
-            WriteOperation.Edit,
-            current[0],
-          );
-          parent.getTriggers = () => [
-            {
-              async changeset() {
-                const keyed = independent(
-                  edit(current[1], 80),
-                  `account:${current[1].id}`,
-                );
-                const wildcard = edit(current[2], 70);
-                const children = keyedFirst
-                  ? [keyed, wildcard]
-                  : [wildcard, keyed];
-                return [
-                  await children[0].changeset(),
-                  await children[1].changeset(),
-                ];
-              },
-            },
-          ];
-          await parent.saveX();
-        }),
-      ).rejects.toThrow("overlapping guarded action preparation branches");
-    },
-  );
+  test.each([true, false])("children can prepare in either order (forward=%s)", async (forward) => {
+    const accounts = await Promise.all([create(), create(), create()]);
+    await withTransactionScope(async () => {
+      const current = await Promise.all(
+        accounts.map((account) => load(account.id as string)),
+      );
+      const parent = edit(current[0], 90);
+      parent.getTriggers = () => [
+        {
+          changeset: async () => {
+            const children = [edit(current[1], 80), edit(current[2], 70)];
+            if (!forward) {
+              children.reverse();
+            }
+            return [
+              await children[0].changeset(),
+              await children[1].changeset(),
+            ];
+          },
+        },
+      ];
+      await parent.saveX();
+    });
+    expect(
+      await Promise.all(
+        accounts.map(
+          async (account) => (await load(account.id as string)).data.balance,
+        ),
+      ),
+    ).toEqual([90, 80, 70]);
+  });
 });

--- a/ts/src/core/transaction.test.ts
+++ b/ts/src/core/transaction.test.ts
@@ -84,7 +84,9 @@ function deferred() {
 function barrier(n: number) {
   const gate = deferred();
   return async () => {
-    if (--n === 0) gate.resolve();
+    if (--n === 0) {
+      gate.resolve();
+    }
     await gate.promise;
   };
 }
@@ -615,8 +617,12 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         const privacy = jest
           .spyOn(ScopedAccount.prototype, "getPrivacyPolicy")
           .mockImplementation(function (this: ScopedAccount) {
-            if (this.data.balance !== 12) return original.call(this);
-            if (source === "privacy throw") throw error;
+            if (this.data.balance !== 12) {
+              return original.call(this);
+            }
+            if (source === "privacy throw") {
+              throw error;
+            }
             if (source === "privacy reject") {
               return {
                 rules: [
@@ -819,7 +825,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       }
       await expect(
         withTransaction(async () => {
-          if (origin === "same scope") await savePrevious();
+          if (origin === "same scope") {
+            await savePrevious();
+          }
           await edit(await load(owner.id as string), 80).saveX();
           const snapshot = await previous[method]();
           expect(snapshot!.data.balance).toBe(90);
@@ -1028,7 +1036,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         async (tx) => {
           attempts.push(tx.attempt);
           const current = await load(account.id as string);
-          if (tx.attempt === 0) await meet();
+          if (tx.attempt === 0) {
+            await meet();
+          }
           const action = edit(current, current.data.balance - amount);
           action.getTriggers = () => [
             {
@@ -1082,8 +1092,12 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
                   clause: Eq("admin", true),
                   context,
                 });
-                if (tx.attempt === 0) await meet();
-                if (rows.length <= 1) throw new Error("last admin");
+                if (tx.attempt === 0) {
+                  await meet();
+                }
+                if (rows.length <= 1) {
+                  throw new Error("last admin");
+                }
               },
             },
           ];
@@ -1383,7 +1397,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
                     clause: Eq("admin", true),
                     context,
                   });
-                  if (rows.length <= 1) throw new Error("last admin");
+                  if (rows.length <= 1) {
+                    throw new Error("last admin");
+                  }
                 },
               },
             ];
@@ -1672,7 +1688,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
                           clause: Eq("admin", true),
                           context,
                         });
-                        if (rows.length <= 1) throw new Error("last admin");
+                        if (rows.length <= 1) {
+                          throw new Error("last admin");
+                        }
                       },
                     },
                   ];
@@ -1710,7 +1728,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           WriteOperation.Edit,
           await load(id),
         );
-        if (key) independent(action, key);
+        if (key) {
+          independent(action, key);
+        }
         action.getValidators = () => [
           {
             async validate() {
@@ -1719,7 +1739,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
                 clause: Eq("admin", true),
                 context,
               });
-              if (rows.length <= 1) throw new Error("last admin");
+              if (rows.length <= 1) {
+                throw new Error("last admin");
+              }
             },
           },
         ];
@@ -1733,7 +1755,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           parent.getTriggers = () => [
             {
               async changeset() {
-                if (!wrapper) return child();
+                if (!wrapper) {
+                  return child();
+                }
                 const intermediate = new SimpleAction(
                   viewer,
                   auditSchema,
@@ -2116,9 +2140,11 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         const candidate = edit(await load(owner.id as string), 50);
         const error = new Error("invalid candidate");
         candidate.getValidators = () => [{ validate: async () => error }];
-        if (method === "validX")
+        if (method === "validX") {
           await expect(candidate.validX()).rejects.toBe(error);
-        else await candidate[method]();
+        } else {
+          await candidate[method]();
+        }
         await edit(await load(target.id as string), 60).saveX();
       });
       expect((await load(owner.id as string)).data.balance).toBe(100);
@@ -2174,12 +2200,13 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         parent.getValidators = () => [
           { validate: async () => (invalid ? error : undefined) },
         ];
-        if (method === "validX")
+        if (method === "validX") {
           await expect(parent.validX()).rejects.toBe(error);
-        else
+        } else {
           expect(await parent[method]()).toEqual(
             method === "valid" ? false : [error],
           );
+        }
         invalid = false;
         await parent[method]();
         await parent.saveX();
@@ -2235,7 +2262,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       await withTransaction(async () => {
         let message = "probe";
         const transform = ({ op }: { op: SQLStatementOperation }) => {
-          if (op !== SQLStatementOperation.Delete) return null;
+          if (op !== SQLStatementOperation.Delete) {
+            return null;
+          }
           return {
             op: SQLStatementOperation.Update,
             data: { admin: false },
@@ -2272,19 +2301,21 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           WriteOperation.Delete,
           await load(owner.id as string),
         );
-        if (source === "action")
+        if (source === "action") {
           Object.assign(parent, { transformWrite: transform });
+        }
         let invalid = true;
         const error = new Error("invalid transformed action");
         parent.getValidators = () => [
           { validate: async () => (invalid ? error : undefined) },
         ];
-        if (method === "validX")
+        if (method === "validX") {
           await expect(parent.validX()).rejects.toBe(error);
-        else
+        } else {
           expect(await parent[method]()).toEqual(
             method === "valid" ? false : [error],
           );
+        }
         invalid = false;
         await parent[method]();
         await parent[method]();
@@ -2316,7 +2347,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       );
       Object.assign(parent, {
         transformWrite: async ({ op }: { op: SQLStatementOperation }) => {
-          if (op !== SQLStatementOperation.Insert) return null;
+          if (op !== SQLStatementOperation.Insert) {
+            return null;
+          }
           return {
             op: SQLStatementOperation.Update,
             existingEnt: await load(owner.id as string),

--- a/ts/src/core/transaction.test.ts
+++ b/ts/src/core/transaction.test.ts
@@ -454,10 +454,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     "paused field privacy cannot freshen stale %s reads",
     async (path) => {
       const owner = await create();
-      const expectedError =
-        path === "strict clause"
-          ? "reload existingEnt"
-          : "cannot cross transaction generations";
+      const expectedError = "cannot cross transaction generations";
       const started = deferred();
       const finish = deferred();
       const policy: PrivacyPolicy = {
@@ -484,17 +481,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           } finally {
             finish.resolve();
           }
-          if (path !== "strict clause") {
-            // Cached readers now reject before returning or priming old Ents.
-            await expect(pending).rejects.toThrow(expectedError);
-            return;
-          }
-          const stale = await pending;
-          expect(stale!.data.admin).toBeNull();
-          expect(stale!.data.balance).toBe(100);
-          await expect(edit(stale!, 90).saveX()).rejects.toThrow(
-            "reload existingEnt",
-          );
+          // Every materialization path rejects before returning stale Ents.
+          await expect(pending).rejects.toThrow(expectedError);
         }),
       ).rejects.toThrow(expectedError);
       expect((await load(owner.id as string)).data.balance).toBe(100);
@@ -1788,7 +1776,6 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
     async (method) => {
       const [owner, target] = await Promise.all([create(), create()]);
       const observe = jest.fn();
-      let retained!: Awaited<ReturnType<GuardedEdit["changeset"]>>;
       await withTransaction(async () => {
         const parent = independent(
           edit(await load(owner.id as string), 90),
@@ -1814,8 +1801,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
                     ).changeset(),
                 },
               ];
-              retained = await child.changeset();
-              return retained;
+              return child.changeset();
             },
           },
         ];
@@ -1825,9 +1811,6 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
         );
         expect((await load(target.id as string)).data.balance).toBe(100);
         expect((await audits()).rowCount).toBe(0);
-        expect(() => retained.executor()).toThrow(
-          "prepared by public validation",
-        );
         await parent.saveX();
         expect((await audits()).rowCount).toBe(1);
         expect(observe).not.toHaveBeenCalled();

--- a/ts/src/core/transaction.test.ts
+++ b/ts/src/core/transaction.test.ts
@@ -1,0 +1,2636 @@
+import DB, { Dialect } from "./db";
+import { withTransaction, TransactionScope } from "./transaction";
+import { getTransactionState } from "./transaction_context";
+import {
+  loadEnt,
+  loadEntX,
+  loadEntFromClause,
+  loadEntXFromClause,
+  loadEnts,
+  loadEntsFromClause,
+  loadCustomEnts,
+  loadRows,
+  loadEdges,
+} from "./ent";
+import { Deny, PrivacyPolicy } from "./base";
+import { ObjectLoaderFactory } from "./loaders";
+import { Eq } from "./clause";
+import { AlwaysDenyPrivacyPolicy } from "./privacy";
+import { WriteOperation } from "../action/action";
+import { Transaction } from "../action/transaction";
+import { EntChangeset } from "../action/orchestrator";
+import {
+  BooleanType,
+  IntegerType,
+  UUIDType,
+  StringType,
+  SQLStatementOperation,
+} from "../schema";
+import {
+  setupPostgres,
+  getSchemaTable,
+  assoc_edge_config_table,
+  assoc_edge_table,
+} from "../testutils/db/temp_db";
+import {
+  BaseEnt,
+  getBuilderSchemaFromFields,
+  SimpleAction,
+  getDbFields,
+} from "../testutils/builder";
+import { TestContext } from "../testutils/context/test_context";
+
+class ScopedAccount extends BaseEnt {
+  nodeType = "ScopedAccount";
+}
+class ScopedAudit extends BaseEnt {
+  nodeType = "ScopedAudit";
+}
+const accountSchema = getBuilderSchemaFromFields(
+  {
+    balance: IntegerType(),
+    admin: BooleanType(),
+    ownerID: UUIDType({ nullable: true }),
+  },
+  ScopedAccount,
+);
+const auditSchema = getBuilderSchemaFromFields(
+  { message: StringType() },
+  ScopedAudit,
+);
+const fields = getDbFields(accountSchema);
+const loaderFactory = new ObjectLoaderFactory({
+  tableName: "scoped_accounts",
+  fields,
+  key: "id",
+});
+const options = {
+  tableName: "scoped_accounts",
+  fields,
+  ent: ScopedAccount,
+  loaderFactory,
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+const load = (id: string) => loadEntX(viewer, id, options);
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+function barrier(n: number) {
+  const gate = deferred();
+  return async () => {
+    if (--n === 0) gate.resolve();
+    await gate.promise;
+  };
+}
+
+class GuardedEdit extends SimpleAction<ScopedAccount> {
+  requiresTransaction() {
+    return true;
+  }
+}
+
+function independent<T extends SimpleAction<ScopedAccount>>(
+  action: T,
+  resource: string,
+): T {
+  return Object.assign(action, { getTransactionResources: () => [resource] });
+}
+
+describe("transaction-scoped actions (disposable Postgres database)", () => {
+  setupPostgres(() => [
+    getSchemaTable(accountSchema, Dialect.Postgres),
+    getSchemaTable(auditSchema, Dialect.Postgres),
+    assoc_edge_config_table(),
+    assoc_edge_table("scoped_account_edges"),
+  ]);
+  beforeEach(() => context.cache.reset());
+
+  const create = (balance = 100, admin = true) =>
+    new SimpleAction(
+      viewer,
+      accountSchema,
+      new Map<string, any>([
+        ["balance", balance],
+        ["admin", admin],
+      ]),
+      WriteOperation.Insert,
+      null,
+    ).saveX();
+  const edit = (ent: ScopedAccount, balance: number) =>
+    new GuardedEdit(
+      viewer,
+      accountSchema,
+      new Map<string, any>([["balance", balance]]),
+      WriteOperation.Edit,
+      ent,
+    );
+  const audits = () =>
+    DB.getInstance().getPool().query("SELECT * FROM scoped_audits");
+
+  const assemblyEntrypoints = [
+    "save",
+    "saveX",
+    "builder.save",
+    "builder.saveX",
+    "Transaction.run",
+    "changeset.executor",
+  ] as const;
+  const assembleCycle = async (
+    parent: SimpleAction<ScopedAccount>,
+    entry: (typeof assemblyEntrypoints)[number],
+  ) => {
+    parent.getTriggers = () => [
+      {
+        async changeset(builder) {
+          const child = new SimpleAction(
+            viewer,
+            accountSchema,
+            new Map<string, any>([
+              ["balance", 20],
+              ["admin", true],
+            ]),
+            WriteOperation.Insert,
+            null,
+          );
+          // Parent needs the child's ID, while the conditional child depends
+          // on the parent. Preparation succeeds; executor assembly finds the cycle.
+          builder.updateInput({ ownerID: child.builder });
+          return child.changesetWithOptions_BETA({
+            conditionalBuilder: builder,
+          });
+        },
+      },
+    ];
+    switch (entry) {
+      case "save":
+      case "saveX":
+        return parent[entry]();
+      case "builder.save":
+        return parent.builder.save();
+      case "builder.saveX":
+        return parent.builder.saveX();
+      case "Transaction.run":
+        return new Transaction(viewer, [parent]).run();
+      case "changeset.executor":
+        return (await parent.changeset()).executor();
+    }
+  };
+
+  test.each(assemblyEntrypoints)(
+    "caught graph assembly failure from %s rolls back earlier writes and observers",
+    async (entry) => {
+      const owner = await create();
+      const observe = jest.fn();
+      let caught: unknown;
+      const outcome = withTransaction(async () => {
+        const first = edit(await load(owner.id as string), 75);
+        first.getObservers = () => [{ observe }];
+        await first.saveX();
+        try {
+          await assembleCycle(edit(await load(owner.id as string), 50), entry);
+        } catch (error) {
+          caught = error;
+        }
+      });
+      await expect(outcome).rejects.toThrow("Cycle found");
+      expect(caught).toEqual(new Error("Cycle found"));
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+      expect(observe).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(assemblyEntrypoints)(
+    "unscoped graph assembly failure from %s still rejects before writes",
+    async (entry) => {
+      const owner = await create();
+      const parent = new SimpleAction(
+        viewer,
+        accountSchema,
+        new Map([["balance", 50]]),
+        WriteOperation.Edit,
+        owner,
+      );
+      const observe = jest.fn();
+      parent.getObservers = () => [{ observe }];
+      await expect(assembleCycle(parent, entry)).rejects.toThrow("Cycle found");
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+      expect(observe).not.toHaveBeenCalled();
+    },
+  );
+
+  const saveFailureStages = [
+    "build sync",
+    "build async",
+    "executor factory",
+    "execute sync",
+    "execute async",
+  ] as const;
+  const failingSave = (
+    action: SimpleAction<ScopedAccount>,
+    stage: (typeof saveFailureStages)[number],
+    failure: Error,
+  ) => {
+    const fail = (): never => {
+      throw failure;
+    };
+    if (stage === "build sync") {
+      action.builder.build = fail;
+    } else if (stage === "build async") {
+      action.builder.build = async () => fail();
+    } else {
+      const build = action.builder.build.bind(action.builder);
+      action.builder.build = async () => {
+        const changeset = await build();
+        if (stage === "executor factory") {
+          changeset.executor = fail;
+        } else {
+          const executor = changeset.executor();
+          executor.execute =
+            stage === "execute sync" ? fail : async () => fail();
+        }
+        return changeset;
+      };
+    }
+  };
+
+  describe.each(["save", "saveX"] as const)(
+    "builder.%s failure boundary",
+    (entry) => {
+      test.each(saveFailureStages)(
+        "caught or suppressed %s failure still aborts the scope with the original error",
+        async (stage) => {
+          const owner = await create();
+          const failure = new Error(stage);
+          const observe = jest.fn();
+          await expect(
+            withTransaction(async () => {
+              const first = edit(await load(owner.id as string), 75);
+              first.getObservers = () => [{ observe }];
+              await first.saveX();
+              const next = edit(await load(owner.id as string), 50);
+              failingSave(next, stage, failure);
+              await next.builder[entry]().catch(() => {});
+            }),
+          ).rejects.toBe(failure);
+          expect((await load(owner.id as string)).data.balance).toBe(100);
+          expect(observe).not.toHaveBeenCalled();
+        },
+      );
+
+      test.each(saveFailureStages)(
+        "unscoped %s failure retains existing rejection and suppression behavior",
+        async (stage) => {
+          const owner = await create();
+          const failure = new Error(stage);
+          const action = new SimpleAction(
+            viewer,
+            accountSchema,
+            new Map([["balance", 50]]),
+            WriteOperation.Edit,
+            owner,
+          );
+          failingSave(action, stage, failure);
+          const result = action.builder[entry]();
+          if (
+            entry === "save" &&
+            (stage.startsWith("build") || stage === "execute sync")
+          ) {
+            await expect(result).resolves.toBeUndefined();
+          } else {
+            await expect(result).rejects.toBe(failure);
+          }
+          expect((await load(owner.id as string)).data.balance).toBe(100);
+        },
+      );
+    },
+  );
+
+  test.each(["sync", "async"] as const)(
+    "caught custom grouped preparation %s failure aborts earlier writes",
+    async (timing) => {
+      const owner = await create();
+      const failure = new Error("custom changeset preparation");
+      const observe = jest.fn();
+      await expect(
+        withTransaction(async () => {
+          const first = edit(await load(owner.id as string), 75);
+          first.getObservers = () => [{ observe }];
+          await first.saveX();
+          const next = edit(await load(owner.id as string), 50);
+          const fail = (): never => {
+            throw failure;
+          };
+          next.changeset = timing === "sync" ? fail : async () => fail();
+          await new Transaction(viewer, [next]).run().catch(() => {});
+        }),
+      ).rejects.toBe(failure);
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+      expect(observe).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(["list", "complex", "Transaction.run"] as const)(
+    "caught %s execution context failure aborts earlier writes",
+    async (entry) => {
+      const owner = await create();
+      const failure = new Error("execution context unavailable");
+      const observe = jest.fn();
+      await expect(
+        withTransaction(async () => {
+          const first = edit(await load(owner.id as string), 75);
+          first.getObservers = () => [{ observe }];
+          await first.saveX();
+          const executionViewer = new TestContext().getViewer();
+          const next = new SimpleAction(
+            executionViewer,
+            accountSchema,
+            new Map([["balance", 50]]),
+            WriteOperation.Edit,
+            await load(owner.id as string),
+          );
+          if (entry === "complex") {
+            next.getTriggers = () => [
+              {
+                changeset: () =>
+                  new SimpleAction(
+                    viewer,
+                    auditSchema,
+                    new Map([["message", "pending audit"]]),
+                    WriteOperation.Insert,
+                    null,
+                  ).changeset(),
+              },
+            ];
+          }
+          const changeset = await next.changeset();
+          const executor = changeset.executor();
+          next.changeset = async () => changeset;
+          Object.defineProperty(executionViewer, "context", {
+            get() {
+              throw failure;
+            },
+          });
+          const execution =
+            entry === "Transaction.run"
+              ? new Transaction(executionViewer, [next]).run()
+              : executor.execute();
+          await execution.catch(() => {});
+        }),
+      ).rejects.toBe(failure);
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+      expect((await audits()).rowCount).toBe(0);
+      expect(observe).not.toHaveBeenCalled();
+    },
+  );
+
+  const privacyReadPaths = [
+    "nullable",
+    "strict",
+    "nullable clause",
+    "strict clause",
+    "bulk ids",
+    "bulk clause",
+    "custom bulk",
+  ] as const;
+  const loadWithFieldPrivacy = async (
+    path: (typeof privacyReadPaths)[number],
+    id: string,
+    policy: PrivacyPolicy = AlwaysDenyPrivacyPolicy,
+  ) => {
+    // Separate request caches keep a paused private read independent of the
+    // unredacted reader used to advance the same transaction's generation.
+    const privateViewer = new TestContext().getViewer();
+    const privateOptions = {
+      ...options,
+      fieldPrivacy: new Map([["admin", policy]]),
+    };
+    switch (path) {
+      case "nullable":
+        return loadEnt(privateViewer, id, privateOptions);
+      case "strict":
+        return loadEntX(privateViewer, id, privateOptions);
+      case "nullable clause":
+        return loadEntFromClause(privateViewer, privateOptions, Eq("id", id));
+      case "strict clause":
+        return loadEntXFromClause(privateViewer, privateOptions, Eq("id", id));
+      case "bulk ids":
+        return (await loadEnts(privateViewer, privateOptions, id)).get(id)!;
+      case "bulk clause":
+        return (
+          await loadEntsFromClause(privateViewer, Eq("id", id), privateOptions)
+        ).get(id)!;
+      case "custom bulk":
+        return (
+          await loadCustomEnts(privateViewer, privateOptions, Eq("id", id))
+        )[0];
+    }
+  };
+
+  test.each(privacyReadPaths)(
+    "fresh field-redacted %s reads remain valid guarded action inputs",
+    async (path) => {
+      const owner = await create();
+      await withTransaction(async () => {
+        const redacted = await loadWithFieldPrivacy(path, owner.id as string);
+        expect(redacted!.data.admin).toBeNull();
+        await edit(redacted!, 75).saveX();
+      });
+      const current = await load(owner.id as string);
+      expect(current.data.balance).toBe(75);
+      expect(current.data.admin).toBe(true);
+    },
+  );
+
+  test.each(["nullable", "strict clause", "custom bulk"] as const)(
+    "paused field privacy cannot freshen stale %s reads",
+    async (path) => {
+      const owner = await create();
+      const expectedError =
+        path === "strict clause"
+          ? "reload existingEnt"
+          : "cannot cross transaction generations";
+      const started = deferred();
+      const finish = deferred();
+      const policy: PrivacyPolicy = {
+        rules: [
+          {
+            async apply() {
+              started.resolve();
+              await finish.promise;
+              return Deny();
+            },
+          },
+        ],
+      };
+      await expect(
+        withTransaction(async () => {
+          const pending = loadWithFieldPrivacy(
+            path,
+            owner.id as string,
+            policy,
+          );
+          await started.promise;
+          try {
+            await edit(await load(owner.id as string), 75).saveX();
+          } finally {
+            finish.resolve();
+          }
+          if (path !== "strict clause") {
+            // Cached readers now reject before returning or priming old Ents.
+            await expect(pending).rejects.toThrow(expectedError);
+            return;
+          }
+          const stale = await pending;
+          expect(stale!.data.admin).toBeNull();
+          expect(stale!.data.balance).toBe(100);
+          await expect(edit(stale!, 90).saveX()).rejects.toThrow(
+            "reload existingEnt",
+          );
+        }),
+      ).rejects.toThrow(expectedError);
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+    },
+  );
+
+  test("field privacy preserves absent provenance for an outside read awaited in a scope", async () => {
+    const owner = await create();
+    const started = deferred();
+    const finish = deferred();
+    const outside = loadWithFieldPrivacy("strict", owner.id as string, {
+      rules: [
+        {
+          async apply() {
+            started.resolve();
+            await finish.promise;
+            return Deny();
+          },
+        },
+      ],
+    });
+    await started.promise;
+    await expect(
+      withTransaction(async () => {
+        try {
+          await edit(await load(owner.id as string), 75).saveX();
+        } finally {
+          finish.resolve();
+        }
+        const unowned = await outside;
+        expect(unowned!.data.admin).toBeNull();
+        await expect(edit(unowned!, 90).saveX()).rejects.toThrow(
+          "reload existingEnt",
+        );
+      }),
+    ).rejects.toThrow("reload existingEnt");
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+  });
+
+  test.each(["saveX", "editedEntX"] as const)(
+    "caught %s result privacy denial rolls back earlier writes, audits and observers",
+    async (method) => {
+      const [earlier, target] = await Promise.all([create(), create()]);
+      const observe = jest.fn();
+      const original = ScopedAccount.prototype.getPrivacyPolicy;
+      const privacy = jest
+        .spyOn(ScopedAccount.prototype, "getPrivacyPolicy")
+        .mockImplementation(function (this: ScopedAccount) {
+          return this.data.balance === 12
+            ? AlwaysDenyPrivacyPolicy
+            : original.call(this);
+        });
+      let caught: unknown;
+      try {
+        const failure = await withTransaction(async () => {
+          for (const [account, balance] of [
+            [earlier, 75],
+            [target, 12],
+          ] as const) {
+            const action = edit(await load(account.id as string), balance);
+            action.getObservers = () => [{ observe }];
+            action.getTriggers = () => [
+              {
+                changeset: () =>
+                  new SimpleAction(
+                    viewer,
+                    auditSchema,
+                    new Map([["message", `balance ${balance}`]]),
+                    WriteOperation.Insert,
+                    null,
+                  ).changeset(),
+              },
+            ];
+            if (account === earlier) {
+              await action.saveX();
+            } else {
+              try {
+                if (method === "editedEntX") {
+                  await action.builder.saveX();
+                  await action.editedEntX();
+                } else {
+                  await action.saveX();
+                }
+              } catch (error) {
+                caught = error;
+              }
+            }
+          }
+        }).then(
+          () => undefined,
+          (error) => error,
+        );
+        expect(caught).toEqual(
+          new Error("was able to edit ent but not load it"),
+        );
+        expect(failure).toBe(caught);
+        const rows = await DB.getInstance()
+          .getPool()
+          .query("SELECT balance FROM scoped_accounts");
+        expect(rows.rows.map((row) => row.balance)).toEqual([100, 100]);
+        expect((await audits()).rowCount).toBe(0);
+        expect(observe).not.toHaveBeenCalled();
+      } finally {
+        privacy.mockRestore();
+      }
+    },
+  );
+
+  test.each(["save", "saveX"] as const)(
+    "caught unexpected result failures from %s poison the owner",
+    async (method) => {
+      for (const source of [
+        "viewer throw",
+        "viewer reject",
+        "privacy throw",
+        "privacy reject",
+      ] as const) {
+        const owner = await create();
+        const error = new Error(source);
+        const original = ScopedAccount.prototype.getPrivacyPolicy;
+        const privacy = jest
+          .spyOn(ScopedAccount.prototype, "getPrivacyPolicy")
+          .mockImplementation(function (this: ScopedAccount) {
+            if (this.data.balance !== 12) return original.call(this);
+            if (source === "privacy throw") throw error;
+            if (source === "privacy reject") {
+              return {
+                rules: [
+                  {
+                    async apply() {
+                      throw error;
+                    },
+                  },
+                ],
+              };
+            }
+            return original.call(this);
+          });
+        try {
+          await expect(
+            withTransaction(async () => {
+              const action = edit(await load(owner.id as string), 12);
+              if (source === "viewer throw") {
+                action.viewerForEntLoad = () => {
+                  throw error;
+                };
+              } else if (source === "viewer reject") {
+                action.viewerForEntLoad = async () => {
+                  throw error;
+                };
+              }
+              await expect(action[method]()).rejects.toBe(error);
+            }),
+          ).rejects.toBe(error);
+          expect((await load(owner.id as string)).data.balance).toBe(100);
+        } finally {
+          privacy.mockRestore();
+        }
+      }
+    },
+  );
+
+  test("normal nullable result privacy denial still permits commit", async () => {
+    const owner = await create();
+    const observe = jest.fn();
+    const original = ScopedAccount.prototype.getPrivacyPolicy;
+    const privacy = jest
+      .spyOn(ScopedAccount.prototype, "getPrivacyPolicy")
+      .mockImplementation(function (this: ScopedAccount) {
+        return this.data.balance === 12
+          ? AlwaysDenyPrivacyPolicy
+          : original.call(this);
+      });
+    try {
+      await withTransaction(async () => {
+        const action = edit(await load(owner.id as string), 12);
+        action.getObservers = () => [{ observe }];
+        action.getTriggers = () => [
+          {
+            changeset: () =>
+              new SimpleAction(
+                viewer,
+                auditSchema,
+                new Map([["message", "nullable result"]]),
+                WriteOperation.Insert,
+                null,
+              ).changeset(),
+          },
+        ];
+        await expect(action.save()).resolves.toBeNull();
+        await expect(action.editedEnt()).resolves.toBeNull();
+      });
+      const rows = await DB.getInstance()
+        .getPool()
+        .query("SELECT balance FROM scoped_accounts WHERE id = $1", [owner.id]);
+      expect(rows.rows[0].balance).toBe(12);
+      expect((await audits()).rowCount).toBe(1);
+      expect(observe).toHaveBeenCalledTimes(1);
+    } finally {
+      privacy.mockRestore();
+    }
+  });
+
+  test.each(["editedEnt", "editedEntX"] as const)(
+    "%s before writing preserves its nullable or throwing result contract",
+    async (method) => {
+      const owner = await create();
+      let caught: unknown;
+      const failure = await withTransaction(async () => {
+        await edit(await load(owner.id as string), 75).saveX();
+        const candidate = edit(await load(owner.id as string), 12);
+        try {
+          expect(await candidate[method]()).toBeNull();
+        } catch (error) {
+          caught = error;
+        }
+      }).then(
+        () => undefined,
+        (error) => error,
+      );
+      if (method === "editedEntX") {
+        expect(caught).toEqual(new Error("ent was not created"));
+        expect(failure).toBe(caught);
+      } else {
+        expect(caught).toBeUndefined();
+        expect(failure).toBeUndefined();
+      }
+      expect((await load(owner.id as string)).data.balance).toBe(
+        method === "editedEntX" ? 100 : 75,
+      );
+    },
+  );
+
+  test.each(["save", "saveX"] as const)(
+    "ordinary %s result privacy behavior remains after its write commit",
+    async (method) => {
+      const owner = await create();
+      const action = new SimpleAction(
+        viewer,
+        accountSchema,
+        new Map([["balance", 12]]),
+        WriteOperation.Edit,
+        owner,
+      );
+      const observe = jest.fn();
+      action.getObservers = () => [{ observe }];
+      const original = ScopedAccount.prototype.getPrivacyPolicy;
+      const privacy = jest
+        .spyOn(ScopedAccount.prototype, "getPrivacyPolicy")
+        .mockImplementation(function (this: ScopedAccount) {
+          return this.data.balance === 12
+            ? AlwaysDenyPrivacyPolicy
+            : original.call(this);
+        });
+      try {
+        if (method === "saveX") {
+          await expect(action.saveX()).rejects.toThrow(
+            "was able to edit ent but not load it",
+          );
+        } else {
+          await expect(action.save()).resolves.toBeNull();
+        }
+        const rows = await DB.getInstance()
+          .getPool()
+          .query("SELECT balance FROM scoped_accounts WHERE id = $1", [
+            owner.id,
+          ]);
+        expect(rows.rows[0].balance).toBe(12);
+        expect(observe).toHaveBeenCalledTimes(1);
+      } finally {
+        privacy.mockRestore();
+      }
+    },
+  );
+
+  test.each(["editedEnt", "editedEntX"] as const)(
+    "%s failures from an already committed owner do not poison another scope",
+    async (method) => {
+      const owner = await create();
+      let previous!: GuardedEdit;
+      await withTransaction(async () => {
+        previous = edit(await load(owner.id as string), 75);
+        await previous.saveX();
+      });
+      const error = new Error("old result viewer failed");
+      previous.viewerForEntLoad = async () => {
+        throw error;
+      };
+      await expect(previous[method]()).rejects.toBe(error);
+      await withTransaction(async () => {
+        await edit(await load(owner.id as string), 50).saveX();
+        await expect(previous[method]()).rejects.toBe(error);
+      });
+      expect((await load(owner.id as string)).data.balance).toBe(50);
+    },
+  );
+
+  test.each([
+    ["same scope", "editedEnt"],
+    ["same scope", "editedEntX"],
+    ["previous scope", "editedEnt"],
+    ["previous scope", "editedEntX"],
+    ["unscoped", "editedEnt"],
+    ["unscoped", "editedEntX"],
+  ] as const)(
+    "%s %s snapshots cannot become fresh inputs to a guarded mutation",
+    async (origin, method) => {
+      const owner = await create();
+      let previous!: SimpleAction<ScopedAccount>;
+      const savePrevious = async () => {
+        previous = edit(await load(owner.id as string), 90);
+        await previous.saveX();
+      };
+      if (origin === "previous scope") {
+        await withTransaction(savePrevious);
+      } else if (origin === "unscoped") {
+        previous = new SimpleAction(
+          viewer,
+          accountSchema,
+          new Map([["balance", 90]]),
+          WriteOperation.Edit,
+          owner,
+        );
+        await previous.saveX();
+      }
+      await expect(
+        withTransaction(async () => {
+          if (origin === "same scope") await savePrevious();
+          await edit(await load(owner.id as string), 80).saveX();
+          const snapshot = await previous[method]();
+          expect(snapshot!.data.balance).toBe(90);
+          await expect(
+            edit(snapshot!, snapshot!.data.balance - 1).saveX(),
+          ).rejects.toThrow("reload existingEnt");
+        }),
+      ).rejects.toThrow("reload existingEnt");
+      expect((await load(owner.id as string)).data.balance).toBe(
+        origin === "same scope" ? 100 : 90,
+      );
+      // Reading a result snapshot remains allowed outside its owning scope.
+      expect((await previous.editedEntX()).data.balance).toBe(90);
+    },
+  );
+
+  test.each(["root", "child"] as const)(
+    "fresh %s results retain the completed write's current provenance",
+    async (source) => {
+      const [owner, target] = await Promise.all([create(), create()]);
+      await withTransaction(async () => {
+        const parent = edit(await load(owner.id as string), 90);
+        let child!: SimpleAction<ScopedAccount>;
+        parent.getTriggers = () => [
+          {
+            async changeset() {
+              child = new SimpleAction(
+                viewer,
+                accountSchema,
+                new Map([["balance", 80]]),
+                WriteOperation.Edit,
+                await load(target.id as string),
+              );
+              return child.changeset();
+            },
+          },
+        ];
+        const parentResult = await parent.saveX();
+        const result =
+          source === "root" ? parentResult : await child.editedEntX();
+        await edit(result, result.data.balance - 1).saveX();
+      });
+      expect((await load(owner.id as string)).data.balance).toBe(
+        source === "root" ? 89 : 90,
+      );
+      expect((await load(target.id as string)).data.balance).toBe(
+        source === "child" ? 79 : 80,
+      );
+    },
+  );
+
+  test("scope covers privacy, triggers, validators, action writes and audit changesets; observers follow outer commit", async () => {
+    const account = await create();
+    const observed: number[] = [];
+    let scopedPid = 0;
+    await withTransaction(async (tx) => {
+      scopedPid = (await tx.query("SELECT pg_backend_pid() AS pid")).rows[0]
+        .pid;
+      const action = edit(await load(account.id as string), 75);
+      action.getPrivacyPolicy = () => ({
+        rules: [
+          {
+            async apply() {
+              expect(getTransactionState()).toBeDefined();
+              const { rows } = await DB.getInstance()
+                .getPool()
+                .query("SELECT pg_backend_pid() AS pid");
+              expect(rows[0].pid).toBe(scopedPid);
+              return (await import("./base")).Allow();
+            },
+          },
+        ],
+      });
+      action.getTriggers = () => [
+        {
+          async changeset() {
+            expect((await load(account.id as string)).data.balance).toBe(100);
+            return new SimpleAction(
+              viewer,
+              auditSchema,
+              new Map([["message", "sale"]]),
+              WriteOperation.Insert,
+              null,
+            ).changeset();
+          },
+        },
+      ];
+      action.getValidators = () => [
+        {
+          async validate() {
+            expect(getTransactionState()).toBeDefined();
+            expect((await load(account.id as string)).data.balance).toBe(100);
+          },
+        },
+      ];
+      action.getObservers = () => [
+        {
+          async observe() {
+            expect(getTransactionState()).toBeUndefined();
+            observed.push((await load(account.id as string)).data.balance);
+          },
+        },
+      ];
+      expect((await action.saveX()).data.balance).toBe(75);
+      expect((await load(account.id as string)).data.balance).toBe(75);
+      expect((await audits()).rowCount).toBe(1);
+      expect(observed).toEqual([]);
+    });
+    expect(observed).toEqual([75]);
+    expect((await audits()).rowCount).toBe(1);
+  });
+
+  test("rollback discards action, trigger audit and observers, and never primes outside caches", async () => {
+    const account = await create();
+    const outside = await load(account.id as string);
+    const observe = jest.fn();
+    await expect(
+      withTransaction(async () => {
+        const action = edit(await load(account.id as string), 30);
+        action.getTriggers = () => [
+          {
+            changeset: () =>
+              new SimpleAction(
+                viewer,
+                auditSchema,
+                new Map([["message", "rolled back"]]),
+                WriteOperation.Insert,
+                null,
+              ).changeset(),
+          },
+        ];
+        action.getObservers = () => [{ observe }];
+        await action.saveX();
+        throw new Error("abort");
+      }),
+    ).rejects.toThrow("abort");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+    expect(outside.data.balance).toBe(100);
+    expect((await audits()).rowCount).toBe(0);
+    expect(observe).not.toHaveBeenCalled();
+  });
+
+  test("observers and callers can read committed builder IDs without rerunning preparation", async () => {
+    const effects: string[] = [];
+    let action!: SimpleAction<ScopedAccount>;
+    const result = await withTransaction(async () => {
+      action = new SimpleAction(
+        viewer,
+        accountSchema,
+        new Map<string, any>([
+          ["balance", 100],
+          ["admin", true],
+        ]),
+        WriteOperation.Insert,
+        null,
+      );
+      action.getObservers = () => [
+        {
+          async observe(builder) {
+            // Generated builder.getEntID() calls this same public method.
+            const edited = await builder.orchestrator.getEditedData();
+            effects.push(edited.id);
+          },
+        },
+      ];
+      return action.saveX();
+    });
+    // Assertion outside observer is essential: observers swallow exceptions.
+    expect(effects).toEqual([result.id]);
+    expect((await action.builder.orchestrator.getEditedData()).id).toBe(
+      result.id,
+    );
+    await expect(action.saveX()).rejects.toThrow("transaction scopes");
+  });
+
+  test("concurrent async flows sharing one viewer never join each other's transactions or caches", async () => {
+    const account = await create();
+    const written = deferred();
+    const release = deferred();
+    const worker = withTransaction(async () => {
+      await edit(await load(account.id as string), 9).saveX();
+      written.resolve();
+      await release.promise;
+      expect((await load(account.id as string)).data.balance).toBe(9);
+    });
+    await written.promise;
+    try {
+      expect((await load(account.id as string)).data.balance).toBe(100);
+      await withTransaction(async () => {
+        expect((await load(account.id as string)).data.balance).toBe(100);
+      });
+    } finally {
+      release.resolve();
+    }
+    await worker;
+    expect((await load(account.id as string)).data.balance).toBe(9);
+  });
+
+  test("serializable retries rebuild absolute balance updates and audit actions, preventing lost sales", async () => {
+    const account = await create();
+    const meet = barrier(2);
+    const attempts: number[] = [];
+    let observers = 0;
+    const sell = (amount: number) =>
+      withTransaction(
+        async (tx) => {
+          attempts.push(tx.attempt);
+          const current = await load(account.id as string);
+          if (tx.attempt === 0) await meet();
+          const action = edit(current, current.data.balance - amount);
+          action.getTriggers = () => [
+            {
+              changeset: () =>
+                new SimpleAction(
+                  viewer,
+                  auditSchema,
+                  new Map([["message", `sold ${amount}`]]),
+                  WriteOperation.Insert,
+                  null,
+                ).changeset(),
+            },
+          ];
+          action.getObservers = () => [
+            {
+              async observe() {
+                observers++;
+              },
+            },
+          ];
+          await action.saveX();
+        },
+        { maxRetries: 3 },
+      );
+    await Promise.all([sell(20), sell(30)]);
+    expect((await load(account.id as string)).data.balance).toBe(50);
+    expect(attempts).toContain(1);
+    expect((await audits()).rowCount).toBe(2);
+    expect(observers).toBe(2);
+  });
+
+  test("serializable predicate conflict preserves the last admin and its audit history", async () => {
+    const accounts = await Promise.all([create(), create()]);
+    const meet = barrier(2);
+    const removeAdmin = (account: ScopedAccount) =>
+      withTransaction(
+        async (tx) => {
+          const current = await load(account.id as string);
+          const action = new GuardedEdit(
+            viewer,
+            accountSchema,
+            new Map([["admin", false]]),
+            WriteOperation.Edit,
+            current,
+          );
+          action.getValidators = () => [
+            {
+              async validate() {
+                const rows = await loadRows({
+                  ...options,
+                  clause: Eq("admin", true),
+                  context,
+                });
+                if (tx.attempt === 0) await meet();
+                if (rows.length <= 1) throw new Error("last admin");
+              },
+            },
+          ];
+          action.getTriggers = () => [
+            {
+              changeset: () =>
+                new SimpleAction(
+                  viewer,
+                  auditSchema,
+                  new Map([["message", "removed admin"]]),
+                  WriteOperation.Insert,
+                  null,
+                ).changeset(),
+            },
+          ];
+          await action.saveX();
+        },
+        { maxRetries: 3 },
+      );
+    const results = await Promise.allSettled(accounts.map(removeAdmin));
+    expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+    expect(
+      results.find((r): r is PromiseRejectedResult => r.status === "rejected")
+        ?.reason.message,
+    ).toBe("last admin");
+    expect(
+      (await loadRows({ ...options, clause: Eq("admin", true), context }))
+        .length,
+    ).toBe(1);
+    expect((await audits()).rowCount).toBe(1);
+  });
+
+  test("read committed lock contract reloads after lock and serializes absolute updates", async () => {
+    const account = await create();
+    const locked = deferred();
+    const release = deferred();
+    const first = withTransaction(
+      async (tx) => {
+        await tx.query(
+          "SELECT id FROM scoped_accounts WHERE id = $1 FOR UPDATE",
+          [account.id],
+        );
+        locked.resolve();
+        await release.promise;
+        const current = await load(account.id as string);
+        await edit(current, current.data.balance - 20).saveX();
+      },
+      { isolationLevel: "read committed" },
+    );
+    await locked.promise;
+    const secondStarted = deferred();
+    const second = withTransaction(
+      async (tx) => {
+        // This cached value must be invalidated by the explicit lock query.
+        expect((await load(account.id as string)).data.balance).toBe(100);
+        const wait = tx.query(
+          "SELECT id FROM scoped_accounts WHERE id = $1 FOR UPDATE",
+          [account.id],
+        );
+        secondStarted.resolve();
+        await wait;
+        const current = await load(account.id as string);
+        expect(current.data.balance).toBe(80);
+        await edit(current, current.data.balance - 30).saveX();
+      },
+      { isolationLevel: "read committed" },
+    );
+    await secondStarted.promise;
+    release.resolve();
+    await Promise.all([first, second]);
+    expect((await load(account.id as string)).data.balance).toBe(50);
+  });
+
+  test("guarded direct saves/builders/changesets fail closed and stale Ents cannot cross scopes", async () => {
+    const account = await create();
+    await expect(edit(account, 1).saveX()).rejects.toThrow(
+      "requires withTransaction",
+    );
+    await expect(edit(account, 1).builder.saveX()).rejects.toThrow(
+      "requires withTransaction",
+    );
+    await expect(edit(account, 1).changeset()).rejects.toThrow(
+      "requires withTransaction",
+    );
+    await expect(
+      withTransaction(async () => edit(account, 1).saveX()),
+    ).rejects.toThrow("reload existingEnt");
+    const oldAction = edit(account, 1);
+    await expect(
+      withTransaction(async () => oldAction.saveX()),
+    ).rejects.toThrow("cannot cross transaction scopes");
+    let oldChangeset: Awaited<ReturnType<GuardedEdit["changeset"]>>;
+    await withTransaction(async () => {
+      oldChangeset = await edit(
+        await load(account.id as string),
+        1,
+      ).changeset();
+    });
+    expect(() => oldChangeset!.executor()).toThrow("transaction");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+  });
+
+  test("privacy denial rolls back earlier actions; legacy action Transaction groups join outer scope", async () => {
+    const account = await create();
+    await expect(
+      withTransaction(async () => {
+        await new Transaction(viewer, [
+          edit(await load(account.id as string), 50),
+        ]).run();
+        const deny = edit(await load(account.id as string), 1);
+        deny.getPrivacyPolicy = () => AlwaysDenyPrivacyPolicy;
+        await deny.saveX();
+      }),
+    ).rejects.toThrow("permission");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+  });
+
+  test("caught SQL errors still abort and borrowed clients/nested scopes are rejected", async () => {
+    const account = await create();
+    await expect(
+      withTransaction(async (tx) => {
+        await edit(await load(account.id as string), 1).saveX();
+        await tx
+          .query("SELECT no_such_column FROM scoped_accounts")
+          .catch(() => {});
+      }),
+    ).rejects.toThrow("no_such_column");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+    await withTransaction(async () => {
+      await expect(withTransaction(async () => {})).rejects.toThrow("nested");
+      await expect(DB.getInstance().getNewClient()).rejects.toThrow("escape");
+      expect(() => DB.getInstance().getConnection()).toThrow("raw connections");
+    });
+  });
+
+  test("serializable action requirement rejects weaker isolation before triggers", async () => {
+    const account = await create();
+    const trigger = jest.fn();
+    await expect(
+      withTransaction(
+        async () => {
+          const action = edit(await load(account.id as string), 0);
+          Object.assign(action, { requiresTransaction: () => "serializable" });
+          action.getTriggers = () => [{ changeset: trigger }];
+          await action.saveX();
+        },
+        { isolationLevel: "read committed" },
+      ),
+    ).rejects.toThrow("serializable");
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  test("a swallowed non-X validation failure still rolls back earlier writes", async () => {
+    const account = await create();
+    await expect(
+      withTransaction(async () => {
+        await edit(await load(account.id as string), 50).saveX();
+        const invalid = edit(await load(account.id as string), 0);
+        invalid.getValidators = () => [
+          {
+            async validate() {
+              throw new Error("invalid balance");
+            },
+          },
+        ];
+        await invalid.builder.save();
+      }),
+    ).rejects.toThrow("invalid balance");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+  });
+
+  test("caught changeset preparation failure still aborts the owning scope", async () => {
+    const account = await create();
+    await expect(
+      withTransaction(async () => {
+        await edit(await load(account.id as string), 50).saveX();
+        const invalid = edit(await load(account.id as string), 0);
+        invalid.getValidators = () => [
+          {
+            async validate() {
+              throw new Error("invalid changeset");
+            },
+          },
+        ];
+        await invalid.changeset().catch(() => {});
+      }),
+    ).rejects.toThrow("invalid changeset");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+  });
+
+  test("retained loaders and queryers reject scope leaks, including detached async work", async () => {
+    const account = await create();
+    const outsideLoader = loaderFactory.createLoader(context);
+    await outsideLoader.load(account.id);
+    let scope!: TransactionScope;
+    let closedQuery!: () => Promise<unknown>;
+    const gate = deferred();
+    let detached!: Promise<unknown>;
+    await withTransaction(async (tx) => {
+      scope = tx;
+      await expect(outsideLoader.load(account.id)).rejects.toThrow(
+        "cannot cross transaction scopes",
+      );
+      const inside = loaderFactory.createLoader(context);
+      await inside.load(account.id);
+      closedQuery = () => inside.load(account.id);
+      detached = gate.promise.then(() => load(account.id as string));
+    });
+    expect(() => scope.query("SELECT 1")).toThrow("outside its callback");
+    await expect(closedQuery()).rejects.toThrow(
+      "cannot cross transaction scopes",
+    );
+    gate.resolve();
+    await expect(detached).rejects.toThrow("scope is closed");
+  });
+
+  test("raw writes invalidate all transaction viewers' caches", async () => {
+    const account = await create();
+    const other = new TestContext();
+    await withTransaction(async (tx) => {
+      expect((await load(account.id as string)).data.balance).toBe(100);
+      expect(
+        (await loadEntX(other.getViewer(), account.id, options)).data.balance,
+      ).toBe(100);
+      await tx.query("UPDATE scoped_accounts SET balance = 12 WHERE id = $1", [
+        account.id,
+      ]);
+      expect((await load(account.id as string)).data.balance).toBe(12);
+      expect(
+        (await loadEntX(other.getViewer(), account.id, options)).data.balance,
+      ).toBe(12);
+    });
+  });
+
+  test("edge deletion invalidates scoped edge reads and committed request reads", async () => {
+    const edgeType = "9ef2a851-15a8-446d-8428-b5f11e641fec";
+    await DB.getInstance()
+      .getPool()
+      .query(
+        "INSERT INTO assoc_edge_config (edge_type, edge_name, edge_table, symmetric_edge, inverse_edge_type, created_at, updated_at) VALUES ($1, 'scoped admin', 'scoped_account_edges', false, NULL, now(), now())",
+        [edgeType],
+      );
+    const [owner, target] = await Promise.all([create(), create()]);
+    const readEdges = () => loadEdges({ id1: owner.id, edgeType, context });
+    await withTransaction(async () => {
+      const action = edit(await load(owner.id as string), 100);
+      action.builder.orchestrator.addOutboundEdge(
+        target.id,
+        edgeType,
+        target.nodeType,
+      );
+      await action.saveX();
+    });
+    expect((await readEdges()).length).toBe(1);
+    await withTransaction(async () => {
+      expect((await readEdges()).length).toBe(1);
+      const action = edit(await load(owner.id as string), 100);
+      action.builder.orchestrator.removeOutboundEdge(target.id, edgeType);
+      await action.saveX();
+      expect(await readEdges()).toEqual([]);
+    });
+    expect(await readEdges()).toEqual([]);
+  });
+
+  test("prebuilt guarded sale roots in one Transaction fail before losing an absolute balance update", async () => {
+    const account = await create();
+    await expect(
+      withTransaction(async () => {
+        const current = await load(account.id as string);
+        await new Transaction(viewer, [
+          edit(current, 80),
+          edit(current, 70),
+        ]).run();
+      }),
+    ).rejects.toThrow("guarded root actions");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+  });
+
+  test("prebuilt guarded admin roots cannot both validate against the old count", async () => {
+    const accounts = await Promise.all([create(), create()]);
+    await expect(
+      withTransaction(async () => {
+        const actions = await Promise.all(
+          accounts.map(async (account) => {
+            const action = new GuardedEdit(
+              viewer,
+              accountSchema,
+              new Map([["admin", false]]),
+              WriteOperation.Edit,
+              await load(account.id as string),
+            );
+            action.getValidators = () => [
+              {
+                async validate() {
+                  const rows = await loadRows({
+                    ...options,
+                    clause: Eq("admin", true),
+                    context,
+                  });
+                  if (rows.length <= 1) throw new Error("last admin");
+                },
+              },
+            ];
+            return action;
+          }),
+        );
+        await new Transaction(viewer, actions).run();
+      }),
+    ).rejects.toThrow("guarded root actions");
+    expect(
+      (await loadRows({ ...options, clause: Eq("admin", true), context }))
+        .length,
+    ).toBe(2);
+  });
+
+  test("parallel guarded root saves roll back, while sequential saves reload fresh state", async () => {
+    const account = await create();
+    await expect(
+      withTransaction(async () => {
+        const current = await load(account.id as string);
+        await Promise.all([
+          edit(current, 80).saveX(),
+          edit(current, 70).saveX(),
+        ]);
+      }),
+    ).rejects.toThrow("guarded root actions");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+    await withTransaction(async () => {
+      await edit(await load(account.id as string), 80).saveX();
+      const fresh = await load(account.id as string);
+      await edit(fresh, fresh.data.balance - 30).saveX();
+    });
+    expect((await load(account.id as string)).data.balance).toBe(50);
+  });
+
+  test("an Ent loaded before a previous guarded save cannot feed the next root", async () => {
+    const account = await create();
+    await expect(
+      withTransaction(async () => {
+        const old = await load(account.id as string);
+        await edit(old, 80).saveX();
+        await edit(old, 70).saveX();
+      }),
+    ).rejects.toThrow("reload existingEnt");
+    expect((await load(account.id as string)).data.balance).toBe(100);
+  });
+
+  test("guarded root permits distinct trigger child changesets and releases the complete tree", async () => {
+    const accounts = await Promise.all([create(), create(), create()]);
+    await withTransaction(async () => {
+      const current = await Promise.all(
+        accounts.map((account) => load(account.id as string)),
+      );
+      const parent = independent(
+        edit(current[0], 90),
+        `account:${current[0].id}`,
+      );
+      parent.getTriggers = () => [
+        {
+          changeset: async () => [
+            await independent(
+              edit(current[1], 80),
+              `account:${current[1].id}`,
+            ).changeset(),
+            await independent(
+              edit(current[2], 70),
+              `account:${current[2].id}`,
+            ).changeset(),
+          ],
+        },
+      ];
+      await parent.saveX();
+      await edit(await load(accounts[0].id as string), 60).saveX();
+    });
+    expect(
+      (
+        await Promise.all(accounts.map((account) => load(account.id as string)))
+      ).map((account) => account.data.balance),
+    ).toEqual([60, 80, 70]);
+  });
+
+  test("nested trigger saves and sibling child writes to one Ent fail closed", async () => {
+    const [owner, target] = await Promise.all([create(), create()]);
+    await expect(
+      withTransaction(async () => {
+        const parent = edit(await load(owner.id as string), 90);
+        parent.getTriggers = () => [
+          {
+            async changeset() {
+              const current = await load(target.id as string);
+              await Promise.all([
+                edit(current, 80).saveX(),
+                edit(current, 70).saveX(),
+              ]);
+            },
+          },
+        ];
+        await parent.saveX();
+      }),
+    ).rejects.toThrow("nested action saves");
+    await expect(
+      withTransaction(async () => {
+        // An unguarded wrapper must not let guarded sibling children bypass checks.
+        const parent = new SimpleAction(
+          viewer,
+          accountSchema,
+          new Map([["balance", 90]]),
+          WriteOperation.Edit,
+          await load(owner.id as string),
+        );
+        parent.getTriggers = () => [
+          {
+            async changeset() {
+              const current = await load(target.id as string);
+              return [
+                // Even mistaken disjoint declarations cannot hide known duplicate row writes.
+                await independent(edit(current, 80), "first").changeset(),
+                await independent(edit(current, 70), "second").changeset(),
+              ];
+            },
+          },
+        ];
+        await parent.saveX();
+      }),
+    ).rejects.toThrow("same Ent through multiple builders");
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+    expect((await load(target.id as string)).data.balance).toBe(100);
+  });
+
+  test("distinct nested edge writes on the same Ent do not count as duplicate row mutations", async () => {
+    const edgeType = "ed93ad2e-20ea-4ab4-b9a4-97051857589d";
+    await DB.getInstance()
+      .getPool()
+      .query(
+        "INSERT INTO assoc_edge_config (edge_type, edge_name, edge_table, symmetric_edge, inverse_edge_type, created_at, updated_at) VALUES ($1, 'scoped member', 'scoped_account_edges', false, NULL, now(), now())",
+        [edgeType],
+      );
+    const [owner, first, second] = await Promise.all([
+      create(),
+      create(),
+      create(),
+    ]);
+    await withTransaction(async () => {
+      const current = await load(owner.id as string);
+      const parent = independent(
+        new GuardedEdit(
+          viewer,
+          accountSchema,
+          new Map(),
+          WriteOperation.Edit,
+          current,
+        ),
+        `edge:${owner.id}:${first.id}`,
+      );
+      parent.builder.orchestrator.addOutboundEdge(
+        first.id,
+        edgeType,
+        first.nodeType,
+      );
+      parent.getTriggers = () => [
+        {
+          async changeset() {
+            const child = independent(
+              new GuardedEdit(
+                viewer,
+                accountSchema,
+                new Map(),
+                WriteOperation.Edit,
+                current,
+              ),
+              `edge:${owner.id}:${second.id}`,
+            );
+            child.builder.orchestrator.addOutboundEdge(
+              second.id,
+              edgeType,
+              second.nodeType,
+            );
+            return child.changeset();
+          },
+        },
+      ];
+      await parent.saveX();
+    });
+    expect(
+      (await loadEdges({ id1: owner.id, edgeType, context }))
+        .map((edge) => edge.id2)
+        .sort(),
+    ).toEqual([first.id, second.id].sort());
+  });
+
+  test("skipped child writes do not conflict and distinct nested deletions remain supported", async () => {
+    const accounts = await Promise.all([create(), create(), create()]);
+    await withTransaction(async () => {
+      const current = await load(accounts[0].id as string);
+      const parent = edit(current, 80);
+      parent.getTriggers = () => [
+        {
+          async changeset() {
+            const child = new SimpleAction(
+              viewer,
+              accountSchema,
+              new Map([["balance", 70]]),
+              WriteOperation.Edit,
+              current,
+            );
+            const changeset = await child.builder.orchestrator.build();
+            changeset.operations[0].shortCircuit = () => true;
+            return changeset;
+          },
+        },
+      ];
+      await parent.saveX();
+    });
+    expect((await load(accounts[0].id as string)).data.balance).toBe(80);
+    await withTransaction(async () => {
+      const current = await Promise.all(
+        accounts.map((account) => load(account.id as string)),
+      );
+      const parent = independent(
+        new GuardedEdit(
+          viewer,
+          accountSchema,
+          new Map(),
+          WriteOperation.Delete,
+          current[0],
+        ),
+        `account:${current[0].id}`,
+      );
+      parent.getTriggers = () => [
+        {
+          changeset: () =>
+            Promise.all(
+              current
+                .slice(1)
+                .map((account) =>
+                  independent(
+                    new GuardedEdit(
+                      viewer,
+                      accountSchema,
+                      new Map(),
+                      WriteOperation.Delete,
+                      account,
+                    ),
+                    `account:${account.id}`,
+                  ).changeset(),
+                ),
+            ),
+        },
+      ];
+      await parent.builder.saveX();
+    });
+    expect(
+      (await DB.getInstance().getPool().query("SELECT * FROM scoped_accounts"))
+        .rowCount,
+    ).toBe(0);
+  });
+
+  test("unguarded wrapper cannot combine guarded last-admin removals of distinct rows", async () => {
+    const accounts = await Promise.all([create(), create()]);
+    await expect(
+      withTransaction(async () => {
+        const parent = new SimpleAction(
+          viewer,
+          auditSchema,
+          new Map([["message", "remove admins"]]),
+          WriteOperation.Insert,
+          null,
+        );
+        parent.getTriggers = () => [
+          {
+            async changeset() {
+              return Promise.all(
+                accounts.map(async (account) => {
+                  const child = new GuardedEdit(
+                    viewer,
+                    accountSchema,
+                    new Map([["admin", false]]),
+                    WriteOperation.Edit,
+                    await load(account.id as string),
+                  );
+                  child.getValidators = () => [
+                    {
+                      async validate() {
+                        const rows = await loadRows({
+                          ...options,
+                          clause: Eq("admin", true),
+                          context,
+                        });
+                        if (rows.length <= 1) throw new Error("last admin");
+                      },
+                    },
+                  ];
+                  return child.changeset();
+                }),
+              );
+            },
+          },
+        ];
+        await parent.saveX();
+      }),
+    ).rejects.toThrow("overlapping guarded action preparation branches");
+    expect(
+      (await loadRows({ ...options, clause: Eq("admin", true), context }))
+        .length,
+    ).toBe(2);
+    expect((await audits()).rowCount).toBe(0);
+  });
+
+  test.each([
+    [undefined, undefined, false],
+    ["admins", "admins", false],
+    [undefined, "admins", false],
+    ["admins", undefined, false],
+    [undefined, undefined, true],
+  ] as const)(
+    "ancestor and descendant cannot independently decide the last-admin invariant (%s, %s, wrapper=%s)",
+    async (parentKey, childKey, wrapper) => {
+      const accounts = await Promise.all([create(), create()]);
+      const remove = async (id: string, key: string | undefined) => {
+        const action = new GuardedEdit(
+          viewer,
+          accountSchema,
+          new Map([["admin", false]]),
+          WriteOperation.Edit,
+          await load(id),
+        );
+        if (key) independent(action, key);
+        action.getValidators = () => [
+          {
+            async validate() {
+              const rows = await loadRows({
+                ...options,
+                clause: Eq("admin", true),
+                context,
+              });
+              if (rows.length <= 1) throw new Error("last admin");
+            },
+          },
+        ];
+        return action;
+      };
+      await expect(
+        withTransaction(async () => {
+          const parent = await remove(accounts[0].id as string, parentKey);
+          const child = async () =>
+            (await remove(accounts[1].id as string, childKey)).changeset();
+          parent.getTriggers = () => [
+            {
+              async changeset() {
+                if (!wrapper) return child();
+                const intermediate = new SimpleAction(
+                  viewer,
+                  auditSchema,
+                  new Map([["message", "remove admins"]]),
+                  WriteOperation.Insert,
+                  null,
+                );
+                intermediate.getTriggers = () => [{ changeset: child }];
+                return intermediate.changeset();
+              },
+            },
+          ];
+          await parent.saveX();
+        }),
+      ).rejects.toThrow("overlapping guarded action preparation branches");
+      expect(
+        (await loadRows({ ...options, clause: Eq("admin", true), context }))
+          .length,
+      ).toBe(2);
+      expect((await audits()).rowCount).toBe(0);
+    },
+  );
+
+  test.each(["valid", "validX", "validWithErrors"] as const)(
+    "%s then save rebuilds independent child changesets and writes each once",
+    async (method) => {
+      const [owner, target] = await Promise.all([create(), create()]);
+      const observe = jest.fn();
+      let retained!: Awaited<ReturnType<GuardedEdit["changeset"]>>;
+      await withTransaction(async () => {
+        const parent = independent(
+          edit(await load(owner.id as string), 90),
+          `account:${owner.id}`,
+        );
+        parent.getTriggers = () => [
+          {
+            async changeset() {
+              const child = independent(
+                edit(await load(target.id as string), 80),
+                `account:${target.id}`,
+              );
+              child.getObservers = () => [{ observe }];
+              child.getTriggers = () => [
+                {
+                  changeset: () =>
+                    new SimpleAction(
+                      viewer,
+                      auditSchema,
+                      new Map([["message", "child write"]]),
+                      WriteOperation.Insert,
+                      null,
+                    ).changeset(),
+                },
+              ];
+              retained = await child.changeset();
+              return retained;
+            },
+          },
+        ];
+        const result = await parent[method]();
+        expect(result).toEqual(
+          method === "valid" ? true : method === "validX" ? undefined : [],
+        );
+        expect((await load(target.id as string)).data.balance).toBe(100);
+        expect((await audits()).rowCount).toBe(0);
+        expect(() => retained.executor()).toThrow(
+          "prepared by public validation",
+        );
+        await parent.saveX();
+        expect((await audits()).rowCount).toBe(1);
+        expect(observe).not.toHaveBeenCalled();
+      });
+      expect((await load(owner.id as string)).data.balance).toBe(90);
+      expect((await load(target.id as string)).data.balance).toBe(80);
+      expect(observe).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(["valid", "validX", "validWithErrors"] as const)(
+    "failed %s discards its child graph before a corrected save",
+    async (method) => {
+      const [owner, oldTarget, newTarget] = await Promise.all([
+        create(),
+        create(),
+        create(),
+      ]);
+      await withTransaction(async () => {
+        const parent = independent(
+          edit(await load(owner.id as string), 90),
+          `account:${owner.id}`,
+        );
+        let target = oldTarget;
+        let invalid = true;
+        const error = new Error("invalid candidate");
+        parent.getValidators = () => [
+          { validate: async () => (invalid ? error : undefined) },
+        ];
+        parent.getTriggers = () => [
+          {
+            changeset: async () =>
+              independent(
+                edit(await load(target.id as string), 80),
+                `account:${target.id}`,
+              ).changeset(),
+          },
+        ];
+        if (method === "validX") {
+          await expect(parent.validX()).rejects.toBe(error);
+        } else {
+          expect(await parent[method]()).toEqual(
+            method === "valid" ? false : [error],
+          );
+        }
+        target = newTarget;
+        invalid = false;
+        await parent.saveX();
+      });
+      expect((await load(owner.id as string)).data.balance).toBe(90);
+      expect((await load(oldTarget.id as string)).data.balance).toBe(100);
+      expect((await load(newTarget.id as string)).data.balance).toBe(80);
+    },
+  );
+
+  describe.each([
+    "siblings",
+    "trigger group",
+    "child array",
+    "user Promise.all",
+  ] as const)("parallel validation with %s", (shape) => {
+    describe.each([false, true])("nested grandchildren %s", (nested) => {
+      test.each(["valid", "validX", "validWithErrors"] as const)(
+        "%s drains children before reporting a recoverable error and supports a corrected save",
+        async (method) => {
+          const accounts = await Promise.all(
+            Array.from({ length: 5 }, () => create()),
+          );
+          const observe = jest.fn();
+          await withTransaction(async () => {
+            const actions = await Promise.all(
+              accounts.map(async (account, index) =>
+                independent(
+                  edit(await load(account.id as string), 90 - index * 10),
+                  `account:${account.id}`,
+                ),
+              ),
+            );
+            const [parent, invalidChild, slowChild, fastBranch, slowBranch] =
+              actions;
+            let invalid = true;
+            const error = new Error("first invalid child");
+            invalidChild.getValidators = () => [
+              { validate: async () => (invalid ? error : undefined) },
+            ];
+            const started = deferred();
+            const finish = deferred();
+            slowChild.getObservers = () => [{ observe }];
+            slowChild.getTriggers = () => [
+              {
+                changeset: async () => {
+                  started.resolve();
+                  await finish.promise;
+                  return new SimpleAction(
+                    viewer,
+                    auditSchema,
+                    new Map([["message", "drained child"]]),
+                    WriteOperation.Insert,
+                    null,
+                  ).changeset();
+                },
+              },
+            ];
+            fastBranch.getTriggers = () => [
+              { changeset: () => invalidChild.changeset() },
+            ];
+            slowBranch.getTriggers = () => [
+              { changeset: () => slowChild.changeset() },
+            ];
+            const fast = nested ? fastBranch : invalidChild;
+            const slow = nested ? slowBranch : slowChild;
+            let pendingSlow!: Promise<unknown>;
+            const prepareSlow = () => {
+              const pending = slow.changeset();
+              pendingSlow = pending;
+              return pending;
+            };
+            if (shape === "siblings") {
+              parent.getTriggers = () => [
+                { changeset: () => fast.changeset() },
+                { changeset: prepareSlow },
+              ];
+            } else if (shape === "trigger group") {
+              parent.getTriggers = () => [
+                [
+                  { changeset: () => fast.changeset() },
+                  { changeset: prepareSlow },
+                ],
+              ];
+            } else if (shape === "child array") {
+              parent.getTriggers = () => [
+                { changeset: () => [fast.changeset(), prepareSlow()] },
+              ];
+            } else {
+              parent.getTriggers = () => [
+                {
+                  changeset: () =>
+                    Promise.all([fast.changeset(), prepareSlow()]),
+                },
+              ];
+            }
+            let settled = false;
+            const validation = parent[method]().then(
+              (value) => {
+                settled = true;
+                return { value };
+              },
+              (error) => {
+                settled = true;
+                return { error };
+              },
+            );
+            await started.promise;
+            // Release independently of validation completion so both the old
+            // fail-fast behavior and the repaired drain remain deterministic.
+            await new Promise((resolve) => setImmediate(resolve));
+            const settledBeforeRelease = settled;
+            finish.resolve();
+            expect(await validation).toEqual({ error });
+            await expect(pendingSlow).resolves.toBeDefined();
+            expect(settledBeforeRelease).toBe(false);
+            expect(getTransactionState()!.failed).toBe(false);
+            expect((await audits()).rowCount).toBe(0);
+            invalid = false;
+            await parent.saveX();
+            expect((await audits()).rowCount).toBe(1);
+            expect(observe).not.toHaveBeenCalled();
+          });
+          expect((await load(accounts[0].id as string)).data.balance).toBe(90);
+          expect((await load(accounts[1].id as string)).data.balance).toBe(80);
+          expect((await load(accounts[2].id as string)).data.balance).toBe(70);
+          expect((await audits()).rowCount).toBe(1);
+          expect(observe).toHaveBeenCalledTimes(1);
+        },
+      );
+    });
+  });
+
+  test.each(["sql", "composition"] as const)(
+    "late %s failures remain fatal while parallel validation preserves its first normal error",
+    async (failure) => {
+      const [owner, one, two] = await Promise.all([
+        create(),
+        create(),
+        create(),
+      ]);
+      const firstError = new Error("first ordinary validation error");
+      const started = deferred();
+      const finish = deferred();
+      await expect(
+        withTransaction(async () => {
+          await edit(await load(owner.id as string), 75).saveX();
+          const parent = independent(
+            edit(await load(owner.id as string), 90),
+            `account:${owner.id}`,
+          );
+          const invalid = independent(
+            edit(await load(one.id as string), 80),
+            `account:${one.id}`,
+          );
+          invalid.getValidators = () => [{ validate: async () => firstError }];
+          const slow = independent(
+            edit(await load(two.id as string), 70),
+            `account:${two.id}`,
+          );
+          slow.getTriggers = () => [
+            {
+              changeset: async () => {
+                started.resolve();
+                await finish.promise;
+                if (failure === "sql") {
+                  await DB.getInstance()
+                    .getPool()
+                    .query("SELECT * FROM missing_parallel_validation_table");
+                } else {
+                  return independent(
+                    edit(await load(owner.id as string), 60),
+                    `account:${owner.id}`,
+                  ).changeset();
+                }
+              },
+            },
+          ];
+          parent.getTriggers = () => [
+            { changeset: () => invalid.changeset() },
+            { changeset: () => slow.changeset() },
+          ];
+          const validation = expect(parent.validX()).rejects.toBe(firstError);
+          await started.promise;
+          await new Promise((resolve) => setImmediate(resolve));
+          finish.resolve();
+          await validation;
+        }),
+      ).rejects.toThrow(
+        failure === "sql"
+          ? "missing_parallel_validation_table"
+          : "overlapping guarded action preparation branches",
+      );
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+    },
+  );
+
+  test("outside a transaction parallel child validation retains fail-fast behavior", async () => {
+    const [owner, one, two] = await Promise.all([create(), create(), create()]);
+    const action = (ent: ScopedAccount) =>
+      new SimpleAction(
+        viewer,
+        accountSchema,
+        new Map([["balance", 80]]),
+        WriteOperation.Edit,
+        ent,
+      );
+    const parent = action(owner);
+    const invalid = action(one);
+    const slow = action(two);
+    const error = new Error("unscoped validation error");
+    invalid.getValidators = () => [{ validate: async () => error }];
+    const started = deferred();
+    const finish = deferred();
+    slow.getTriggers = () => [
+      {
+        changeset: async () => {
+          started.resolve();
+          await finish.promise;
+        },
+      },
+    ];
+    let pendingSlow!: Promise<unknown>;
+    parent.getTriggers = () => [
+      { changeset: () => invalid.changeset() },
+      {
+        changeset: () => {
+          const pending = slow.changeset();
+          pendingSlow = pending;
+          return pending;
+        },
+      },
+    ];
+    let settled = false;
+    const validation = parent.validX().catch((e) => {
+      settled = true;
+      return e;
+    });
+    await started.promise;
+    await new Promise((resolve) => setImmediate(resolve));
+    const settledBeforeRelease = settled;
+    finish.resolve();
+    expect(await validation).toBe(error);
+    await pendingSlow;
+    expect(settledBeforeRelease).toBe(true);
+  });
+
+  test.each(["valid", "validX", "validWithErrors"] as const)(
+    "%s releases successful and failed validation reservations for another root",
+    async (method) => {
+      const [owner, target] = await Promise.all([create(), create()]);
+      await withTransaction(async () => {
+        const parent = independent(
+          edit(await load(owner.id as string), 90),
+          `account:${owner.id}`,
+        );
+        parent.getTriggers = () => [
+          {
+            changeset: async () =>
+              independent(
+                edit(await load(target.id as string), 80),
+                `account:${target.id}`,
+              ).changeset(),
+          },
+        ];
+        await parent[method]();
+        const candidate = edit(await load(owner.id as string), 50);
+        const error = new Error("invalid candidate");
+        candidate.getValidators = () => [{ validate: async () => error }];
+        if (method === "validX")
+          await expect(candidate.validX()).rejects.toBe(error);
+        else await candidate[method]();
+        await edit(await load(target.id as string), 60).saveX();
+      });
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+      expect((await load(target.id as string)).data.balance).toBe(60);
+    },
+  );
+
+  test.each(["valid", "validX", "validWithErrors"] as const)(
+    "%s discards probe graphs from retained children and their grandchildren",
+    async (method) => {
+      const [owner, childTarget, grandchildTarget] = await Promise.all([
+        create(),
+        create(),
+        create(),
+      ]);
+      const observe = jest.fn();
+      await withTransaction(async () => {
+        const parent = independent(
+          edit(await load(owner.id as string), 90),
+          `account:${owner.id}`,
+        );
+        const child = independent(
+          edit(await load(childTarget.id as string), 80),
+          `account:${childTarget.id}`,
+        );
+        child.getTriggers = () => [
+          {
+            async changeset() {
+              const grandchild = independent(
+                edit(await load(grandchildTarget.id as string), 70),
+                `account:${grandchildTarget.id}`,
+              );
+              grandchild.getObservers = () => [{ observe }];
+              grandchild.getTriggers = () => [
+                {
+                  changeset: () =>
+                    new SimpleAction(
+                      viewer,
+                      auditSchema,
+                      new Map([["message", "grandchild write"]]),
+                      WriteOperation.Insert,
+                      null,
+                    ).changeset(),
+                },
+              ];
+              return grandchild.changeset();
+            },
+          },
+        ];
+        parent.getTriggers = () => [{ changeset: () => child.changeset() }];
+        let invalid = true;
+        const error = new Error("invalid parent");
+        parent.getValidators = () => [
+          { validate: async () => (invalid ? error : undefined) },
+        ];
+        if (method === "validX")
+          await expect(parent.validX()).rejects.toBe(error);
+        else
+          expect(await parent[method]()).toEqual(
+            method === "valid" ? false : [error],
+          );
+        invalid = false;
+        await parent[method]();
+        await parent.saveX();
+      });
+      expect((await load(owner.id as string)).data.balance).toBe(90);
+      expect((await load(childTarget.id as string)).data.balance).toBe(80);
+      expect((await load(grandchildTarget.id as string)).data.balance).toBe(70);
+      expect((await audits()).rowCount).toBe(1);
+      expect(observe).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(["valid", "validX", "validWithErrors"] as const)(
+    "%s permits correcting an invalid retained child before saving",
+    async (method) => {
+      const [owner, target] = await Promise.all([create(), create()]);
+      await withTransaction(async () => {
+        const parent = independent(
+          edit(await load(owner.id as string), 90),
+          `account:${owner.id}`,
+        );
+        const child = independent(
+          edit(await load(target.id as string), 80),
+          `account:${target.id}`,
+        );
+        let invalid = true;
+        const error = new Error("invalid child");
+        child.getValidators = () => [
+          { validate: async () => (invalid ? error : undefined) },
+        ];
+        parent.getTriggers = () => [{ changeset: () => child.changeset() }];
+        // Trigger changeset failures propagate even from valid/validWithErrors.
+        await expect(parent[method]()).rejects.toBe(error);
+        invalid = false;
+        await parent.saveX();
+      });
+      expect((await load(owner.id as string)).data.balance).toBe(90);
+      expect((await load(target.id as string)).data.balance).toBe(80);
+    },
+  );
+
+  test.each([
+    ["action", "valid"],
+    ["action", "validX"],
+    ["action", "validWithErrors"],
+    ["schema", "valid"],
+    ["schema", "validX"],
+    ["schema", "validWithErrors"],
+  ] as const)(
+    "%s transform children survive failed and repeated %s probes",
+    async (source, method) => {
+      const owner = await create();
+      await withTransaction(async () => {
+        let message = "probe";
+        const transform = ({ op }: { op: SQLStatementOperation }) => {
+          if (op !== SQLStatementOperation.Delete) return null;
+          return {
+            op: SQLStatementOperation.Update,
+            data: { admin: false },
+            changeset: () =>
+              new SimpleAction(
+                viewer,
+                auditSchema,
+                new Map([["message", message]]),
+                WriteOperation.Insert,
+                null,
+              ).changeset(),
+          };
+        };
+        const schema =
+          source === "schema"
+            ? getBuilderSchemaFromFields(
+                { balance: IntegerType(), admin: BooleanType() },
+                ScopedAccount,
+                {
+                  patterns: [
+                    {
+                      name: "soft_delete",
+                      fields: {},
+                      transformWrite: transform,
+                    },
+                  ],
+                },
+              )
+            : accountSchema;
+        const parent = new GuardedEdit(
+          viewer,
+          schema,
+          new Map([["balance", 90]]),
+          WriteOperation.Delete,
+          await load(owner.id as string),
+        );
+        if (source === "action")
+          Object.assign(parent, { transformWrite: transform });
+        let invalid = true;
+        const error = new Error("invalid transformed action");
+        parent.getValidators = () => [
+          { validate: async () => (invalid ? error : undefined) },
+        ];
+        if (method === "validX")
+          await expect(parent.validX()).rejects.toBe(error);
+        else
+          expect(await parent[method]()).toEqual(
+            method === "valid" ? false : [error],
+          );
+        invalid = false;
+        await parent[method]();
+        await parent[method]();
+        expect((await audits()).rowCount).toBe(0);
+        message = "saved transform";
+        await parent.saveX();
+      });
+      const current = await load(owner.id as string);
+      expect(current.data.balance).toBe(90);
+      expect(current.data.admin).toBe(false);
+      expect((await audits()).rows.map((row) => row.message)).toEqual([
+        "saved transform",
+      ]);
+    },
+  );
+
+  test("public validation restores an insert transformed into an existing target update", async () => {
+    const owner = await create();
+    await withTransaction(async () => {
+      const parent = new GuardedEdit(
+        viewer,
+        accountSchema,
+        new Map<string, any>([
+          ["balance", 90],
+          ["admin", false],
+        ]),
+        WriteOperation.Insert,
+        null,
+      );
+      Object.assign(parent, {
+        transformWrite: async ({ op }: { op: SQLStatementOperation }) => {
+          if (op !== SQLStatementOperation.Insert) return null;
+          return {
+            op: SQLStatementOperation.Update,
+            existingEnt: await load(owner.id as string),
+            changeset: () =>
+              new SimpleAction(
+                viewer,
+                auditSchema,
+                new Map([["message", "transformed insert"]]),
+                WriteOperation.Insert,
+                null,
+              ).changeset(),
+          };
+        },
+      });
+      await parent.validX();
+      await parent.validX();
+      expect((await parent.saveX()).id).toBe(owner.id);
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(90);
+    expect(
+      (await DB.getInstance().getPool().query("SELECT * FROM scoped_accounts"))
+        .rowCount,
+    ).toBe(1);
+    expect((await audits()).rowCount).toBe(1);
+  });
+
+  test("validation discards edges referencing probe-created child builders", async () => {
+    const owner = await create();
+    const edgeType = "df87f15a-6950-4733-81d0-b638bb06f310";
+    await DB.getInstance()
+      .getPool()
+      .query(
+        "INSERT INTO assoc_edge_config (edge_type, edge_name, edge_table, symmetric_edge, inverse_edge_type, created_at, updated_at) VALUES ($1, 'probe child', 'scoped_account_edges', false, NULL, now(), now())",
+        [edgeType],
+      );
+    await withTransaction(async () => {
+      const parent = edit(await load(owner.id as string), 90);
+      parent.getTriggers = () => [
+        {
+          changeset: async () => {
+            const child = new SimpleAction(
+              viewer,
+              accountSchema,
+              new Map<string, any>([
+                ["balance", 80],
+                ["admin", true],
+              ]),
+              WriteOperation.Insert,
+              null,
+            );
+            parent.builder.orchestrator.addOutboundEdge(
+              child.builder,
+              edgeType,
+              "ScopedAccount",
+            );
+            return child.changeset();
+          },
+        },
+      ];
+      await parent.validX();
+      await parent.validX();
+      await parent.saveX();
+    });
+    const edges = await loadEdges({ id1: owner.id, edgeType, context });
+    expect(edges).toHaveLength(1);
+    expect((await load(edges[0].id2 as string)).data.balance).toBe(80);
+    expect(
+      (await DB.getInstance().getPool().query("SELECT * FROM scoped_accounts"))
+        .rowCount,
+    ).toBe(2);
+  });
+
+  test.each(["valid", "validX", "validWithErrors"] as const)(
+    "%s does not transform already-transformed action input twice",
+    async (method) => {
+      const owner = await create();
+      await withTransaction(async () => {
+        const parent = edit(await load(owner.id as string), 90);
+        Object.assign(parent, {
+          transformWrite: ({
+            op,
+            input,
+          }: {
+            op: SQLStatementOperation;
+            input: { balance: number };
+          }) => ({
+            op,
+            data: { balance: input.balance + 1 },
+          }),
+        });
+        await parent[method]();
+        await parent[method]();
+        await parent.saveX();
+      });
+      expect((await load(owner.id as string)).data.balance).toBe(91);
+    },
+  );
+
+  test("validation preserves previously read builder IDs and defaults", async () => {
+    let defaults = 0;
+    const schema = getBuilderSchemaFromFields(
+      {
+        balance: IntegerType({
+          defaultValueOnCreate: () => {
+            defaults++;
+            return 42;
+          },
+        }),
+        admin: BooleanType(),
+      },
+      ScopedAccount,
+    );
+    await withTransaction(async () => {
+      const action = new GuardedEdit(
+        viewer,
+        schema,
+        new Map([["admin", true]]),
+        WriteOperation.Insert,
+        null,
+      );
+      const before = await action.builder.orchestrator.getEditedData();
+      await action.validX();
+      await action.validX();
+      const result = await action.saveX();
+      expect(result.id).toBe(before.id);
+      expect(result.data.balance).toBe(before.balance);
+      expect(defaults).toBe(1);
+    });
+  });
+
+  test("validation preserves inverse edges established by default-field updateInput", async () => {
+    const target = await create();
+    const edgeType = "046b59f0-0d2d-431b-ae28-a2ea845acb15";
+    await DB.getInstance()
+      .getPool()
+      .query(
+        "INSERT INTO assoc_edge_config (edge_type, edge_name, edge_table, symmetric_edge, inverse_edge_type, created_at, updated_at) VALUES ($1, 'default inverse', 'scoped_account_edges', false, NULL, now(), now())",
+        [edgeType],
+      );
+    let owner!: ScopedAccount;
+    await withTransaction(async () => {
+      const schema = getBuilderSchemaFromFields(
+        {
+          balance: IntegerType({ defaultValueOnCreate: () => 42 }),
+          admin: BooleanType(),
+        },
+        ScopedAccount,
+      );
+      const action = new GuardedEdit(
+        viewer,
+        schema,
+        new Map([["admin", true]]),
+        WriteOperation.Insert,
+        null,
+      );
+      const orchestration = action.builder.orchestrator;
+      const opts = orchestration.__getOptions();
+      const updateInput = opts.updateInput!;
+      // Generated builders can add inverse edges while applying defaults.
+      opts.updateInput = (input) => {
+        updateInput(input);
+        orchestration.addOutboundEdge(target.id, edgeType, target.nodeType);
+      };
+      await action.validX();
+      await action.validX();
+      owner = await action.saveX();
+    });
+    expect(
+      (await loadEdges({ id1: owner.id, edgeType, context })).map(
+        (edge) => edge.id2,
+      ),
+    ).toEqual([target.id]);
+  });
+
+  test("scoped transform factories preserve their receiver and synchronous changesets", async () => {
+    const owner = await create();
+    await withTransaction(async () => {
+      const parent = edit(await load(owner.id as string), 90);
+      Object.assign(parent, {
+        transformWrite: ({ op }: { op: SQLStatementOperation }) => ({
+          op,
+          message: "bound transform",
+          changeset() {
+            return EntChangeset.changesetFromQueries(parent.builder, [
+              {
+                query:
+                  "INSERT INTO scoped_audits (id, created_at, updated_at, message) VALUES ($1, now(), now(), $2)",
+                values: [owner.id, this.message],
+              },
+            ]);
+          },
+        }),
+      });
+      await parent.validX();
+      await parent.saveX();
+    });
+    expect((await audits()).rows.map((row) => row.message)).toEqual([
+      "bound transform",
+    ]);
+  });
+
+  test("public validation preserves an unguarded parent's ancestry", async () => {
+    const [owner, target] = await Promise.all([create(), create()]);
+    await withTransaction(async () => {
+      const parent = new SimpleAction(
+        viewer,
+        accountSchema,
+        new Map([["balance", 90]]),
+        WriteOperation.Edit,
+        await load(owner.id as string),
+      );
+      parent.getTriggers = () => [
+        {
+          changeset: async () =>
+            edit(await load(target.id as string), 80).changeset(),
+        },
+      ];
+      await parent.validX();
+      await parent.saveX();
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(90);
+    expect((await load(target.id as string)).data.balance).toBe(80);
+  });
+
+  test.each(["valid", "validX", "validWithErrors"] as const)(
+    "%s applies the ancestor conflict guard before preparing overlapping children",
+    async (method) => {
+      const [owner, target] = await Promise.all([create(), create()]);
+      await expect(
+        withTransaction(async () => {
+          const parent = edit(await load(owner.id as string), 90);
+          parent.getTriggers = () => [
+            {
+              changeset: async () =>
+                edit(await load(target.id as string), 80).changeset(),
+            },
+          ];
+          await expect(parent[method]()).rejects.toThrow(
+            "overlapping guarded action preparation branches",
+          );
+        }),
+      ).rejects.toThrow("overlapping guarded action preparation branches");
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+      expect((await load(target.id as string)).data.balance).toBe(100);
+    },
+  );
+
+  test("saving while public validation is pending fails closed", async () => {
+    const owner = await create();
+    await expect(
+      withTransaction(async () => {
+        const parent = edit(await load(owner.id as string), 90);
+        const started = deferred();
+        const finish = deferred();
+        parent.getValidators = () => [
+          {
+            async validate() {
+              started.resolve();
+              await finish.promise;
+            },
+          },
+        ];
+        const validation = parent.validX();
+        await started.promise;
+        try {
+          await expect(parent.saveX()).rejects.toThrow(
+            "preparation is already in progress",
+          );
+        } finally {
+          finish.resolve();
+          await validation;
+        }
+      }),
+    ).rejects.toThrow("preparation is already in progress");
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+  });
+
+  test.each([true, false])(
+    "default wildcard conflicts with keyed sibling regardless preparation order (%s)",
+    async (keyedFirst) => {
+      const accounts = await Promise.all([create(), create(), create()]);
+      await expect(
+        withTransaction(async () => {
+          const current = await Promise.all(
+            accounts.map((account) => load(account.id as string)),
+          );
+          const parent = new SimpleAction(
+            viewer,
+            accountSchema,
+            new Map([["balance", 90]]),
+            WriteOperation.Edit,
+            current[0],
+          );
+          parent.getTriggers = () => [
+            {
+              async changeset() {
+                const keyed = independent(
+                  edit(current[1], 80),
+                  `account:${current[1].id}`,
+                );
+                const wildcard = edit(current[2], 70);
+                const children = keyedFirst
+                  ? [keyed, wildcard]
+                  : [wildcard, keyed];
+                return [
+                  await children[0].changeset(),
+                  await children[1].changeset(),
+                ];
+              },
+            },
+          ];
+          await parent.saveX();
+        }),
+      ).rejects.toThrow("overlapping guarded action preparation branches");
+    },
+  );
+});

--- a/ts/src/core/transaction.test.ts
+++ b/ts/src/core/transaction.test.ts
@@ -161,8 +161,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
             null,
           );
           // The parent needs the child's ID, and the conditional child depends
-          // on the parent. Preparation succeeds; executor assembly detects the
-          // cycle.
+          // on the parent. Preparation succeeds; executor
+          // assembly detects the cycle.
           builder.updateInput({ ownerID: child.builder });
           return child.changesetWithOptions_BETA({
             conditionalBuilder: builder,
@@ -1516,8 +1516,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
             async changeset() {
               const current = await load(target.id as string);
               return [
-                // Even incorrect resource keys cannot hide known duplicate row
-                // writes.
+                // Even incorrect resource keys cannot hide
+                // known duplicate row writes.
                 await independent(edit(current, 80), "first").changeset(),
                 await independent(edit(current, 70), "second").changeset(),
               ];
@@ -1982,8 +1982,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
             );
             await started.promise;
             // Release without waiting for validation so the test is
-            // deterministic
-            // whether validation rejects early or waits for the pending work.
+            // deterministic whether validation rejects early or
+            // waits for the pending work.
             await new Promise((resolve) => setImmediate(resolve));
             const settledBeforeRelease = settled;
             finish.resolve();
@@ -2241,8 +2241,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           { validate: async () => (invalid ? error : undefined) },
         ];
         parent.getTriggers = () => [{ changeset: () => child.changeset() }];
-        // Trigger changeset failures propagate even from valid and
-        // validWithErrors.
+        // Trigger changeset failures propagate even
+        // from valid and validWithErrors.
         await expect(parent[method]()).rejects.toBe(error);
         invalid = false;
         await parent.saveX();

--- a/ts/src/core/transaction.test.ts
+++ b/ts/src/core/transaction.test.ts
@@ -160,8 +160,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
             WriteOperation.Insert,
             null,
           );
-          // Parent needs the child's ID, while the conditional child depends
-          // on the parent. Preparation succeeds; executor assembly finds the cycle.
+          // The parent needs the child's ID, and the conditional child depends
+          // on the parent. Preparation succeeds; executor assembly detects the
+          // cycle.
           builder.updateInput({ ownerID: child.builder });
           return child.changesetWithOptions_BETA({
             conditionalBuilder: builder,
@@ -995,7 +996,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
       ];
       return action.saveX();
     });
-    // Assertion outside observer is essential: observers swallow exceptions.
+    // Assert outside the observer because observers suppress exceptions.
     expect(effects).toEqual([result.id]);
     expect((await action.builder.orchestrator.getEditedData()).id).toBe(
       result.id,
@@ -1515,7 +1516,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
             async changeset() {
               const current = await load(target.id as string);
               return [
-                // Even mistaken disjoint declarations cannot hide known duplicate row writes.
+                // Even incorrect resource keys cannot hide known duplicate row
+                // writes.
                 await independent(edit(current, 80), "first").changeset(),
                 await independent(edit(current, 70), "second").changeset(),
               ];
@@ -1979,8 +1981,9 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
               },
             );
             await started.promise;
-            // Release independently of validation completion so both the old
-            // fail-fast behavior and the repaired drain remain deterministic.
+            // Release without waiting for validation so the test is
+            // deterministic
+            // whether validation rejects early or waits for the pending work.
             await new Promise((resolve) => setImmediate(resolve));
             const settledBeforeRelease = settled;
             finish.resolve();
@@ -2238,7 +2241,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           { validate: async () => (invalid ? error : undefined) },
         ];
         parent.getTriggers = () => [{ changeset: () => child.changeset() }];
-        // Trigger changeset failures propagate even from valid/validWithErrors.
+        // Trigger changeset failures propagate even from valid and
+        // validWithErrors.
         await expect(parent[method]()).rejects.toBe(error);
         invalid = false;
         await parent.saveX();

--- a/ts/src/core/transaction.test.ts
+++ b/ts/src/core/transaction.test.ts
@@ -161,8 +161,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
             null,
           );
           // The parent needs the child's ID, and the conditional child depends
-          // on the parent. Preparation succeeds; executor
-          // assembly detects the cycle.
+          // on the parent. Preparation succeeds; executor assembly detects the cycle.
           builder.updateInput({ ownerID: child.builder });
           return child.changesetWithOptions_BETA({
             conditionalBuilder: builder,
@@ -1504,8 +1503,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
             async changeset() {
               const current = await load(target.id as string);
               return [
-                // Even incorrect resource keys cannot hide
-                // known duplicate row writes.
+                // Reject known duplicate row writes even with incorrect resource keys.
                 await independent(edit(current, 80), "first").changeset(),
                 await independent(edit(current, 70), "second").changeset(),
               ];
@@ -1964,9 +1962,8 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
               },
             );
             await started.promise;
-            // Release without waiting for validation so the test is
-            // deterministic whether validation rejects early or
-            // waits for the pending work.
+            // Release independently of validation so the test completes whether
+            // validation rejects early or waits for pending work.
             await new Promise((resolve) => setImmediate(resolve));
             const settledBeforeRelease = settled;
             finish.resolve();
@@ -2224,8 +2221,7 @@ describe("transaction-scoped actions (disposable Postgres database)", () => {
           { validate: async () => (invalid ? error : undefined) },
         ];
         parent.getTriggers = () => [{ changeset: () => child.changeset() }];
-        // Trigger changeset failures propagate even
-        // from valid and validWithErrors.
+        // Trigger changeset failures propagate from valid and validWithErrors too.
         await expect(parent[method]()).rejects.toBe(error);
         invalid = false;
         await parent.saveX();

--- a/ts/src/core/transaction.ts
+++ b/ts/src/core/transaction.ts
@@ -2,6 +2,7 @@ import DB, { Dialect, Queryer } from "./db";
 import { log } from "./logger";
 import {
   assertTransactionRead,
+  createTransactionToken,
   failTransaction,
   getTransactionState,
   recordRowTransaction,
@@ -12,8 +13,11 @@ import {
 
 export interface TransactionOptions {
   /**
-   * PostgreSQL only. Defaults to `serializable`.
-   * Use explicit locks to protect invariants with `read committed`.
+   * Defaults to `serializable` so conflicting read/validate/write decisions
+   * can fail instead of violating an invariant. Only this opt-in API uses this
+   * default; ordinary action transactions keep their configured isolation.
+   * Serializable conflicts may require retrying the whole callback. Use
+   * explicit locks to protect invariants with `read committed`.
    */
   isolationLevel?: "serializable" | "read committed";
   /**
@@ -54,7 +58,7 @@ function retryable(error: unknown): boolean {
 
 function dispose(state: TransactionState) {
   state.caches.clear();
-  state.resources.clear();
+  state.edgeMetadataLoader = undefined;
   state.receipts.length = 0;
   state.observers.length = 0;
   state.guardedRoot = undefined;
@@ -62,9 +66,10 @@ function dispose(state: TransactionState) {
 }
 
 /**
- * Include Ent loads, action preparation, validators, triggers, and writes in one
- * PostgreSQL transaction. Reject nested scopes and let existing `Transaction`
- * groups join this scope. Run action observers after commit, outside the scope.
+ * Include Ent loads, field defaults and transformations, privacy checks,
+ * triggers, validators, and writes in one PostgreSQL transaction. Reject nested
+ * scopes and let existing `Transaction` groups join this scope. Run action
+ * observers after commit, outside the scope.
  * Await every operation. Construct actions, queries, and loaders inside the
  * callback. If the callback can be retried, keep external side effects outside it.
  */
@@ -75,6 +80,8 @@ export async function withTransaction<T>(
   if (getTransactionState()) {
     throw new Error("nested withTransaction is not supported");
   }
+  // Serializable protects decisions based on earlier reads. This default is
+  // local to the new scope and doesn't change ordinary action transactions.
   const isolation = options.isolationLevel ?? "serializable";
   if (isolation !== "serializable" && isolation !== "read committed") {
     throw new Error(`unsupported transaction isolation level: ${isolation}`);
@@ -92,62 +99,69 @@ export async function withTransaction<T>(
 
   for (let attempt = 0; ; attempt++) {
     const client = await db.getNewClient();
+    const scopedQuery =
+      (
+        invalidate: boolean,
+        method: "query" | "exec" = "query",
+      ): Queryer["query"] =>
+      (sql, values) => {
+        if (getTransactionState() !== state) {
+          throw new Error(
+            "transaction queryer cannot be used outside its callback",
+          );
+        }
+        if (state.failed) {
+          return Promise.reject(state.error);
+        }
+        const read = { transaction: state, generation: state.generation };
+        // Public SQL can write or acquire locks. Framework read loaders use a
+        // separate path; their generated reads preserve other cached results.
+        const pending = client[method](sql, values)
+          .then((result) => {
+            assertTransactionRead(read);
+            const results = Array.isArray(result) ? result : [result];
+            for (const statement of results) {
+              for (const row of statement.rows) {
+                recordRowTransaction(row, read);
+              }
+            }
+            if (invalidate) {
+              for (const cache of state.caches.values()) {
+                cache.clearCache();
+              }
+              state.edgeMetadataLoader?.clearAll();
+            }
+            return result;
+          })
+          .catch((error) => {
+            failTransaction(state, error);
+            throw error;
+          });
+        state.pending.add(pending);
+        // Register both handlers to avoid creating an unhandled rejection.
+        void pending.then(
+          () => state.pending.delete(pending),
+          () => state.pending.delete(pending),
+        );
+        return trackValidationRead(pending);
+      };
+    const query = scopedQuery(true);
+    const readQuery = scopedQuery(false);
     const state: TransactionState = {
-      token: {},
+      token: createTransactionToken(),
       isolationLevel: isolation,
       attempt,
-      queryer: undefined as unknown as Queryer,
+      queryer: { query, queryAll: query, exec: scopedQuery(true, "exec") },
+      readQueryer: { query: readQuery, queryAll: readQuery },
       active: true,
       failed: false,
       pending: new Set(),
       caches: new Map(),
-      resources: new Map(),
       observers: [],
       receipts: [],
       generation: 0,
       branchClaims: [],
     };
-    const query: Queryer["query"] = (sql, values) => {
-      if (getTransactionState() !== state) {
-        throw new Error(
-          "transaction queryer cannot be used outside its callback",
-        );
-      }
-      if (state.failed) {
-        return Promise.reject(state.error);
-      }
-      const read = { transaction: state, generation: state.generation };
-      // Raw SQL can write or acquire a lock after a cached read. Clear every
-      // participating cache, including caches for other
-      // viewers in this attempt.
-      const pending = client
-        .query(sql, values)
-        .then((result) => {
-          assertTransactionRead(read);
-          for (const row of result.rows) {
-            recordRowTransaction(row, read);
-          }
-          for (const cache of state.caches.values()) {
-            cache.clearCache();
-          }
-          for (const resource of state.resources.values()) {
-            (resource as { clearAll?(): void }).clearAll?.();
-          }
-          return result;
-        })
-        .catch((error) => {
-          failTransaction(state, error);
-          throw error;
-        });
-      state.pending.add(pending);
-      // Register both handlers to avoid creating an unhandled rejection.
-      void pending.then(
-        () => state.pending.delete(pending),
-        () => state.pending.delete(pending),
-      );
-      return trackValidationRead(pending);
-    };
-    state.queryer = { query, queryAll: query, exec: query };
     let committed = false;
     let releaseError: Error | boolean | undefined;
     let result: T;

--- a/ts/src/core/transaction.ts
+++ b/ts/src/core/transaction.ts
@@ -11,9 +11,15 @@ import {
 } from "./transaction_context";
 
 export interface TransactionOptions {
-  /** PostgreSQL only. Defaults to serializable. Read committed needs explicit locks. */
+  /**
+   * PostgreSQL only. Defaults to `serializable`.
+   * Use explicit locks to protect invariants with `read committed`.
+   */
   isolationLevel?: "serializable" | "read committed";
-  /** Additional attempts for PostgreSQL serialization failures/deadlocks. Default: 0. */
+  /**
+   * Additional attempts for PostgreSQL serialization failures or deadlocks.
+   * Defaults to 0.
+   */
   maxRetries?: number;
 }
 
@@ -56,11 +62,11 @@ function dispose(state: TransactionState) {
 }
 
 /**
- * Include Ent loads, action preparation, validators, triggers and writes in one
- * PostgreSQL transaction. Nested scopes are rejected. Existing action Transaction
- * groups join this scope. Action observers run after commit, outside the scope.
- * Await every operation; construct actions, queries and loaders inside callback.
- * Retried callbacks must not perform external side effects.
+ * Include Ent loads, action preparation, validators, triggers, and writes in one
+ * PostgreSQL transaction. Reject nested scopes and let existing `Transaction`
+ * groups join this scope. Run action observers after commit, outside the scope.
+ * Await every operation. Construct actions, queries, and loaders inside the
+ * callback. If the callback can be retried, keep external side effects outside it.
  */
 export async function withTransaction<T>(
   callback: (scope: TransactionScope) => Promise<T>,
@@ -111,8 +117,9 @@ export async function withTransaction<T>(
         return Promise.reject(state.error);
       }
       const read = { transaction: state, generation: state.generation };
-      // Raw SQL may write or acquire a lock after an earlier cached read. Flush
-      // every participating cache, including other viewers in this attempt.
+      // Raw SQL can write or acquire a lock after a cached read. Clear every
+      // participating cache, including caches for other viewers in this
+      // attempt.
       const pending = client
         .query(sql, values)
         .then((result) => {
@@ -181,7 +188,7 @@ export async function withTransaction<T>(
         await client.release(releaseError);
       } catch (error) {
         releaseError = true;
-        // A successful COMMIT must never be retried because cleanup failed.
+        // Never retry a successful COMMIT because cleanup failed.
         log("error", error);
       }
     }
@@ -200,8 +207,8 @@ export async function withTransaction<T>(
           log("error", error);
         }
       }
-      // Clear every participating request cache only after commit. Transaction
-      // rows were never primed into them, and rollback leaves them untouched.
+      // Clear participating request caches only after commit. Transaction rows
+      // never enter these caches, so rollback leaves the caches unchanged.
       for (const cache of state.caches.keys()) {
         try {
           cache.clearCache();
@@ -213,8 +220,9 @@ export async function withTransaction<T>(
         try {
           await observe();
         } catch (error) {
-          // Match existing Ent observer semantics: observer failure cannot undo
-          // committed writes or trigger callback retries.
+          // Preserve existing observer behavior: a failure cannot undo
+          // committed
+          // writes or cause the callback to retry.
           log("error", error);
         }
       }

--- a/ts/src/core/transaction.ts
+++ b/ts/src/core/transaction.ts
@@ -118,8 +118,8 @@ export async function withTransaction<T>(
       }
       const read = { transaction: state, generation: state.generation };
       // Raw SQL can write or acquire a lock after a cached read. Clear every
-      // participating cache, including caches for other viewers in this
-      // attempt.
+      // participating cache, including caches for other
+      // viewers in this attempt.
       const pending = client
         .query(sql, values)
         .then((result) => {
@@ -221,8 +221,7 @@ export async function withTransaction<T>(
           await observe();
         } catch (error) {
           // Preserve existing observer behavior: a failure cannot undo
-          // committed
-          // writes or cause the callback to retry.
+          // committed writes or cause the callback to retry.
           log("error", error);
         }
       }

--- a/ts/src/core/transaction.ts
+++ b/ts/src/core/transaction.ts
@@ -13,11 +13,10 @@ import {
 
 export interface TransactionOptions {
   /**
-   * Defaults to `serializable` so conflicting read/validate/write decisions
-   * can fail instead of violating an invariant. Only this opt-in API uses this
-   * default; ordinary action transactions keep their configured isolation.
-   * Serializable conflicts may require retrying the whole callback. Use
-   * explicit locks to protect invariants with `read committed`.
+   * Defaults to `serializable`. Conflicting decisions based on earlier reads
+   * can abort the transaction and require a retry of the whole callback.
+   * Use explicit locks to protect invariants with `read committed`.
+   * Ordinary action transactions keep their configured isolation level.
    */
   isolationLevel?: "serializable" | "read committed";
   /**
@@ -69,7 +68,8 @@ function dispose(state: TransactionState) {
  * Include Ent loads, field defaults and transformations, privacy checks,
  * triggers, validators, and writes in one PostgreSQL transaction. Reject nested
  * scopes and let existing `Transaction` groups join this scope. Run action
- * observers after commit, outside the scope.
+ * observers after commit and connection release, outside the scope.
+ *
  * Await every operation. Construct actions, queries, and loaders inside the
  * callback. If the callback can be retried, keep external side effects outside it.
  */
@@ -80,8 +80,8 @@ export async function withTransaction<T>(
   if (getTransactionState()) {
     throw new Error("nested withTransaction is not supported");
   }
-  // Serializable protects decisions based on earlier reads. This default is
-  // local to the new scope and doesn't change ordinary action transactions.
+  // Serializable isolation protects decisions based on earlier reads.
+  // This default applies only to withTransaction.
   const isolation = options.isolationLevel ?? "serializable";
   if (isolation !== "serializable" && isolation !== "read committed") {
     throw new Error(`unsupported transaction isolation level: ${isolation}`);
@@ -114,8 +114,8 @@ export async function withTransaction<T>(
           return Promise.reject(state.error);
         }
         const read = { transaction: state, generation: state.generation };
-        // Public SQL can write or acquire locks. Framework read loaders use a
-        // separate path; their generated reads preserve other cached results.
+        // Public SQL can write or acquire locks, so invalidate caches after it
+        // completes. Framework reads preserve cached results.
         const pending = client[method](sql, values)
           .then((result) => {
             assertTransactionRead(read);
@@ -193,7 +193,7 @@ export async function withTransaction<T>(
       try {
         await client.query("ROLLBACK");
       } catch {
-        // Preserve the original failure and discard the unusable pg connection.
+        // Preserve the original failure and discard the unusable connection.
         releaseError = true;
       }
     } finally {

--- a/ts/src/core/transaction.ts
+++ b/ts/src/core/transaction.ts
@@ -1,0 +1,219 @@
+import DB, { Dialect, Queryer } from "./db";
+import { log } from "./logger";
+import {
+  assertTransactionRead,
+  failTransaction,
+  getTransactionState,
+  recordRowTransaction,
+  trackValidationRead,
+  transactionStorage,
+  TransactionState,
+} from "./transaction_context";
+
+export interface TransactionOptions {
+  /** PostgreSQL only. Defaults to serializable. Read committed needs explicit locks. */
+  isolationLevel?: "serializable" | "read committed";
+  /** Additional attempts for PostgreSQL serialization failures/deadlocks. Default: 0. */
+  maxRetries?: number;
+}
+
+export interface TransactionScope extends Queryer {
+  readonly isolationLevel: "serializable" | "read committed";
+  /** Zero-based attempt number. Rebuild actions and reload Ents on every attempt. */
+  readonly attempt: number;
+}
+
+/** Inspect the current scope so a composed operation can join its caller. */
+export function getTransactionScope(): TransactionScope | undefined {
+  const state = getTransactionState();
+  if (!state) return undefined;
+  return {
+    ...state.queryer,
+    attempt: state.attempt,
+    isolationLevel: state.isolationLevel,
+  };
+}
+
+function retryable(error: unknown): boolean {
+  const postgresError = error as { code?: string; errno?: string } | null;
+  // Bun SQL exposes SQLSTATE in errno, while pg exposes it in code.
+  const code =
+    postgresError?.code === "ERR_POSTGRES_SERVER_ERROR"
+      ? postgresError.errno
+      : postgresError?.code;
+  return code === "40001" || code === "40P01";
+}
+
+function dispose(state: TransactionState) {
+  state.caches.clear();
+  state.resources.clear();
+  state.receipts.length = 0;
+  state.observers.length = 0;
+  state.guardedRoot = undefined;
+  state.branchClaims.length = 0;
+}
+
+/**
+ * Include Ent loads, action preparation, validators, triggers and writes in one
+ * PostgreSQL transaction. Nested scopes are rejected. Existing action Transaction
+ * groups join this scope. Action observers run after commit, outside the scope.
+ * Await every operation; construct actions, queries and loaders inside callback.
+ * Retried callbacks must not perform external side effects.
+ */
+export async function withTransaction<T>(
+  callback: (scope: TransactionScope) => Promise<T>,
+  options: TransactionOptions = {},
+): Promise<T> {
+  if (getTransactionState()) {
+    throw new Error("nested withTransaction is not supported");
+  }
+  const isolation = options.isolationLevel ?? "serializable";
+  if (isolation !== "serializable" && isolation !== "read committed") {
+    throw new Error(`unsupported transaction isolation level: ${isolation}`);
+  }
+  const maxRetries = options.maxRetries ?? 0;
+  if (!Number.isSafeInteger(maxRetries) || maxRetries < 0) {
+    throw new Error("maxRetries must be a non-negative safe integer");
+  }
+  const db = DB.getInstance();
+  if (db.db.dialect !== Dialect.Postgres) {
+    throw new Error(
+      "withTransaction only supports PostgreSQL (pg or Bun SQL); SQLite is not supported",
+    );
+  }
+
+  for (let attempt = 0; ; attempt++) {
+    const client = await db.getNewClient();
+    const state: TransactionState = {
+      token: {},
+      isolationLevel: isolation,
+      attempt,
+      queryer: undefined as unknown as Queryer,
+      active: true,
+      failed: false,
+      pending: new Set(),
+      caches: new Map(),
+      resources: new Map(),
+      observers: [],
+      receipts: [],
+      generation: 0,
+      branchClaims: [],
+    };
+    const query: Queryer["query"] = (sql, values) => {
+      if (getTransactionState() !== state) {
+        throw new Error(
+          "transaction queryer cannot be used outside its callback",
+        );
+      }
+      if (state.failed) {
+        return Promise.reject(state.error);
+      }
+      const read = { transaction: state, generation: state.generation };
+      // Raw SQL may write or acquire a lock after an earlier cached read. Flush
+      // every participating cache, including other viewers in this attempt.
+      const pending = client
+        .query(sql, values)
+        .then((result) => {
+          assertTransactionRead(read);
+          for (const row of result.rows) recordRowTransaction(row, read);
+          for (const cache of state.caches.values()) cache.clearCache();
+          for (const resource of state.resources.values()) {
+            (resource as { clearAll?(): void }).clearAll?.();
+          }
+          return result;
+        })
+        .catch((error) => {
+          failTransaction(state, error);
+          throw error;
+        });
+      state.pending.add(pending);
+      // Register both handlers to avoid creating an unhandled rejection.
+      void pending.then(
+        () => state.pending.delete(pending),
+        () => state.pending.delete(pending),
+      );
+      return trackValidationRead(pending);
+    };
+    state.queryer = { query, queryAll: query, exec: query };
+    let committed = false;
+    let releaseError: Error | boolean | undefined;
+    let result: T;
+    let failure: unknown;
+    let failed = false;
+    try {
+      await client.query(`BEGIN ISOLATION LEVEL ${isolation.toUpperCase()}`);
+      result = await transactionStorage.run(state, () =>
+        callback({ ...state.queryer, attempt, isolationLevel: isolation }),
+      );
+      state.active = false;
+      if (state.pending.size) {
+        failTransaction(
+          state,
+          new Error("await all queries inside withTransaction"),
+        );
+        await Promise.allSettled([...state.pending]);
+      }
+      if (state.failed) {
+        throw state.error;
+      }
+      await client.query("COMMIT");
+      committed = true;
+    } catch (error) {
+      failed = true;
+      failure = state.failed ? state.error : error;
+      state.active = false;
+      await Promise.allSettled([...state.pending]);
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        // Preserve the original failure and discard the unusable pg connection.
+        releaseError = true;
+      }
+    } finally {
+      state.active = false;
+      try {
+        await client.release(releaseError);
+      } catch (error) {
+        releaseError = true;
+        // A successful COMMIT must never be retried because cleanup failed.
+        log("error", error);
+      }
+    }
+    if (failed) {
+      dispose(state);
+      if (!releaseError && retryable(failure) && attempt < maxRetries) {
+        continue;
+      }
+      throw failure;
+    }
+    if (committed) {
+      for (const receipt of state.receipts) {
+        try {
+          receipt();
+        } catch (error) {
+          log("error", error);
+        }
+      }
+      // Clear every participating request cache only after commit. Transaction
+      // rows were never primed into them, and rollback leaves them untouched.
+      for (const cache of state.caches.keys()) {
+        try {
+          cache.clearCache();
+        } catch (error) {
+          log("error", error);
+        }
+      }
+      for (const observe of state.observers) {
+        try {
+          await observe();
+        } catch (error) {
+          // Match existing Ent observer semantics: observer failure cannot undo
+          // committed writes or trigger callback retries.
+          log("error", error);
+        }
+      }
+    }
+    dispose(state);
+    return result!;
+  }
+}

--- a/ts/src/core/transaction.ts
+++ b/ts/src/core/transaction.ts
@@ -7,9 +7,11 @@ import {
   getTransactionState,
   recordRowTransaction,
   trackValidationRead,
+  runFinalScopeValidation,
   transactionStorage,
   TransactionState,
 } from "./transaction_context";
+import { assertValidationQuery } from "./transaction_validation";
 
 export interface TransactionOptions {
   /**
@@ -29,6 +31,13 @@ export interface TransactionOptions {
 export interface TransactionScope extends Queryer {
   readonly isolationLevel: "serializable" | "read committed";
   /** Zero-based attempt number. Rebuild actions and reload Ents on every attempt. */
+  readonly attempt: number;
+}
+
+/** Uncached database reads on the transaction that owns final action validation. */
+export interface ScopeValidationContext
+  extends Pick<Queryer, "query" | "queryAll"> {
+  readonly isolationLevel: "serializable" | "read committed";
   readonly attempt: number;
 }
 
@@ -60,28 +69,31 @@ function dispose(state: TransactionState) {
   state.edgeMetadataLoader = undefined;
   state.receipts.length = 0;
   state.observers.length = 0;
-  state.guardedRoot = undefined;
-  state.branchClaims.length = 0;
+  state.preparingRoot = undefined;
+  state.preparingValidation = undefined;
+  state.validators.clear();
+  state.pendingActions.clear();
+  state.pendingPreparations.clear();
 }
 
 /**
  * Include Ent loads, field defaults and transformations, privacy checks,
  * triggers, validators, and writes in one PostgreSQL transaction. Reject nested
- * scopes and let existing `Transaction` groups join this scope. Run action
+ * scopes and prepare each top-level action after the preceding save. Run action
  * observers after commit and connection release, outside the scope.
  *
  * Await every operation. Construct actions, queries, and loaders inside the
  * callback. If the callback can be retried, keep external side effects outside it.
  */
-export async function withTransaction<T>(
+export async function withTransactionScope<T>(
   callback: (scope: TransactionScope) => Promise<T>,
   options: TransactionOptions = {},
 ): Promise<T> {
   if (getTransactionState()) {
-    throw new Error("nested withTransaction is not supported");
+    throw new Error("nested withTransactionScope is not supported");
   }
   // Serializable isolation protects decisions based on earlier reads.
-  // This default applies only to withTransaction.
+  // This default applies only to withTransactionScope.
   const isolation = options.isolationLevel ?? "serializable";
   if (isolation !== "serializable" && isolation !== "read committed") {
     throw new Error(`unsupported transaction isolation level: ${isolation}`);
@@ -93,7 +105,7 @@ export async function withTransaction<T>(
   const db = DB.getInstance();
   if (db.db.dialect !== Dialect.Postgres) {
     throw new Error(
-      "withTransaction only supports PostgreSQL (pg or Bun SQL); SQLite is not supported",
+      "withTransactionScope only supports PostgreSQL (pg or Bun SQL); SQLite is not supported",
     );
   }
 
@@ -112,6 +124,14 @@ export async function withTransaction<T>(
         }
         if (state.failed) {
           return Promise.reject(state.error);
+        }
+        if (state.validating) {
+          try {
+            assertValidationQuery(sql);
+          } catch (error) {
+            failTransaction(state, error);
+            throw error;
+          }
         }
         const read = { transaction: state, generation: state.generation };
         // Public SQL can write or acquire locks, so invalidate caches after it
@@ -160,7 +180,10 @@ export async function withTransaction<T>(
       observers: [],
       receipts: [],
       generation: 0,
-      branchClaims: [],
+      validating: false,
+      pendingActions: new Set(),
+      pendingPreparations: new Set(),
+      validators: new Map(),
     };
     let committed = false;
     let releaseError: Error | boolean | undefined;
@@ -169,14 +192,65 @@ export async function withTransaction<T>(
     let failed = false;
     try {
       await client.query(`BEGIN ISOLATION LEVEL ${isolation.toUpperCase()}`);
-      result = await transactionStorage.run(state, () =>
-        callback({ ...state.queryer, attempt, isolationLevel: isolation }),
-      );
+      result = await transactionStorage.run(state, async () => {
+        const value = await callback({
+          ...state.queryer,
+          attempt,
+          isolationLevel: isolation,
+        });
+        if (state.pendingActions.size || state.pendingPreparations.size) {
+          failTransaction(
+            state,
+            new Error(
+              "await each action save before leaving withTransactionScope",
+            ),
+          );
+        }
+        if (state.pending.size) {
+          failTransaction(
+            state,
+            new Error("await all queries inside withTransactionScope"),
+          );
+        }
+        if (state.failed) {
+          throw state.error;
+        }
+        if (state.validators.size) {
+          state.validating = true;
+          state.generation++;
+          state.edgeMetadataLoader = undefined;
+          for (const cache of state.caches.values()) {
+            cache.clearCache();
+          }
+          // Run deferred constraints and triggers while writes and row locks
+          // are still allowed. Final checks must include their effects.
+          await client.query("SET CONSTRAINTS ALL IMMEDIATE");
+          // PostgreSQL permits switching to read-only after writes. Keep the
+          // same connection so checks can see those uncommitted changes.
+          await client.query("SET TRANSACTION READ ONLY");
+          await client.query("SET LOCAL standard_conforming_strings = on");
+          await runFinalScopeValidation(state, async () => {
+            const context: ScopeValidationContext = Object.freeze({
+              query: readQuery,
+              queryAll: readQuery,
+              attempt,
+              isolationLevel: isolation,
+            });
+            for (const validate of state.validators.values()) {
+              await validate(context);
+              if (state.failed) {
+                throw state.error;
+              }
+            }
+          });
+        }
+        return value;
+      });
       state.active = false;
       if (state.pending.size) {
         failTransaction(
           state,
-          new Error("await all queries inside withTransaction"),
+          new Error("await all queries inside withTransactionScope"),
         );
         await Promise.allSettled([...state.pending]);
       }
@@ -189,7 +263,11 @@ export async function withTransaction<T>(
       failed = true;
       failure = state.failed ? state.error : error;
       state.active = false;
-      await Promise.allSettled([...state.pending]);
+      await Promise.allSettled([
+        ...state.pending,
+        ...state.pendingActions,
+        ...state.pendingPreparations,
+      ]);
       try {
         await client.query("ROLLBACK");
       } catch {

--- a/ts/src/core/transaction.ts
+++ b/ts/src/core/transaction.ts
@@ -26,7 +26,9 @@ export interface TransactionScope extends Queryer {
 /** Inspect the current scope so a composed operation can join its caller. */
 export function getTransactionScope(): TransactionScope | undefined {
   const state = getTransactionState();
-  if (!state) return undefined;
+  if (!state) {
+    return undefined;
+  }
   return {
     ...state.queryer,
     attempt: state.attempt,
@@ -115,8 +117,12 @@ export async function withTransaction<T>(
         .query(sql, values)
         .then((result) => {
           assertTransactionRead(read);
-          for (const row of result.rows) recordRowTransaction(row, read);
-          for (const cache of state.caches.values()) cache.clearCache();
+          for (const row of result.rows) {
+            recordRowTransaction(row, read);
+          }
+          for (const cache of state.caches.values()) {
+            cache.clearCache();
+          }
           for (const resource of state.resources.values()) {
             (resource as { clearAll?(): void }).clearAll?.();
           }

--- a/ts/src/core/transaction_cache.test.ts
+++ b/ts/src/core/transaction_cache.test.ts
@@ -13,7 +13,7 @@ import {
 import { ObjectLoaderFactory } from "./loaders";
 import { QueryLoaderFactory } from "./loaders/query_loader";
 import { AssocEdgeLoaderFactory } from "./loaders/assoc_edge_loader";
-import { withTransaction } from "../action";
+import { withTransactionScope } from "../action";
 import { WriteOperation } from "../action/action";
 import { EntChangeset } from "../action/orchestrator";
 import { IntegerType } from "../schema";
@@ -82,7 +82,7 @@ describe.each([
     const account = await create();
     const otherViewer = new TestContext().getViewer();
     const abort = new Error("abort after SQL commands");
-    const transaction = withTransaction(async (tx) => {
+    const transaction = withTransactionScope(async (tx) => {
       expect((await load(account.id)).data.balance).toBe(100);
       expect(
         (await loadEntX(otherViewer, account.id, options)).data.balance,
@@ -147,12 +147,12 @@ test("pending multi-command exec prevents commit", async () => {
   const account = await create();
   let pending: Promise<unknown> | undefined;
   await expect(
-    withTransaction(async (tx) => {
+    withTransactionScope(async (tx) => {
       pending = tx
         .exec("SELECT pg_sleep(0.02); UPDATE cached_accounts SET balance = 70")
         .catch(() => undefined);
     }),
-  ).rejects.toThrow("await all queries inside withTransaction");
+  ).rejects.toThrow("await all queries inside withTransactionScope");
   await pending;
   expect((await load(account.id)).data.balance).toBe(100);
 });
@@ -164,7 +164,7 @@ test.each([
   ["queryAll", 1],
 ] as const)("%s result set %s retains row provenance", async (method, index) => {
   const account = await create();
-  await withTransaction(async (tx) => {
+  await withTransactionScope(async (tx) => {
     const results = await tx[method](
       "SELECT * FROM cached_accounts; SELECT * FROM cached_accounts",
     );
@@ -185,7 +185,7 @@ test.each([
         WriteOperation.Edit,
         ent,
       ),
-      { requiresTransaction: () => true },
+      { requiresTransactionScope: () => true },
     );
     await action.saveX();
   });
@@ -234,7 +234,7 @@ test.each([
     }
   };
   const sql = await captureSQL(() =>
-    withTransaction(async () => {
+    withTransactionScope(async () => {
       for (let i = 0; i < 3; i++) {
         await read(accounts[0].id);
         await read(accounts[1].id);
@@ -247,7 +247,7 @@ test.each([
 test("grouped query reads preserve existing Ent and query caches", async () => {
   const accounts = await Promise.all([create(), create()]);
   const sql = await captureSQL(() =>
-    withTransaction(async () => {
+    withTransactionScope(async () => {
       await load(accounts[0].id);
       const grouped = new QueryLoaderFactory({
         ...loader,
@@ -276,7 +276,7 @@ test("grouped edge reads preserve Ent, edge, and metadata caches", async () => {
       [edgeType],
     );
   const sql = await captureSQL(() =>
-    withTransaction(async () => {
+    withTransactionScope(async () => {
       await load(accounts[0].id);
       const grouped = new AssocEdgeLoaderFactory(
         edgeType,
@@ -305,7 +305,7 @@ test.each([
 ] as const)("%s SQL invalidates cached reads even for SELECT", async (method) => {
   const accounts = await Promise.all([create(), create()]);
   const sql = await captureSQL(() =>
-    withTransaction(async (tx) => {
+    withTransactionScope(async (tx) => {
       await load(accounts[0].id);
       await load(accounts[1].id);
       if (method === "pool") {
@@ -325,7 +325,7 @@ test.each([
 test("ordinary action writes invalidate every viewer's scoped cache", async () => {
   const account = await create();
   const otherViewer = new TestContext().getViewer();
-  await withTransaction(async () => {
+  await withTransactionScope(async () => {
     const current = await load(account.id);
     expect(
       (await loadEntX(otherViewer, account.id, options)).data.balance,

--- a/ts/src/core/transaction_cache.test.ts
+++ b/ts/src/core/transaction_cache.test.ts
@@ -1,0 +1,345 @@
+import { randomUUID } from "crypto";
+import DB, { Dialect } from "./db";
+import { ID } from "./base";
+import { Eq } from "./clause";
+import {
+  applyPrivacyPolicyForRow,
+  AssocEdge,
+  loadEntX,
+  loadRow,
+  loadRows,
+  performRawQuery,
+} from "./ent";
+import { ObjectLoaderFactory } from "./loaders";
+import { QueryLoaderFactory } from "./loaders/query_loader";
+import { AssocEdgeLoaderFactory } from "./loaders/assoc_edge_loader";
+import { withTransaction } from "../action";
+import { WriteOperation } from "../action/action";
+import { EntChangeset } from "../action/orchestrator";
+import { IntegerType } from "../schema";
+import {
+  BaseEnt,
+  SimpleAction,
+  getBuilderSchemaFromFields,
+  getDbFields,
+} from "../testutils/builder";
+import {
+  assoc_edge_config_table,
+  assoc_edge_table,
+  getSchemaTable,
+  setupPostgres,
+} from "../testutils/db/temp_db";
+import { TestContext } from "../testutils/context/test_context";
+
+class CachedAccount extends BaseEnt {
+  nodeType = "CachedAccount";
+}
+const schema = getBuilderSchemaFromFields(
+  { balance: IntegerType() },
+  CachedAccount,
+);
+const loader = {
+  tableName: "cached_accounts",
+  fields: getDbFields(schema),
+  key: "id",
+};
+const options = {
+  ...loader,
+  ent: CachedAccount,
+  loaderFactory: new ObjectLoaderFactory(loader),
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+const load = (id: ID) => loadEntX(viewer, id, options);
+const create = () =>
+  new SimpleAction(
+    viewer,
+    schema,
+    new Map([["balance", 100]]),
+    WriteOperation.Insert,
+    null,
+  ).saveX();
+
+setupPostgres(() => [
+  getSchemaTable(schema, Dialect.Postgres),
+  assoc_edge_config_table(),
+  assoc_edge_table("cached_account_edges"),
+]);
+beforeEach(() => context.cache.reset());
+
+describe.each([
+  "exec",
+  "pool exec",
+  "raw changeset",
+  "query",
+  "queryAll",
+] as const)("%s with multiple SQL commands", (method) => {
+  test.each([
+    "commit",
+    "callback rollback",
+    "caught SQL failure",
+  ])("%s preserves transaction and cache behavior", async (outcome) => {
+    const account = await create();
+    const otherViewer = new TestContext().getViewer();
+    const abort = new Error("abort after SQL commands");
+    const transaction = withTransaction(async (tx) => {
+      expect((await load(account.id)).data.balance).toBe(100);
+      expect(
+        (await loadEntX(otherViewer, account.id, options)).data.balance,
+      ).toBe(100);
+      const sql =
+        "UPDATE cached_accounts SET balance = 80; " +
+        (outcome === "caught SQL failure"
+          ? "SELECT unknown_column FROM cached_accounts"
+          : "UPDATE cached_accounts SET balance = 70");
+      const execute = () => {
+        if (method === "raw changeset") {
+          const action = new SimpleAction(
+            viewer,
+            schema,
+            new Map(),
+            WriteOperation.Edit,
+            account,
+          );
+          return EntChangeset.changesetFromQueries(action.builder, [sql])
+            .executor()
+            .execute();
+        }
+        return method === "pool exec"
+          ? DB.getInstance().getPool().exec(sql)
+          : tx[method](sql);
+      };
+      if (outcome === "caught SQL failure") {
+        await expect(execute()).rejects.toHaveProperty("code", "42703");
+        return;
+      }
+      const result = await execute();
+      if (method === "query" || method === "queryAll") {
+        expect(result).toEqual([
+          expect.objectContaining({ rowCount: 1 }),
+          expect.objectContaining({ rowCount: 1 }),
+        ]);
+      } else if (method !== "raw changeset") {
+        expect(result).toEqual({ rows: [], rowCount: 0 });
+      }
+      expect((await load(account.id)).data.balance).toBe(70);
+      expect(
+        (await loadEntX(otherViewer, account.id, options)).data.balance,
+      ).toBe(70);
+      if (outcome === "callback rollback") {
+        throw abort;
+      }
+    });
+    if (outcome === "commit") {
+      await transaction;
+    } else if (outcome === "callback rollback") {
+      await expect(transaction).rejects.toBe(abort);
+    } else {
+      await expect(transaction).rejects.toHaveProperty("code", "42703");
+    }
+    expect((await load(account.id)).data.balance).toBe(
+      outcome === "commit" ? 70 : 100,
+    );
+  });
+});
+
+test("pending multi-command exec prevents commit", async () => {
+  const account = await create();
+  let pending: Promise<unknown> | undefined;
+  await expect(
+    withTransaction(async (tx) => {
+      pending = tx
+        .exec("SELECT pg_sleep(0.02); UPDATE cached_accounts SET balance = 70")
+        .catch(() => undefined);
+    }),
+  ).rejects.toThrow("await all queries inside withTransaction");
+  await pending;
+  expect((await load(account.id)).data.balance).toBe(100);
+});
+
+test.each([
+  ["query", 0],
+  ["query", 1],
+  ["queryAll", 0],
+  ["queryAll", 1],
+] as const)("%s result set %s retains row provenance", async (method, index) => {
+  const account = await create();
+  await withTransaction(async (tx) => {
+    const results = await tx[method](
+      "SELECT * FROM cached_accounts; SELECT * FROM cached_accounts",
+    );
+    if (!Array.isArray(results)) {
+      throw new Error("expected multiple result sets");
+    }
+    const ent = await applyPrivacyPolicyForRow(
+      viewer,
+      options,
+      results[index].rows[0],
+    );
+    expect(ent?.data.balance).toBe(100);
+    const action = Object.assign(
+      new SimpleAction(
+        viewer,
+        schema,
+        new Map([["balance", ent!.data.balance - 20]]),
+        WriteOperation.Edit,
+        ent,
+      ),
+      { requiresTransaction: () => true },
+    );
+    await action.saveX();
+  });
+  expect((await load(account.id)).data.balance).toBe(80);
+});
+
+async function captureSQL(run: () => Promise<void>): Promise<string[]> {
+  const db = DB.getInstance();
+  const acquire = db.getNewClient.bind(db);
+  const statements: string[] = [];
+  const spy = jest
+    .spyOn(db, "getNewClient")
+    .mockImplementationOnce(async () => {
+      const client = await acquire();
+      for (const method of ["query", "exec"] as const) {
+        const query = client[method].bind(client);
+        client[method] = async (sql, values) => {
+          statements.push(sql);
+          return query(sql, values);
+        };
+      }
+      return client;
+    });
+  try {
+    await run();
+    return statements.filter((sql) => sql.startsWith("SELECT"));
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+test.each([
+  "Ent",
+  "row",
+  "rows",
+] as const)("alternating %s reads keep both results cached", async (method) => {
+  const accounts = await Promise.all([create(), create()]);
+  const read = (id: ID) => {
+    switch (method) {
+      case "Ent":
+        return load(id);
+      case "row":
+        return loadRow({ ...loader, clause: Eq("id", id), context });
+      case "rows":
+        return loadRows({ ...loader, clause: Eq("id", id), context });
+    }
+  };
+  const sql = await captureSQL(() =>
+    withTransaction(async () => {
+      for (let i = 0; i < 3; i++) {
+        await read(accounts[0].id);
+        await read(accounts[1].id);
+      }
+    }),
+  );
+  expect(sql).toHaveLength(2);
+});
+
+test("grouped query reads preserve existing Ent and query caches", async () => {
+  const accounts = await Promise.all([create(), create()]);
+  const sql = await captureSQL(() =>
+    withTransaction(async () => {
+      await load(accounts[0].id);
+      const grouped = new QueryLoaderFactory({
+        ...loader,
+        groupCol: "id",
+      }).createLoader(context);
+      for (let i = 0; i < 3; i++) {
+        const rows = await Promise.all(
+          accounts.map((account) => grouped.load(account.id)),
+        );
+        expect(rows.map((group) => group.length)).toEqual([1, 1]);
+        await load(accounts[0].id);
+      }
+    }),
+  );
+  expect(sql).toHaveLength(2);
+  expect(sql.some((query) => query.includes("row_number()"))).toBe(true);
+});
+
+test("grouped edge reads preserve Ent, edge, and metadata caches", async () => {
+  const accounts = await Promise.all([create(), create()]);
+  const edgeType = randomUUID();
+  await DB.getInstance()
+    .getPool()
+    .query(
+      "INSERT INTO assoc_edge_config (edge_type, edge_name, symmetric_edge, edge_table, created_at, updated_at) VALUES ($1, 'CachedAccountToPeers', false, 'cached_account_edges', now(), now())",
+      [edgeType],
+    );
+  const sql = await captureSQL(() =>
+    withTransaction(async () => {
+      await load(accounts[0].id);
+      const grouped = new AssocEdgeLoaderFactory(
+        edgeType,
+        AssocEdge,
+      ).createLoader(context);
+      for (let i = 0; i < 3; i++) {
+        expect(
+          await Promise.all(
+            accounts.map((account) => grouped.load(account.id)),
+          ),
+        ).toEqual([[], []]);
+        await load(accounts[0].id);
+      }
+    }),
+  );
+  expect(sql).toHaveLength(3);
+  expect(sql.some((query) => query.includes("row_number()"))).toBe(true);
+});
+
+test.each([
+  "query",
+  "queryAll",
+  "exec",
+  "pool",
+  "raw",
+] as const)("%s SQL invalidates cached reads even for SELECT", async (method) => {
+  const accounts = await Promise.all([create(), create()]);
+  const sql = await captureSQL(() =>
+    withTransaction(async (tx) => {
+      await load(accounts[0].id);
+      await load(accounts[1].id);
+      if (method === "pool") {
+        await DB.getInstance().getPool().query("SELECT 1");
+      } else if (method === "raw") {
+        await performRawQuery("SELECT 1", []);
+      } else {
+        await tx[method]("SELECT 1");
+      }
+      await load(accounts[0].id);
+      await load(accounts[1].id);
+    }),
+  );
+  expect(sql).toHaveLength(5);
+});
+
+test("ordinary action writes invalidate every viewer's scoped cache", async () => {
+  const account = await create();
+  const otherViewer = new TestContext().getViewer();
+  await withTransaction(async () => {
+    const current = await load(account.id);
+    expect(
+      (await loadEntX(otherViewer, account.id, options)).data.balance,
+    ).toBe(100);
+    await new SimpleAction(
+      viewer,
+      schema,
+      new Map([["balance", 80]]),
+      WriteOperation.Edit,
+      current,
+    ).saveX();
+    expect((await load(account.id)).data.balance).toBe(80);
+    expect(
+      (await loadEntX(otherViewer, account.id, options)).data.balance,
+    ).toBe(80);
+  });
+});

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -16,7 +16,7 @@ export function createTransactionToken(): TransactionToken {
   return { [transactionTokenBrand]: true };
 }
 
-// Internal state only. Never replace DB.instance or a viewer's request context.
+// Keep transaction state separate from DB.instance and viewer request contexts.
 export interface TransactionState {
   token: TransactionToken;
   isolationLevel: "serializable" | "read committed";
@@ -96,17 +96,15 @@ export function runInActionPreparation<T>(
     try {
       return await prepare();
     } finally {
-      // If a trigger's Promise.all rejects, other children can still be
-      // running. Wait for descendants before restoring this participant or
-      // completing root validation. Exclude the owner from its
-      // own set of pending work.
+      // If a trigger's Promise.all rejects, other children can still be running.
+      // Wait for descendants before restoring this action or completing root
+      // validation. The action must not wait on its own preparation promise.
       if (node.pending) {
         do {
           await Promise.allSettled([...node.pending]);
-          // A completed SQL or loader promise can resume several async wrappers
-          // before the caller starts child preparation. Wait one event loop
-          // turn for those wrappers to register reads
-          // and children before checking again.
+          // Completed SQL or loader reads can resume several asynchronous
+          // wrappers before child preparation starts. Allow one event loop turn
+          // for those wrappers to register reads and children before checking again.
           await new Promise<void>((resolve) => setImmediate(resolve));
         } while (node.pending.size);
       }
@@ -131,8 +129,8 @@ export function runInActionPreparation<T>(
 
 export function trackValidationRead<T>(read: Promise<T>): Promise<T> {
   const node = preparationStorage.getStore();
-  // Once a read returns a promise, tracking must not throw and leave that
-  // promise unhandled. The read itself reports errors if its scope has closed.
+  // Track the returned promise without throwing and leaving it unhandled.
+  // The read reports an error if its scope has closed.
   const state = transactionStorage.getStore();
   if (
     state?.active &&
@@ -205,8 +203,8 @@ function getGuardedPreparation() {
 
 export function reserveGuardedPreparation(): TransactionReadState {
   const { state, node } = getGuardedPreparation();
-  // Reserve the root before user code can await. Keep the pending claim through
-  // nested validation cleanup, then check its resource keys when they resolve.
+  // Reserve the root before awaiting application code. Retain the pending claim
+  // through nested validation cleanup, then check the resolved resource keys.
   node.resourcesPending = true;
   if (!state.branchClaims.includes(node)) {
     state.branchClaims.push(node);
@@ -228,10 +226,10 @@ export function claimGuardedPreparation(resources?: readonly string[]) {
     );
   }
   for (const owner of state.branchClaims) {
-    // The same action can validate while being built. Different actions must
-    // prove independence even when one was created by the other's trigger.
-    // A pending hook checks resolved claims when it finishes, so independent
-    // siblings can resolve their keys concurrently.
+    // An action can validate during its own preparation. Other actions must
+    // declare disjoint resources, including children created by its triggers.
+    // Check resolved claims when each hook finishes so independent siblings can
+    // resolve their keys concurrently.
     if (owner.builder === node.builder || owner.resourcesPending) {
       continue;
     }

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -55,7 +55,9 @@ export function runInActionPreparation<T>(
   validationOnly = false,
 ): Promise<T> {
   const state = getTransactionState();
-  if (!state) return prepare();
+  if (!state) {
+    return prepare();
+  }
   const parent = preparationStorage.getStore();
   const scopedParent = parent?.token === state.token ? parent : undefined;
   const root = scopedParent?.root ?? builder;
@@ -140,7 +142,9 @@ export function isValidationPreparation(): boolean {
 export async function awaitActionPreparations<T>(
   work: Iterable<T | PromiseLike<T>>,
 ): Promise<Awaited<T>[]> {
-  if (!isValidationPreparation()) return Promise.all(work);
+  if (!isValidationPreparation()) {
+    return Promise.all(work);
+  }
   let failed = false;
   let failure: unknown;
   const results = await Promise.all(
@@ -153,7 +157,9 @@ export async function awaitActionPreparations<T>(
       }),
     ),
   );
-  if (failed) throw failure;
+  if (failed) {
+    throw failure;
+  }
   return results as Awaited<T>[];
 }
 
@@ -181,7 +187,9 @@ export function claimGuardedPreparation(resources?: readonly string[]) {
   for (const owner of state.branchClaims) {
     // The same action can validate while being built. Different actions must
     // prove independence even when one was created by the other's trigger.
-    if (owner.builder === node.builder) continue;
+    if (owner.builder === node.builder) {
+      continue;
+    }
     if (
       !owner.resources ||
       !resources ||
@@ -225,12 +233,16 @@ export function completeGuardedPreparation(
     state.branchClaims.length = 0;
     state.generation++;
     state.resources.clear();
-    for (const cache of state.caches.values()) cache.clearCache();
+    for (const cache of state.caches.values()) {
+      cache.clearCache();
+    }
   }
   // A result getter reconstructs a snapshot, not a new database read. Capture
   // the completed write's provenance for every builder in the composed graph.
   const provenance = { token: state.token, generation: state.generation };
-  for (const builder of builders) resultTransactions.set(builder, provenance);
+  for (const builder of builders) {
+    resultTransactions.set(builder, provenance);
+  }
 }
 
 export const transactionStorage = new AsyncLocalStorage<TransactionState>();
@@ -268,16 +280,20 @@ export function hasActionResultTransaction(builder: object): boolean {
 export function recordEntTransaction(ent: object, row?: object) {
   if (row && rowTransactions.has(row)) {
     const provenance = rowTransactions.get(row);
-    if (provenance) entTransactions.set(ent, provenance);
-    else entTransactions.delete(ent);
+    if (provenance) {
+      entTransactions.set(ent, provenance);
+    } else {
+      entTransactions.delete(ent);
+    }
     return;
   }
   const state = getTransactionState();
-  if (state)
+  if (state) {
     entTransactions.set(ent, {
       token: state.token,
       generation: state.generation,
     });
+  }
 }
 
 export interface TransactionReadState {
@@ -388,7 +404,9 @@ export async function runActionExecution<T>(
   try {
     return await execute();
   } catch (error) {
-    if (state) failTransaction(state, error);
+    if (state) {
+      failTransaction(state, error);
+    }
     throw error;
   }
 }

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -26,6 +26,7 @@ interface PreparationNode {
   root: object;
   token: object;
   resources?: readonly string[];
+  resourcesPending?: boolean;
   validation?: { active: boolean };
   pending?: Set<Promise<unknown>>;
 }
@@ -167,7 +168,7 @@ export async function awaitActionPreparations<T>(
   return results as Awaited<T>[];
 }
 
-export function claimGuardedPreparation(resources?: readonly string[]) {
+function getGuardedPreparation() {
   const state = getTransactionState();
   const node = preparationStorage.getStore();
   if (!state || !node || node.token !== state.token) {
@@ -178,6 +179,23 @@ export function claimGuardedPreparation(resources?: readonly string[]) {
       "guarded root actions must be prepared and saved sequentially; await each save and reload before preparing the next action",
     );
   }
+  return { state, node };
+}
+
+export function reserveGuardedPreparation(): TransactionReadState {
+  const { state, node } = getGuardedPreparation();
+  // Reserve the root before user code can await. Keep the pending claim through
+  // nested validation cleanup, then check its resource keys when they resolve.
+  node.resourcesPending = true;
+  if (!state.branchClaims.includes(node)) {
+    state.branchClaims.push(node);
+  }
+  state.guardedRoot = node.root;
+  return { transaction: state, generation: state.generation };
+}
+
+export function claimGuardedPreparation(resources?: readonly string[]) {
+  const { state, node } = getGuardedPreparation();
   if (
     resources !== undefined &&
     (!Array.isArray(resources) ||
@@ -191,7 +209,9 @@ export function claimGuardedPreparation(resources?: readonly string[]) {
   for (const owner of state.branchClaims) {
     // The same action can validate while being built. Different actions must
     // prove independence even when one was created by the other's trigger.
-    if (owner.builder === node.builder) {
+    // A pending hook checks resolved claims when it finishes, so independent
+    // siblings can resolve their keys concurrently.
+    if (owner.builder === node.builder || owner.resourcesPending) {
       continue;
     }
     if (
@@ -205,7 +225,10 @@ export function claimGuardedPreparation(resources?: readonly string[]) {
     }
   }
   node.resources = resources && [...resources];
-  state.branchClaims.push(node);
+  node.resourcesPending = false;
+  if (!state.branchClaims.includes(node)) {
+    state.branchClaims.push(node);
+  }
   state.guardedRoot = node.root;
 }
 

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -3,6 +3,7 @@ import type { Context, Data, Ent, Viewer } from "./base";
 import type { Builder, Executor } from "../action/action";
 import type { assocEdgeLoader } from "./ent";
 import type { Queryer } from "./db";
+import type { ScopeValidationContext } from "./transaction";
 
 type TransactionBuilderIdentity = Pick<Builder<Ent>, "placeholderID">;
 
@@ -31,17 +32,36 @@ export interface TransactionState {
   edgeMetadataLoader?: typeof assocEdgeLoader;
   observers: (() => Promise<void>)[];
   receipts: (() => void)[];
-  guardedRoot?: TransactionBuilderIdentity;
+  preparingRoot?: TransactionBuilderIdentity;
+  preparingValidation?: { active: boolean };
   generation: number;
-  branchClaims: PreparationNode[];
+  validating: boolean;
+  pendingActions: Set<Promise<unknown>>;
+  pendingPreparations: Set<Promise<unknown>>;
+  validators: Map<TransactionBuilderIdentity, ScopeValidator>;
 }
+
+export type ScopeValidator = (
+  context: ScopeValidationContext,
+) => void | Promise<void>;
+
+interface ActionScopeValidator {
+  builder: TransactionBuilderIdentity;
+  validate: ScopeValidator;
+}
+
+interface FinalValidation {
+  transaction: TransactionState;
+  active: boolean;
+  pending: Set<Promise<unknown>>;
+}
+
+const finalValidationStorage = new AsyncLocalStorage<FinalValidation>();
 
 interface PreparationNode {
   builder: TransactionBuilderIdentity;
   root: TransactionBuilderIdentity;
   token: TransactionToken;
-  resources?: readonly string[];
-  resourcesPending?: boolean;
   validation?: { active: boolean };
   pending?: Set<Promise<unknown>>;
 }
@@ -57,6 +77,10 @@ const executorBuilders = new WeakMap<
   readonly TransactionBuilderIdentity[]
 >();
 const executorReads = new WeakMap<Executor, TransactionReadState | undefined>();
+const executorValidators = new WeakMap<
+  Executor,
+  readonly ActionScopeValidator[]
+>();
 const resultTransactions = new WeakMap<
   TransactionBuilderIdentity,
   EntTransaction
@@ -64,11 +88,55 @@ const resultTransactions = new WeakMap<
 
 export function assertIndependentActionSave() {
   const state = getTransactionState();
+  assertActionPreparationAllowed();
   if (state && preparationStorage.getStore()?.token === state.token) {
     throw new Error(
       "return child changesets from triggers; nested action saves during transaction preparation are not supported",
     );
   }
+}
+
+export function assertActionPreparationAllowed() {
+  const state = getTransactionState();
+  if (state?.validating) {
+    const error = new Error(
+      "actions cannot prepare or save during scope validation",
+    );
+    failTransaction(state, error);
+    throw error;
+  }
+}
+
+export function isFinalScopeValidation(): boolean {
+  return getTransactionState()?.validating === true;
+}
+
+export async function runFinalScopeValidation<T>(
+  transaction: TransactionState,
+  validate: () => Promise<T>,
+): Promise<T> {
+  const validation: FinalValidation = {
+    transaction,
+    active: true,
+    pending: new Set(),
+  };
+  return finalValidationStorage.run(validation, async () => {
+    try {
+      return await validate();
+    } catch (error) {
+      failTransaction(transaction, error);
+      throw error;
+    } finally {
+      validation.active = false;
+      if (validation.pending.size) {
+        failTransaction(
+          transaction,
+          new Error("await all reads during scope validation"),
+        );
+        await Promise.allSettled([...validation.pending]);
+      }
+    }
+  });
 }
 
 export function runInActionPreparation<T>(
@@ -80,11 +148,23 @@ export function runInActionPreparation<T>(
   if (!state) {
     return prepare();
   }
+  assertActionPreparationAllowed();
   const parent = preparationStorage.getStore();
   const scopedParent = parent?.token === state.token ? parent : undefined;
   const root = scopedParent?.root ?? builder;
   const validation =
     scopedParent?.validation ?? (validationOnly ? { active: true } : undefined);
+  if (state.preparingRoot && state.preparingRoot !== root) {
+    const error = new Error(
+      "root actions must be prepared and saved sequentially; await each save and reload before preparing the next action",
+    );
+    failTransaction(state, error);
+    throw error;
+  }
+  if (!state.preparingRoot) {
+    state.preparingRoot = root;
+    state.preparingValidation = validation;
+  }
   const node: PreparationNode = {
     builder,
     root,
@@ -110,13 +190,18 @@ export function runInActionPreparation<T>(
       }
       if (validation && validation !== scopedParent?.validation) {
         validation.active = false;
-        state.branchClaims = state.branchClaims.filter(
-          (claim) => claim.validation !== validation,
-        );
-        state.guardedRoot = state.branchClaims[0]?.root;
+        if (state.preparingValidation === validation) {
+          state.preparingRoot = undefined;
+          state.preparingValidation = undefined;
+        }
       }
     }
   });
+  state.pendingPreparations.add(prepared);
+  void prepared.then(
+    () => state.pendingPreparations.delete(prepared),
+    () => state.pendingPreparations.delete(prepared),
+  );
   if (scopedParent?.pending) {
     scopedParent.pending.add(prepared);
     void prepared.then(
@@ -132,6 +217,14 @@ export function trackValidationRead<T>(read: Promise<T>): Promise<T> {
   // Track the returned promise without throwing and leaving it unhandled.
   // The read reports an error if its scope has closed.
   const state = transactionStorage.getStore();
+  const final = finalValidationStorage.getStore();
+  if (state?.active && final?.active && final.transaction === state) {
+    final.pending.add(read);
+    void read.then(
+      () => final.pending.delete(read),
+      () => final.pending.delete(read),
+    );
+  }
   if (
     state?.active &&
     node?.token === state.token &&
@@ -166,14 +259,24 @@ export function isValidationPreparation(): boolean {
 export async function awaitActionPreparations<T>(
   work: Iterable<T | PromiseLike<T>>,
 ): Promise<Awaited<T>[]> {
-  if (!isValidationPreparation()) {
-    return Promise.all(work);
+  // Attach rejection handlers even if this scope closed while work was starting.
+  // The supplied promises already exist and must not become unhandled rejections.
+  const promises = Array.from(work, (pending) => Promise.resolve(pending));
+  let validation: boolean;
+  try {
+    validation = isValidationPreparation();
+  } catch (error) {
+    await Promise.allSettled(promises);
+    throw error;
+  }
+  if (!validation) {
+    return Promise.all(promises);
   }
   let failed = false;
   let failure: unknown;
   const results = await Promise.all(
-    Array.from(work, (pending) =>
-      Promise.resolve(pending).catch((error) => {
+    promises.map((pending) =>
+      pending.catch((error) => {
         if (!failed) {
           failed = true;
           failure = error;
@@ -187,76 +290,23 @@ export async function awaitActionPreparations<T>(
   return results as Awaited<T>[];
 }
 
-function getGuardedPreparation() {
-  const state = getTransactionState();
-  const node = preparationStorage.getStore();
-  if (!state || !node || node.token !== state.token) {
-    throw new Error("guarded actions require withTransaction");
-  }
-  if (state.guardedRoot && state.guardedRoot !== node.root) {
-    throw new Error(
-      "guarded root actions must be prepared and saved sequentially; await each save and reload before preparing the next action",
-    );
-  }
-  return { state, node };
-}
-
-export function reserveGuardedPreparation(): TransactionReadState {
-  const { state, node } = getGuardedPreparation();
-  // Reserve the root before awaiting application code. Retain the pending claim
-  // through nested validation cleanup, then check the resolved resource keys.
-  node.resourcesPending = true;
-  if (!state.branchClaims.includes(node)) {
-    state.branchClaims.push(node);
-  }
-  state.guardedRoot = node.root;
-  return { transaction: state, generation: state.generation };
-}
-
-export function claimGuardedPreparation(resources?: readonly string[]) {
-  const { state, node } = getGuardedPreparation();
-  if (
-    resources !== undefined &&
-    (!Array.isArray(resources) ||
-      !resources.length ||
-      resources.some((key) => typeof key !== "string" || !key.length))
-  ) {
-    throw new Error(
-      "getTransactionResources must return a non-empty array of non-empty strings",
-    );
-  }
-  for (const owner of state.branchClaims) {
-    // An action can validate during its own preparation. Other actions must
-    // declare disjoint resources, including children created by its triggers.
-    // Check resolved claims when each hook finishes so independent siblings can
-    // resolve their keys concurrently.
-    if (owner.builder === node.builder || owner.resourcesPending) {
-      continue;
-    }
-    if (
-      !owner.resources ||
-      !resources ||
-      resources.some((key) => owner.resources!.includes(key))
-    ) {
-      throw new Error(
-        "overlapping guarded action preparation branches; consolidate dependent child changesets or declare independent child transaction resources",
-      );
-    }
-  }
-  node.resources = resources && [...resources];
-  node.resourcesPending = false;
-  if (!state.branchClaims.includes(node)) {
-    state.branchClaims.push(node);
-  }
-  state.guardedRoot = node.root;
-}
-
 export function setExecutorBuilders(
   executor: Executor,
   builders: readonly TransactionBuilderIdentity[],
 ) {
   executorBuilders.set(executor, builders);
   executorReads.set(executor, getTransactionReadState());
+}
+
+export function setExecutorScopeValidators(
+  executor: Executor,
+  validators: readonly ActionScopeValidator[],
+) {
+  executorValidators.set(executor, validators);
+}
+
+export function getExecutorScopeValidators(executor: Executor) {
+  return executorValidators.get(executor) ?? [];
 }
 
 export function assertExecutorTransaction(executor: Executor) {
@@ -271,19 +321,17 @@ export function getExecutorBuilders(
   return executorBuilders.get(executor) ?? [];
 }
 
-export function completeGuardedPreparation(
+export function completeActionPreparation(
   state: TransactionState,
   executor: Executor,
 ) {
   const builders = getExecutorBuilders(executor);
-  if (state.guardedRoot && builders.includes(state.guardedRoot)) {
-    state.guardedRoot = undefined;
-    state.branchClaims.length = 0;
-    state.generation++;
-    state.edgeMetadataLoader = undefined;
-    for (const cache of state.caches.values()) {
-      cache.clearCache();
-    }
+  state.preparingRoot = undefined;
+  state.preparingValidation = undefined;
+  state.generation++;
+  state.edgeMetadataLoader = undefined;
+  for (const cache of state.caches.values()) {
+    cache.clearCache();
   }
   // A result getter reconstructs a snapshot without reading the database again.
   // Record the completed write's transaction and generation for every builder.
@@ -355,7 +403,7 @@ export function assertTransactionRead(read: TransactionReadState | undefined) {
   assertLoaderTransaction(read?.transaction);
   if (read && read.generation !== read.transaction.generation) {
     const error = new Error(
-      "recreate queries and loaders after each guarded save; a read cannot cross transaction generations",
+      "recreate queries and loaders after each save; a read cannot cross transaction generations",
     );
     failTransaction(read.transaction, error);
     throw error;
@@ -409,7 +457,7 @@ export function assertEntTransaction(ent: Ent) {
     (loaded?.token !== state.token || loaded?.generation !== state.generation)
   ) {
     const error = new Error(
-      "reload existingEnt inside the withTransaction callback on every attempt",
+      "reload existingEnt inside the withTransactionScope callback on every attempt",
     );
     failTransaction(state, error);
     throw error;
@@ -420,8 +468,18 @@ export function getTransactionState(): TransactionState | undefined {
   const state = transactionStorage.getStore();
   if (state && !state.active) {
     throw new Error(
-      "transaction scope is closed; await all work inside withTransaction",
+      "transaction scope is closed; await all work inside withTransactionScope",
     );
+  }
+  if (state?.validating) {
+    const validation = finalValidationStorage.getStore();
+    if (validation?.transaction !== state || !validation.active) {
+      const error = new Error(
+        "transaction callback is closed; await all work before scope validation",
+      );
+      failTransaction(state, error);
+      throw error;
+    }
   }
   const preparation = preparationStorage.getStore();
   if (
@@ -445,18 +503,26 @@ export function failTransaction(state: TransactionState, error: unknown) {
 
 // Save entry points include preparation, executor assembly, and execution
 // setup. An error in any of these stages must abort the owning scope, even if a
-// caller catches it before the withTransaction callback returns.
+// caller catches it before the withTransactionScope callback returns.
 export async function runActionExecution<T>(
   execute: () => Promise<T>,
 ): Promise<T> {
   const state = getTransactionState();
+  let pending: Promise<T> | undefined;
   try {
-    return await execute();
+    assertActionPreparationAllowed();
+    pending = execute();
+    state?.pendingActions.add(pending);
+    return await pending;
   } catch (error) {
     if (state) {
       failTransaction(state, error);
     }
     throw error;
+  } finally {
+    if (pending) {
+      state?.pendingActions.delete(pending);
+    }
   }
 }
 
@@ -470,7 +536,7 @@ export function runActionChangeset<T>(prepare: () => Promise<T>): Promise<T> {
 export function assertLoaderTransaction(owner: TransactionState | undefined) {
   if (getTransactionState() !== owner) {
     throw new Error(
-      "create loaders and queries inside the withTransaction callback; loaders cannot cross transaction scopes",
+      "create loaders and queries inside the withTransactionScope callback; loaders cannot cross transaction scopes",
     );
   }
 }

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -1,30 +1,45 @@
 import { AsyncLocalStorage } from "async_hooks";
-import type { Context } from "./base";
+import type { Context, Data, Ent, Viewer } from "./base";
+import type { Builder, Executor } from "../action/action";
+import type { assocEdgeLoader } from "./ent";
 import type { Queryer } from "./db";
+
+type TransactionBuilderIdentity = Pick<Builder<Ent>, "placeholderID">;
+
+const transactionTokenBrand = Symbol("transaction token");
+
+export interface TransactionToken {
+  readonly [transactionTokenBrand]: true;
+}
+
+export function createTransactionToken(): TransactionToken {
+  return { [transactionTokenBrand]: true };
+}
 
 // Internal state only. Never replace DB.instance or a viewer's request context.
 export interface TransactionState {
-  token: object;
+  token: TransactionToken;
   isolationLevel: "serializable" | "read committed";
   attempt: number;
   queryer: Queryer;
+  readQueryer: Pick<Queryer, "query" | "queryAll">;
   active: boolean;
   failed: boolean;
   error?: unknown;
   pending: Set<Promise<unknown>>;
   caches: Map<NonNullable<Context["cache"]>, NonNullable<Context["cache"]>>;
-  resources: Map<object, unknown>;
+  edgeMetadataLoader?: typeof assocEdgeLoader;
   observers: (() => Promise<void>)[];
   receipts: (() => void)[];
-  guardedRoot?: object;
+  guardedRoot?: TransactionBuilderIdentity;
   generation: number;
   branchClaims: PreparationNode[];
 }
 
 interface PreparationNode {
-  builder: object;
-  root: object;
-  token: object;
+  builder: TransactionBuilderIdentity;
+  root: TransactionBuilderIdentity;
+  token: TransactionToken;
   resources?: readonly string[];
   resourcesPending?: boolean;
   validation?: { active: boolean };
@@ -32,14 +47,20 @@ interface PreparationNode {
 }
 
 interface EntTransaction {
-  readonly token: object;
+  readonly token: TransactionToken;
   readonly generation: number;
 }
 
 const preparationStorage = new AsyncLocalStorage<PreparationNode>();
-const executorBuilders = new WeakMap<object, readonly object[]>();
-const executorReads = new WeakMap<object, TransactionReadState | undefined>();
-const resultTransactions = new WeakMap<object, EntTransaction>();
+const executorBuilders = new WeakMap<
+  Executor,
+  readonly TransactionBuilderIdentity[]
+>();
+const executorReads = new WeakMap<Executor, TransactionReadState | undefined>();
+const resultTransactions = new WeakMap<
+  TransactionBuilderIdentity,
+  EntTransaction
+>();
 
 export function assertIndependentActionSave() {
   const state = getTransactionState();
@@ -51,7 +72,7 @@ export function assertIndependentActionSave() {
 }
 
 export function runInActionPreparation<T>(
-  builder: object,
+  builder: TransactionBuilderIdentity,
   prepare: () => Promise<T>,
   validationOnly = false,
 ): Promise<T> {
@@ -128,7 +149,9 @@ export function trackValidationRead<T>(read: Promise<T>): Promise<T> {
   return read;
 }
 
-export function isPreparingAction(builder: object): boolean {
+export function isPreparingAction(
+  builder: TransactionBuilderIdentity,
+): boolean {
   const state = getTransactionState();
   const node = preparationStorage.getStore();
   return !!state && node?.token === state.token && node.builder === builder;
@@ -231,33 +254,35 @@ export function claimGuardedPreparation(resources?: readonly string[]) {
 }
 
 export function setExecutorBuilders(
-  executor: object,
-  builders: readonly object[],
+  executor: Executor,
+  builders: readonly TransactionBuilderIdentity[],
 ) {
   executorBuilders.set(executor, builders);
   executorReads.set(executor, getTransactionReadState());
 }
 
-export function assertExecutorTransaction(executor: object) {
+export function assertExecutorTransaction(executor: Executor) {
   if (executorReads.has(executor)) {
     assertTransactionRead(executorReads.get(executor));
   }
 }
 
-export function getExecutorBuilders(executor: object): readonly object[] {
+export function getExecutorBuilders(
+  executor: Executor,
+): readonly TransactionBuilderIdentity[] {
   return executorBuilders.get(executor) ?? [];
 }
 
 export function completeGuardedPreparation(
   state: TransactionState,
-  executor: object,
+  executor: Executor,
 ) {
   const builders = getExecutorBuilders(executor);
   if (state.guardedRoot && builders.includes(state.guardedRoot)) {
     state.guardedRoot = undefined;
     state.branchClaims.length = 0;
     state.generation++;
-    state.resources.clear();
+    state.edgeMetadataLoader = undefined;
     for (const cache of state.caches.values()) {
       cache.clearCache();
     }
@@ -271,11 +296,11 @@ export function completeGuardedPreparation(
 }
 
 export const transactionStorage = new AsyncLocalStorage<TransactionState>();
-const entTransactions = new WeakMap<object, EntTransaction>();
-const rowTransactions = new WeakMap<object, EntTransaction | undefined>();
+const entTransactions = new WeakMap<Ent, EntTransaction>();
+const rowTransactions = new WeakMap<Data, EntTransaction>();
 
 export function recordPreparedEntTransaction(
-  ent: object,
+  ent: Ent,
   read: TransactionReadState | undefined,
 ) {
   if (read) {
@@ -288,7 +313,10 @@ export function recordPreparedEntTransaction(
   }
 }
 
-export function recordActionResultTransaction(ent: object, builder: object) {
+export function recordActionResultTransaction<
+  TEnt extends Ent<TViewer>,
+  TViewer extends Viewer,
+>(ent: TEnt, builder: Builder<TEnt, TViewer>) {
   const provenance = resultTransactions.get(builder);
   if (provenance) {
     entTransactions.set(ent, provenance);
@@ -298,11 +326,13 @@ export function recordActionResultTransaction(ent: object, builder: object) {
   }
 }
 
-export function hasActionResultTransaction(builder: object): boolean {
+export function hasActionResultTransaction(
+  builder: TransactionBuilderIdentity,
+): boolean {
   return resultTransactions.has(builder);
 }
 
-export function recordDerivedEntTransaction(ent: object, row: object) {
+export function recordEntTransaction(ent: Ent, row: Data) {
   // Copy only the row's recorded transaction and generation. Unknown data must
   // not inherit the current scope.
   const provenance = rowTransactions.get(row);
@@ -310,25 +340,6 @@ export function recordDerivedEntTransaction(ent: object, row: object) {
     entTransactions.set(ent, provenance);
   } else {
     entTransactions.delete(ent);
-  }
-}
-
-export function recordEntTransaction(ent: object, row?: object) {
-  if (row && rowTransactions.has(row)) {
-    const provenance = rowTransactions.get(row);
-    if (provenance) {
-      entTransactions.set(ent, provenance);
-    } else {
-      entTransactions.delete(ent);
-    }
-    return;
-  }
-  const state = getTransactionState();
-  if (state) {
-    entTransactions.set(ent, {
-      token: state.token,
-      generation: state.generation,
-    });
   }
 }
 
@@ -368,16 +379,20 @@ export async function runTransactionRead<T>(
 }
 
 export function recordRowTransaction(
-  row: object,
+  row: Data,
   read: TransactionReadState | undefined,
 ) {
-  rowTransactions.set(
-    row,
-    read && { token: read.transaction.token, generation: read.generation },
-  );
+  if (read) {
+    rowTransactions.set(row, {
+      token: read.transaction.token,
+      generation: read.generation,
+    });
+  } else {
+    rowTransactions.delete(row);
+  }
 }
 
-export function copyEntTransaction(source: object, target: object) {
+export function copyEntTransaction(source: Ent, target: Ent) {
   // Privacy checks can replace an Ent after an await. Preserve the original
   // transaction and generation, even if absent. Don't use the current scope.
   const provenance = entTransactions.get(source);
@@ -388,7 +403,7 @@ export function copyEntTransaction(source: object, target: object) {
   }
 }
 
-export function assertEntTransaction(ent: object) {
+export function assertEntTransaction(ent: Ent) {
   const state = getTransactionState();
   const loaded = entTransactions.get(ent);
   if (
@@ -445,6 +460,12 @@ export async function runActionExecution<T>(
     }
     throw error;
   }
+}
+
+// Let public validation classify a child's errors. Correctable validation
+// errors remain recoverable; SQL and composition errors still fail the scope.
+export function runActionChangeset<T>(prepare: () => Promise<T>): Promise<T> {
+  return isValidationPreparation() ? prepare() : runActionExecution(prepare);
 }
 
 // Captured loaders must not carry cached rows or pending batches across scopes.

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -76,17 +76,16 @@ export function runInActionPreparation<T>(
       return await prepare();
     } finally {
       // If a trigger's Promise.all rejects, other children can still be
-      // running.
-      // Wait for descendants before restoring this participant or completing
-      // root validation. Exclude the owner from its own set of pending work.
+      // running. Wait for descendants before restoring this participant or
+      // completing root validation. Exclude the owner from its
+      // own set of pending work.
       if (node.pending) {
         do {
           await Promise.allSettled([...node.pending]);
           // A completed SQL or loader promise can resume several async wrappers
           // before the caller starts child preparation. Wait one event loop
-          // turn
-          // for those wrappers to register reads and children before checking
-          // again.
+          // turn for those wrappers to register reads
+          // and children before checking again.
           await new Promise<void>((resolve) => setImmediate(resolve));
         } while (node.pending.size);
       }
@@ -112,8 +111,7 @@ export function runInActionPreparation<T>(
 export function trackValidationRead<T>(read: Promise<T>): Promise<T> {
   const node = preparationStorage.getStore();
   // Once a read returns a promise, tracking must not throw and leave that
-  // promise
-  // unhandled. The read itself reports errors if its scope has closed.
+  // promise unhandled. The read itself reports errors if its scope has closed.
   const state = transactionStorage.getStore();
   if (
     state?.active &&
@@ -433,9 +431,8 @@ export function failTransaction(state: TransactionState, error: unknown) {
 }
 
 // Save entry points include preparation, executor assembly, and execution
-// setup.
-// An error in any of these stages must abort the owning scope, even if a caller
-// catches it before the withTransaction callback returns.
+// setup. An error in any of these stages must abort the owning scope, even if a
+// caller catches it before the withTransaction callback returns.
 export async function runActionExecution<T>(
   execute: () => Promise<T>,
 ): Promise<T> {

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -1,0 +1,403 @@
+import { AsyncLocalStorage } from "async_hooks";
+import type { Context } from "./base";
+import type { Queryer } from "./db";
+
+// Internal state only. Never replace DB.instance or a viewer's request context.
+export interface TransactionState {
+  token: object;
+  isolationLevel: "serializable" | "read committed";
+  attempt: number;
+  queryer: Queryer;
+  active: boolean;
+  failed: boolean;
+  error?: unknown;
+  pending: Set<Promise<unknown>>;
+  caches: Map<NonNullable<Context["cache"]>, NonNullable<Context["cache"]>>;
+  resources: Map<object, unknown>;
+  observers: (() => Promise<void>)[];
+  receipts: (() => void)[];
+  guardedRoot?: object;
+  generation: number;
+  branchClaims: PreparationNode[];
+}
+
+interface PreparationNode {
+  builder: object;
+  root: object;
+  token: object;
+  resources?: readonly string[];
+  validation?: { active: boolean };
+  pending?: Set<Promise<unknown>>;
+}
+
+interface EntTransaction {
+  readonly token: object;
+  readonly generation: number;
+}
+
+const preparationStorage = new AsyncLocalStorage<PreparationNode>();
+const executorBuilders = new WeakMap<object, readonly object[]>();
+const executorReads = new WeakMap<object, TransactionReadState | undefined>();
+const resultTransactions = new WeakMap<object, EntTransaction>();
+
+export function assertIndependentActionSave() {
+  const state = getTransactionState();
+  if (state && preparationStorage.getStore()?.token === state.token) {
+    throw new Error(
+      "return child changesets from triggers; nested action saves during transaction preparation are not supported",
+    );
+  }
+}
+
+export function runInActionPreparation<T>(
+  builder: object,
+  prepare: () => Promise<T>,
+  validationOnly = false,
+): Promise<T> {
+  const state = getTransactionState();
+  if (!state) return prepare();
+  const parent = preparationStorage.getStore();
+  const scopedParent = parent?.token === state.token ? parent : undefined;
+  const root = scopedParent?.root ?? builder;
+  const validation =
+    scopedParent?.validation ?? (validationOnly ? { active: true } : undefined);
+  const node: PreparationNode = {
+    builder,
+    root,
+    token: state.token,
+    validation,
+    pending: validation ? new Set() : undefined,
+  };
+  const prepared = preparationStorage.run(node, async () => {
+    try {
+      return await prepare();
+    } finally {
+      // A user trigger may hide a still-running child behind a rejected
+      // Promise.all. Drain descendants before restoring this participant or
+      // closing the root probe, without including the owner in its own set.
+      if (node.pending) {
+        do {
+          await Promise.allSettled([...node.pending]);
+          // A completed SQL/loader promise can resume several async wrappers
+          // before the caller enters its child preparation. Let that complete
+          // turn register subsequent reads/children before deciding we're idle.
+          await new Promise<void>((resolve) => setImmediate(resolve));
+        } while (node.pending.size);
+      }
+      if (validation && validation !== scopedParent?.validation) {
+        validation.active = false;
+        state.branchClaims = state.branchClaims.filter(
+          (claim) => claim.validation !== validation,
+        );
+        state.guardedRoot = state.branchClaims[0]?.root;
+      }
+    }
+  });
+  if (scopedParent?.pending) {
+    scopedParent.pending.add(prepared);
+    void prepared.then(
+      () => scopedParent.pending!.delete(prepared),
+      () => scopedParent.pending!.delete(prepared),
+    );
+  }
+  return prepared;
+}
+
+export function trackValidationRead<T>(read: Promise<T>): Promise<T> {
+  const node = preparationStorage.getStore();
+  // Tracking must not throw after a read has already produced a promise. The
+  // read's own boundary reports closed-scope errors without orphaning it.
+  const state = transactionStorage.getStore();
+  if (
+    state?.active &&
+    node?.token === state.token &&
+    node.validation?.active &&
+    node.pending
+  ) {
+    node.pending.add(read);
+    void read.then(
+      () => node.pending!.delete(read),
+      () => node.pending!.delete(read),
+    );
+  }
+  return read;
+}
+
+export function isPreparingAction(builder: object): boolean {
+  const state = getTransactionState();
+  const node = preparationStorage.getStore();
+  return !!state && node?.token === state.token && node.builder === builder;
+}
+
+export function isValidationPreparation(): boolean {
+  const state = getTransactionState();
+  const node = preparationStorage.getStore();
+  return !!state && node?.token === state.token && !!node.validation;
+}
+
+// Drain framework-owned parallel work as well as registered child actions.
+// Keep Promise.all's first rejection, rather than choosing errors by array order.
+export async function awaitActionPreparations<T>(
+  work: Iterable<T | PromiseLike<T>>,
+): Promise<Awaited<T>[]> {
+  if (!isValidationPreparation()) return Promise.all(work);
+  let failed = false;
+  let failure: unknown;
+  const results = await Promise.all(
+    Array.from(work, (pending) =>
+      Promise.resolve(pending).catch((error) => {
+        if (!failed) {
+          failed = true;
+          failure = error;
+        }
+      }),
+    ),
+  );
+  if (failed) throw failure;
+  return results as Awaited<T>[];
+}
+
+export function claimGuardedPreparation(resources?: readonly string[]) {
+  const state = getTransactionState();
+  const node = preparationStorage.getStore();
+  if (!state || !node || node.token !== state.token) {
+    throw new Error("guarded actions require withTransaction");
+  }
+  if (state.guardedRoot && state.guardedRoot !== node.root) {
+    throw new Error(
+      "guarded root actions must be prepared and saved sequentially; await each save and reload before preparing the next action",
+    );
+  }
+  if (
+    resources !== undefined &&
+    (!Array.isArray(resources) ||
+      !resources.length ||
+      resources.some((key) => typeof key !== "string" || !key.length))
+  ) {
+    throw new Error(
+      "getTransactionResources must return a non-empty array of non-empty strings",
+    );
+  }
+  for (const owner of state.branchClaims) {
+    // The same action can validate while being built. Different actions must
+    // prove independence even when one was created by the other's trigger.
+    if (owner.builder === node.builder) continue;
+    if (
+      !owner.resources ||
+      !resources ||
+      resources.some((key) => owner.resources!.includes(key))
+    ) {
+      throw new Error(
+        "overlapping guarded action preparation branches; consolidate dependent child changesets or declare independent child transaction resources",
+      );
+    }
+  }
+  node.resources = resources && [...resources];
+  state.branchClaims.push(node);
+  state.guardedRoot = node.root;
+}
+
+export function setExecutorBuilders(
+  executor: object,
+  builders: readonly object[],
+) {
+  executorBuilders.set(executor, builders);
+  executorReads.set(executor, getTransactionReadState());
+}
+
+export function assertExecutorTransaction(executor: object) {
+  if (executorReads.has(executor)) {
+    assertTransactionRead(executorReads.get(executor));
+  }
+}
+
+export function getExecutorBuilders(executor: object): readonly object[] {
+  return executorBuilders.get(executor) ?? [];
+}
+
+export function completeGuardedPreparation(
+  state: TransactionState,
+  executor: object,
+) {
+  const builders = getExecutorBuilders(executor);
+  if (state.guardedRoot && builders.includes(state.guardedRoot)) {
+    state.guardedRoot = undefined;
+    state.branchClaims.length = 0;
+    state.generation++;
+    state.resources.clear();
+    for (const cache of state.caches.values()) cache.clearCache();
+  }
+  // A result getter reconstructs a snapshot, not a new database read. Capture
+  // the completed write's provenance for every builder in the composed graph.
+  const provenance = { token: state.token, generation: state.generation };
+  for (const builder of builders) resultTransactions.set(builder, provenance);
+}
+
+export const transactionStorage = new AsyncLocalStorage<TransactionState>();
+const entTransactions = new WeakMap<object, EntTransaction>();
+const rowTransactions = new WeakMap<object, EntTransaction | undefined>();
+
+export function recordPreparedEntTransaction(
+  ent: object,
+  read: TransactionReadState | undefined,
+) {
+  if (read) {
+    entTransactions.set(ent, {
+      token: read.transaction.token,
+      generation: read.generation,
+    });
+  } else {
+    entTransactions.delete(ent);
+  }
+}
+
+export function recordActionResultTransaction(ent: object, builder: object) {
+  const provenance = resultTransactions.get(builder);
+  if (provenance) {
+    entTransactions.set(ent, provenance);
+  } else {
+    // An unscoped result must not inherit the scope used to inspect it later.
+    entTransactions.delete(ent);
+  }
+}
+
+export function hasActionResultTransaction(builder: object): boolean {
+  return resultTransactions.has(builder);
+}
+
+export function recordEntTransaction(ent: object, row?: object) {
+  if (row && rowTransactions.has(row)) {
+    const provenance = rowTransactions.get(row);
+    if (provenance) entTransactions.set(ent, provenance);
+    else entTransactions.delete(ent);
+    return;
+  }
+  const state = getTransactionState();
+  if (state)
+    entTransactions.set(ent, {
+      token: state.token,
+      generation: state.generation,
+    });
+}
+
+export interface TransactionReadState {
+  readonly transaction: TransactionState;
+  readonly generation: number;
+}
+
+export function getTransactionReadState(): TransactionReadState | undefined {
+  const transaction = getTransactionState();
+  return transaction && { transaction, generation: transaction.generation };
+}
+
+export function assertTransactionRead(read: TransactionReadState | undefined) {
+  assertLoaderTransaction(read?.transaction);
+  if (read && read.generation !== read.transaction.generation) {
+    const error = new Error(
+      "recreate queries and loaders after each guarded save; a read cannot cross transaction generations",
+    );
+    failTransaction(read.transaction, error);
+    throw error;
+  }
+}
+
+export async function runTransactionRead<T>(
+  read: TransactionReadState | undefined,
+  load: () => Promise<T>,
+): Promise<T> {
+  return trackValidationRead(
+    (async () => {
+      assertTransactionRead(read);
+      const result = await load();
+      assertTransactionRead(read);
+      return result;
+    })(),
+  );
+}
+
+export function recordRowTransaction(
+  row: object,
+  read: TransactionReadState | undefined,
+) {
+  rowTransactions.set(
+    row,
+    read && { token: read.transaction.token, generation: read.generation },
+  );
+}
+
+export function copyEntTransaction(source: object, target: object) {
+  // Privacy can replace an Ent after awaiting policy checks. Preserve the
+  // original provenance, including absence, rather than reading ambient state.
+  const provenance = entTransactions.get(source);
+  if (provenance) {
+    entTransactions.set(target, provenance);
+  } else {
+    entTransactions.delete(target);
+  }
+}
+
+export function assertEntTransaction(ent: object) {
+  const state = getTransactionState();
+  const loaded = entTransactions.get(ent);
+  if (
+    state &&
+    (loaded?.token !== state.token || loaded?.generation !== state.generation)
+  ) {
+    const error = new Error(
+      "reload existingEnt inside the withTransaction callback on every attempt",
+    );
+    failTransaction(state, error);
+    throw error;
+  }
+}
+
+export function getTransactionState(): TransactionState | undefined {
+  const state = transactionStorage.getStore();
+  if (state && !state.active) {
+    throw new Error(
+      "transaction scope is closed; await all work inside withTransaction",
+    );
+  }
+  const preparation = preparationStorage.getStore();
+  if (
+    state &&
+    preparation?.token === state.token &&
+    preparation.validation?.active === false
+  ) {
+    throw new Error(
+      "action validation scope is closed; await all validation work",
+    );
+  }
+  return state;
+}
+
+export function failTransaction(state: TransactionState, error: unknown) {
+  if (!state.failed) {
+    state.failed = true;
+    state.error = error;
+  }
+}
+
+// Save entrypoints include preparation, executor assembly, and execution setup.
+// Any thrown or rejected error in those stages must abort the owning scope,
+// even if a caller catches it before withTransaction's callback returns.
+export async function runActionExecution<T>(
+  execute: () => Promise<T>,
+): Promise<T> {
+  const state = getTransactionState();
+  try {
+    return await execute();
+  } catch (error) {
+    if (state) failTransaction(state, error);
+    throw error;
+  }
+}
+
+// Captured loaders must not carry cached rows or pending batches across scopes.
+export function assertLoaderTransaction(owner: TransactionState | undefined) {
+  if (getTransactionState() !== owner) {
+    throw new Error(
+      "create loaders and queries inside the withTransaction callback; loaders cannot cross transaction scopes",
+    );
+  }
+}

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -74,15 +74,18 @@ export function runInActionPreparation<T>(
     try {
       return await prepare();
     } finally {
-      // A user trigger may hide a still-running child behind a rejected
-      // Promise.all. Drain descendants before restoring this participant or
-      // closing the root probe, without including the owner in its own set.
+      // If a trigger's Promise.all rejects, other children can still be
+      // running.
+      // Wait for descendants before restoring this participant or completing
+      // root validation. Exclude the owner from its own set of pending work.
       if (node.pending) {
         do {
           await Promise.allSettled([...node.pending]);
-          // A completed SQL/loader promise can resume several async wrappers
-          // before the caller enters its child preparation. Let that complete
-          // turn register subsequent reads/children before deciding we're idle.
+          // A completed SQL or loader promise can resume several async wrappers
+          // before the caller starts child preparation. Wait one event loop
+          // turn
+          // for those wrappers to register reads and children before checking
+          // again.
           await new Promise<void>((resolve) => setImmediate(resolve));
         } while (node.pending.size);
       }
@@ -107,8 +110,9 @@ export function runInActionPreparation<T>(
 
 export function trackValidationRead<T>(read: Promise<T>): Promise<T> {
   const node = preparationStorage.getStore();
-  // Tracking must not throw after a read has already produced a promise. The
-  // read's own boundary reports closed-scope errors without orphaning it.
+  // Once a read returns a promise, tracking must not throw and leave that
+  // promise
+  // unhandled. The read itself reports errors if its scope has closed.
   const state = transactionStorage.getStore();
   if (
     state?.active &&
@@ -137,8 +141,8 @@ export function isValidationPreparation(): boolean {
   return !!state && node?.token === state.token && !!node.validation;
 }
 
-// Drain framework-owned parallel work as well as registered child actions.
-// Keep Promise.all's first rejection, rather than choosing errors by array order.
+// Wait for parallel work started by the framework and registered child actions.
+// Preserve the first Promise.all rejection, regardless of the array order.
 export async function awaitActionPreparations<T>(
   work: Iterable<T | PromiseLike<T>>,
 ): Promise<Awaited<T>[]> {
@@ -237,8 +241,8 @@ export function completeGuardedPreparation(
       cache.clearCache();
     }
   }
-  // A result getter reconstructs a snapshot, not a new database read. Capture
-  // the completed write's provenance for every builder in the composed graph.
+  // A result getter reconstructs a snapshot without reading the database again.
+  // Record the completed write's transaction and generation for every builder.
   const provenance = { token: state.token, generation: state.generation };
   for (const builder of builders) {
     resultTransactions.set(builder, provenance);
@@ -342,8 +346,8 @@ export function recordRowTransaction(
 }
 
 export function copyEntTransaction(source: object, target: object) {
-  // Privacy can replace an Ent after awaiting policy checks. Preserve the
-  // original provenance, including absence, rather than reading ambient state.
+  // Privacy checks can replace an Ent after an await. Preserve the original
+  // transaction and generation, even if absent. Don't use the current scope.
   const provenance = entTransactions.get(source);
   if (provenance) {
     entTransactions.set(target, provenance);
@@ -394,9 +398,10 @@ export function failTransaction(state: TransactionState, error: unknown) {
   }
 }
 
-// Save entrypoints include preparation, executor assembly, and execution setup.
-// Any thrown or rejected error in those stages must abort the owning scope,
-// even if a caller catches it before withTransaction's callback returns.
+// Save entry points include preparation, executor assembly, and execution
+// setup.
+// An error in any of these stages must abort the owning scope, even if a caller
+// catches it before the withTransaction callback returns.
 export async function runActionExecution<T>(
   execute: () => Promise<T>,
 ): Promise<T> {

--- a/ts/src/core/transaction_context.ts
+++ b/ts/src/core/transaction_context.ts
@@ -281,6 +281,17 @@ export function hasActionResultTransaction(builder: object): boolean {
   return resultTransactions.has(builder);
 }
 
+export function recordDerivedEntTransaction(ent: object, row: object) {
+  // Copy only the row's recorded transaction and generation. Unknown data must
+  // not inherit the current scope.
+  const provenance = rowTransactions.get(row);
+  if (provenance) {
+    entTransactions.set(ent, provenance);
+  } else {
+    entTransactions.delete(ent);
+  }
+}
+
 export function recordEntTransaction(ent: object, row?: object) {
   if (row && rowTransactions.has(row)) {
     const provenance = rowTransactions.get(row);

--- a/ts/src/core/transaction_derived.test.ts
+++ b/ts/src/core/transaction_derived.test.ts
@@ -1,0 +1,311 @@
+import { Allow, Data } from "./base";
+import { Dialect } from "./db";
+import { Eq } from "./clause";
+import { loadDerivedEnt, loadDerivedEntX, loadEntX, loadRows } from "./ent";
+import { ObjectLoaderFactory } from "./loaders";
+import { withTransaction } from "./transaction";
+import {
+  assertEntTransaction,
+  getTransactionState,
+} from "./transaction_context";
+import { WriteOperation } from "../action/action";
+import { IntegerType } from "../schema";
+import {
+  BaseEnt,
+  SimpleAction,
+  getBuilderSchemaFromFields,
+  getDbFields,
+} from "../testutils/builder";
+import { setupPostgres, getSchemaTable } from "../testutils/db/temp_db";
+import { TestContext } from "../testutils/context/test_context";
+
+class DerivedAccount extends BaseEnt {
+  nodeType = "DerivedAccount";
+}
+const schema = getBuilderSchemaFromFields(
+  { balance: IntegerType() },
+  DerivedAccount,
+);
+const loader = {
+  tableName: "derived_accounts",
+  fields: getDbFields(schema),
+  key: "id",
+};
+const options = {
+  ...loader,
+  ent: DerivedAccount,
+  loaderFactory: new ObjectLoaderFactory(loader),
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+const load = (id: any) => loadEntX(viewer, id, options);
+const create = () =>
+  new SimpleAction(
+    viewer,
+    schema,
+    new Map([["balance", 100]]),
+    WriteOperation.Insert,
+    null,
+  ).saveX();
+class GuardedEdit extends SimpleAction<DerivedAccount> {
+  requiresTransaction() {
+    return true;
+  }
+}
+const edit = (ent: DerivedAccount, balance: number) =>
+  new GuardedEdit(
+    viewer,
+    schema,
+    new Map([["balance", balance]]),
+    WriteOperation.Edit,
+    ent,
+  );
+let privacy: ((ent: DerivedAccount) => void | Promise<void>) | undefined;
+class PrivacyAccount extends DerivedAccount {
+  getPrivacyPolicy() {
+    return {
+      rules: [
+        {
+          async apply(_viewer: any, ent: DerivedAccount) {
+            await privacy?.(ent);
+            return Allow();
+          },
+        },
+      ],
+    };
+  }
+}
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+const independent = (action: GuardedEdit, key: string) =>
+  Object.assign(action, { getTransactionResources: () => [key] });
+
+setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
+beforeEach(() => {
+  context.cache.reset();
+  privacy = undefined;
+});
+
+describe.each([
+  "loadDerivedEnt",
+  "loadDerivedEntX",
+] as const)("%s transaction provenance", (method) => {
+  const derive = (row: Data, ctor = DerivedAccount) =>
+    method === "loadDerivedEnt"
+      ? loadDerivedEnt(viewer, row, ctor)
+      : loadDerivedEntX(viewer, row, ctor);
+
+  test.each([
+    "query",
+    "queryAll",
+    "exec",
+  ] as const)("%s rows retain their provenance before privacy and support guarded saves", async (queryMethod) => {
+    const account = await create();
+    let checks = 0;
+    await withTransaction(async (tx) => {
+      const row = (
+        await tx[queryMethod]("SELECT * FROM derived_accounts WHERE id = $1", [
+          account.id,
+        ])
+      ).rows[0];
+      privacy = (ent) => {
+        assertEntTransaction(ent);
+        checks++;
+      };
+      const derived = await derive(row, PrivacyAccount);
+      await edit(derived!, 80).saveX();
+    });
+    expect(checks).toBe(1);
+    expect((await load(account.id)).data.balance).toBe(80);
+  });
+
+  test.each([
+    "stale generation",
+    "previous scope",
+    "outside row",
+    "unknown outside row",
+    "unknown current row",
+  ])("%s cannot become a fresh mutation input", async (origin) => {
+    const account = await create();
+    let row: Data;
+    if (origin === "previous scope") {
+      row = await withTransaction(async (tx) => {
+        return (
+          await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
+            account.id,
+          ])
+        ).rows[0];
+      });
+    } else if (origin === "outside row") {
+      row = (
+        await loadRows({ ...loader, clause: Eq("id", account.id), context })
+      )[0];
+    } else if (origin === "unknown outside row") {
+      row = { ...account.data };
+    }
+    let caught: unknown;
+    let outer: unknown;
+    try {
+      await withTransaction(async (tx) => {
+        if (origin === "stale generation" || origin === "unknown current row") {
+          row = (
+            await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
+              account.id,
+            ])
+          ).rows[0];
+          if (origin === "unknown current row") {
+            row = { ...row };
+          } else {
+            await edit(await load(account.id), 90).saveX();
+          }
+        }
+        const derived = await derive(row!);
+        expect(derived!.data.balance).toBe(100);
+        try {
+          await edit(derived!, 80).saveX();
+        } catch (error) {
+          caught = error;
+        }
+      });
+    } catch (error) {
+      outer = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(outer).toBe(caught);
+    expect((await load(account.id)).data.balance).toBe(100);
+  });
+
+  test("unknown data still supports derived reads outside a transaction", async () => {
+    const account = await create();
+    const derived = await derive({ ...account.data });
+    expect(derived!.id).toBe(account.id);
+    expect(derived!.data.balance).toBe(100);
+  });
+
+  test("pending derived privacy cannot cross a guarded save", async () => {
+    const account = await create();
+    const started = deferred();
+    const release = deferred();
+    await expect(
+      withTransaction(async (tx) => {
+        const row = (
+          await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
+            account.id,
+          ])
+        ).rows[0];
+        privacy = async () => {
+          started.resolve();
+          await release.promise;
+        };
+        const outcome = derive(row, PrivacyAccount).then(
+          (value) => ({ value }),
+          (error) => ({ error }),
+        );
+        await started.promise;
+        try {
+          await edit(await load(account.id), 80).saveX();
+        } finally {
+          release.resolve();
+        }
+        const result = await outcome;
+        expect(result).toHaveProperty("error");
+      }),
+    ).rejects.toThrow("cannot cross transaction generations");
+    expect((await load(account.id)).data.balance).toBe(100);
+  });
+
+  test.each([
+    "valid",
+    "validX",
+    "validWithErrors",
+  ] as const)("%s waits for derived privacy used to prepare a child", async (validationMethod) => {
+    const accounts = await Promise.all([create(), create(), create()]);
+    const started = deferred();
+    const release = deferred();
+    const failure = new Error("correctable validation failure");
+    let invalid = true;
+    let settled = false;
+    let settledBeforeRelease = false;
+    let prepared = 0;
+    const transaction = withTransaction(async (tx) => {
+      const parent = independent(
+        edit(await load(accounts[0].id), 90),
+        "parent",
+      );
+      const bad = independent(edit(await load(accounts[1].id), 80), "bad");
+      bad.getValidators = () => [
+        { validate: async () => (invalid ? failure : undefined) },
+      ];
+      const row = (
+        await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
+          accounts[2].id,
+        ])
+      ).rows[0];
+      privacy = async () => {
+        started.resolve();
+        await release.promise;
+      };
+      let setupOutcome!: Promise<any>;
+      parent.getTriggers = () => [
+        {
+          changeset: () => {
+            const setup = (async () => {
+              const derived = await derive(row, PrivacyAccount);
+              const changeset = await independent(
+                edit(derived!, 70),
+                "slow",
+              ).changeset();
+              prepared++;
+              return changeset;
+            })();
+            setupOutcome = setup.then(
+              (value) => ({ value }),
+              (error) => ({ error }),
+            );
+            return Promise.all([bad.changeset(), setup]);
+          },
+        },
+      ];
+      const validation = parent[validationMethod]().then(
+        () => {
+          settled = true;
+          return undefined;
+        },
+        (error) => {
+          settled = true;
+          return error;
+        },
+      );
+      expect(await validation).toBe(failure);
+      expect(await setupOutcome).toHaveProperty("value");
+      expect(settledBeforeRelease).toBe(false);
+      expect(getTransactionState()!.failed).toBe(false);
+      invalid = false;
+      await parent.saveX();
+    });
+    const outcome = transaction.then(
+      (value) => ({ value }),
+      (error) => ({ error }),
+    );
+    try {
+      await started.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      settledBeforeRelease = settled;
+      release.resolve();
+      expect(await outcome).not.toHaveProperty("error");
+      expect(prepared).toBe(2);
+      const balances = await Promise.all(
+        accounts.map(async (account) => (await load(account.id)).data.balance),
+      );
+      expect(balances).toEqual([90, 80, 70]);
+    } finally {
+      release.resolve();
+      await outcome;
+    }
+  });
+});

--- a/ts/src/core/transaction_derived.test.ts
+++ b/ts/src/core/transaction_derived.test.ts
@@ -1,7 +1,14 @@
-import { Allow, Data } from "./base";
-import { Dialect } from "./db";
+import { Allow, Data, ID, Viewer } from "./base";
+import DB, { Dialect } from "./db";
 import { Eq } from "./clause";
-import { loadDerivedEnt, loadDerivedEntX, loadEntX, loadRows } from "./ent";
+import {
+  applyPrivacyPolicyForRow,
+  applyPrivacyPolicyForRows,
+  loadDerivedEnt,
+  loadDerivedEntX,
+  loadEntX,
+  loadRows,
+} from "./ent";
 import { ObjectLoaderFactory } from "./loaders";
 import { withTransaction } from "./transaction";
 import {
@@ -38,7 +45,7 @@ const options = {
 };
 const context = new TestContext();
 const viewer = context.getViewer();
-const load = (id: any) => loadEntX(viewer, id, options);
+const load = (id: ID) => loadEntX(viewer, id, options);
 const create = () =>
   new SimpleAction(
     viewer,
@@ -66,7 +73,7 @@ class PrivacyAccount extends DerivedAccount {
     return {
       rules: [
         {
-          async apply(_viewer: any, ent: DerivedAccount) {
+          async apply(_viewer: Viewer, ent: DerivedAccount) {
             await privacy?.(ent);
             return Allow();
           },
@@ -94,11 +101,26 @@ beforeEach(() => {
 describe.each([
   "loadDerivedEnt",
   "loadDerivedEntX",
+  "applyPrivacyPolicyForRow",
+  "applyPrivacyPolicyForRows",
 ] as const)("%s transaction provenance", (method) => {
-  const derive = (row: Data, ctor = DerivedAccount) =>
-    method === "loadDerivedEnt"
-      ? loadDerivedEnt(viewer, row, ctor)
-      : loadDerivedEntX(viewer, row, ctor);
+  const derive = async (row: Data, ctor = DerivedAccount) => {
+    switch (method) {
+      case "loadDerivedEnt":
+        return loadDerivedEnt(viewer, row, ctor);
+      case "loadDerivedEntX":
+        return loadDerivedEntX(viewer, row, ctor);
+      case "applyPrivacyPolicyForRow":
+        return applyPrivacyPolicyForRow(viewer, { ...options, ent: ctor }, row);
+      case "applyPrivacyPolicyForRows":
+        return (
+          await applyPrivacyPolicyForRows(viewer, [row], {
+            ...options,
+            ent: ctor,
+          })
+        )[0];
+    }
+  };
 
   test.each([
     "query",
@@ -128,6 +150,7 @@ describe.each([
     "stale generation",
     "previous scope",
     "outside row",
+    "untracked driver row",
     "unknown outside row",
     "unknown current row",
   ])("%s cannot become a fresh mutation input", async (origin) => {
@@ -145,6 +168,12 @@ describe.each([
       row = (
         await loadRows({ ...loader, clause: Eq("id", account.id), context })
       )[0];
+    } else if (origin === "untracked driver row") {
+      row = (
+        await DB.getInstance()
+          .getPool()
+          .query("SELECT * FROM derived_accounts WHERE id = $1", [account.id])
+      ).rows[0];
     } else if (origin === "unknown outside row") {
       row = { ...account.data };
     }
@@ -180,6 +209,31 @@ describe.each([
     expect((await load(account.id)).data.balance).toBe(100);
   });
 
+  test("copied old data cannot overwrite a later committed balance", async () => {
+    const account = await create();
+    const copied = { ...account.data };
+    await withTransaction(async () => {
+      await edit(await load(account.id), 80).saveX();
+    });
+    await expect(
+      withTransaction(async () => {
+        const stale = await derive(copied);
+        await edit(stale!, stale!.data.balance - 30).saveX();
+      }),
+    ).rejects.toThrow("reload existingEnt");
+    expect((await load(account.id)).data.balance).toBe(80);
+    await withTransaction(async (tx) => {
+      const row = (
+        await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
+          account.id,
+        ])
+      ).rows[0];
+      const fresh = await derive(row);
+      await edit(fresh!, fresh!.data.balance - 30).saveX();
+    });
+    expect((await load(account.id)).data.balance).toBe(50);
+  });
+
   test("unknown data still supports derived reads outside a transaction", async () => {
     const account = await create();
     const derived = await derive({ ...account.data });
@@ -198,6 +252,7 @@ describe.each([
             account.id,
           ])
         ).rows[0];
+        const current = await loadDerivedEntX(viewer, row, DerivedAccount);
         privacy = async () => {
           started.resolve();
           await release.promise;
@@ -208,7 +263,7 @@ describe.each([
         );
         await started.promise;
         try {
-          await edit(await load(account.id), 80).saveX();
+          await edit(current, 80).saveX();
         } finally {
           release.resolve();
         }

--- a/ts/src/core/transaction_derived.test.ts
+++ b/ts/src/core/transaction_derived.test.ts
@@ -10,7 +10,7 @@ import {
   loadRows,
 } from "./ent";
 import { ObjectLoaderFactory } from "./loaders";
-import { withTransaction } from "./transaction";
+import { withTransactionScope } from "./transaction";
 import {
   assertEntTransaction,
   getTransactionState,
@@ -55,7 +55,7 @@ const create = () =>
     null,
   ).saveX();
 class GuardedEdit extends SimpleAction<DerivedAccount> {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return true;
   }
 }
@@ -89,9 +89,6 @@ function deferred() {
   });
   return { promise, resolve };
 }
-const independent = (action: GuardedEdit, key: string) =>
-  Object.assign(action, { getTransactionResources: () => [key] });
-
 setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
 beforeEach(() => {
   context.cache.reset();
@@ -126,10 +123,10 @@ describe.each([
     "query",
     "queryAll",
     "exec",
-  ] as const)("%s rows retain their provenance before privacy and support guarded saves", async (queryMethod) => {
+  ] as const)("%s rows retain their provenance before privacy and support scoped saves", async (queryMethod) => {
     const account = await create();
     let checks = 0;
-    await withTransaction(async (tx) => {
+    await withTransactionScope(async (tx) => {
       const row = (
         await tx[queryMethod]("SELECT * FROM derived_accounts WHERE id = $1", [
           account.id,
@@ -157,7 +154,7 @@ describe.each([
     const account = await create();
     let row: Data;
     if (origin === "previous scope") {
-      row = await withTransaction(async (tx) => {
+      row = await withTransactionScope(async (tx) => {
         return (
           await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
             account.id,
@@ -180,7 +177,7 @@ describe.each([
     let caught: unknown;
     let outer: unknown;
     try {
-      await withTransaction(async (tx) => {
+      await withTransactionScope(async (tx) => {
         if (origin === "stale generation" || origin === "unknown current row") {
           row = (
             await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
@@ -212,17 +209,17 @@ describe.each([
   test("copied old data cannot overwrite a later committed balance", async () => {
     const account = await create();
     const copied = { ...account.data };
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       await edit(await load(account.id), 80).saveX();
     });
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const stale = await derive(copied);
         await edit(stale!, stale!.data.balance - 30).saveX();
       }),
     ).rejects.toThrow("reload existingEnt");
     expect((await load(account.id)).data.balance).toBe(80);
-    await withTransaction(async (tx) => {
+    await withTransactionScope(async (tx) => {
       const row = (
         await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
           account.id,
@@ -241,12 +238,12 @@ describe.each([
     expect(derived!.data.balance).toBe(100);
   });
 
-  test("pending derived privacy cannot cross a guarded save", async () => {
+  test("pending derived privacy cannot cross a scoped save", async () => {
     const account = await create();
     const started = deferred();
     const release = deferred();
     await expect(
-      withTransaction(async (tx) => {
+      withTransactionScope(async (tx) => {
         const row = (
           await tx.query("SELECT * FROM derived_accounts WHERE id = $1", [
             account.id,
@@ -287,12 +284,9 @@ describe.each([
     let settled = false;
     let settledBeforeRelease = false;
     let prepared = 0;
-    const transaction = withTransaction(async (tx) => {
-      const parent = independent(
-        edit(await load(accounts[0].id), 90),
-        "parent",
-      );
-      const bad = independent(edit(await load(accounts[1].id), 80), "bad");
+    const transaction = withTransactionScope(async (tx) => {
+      const parent = edit(await load(accounts[0].id), 90);
+      const bad = edit(await load(accounts[1].id), 80);
       bad.getValidators = () => [
         { validate: async () => (invalid ? failure : undefined) },
       ];
@@ -311,10 +305,7 @@ describe.each([
           changeset: () => {
             const setup = (async () => {
               const derived = await derive(row, PrivacyAccount);
-              const changeset = await independent(
-                edit(derived!, 70),
-                "slow",
-              ).changeset();
+              const changeset = await edit(derived!, 70).changeset();
               prepared++;
               return changeset;
             })();

--- a/ts/src/core/transaction_execution.test.ts
+++ b/ts/src/core/transaction_execution.test.ts
@@ -1,5 +1,6 @@
 import DB, { Dialect } from "./db";
 import { withTransaction } from "./transaction";
+import { runActionChangeset } from "../action";
 import { IntegerType } from "../schema";
 import {
   BaseEnt,
@@ -59,100 +60,198 @@ const edit = (ent: ExecutionAccount, balance: number) =>
 describe("transaction execution preparation generations", () => {
   setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
   beforeEach(() => context.cache.reset());
+  test("caught changeset setup failure aborts earlier writes", async () => {
+    const owner = await create();
+    const failure = new Error("edge setup failed");
+    await expect(
+      withTransaction(async (tx) => {
+        await tx.exec(
+          "UPDATE execution_accounts SET balance = 80 WHERE id = $1",
+          [owner.id],
+        );
+        await expect(
+          runActionChangeset(async () => {
+            throw failure;
+          }),
+        ).rejects.toBe(failure);
+      }),
+    ).rejects.toBe(failure);
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+  });
+
+  test("standalone validation can recover from child changeset validation errors", async () => {
+    const owner = await create();
+    const failure = new Error("correctable child validation failed");
+    await withTransaction(async () => {
+      const action = edit(await load(owner.id as string), 80);
+      action.getTriggers = () => [
+        {
+          changeset: () =>
+            runActionChangeset(async () => {
+              const child = edit(await load(owner.id as string), 70);
+              child.getValidators = () => [{ validate: () => failure }];
+              return child.changeset();
+            }),
+        },
+      ];
+      await expect(action.validX()).rejects.toBe(failure);
+      action.getTriggers = () => [];
+      await action.saveX();
+    });
+    expect((await load(owner.id as string)).data.balance).toBe(80);
+  });
+  test.each([
+    "valid",
+    "validX",
+    "validWithErrors",
+    "outside",
+    "previous",
+  ] as const)(
+    "caught executor assembly failure from %s preparation aborts earlier writes",
+    async (source) => {
+      const owner = await create();
+      const other = await create();
+      let captured!: Awaited<
+        ReturnType<SimpleAction<ExecutionAccount>["changeset"]>
+      >;
+      let failure: unknown;
+      const prepare = async () =>
+        edit(await load(other.id as string), 70).changeset();
+      if (source === "outside") {
+        captured = await prepare();
+      } else if (source === "previous") {
+        captured = await withTransaction(prepare);
+      }
+      const outcome = withTransaction(async () => {
+        if (source !== "outside" && source !== "previous") {
+          const probe = edit(await load(owner.id as string), 90);
+          probe.getTriggers = () => [
+            {
+              changeset: async () => {
+                captured = await prepare();
+                return captured;
+              },
+            },
+          ];
+          await probe[source]();
+        }
+        await edit(await load(owner.id as string), 80).saveX();
+        try {
+          captured.executor();
+        } catch (error) {
+          failure = error;
+        }
+        expect(failure).toBeInstanceOf(Error);
+        expect(failure).toMatchObject({
+          message: expect.stringContaining(
+            source === "outside" || source === "previous"
+              ? "loaders cannot cross transaction scopes"
+              : "changesets prepared by public validation cannot execute",
+          ),
+        });
+      });
+      const result = await outcome.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      const balance = (await load(owner.id as string)).data.balance;
+      expect({ rejectedWithOriginalError: result === failure, balance }).toEqual({
+        rejectedWithOriginalError: true,
+        balance: 100,
+      });
+    },
+  );
   test.each([
     "changeset",
     "list executor",
     "complex executor",
     "executeOperations",
     "iterator",
-  ])(
-    "stale %s rejects before preFetch and rolls back even when caught",
-    async (mode) => {
-      const owner = await create(),
-        other = await create();
-      let prefetched = false;
-      await expect(
-        withTransaction(async () => {
-          const first = await load(owner.id as string);
-          const retained = edit(first, first.data.balance - 30);
-          if (mode === "complex executor") {
-            const second = await load(other.id as string);
-            retained.getTriggers = () => [
-              { changeset: () => edit(second, 70).changeset() },
-            ];
-          }
-          const changeset = await retained.changeset();
-          const executor =
-            mode === "changeset" ? undefined : changeset.executor();
-          if (executor) {
-            const before = executor.preFetch?.bind(executor);
-            executor.preFetch = async (...args) => {
-              prefetched = true;
-              return before?.(...args);
-            };
-          }
-          await new Guarded(
-            viewer,
-            schema,
-            new Map([["balance", 80]]),
-            WriteOperation.Edit,
-            first,
-          ).saveX();
-          const execute = async () => {
-            if (mode === "iterator") {
-              return executor!.next();
-            }
-            if (mode === "executeOperations") {
-              return executeOperations(executor!);
-            }
-            return (executor ?? changeset.executor()).execute();
+  ])("stale %s rejects before preFetch and rolls back even when caught", async (mode) => {
+    const owner = await create(),
+      other = await create();
+    let prefetched = false;
+    await expect(
+      withTransaction(async () => {
+        const first = await load(owner.id as string);
+        const retained = edit(first, first.data.balance - 30);
+        if (mode === "complex executor") {
+          const second = await load(other.id as string);
+          retained.getTriggers = () => [
+            { changeset: () => edit(second, 70).changeset() },
+          ];
+        }
+        const changeset = await retained.changeset();
+        const executor =
+          mode === "changeset" ? undefined : changeset.executor();
+        if (executor) {
+          const before = executor.preFetch?.bind(executor);
+          executor.preFetch = async (...args) => {
+            prefetched = true;
+            return before?.(...args);
           };
-          await expect(execute()).rejects.toThrow(
-            "cannot cross transaction generations",
-          );
-        }),
-      ).rejects.toThrow("cannot cross transaction generations");
-      expect(prefetched).toBe(false);
-      expect((await load(owner.id as string)).data.balance).toBe(100);
-      expect((await load(other.id as string)).data.balance).toBe(100);
-    },
-  );
-  test.each(["list", "complex", "Transaction"])(
-    "same-generation ordinary %s batch and postcommit results remain supported",
-    async (mode) => {
-      const owner = await create(),
-        other = await create();
-      let observations = 0;
-      const retained = await withTransaction(async () => {
-        const first = edit(await load(owner.id as string), 70);
-        const second = edit(await load(other.id as string), 60);
-        first.getObservers = () => [
-          {
-            observe: async () => {
-              observations++;
-              expect((await first.editedEntX()).data.balance).toBe(70);
-            },
+        }
+        await new Guarded(
+          viewer,
+          schema,
+          new Map([["balance", 80]]),
+          WriteOperation.Edit,
+          first,
+        ).saveX();
+        const execute = async () => {
+          if (mode === "iterator") {
+            return executor!.next();
+          }
+          if (mode === "executeOperations") {
+            return executeOperations(executor!);
+          }
+          return (executor ?? changeset.executor()).execute();
+        };
+        await expect(execute()).rejects.toThrow(
+          "cannot cross transaction generations",
+        );
+      }),
+    ).rejects.toThrow("cannot cross transaction generations");
+    expect(prefetched).toBe(false);
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+    expect((await load(other.id as string)).data.balance).toBe(100);
+  });
+  test.each([
+    "list",
+    "complex",
+    "Transaction",
+  ])("same-generation ordinary %s batch and postcommit results remain supported", async (mode) => {
+    const owner = await create(),
+      other = await create();
+    let observations = 0;
+    const retained = await withTransaction(async () => {
+      const first = edit(await load(owner.id as string), 70);
+      const second = edit(await load(other.id as string), 60);
+      first.getObservers = () => [
+        {
+          observe: async () => {
+            observations++;
+            expect((await first.editedEntX()).data.balance).toBe(70);
           },
-        ];
-        if (mode === "Transaction") {
-          await new Transaction(viewer, [first, second]).run();
+        },
+      ];
+      if (mode === "Transaction") {
+        await new Transaction(viewer, [first, second]).run();
+      } else {
+        if (mode === "complex") {
+          first.getTriggers = () => [{ changeset: () => second.changeset() }];
         }
-        else {
-          if (mode === "complex") {
-            first.getTriggers = () => [{ changeset: () => second.changeset() }];
-          }
-          await (await first.changeset()).executor().execute();
-          if (mode === "list") {
-            await (await second.changeset()).executor().execute();
-          }
+        await (await first.changeset()).executor().execute();
+        if (mode === "list") {
+          await (await second.changeset()).executor().execute();
         }
-        return first;
-      });
-      expect((await retained.editedEntX()).data.balance).toBe(70);
-      expect(observations).toBe(1);
-      expect((await load(other.id as string)).data.balance).toBe(60);
-    },
-  );
+      }
+      return first;
+    });
+    expect((await retained.editedEntX()).data.balance).toBe(70);
+    expect(observations).toBe(1);
+    expect((await load(other.id as string)).data.balance).toBe(60);
+  });
   test("ordinary changeset preparation cannot finish after a guarded save", async () => {
     const owner = await create();
     let start!: () => void;

--- a/ts/src/core/transaction_execution.test.ts
+++ b/ts/src/core/transaction_execution.test.ts
@@ -99,9 +99,12 @@ describe("transaction execution preparation generations", () => {
             first,
           ).saveX();
           const execute = async () => {
-            if (mode === "iterator") return executor!.next();
-            if (mode === "executeOperations")
+            if (mode === "iterator") {
+              return executor!.next();
+            }
+            if (mode === "executeOperations") {
               return executeOperations(executor!);
+            }
             return (executor ?? changeset.executor()).execute();
           };
           await expect(execute()).rejects.toThrow(
@@ -131,14 +134,17 @@ describe("transaction execution preparation generations", () => {
             },
           },
         ];
-        if (mode === "Transaction")
+        if (mode === "Transaction") {
           await new Transaction(viewer, [first, second]).run();
+        }
         else {
-          if (mode === "complex")
+          if (mode === "complex") {
             first.getTriggers = () => [{ changeset: () => second.changeset() }];
+          }
           await (await first.changeset()).executor().execute();
-          if (mode === "list")
+          if (mode === "list") {
             await (await second.changeset()).executor().execute();
+          }
         }
         return first;
       });

--- a/ts/src/core/transaction_execution.test.ts
+++ b/ts/src/core/transaction_execution.test.ts
@@ -1,5 +1,5 @@
 import DB, { Dialect } from "./db";
-import { withTransaction } from "./transaction";
+import { withTransactionScope } from "./transaction";
 import { runActionChangeset } from "../action";
 import { IntegerType } from "../schema";
 import {
@@ -36,7 +36,7 @@ const context = new TestContext();
 const viewer = context.getViewer();
 const load = (id: string) => loadEntX(viewer, id, options);
 class Guarded extends SimpleAction<ExecutionAccount> {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return true;
   }
 }
@@ -64,7 +64,7 @@ describe("transaction execution preparation generations", () => {
     const owner = await create();
     const failure = new Error("edge setup failed");
     await expect(
-      withTransaction(async (tx) => {
+      withTransactionScope(async (tx) => {
         await tx.exec(
           "UPDATE execution_accounts SET balance = 80 WHERE id = $1",
           [owner.id],
@@ -82,7 +82,7 @@ describe("transaction execution preparation generations", () => {
   test("standalone validation can recover from child changeset validation errors", async () => {
     const owner = await create();
     const failure = new Error("correctable child validation failed");
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const action = edit(await load(owner.id as string), 80);
       action.getTriggers = () => [
         {
@@ -120,9 +120,9 @@ describe("transaction execution preparation generations", () => {
       if (source === "outside") {
         captured = await prepare();
       } else if (source === "previous") {
-        captured = await withTransaction(prepare);
+        captured = await withTransactionScope(prepare);
       }
-      const outcome = withTransaction(async () => {
+      const outcome = withTransactionScope(async () => {
         if (source !== "outside" && source !== "previous") {
           const probe = edit(await load(owner.id as string), 90);
           probe.getTriggers = () => [
@@ -172,7 +172,7 @@ describe("transaction execution preparation generations", () => {
       other = await create();
     let prefetched = false;
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const first = await load(owner.id as string);
         const retained = edit(first, first.data.balance - 30);
         if (mode === "complex executor") {
@@ -184,6 +184,7 @@ describe("transaction execution preparation generations", () => {
         const changeset = await retained.changeset();
         const executor =
           mode === "changeset" ? undefined : changeset.executor();
+        await (executor ?? changeset.executor()).execute();
         if (executor) {
           const before = executor.preFetch?.bind(executor);
           executor.preFetch = async (...args) => {
@@ -191,13 +192,6 @@ describe("transaction execution preparation generations", () => {
             return before?.(...args);
           };
         }
-        await new Guarded(
-          viewer,
-          schema,
-          new Map([["balance", 80]]),
-          WriteOperation.Edit,
-          first,
-        ).saveX();
         const execute = async () => {
           if (mode === "iterator") {
             return executor!.next();
@@ -219,14 +213,12 @@ describe("transaction execution preparation generations", () => {
   test.each([
     "list",
     "complex",
-    "Transaction",
-  ])("same-generation ordinary %s batch and postcommit results remain supported", async (mode) => {
+  ])("ordinary %s saves and postcommit results remain supported", async (mode) => {
     const owner = await create(),
       other = await create();
     let observations = 0;
-    const retained = await withTransaction(async () => {
+    const retained = await withTransactionScope(async () => {
       const first = edit(await load(owner.id as string), 70);
-      const second = edit(await load(other.id as string), 60);
       first.getObservers = () => [
         {
           observe: async () => {
@@ -235,16 +227,19 @@ describe("transaction execution preparation generations", () => {
           },
         },
       ];
-      if (mode === "Transaction") {
-        await new Transaction(viewer, [first, second]).run();
-      } else {
-        if (mode === "complex") {
-          first.getTriggers = () => [{ changeset: () => second.changeset() }];
-        }
-        await (await first.changeset()).executor().execute();
-        if (mode === "list") {
-          await (await second.changeset()).executor().execute();
-        }
+      if (mode === "complex") {
+        first.getTriggers = () => [
+          {
+            changeset: async () =>
+              edit(await load(other.id as string), 60).changeset(),
+          },
+        ];
+      }
+      await (await first.changeset()).executor().execute();
+      if (mode === "list") {
+        await (await edit(await load(other.id as string), 60).changeset())
+          .executor()
+          .execute();
       }
       return first;
     });
@@ -252,7 +247,22 @@ describe("transaction execution preparation generations", () => {
     expect(observations).toBe(1);
     expect((await load(other.id as string)).data.balance).toBe(60);
   });
-  test("ordinary changeset preparation cannot finish after a guarded save", async () => {
+  test("Transaction groups cannot prepare multiple roots in a scope", async () => {
+    const owner = await create();
+    const other = await create();
+    await expect(
+      withTransactionScope(async () => {
+        await new Transaction(viewer, [
+          edit(await load(owner.id as string), 70),
+          edit(await load(other.id as string), 60),
+        ]).run();
+      }),
+    ).rejects.toThrow("root actions must be prepared and saved sequentially");
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+    expect((await load(other.id as string)).data.balance).toBe(100);
+  });
+
+  test("ordinary preparation reserves the root before another action requires a scope", async () => {
     const owner = await create();
     let start!: () => void;
     let release!: () => void;
@@ -263,7 +273,7 @@ describe("transaction execution preparation generations", () => {
       release = resolve;
     });
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const first = await load(owner.id as string);
         const action = edit(first, 70);
         action.getValidators = () => [
@@ -274,9 +284,9 @@ describe("transaction execution preparation generations", () => {
             },
           },
         ];
-        const prepared = action.changeset();
-        const checked = expect(prepared).rejects.toThrow(
-          "cannot cross transaction generations",
+        const prepared = action.changeset().then(
+          (value) => ({ value }),
+          (error) => ({ error }),
         );
         await started;
         try {
@@ -289,10 +299,10 @@ describe("transaction execution preparation generations", () => {
           ).saveX();
         } finally {
           release();
+          await prepared;
         }
-        await checked;
       }),
-    ).rejects.toThrow("cannot cross transaction generations");
+    ).rejects.toThrow("root actions must be prepared and saved sequentially");
     expect((await load(owner.id as string)).data.balance).toBe(100);
   });
 });

--- a/ts/src/core/transaction_execution.test.ts
+++ b/ts/src/core/transaction_execution.test.ts
@@ -1,0 +1,193 @@
+import DB, { Dialect } from "./db";
+import { withTransaction } from "./transaction";
+import { IntegerType } from "../schema";
+import {
+  BaseEnt,
+  SimpleAction,
+  getBuilderSchemaFromFields,
+  getDbFields,
+} from "../testutils/builder";
+import { setupPostgres, getSchemaTable } from "../testutils/db/temp_db";
+import { TestContext } from "../testutils/context/test_context";
+import { WriteOperation } from "../action/action";
+import { executeOperations } from "../action/executor";
+import { Transaction } from "../action/transaction";
+import { ObjectLoaderFactory } from "./loaders";
+import { loadEntX } from "./ent";
+class ExecutionAccount extends BaseEnt {
+  nodeType = "ExecutionAccount";
+}
+const schema = getBuilderSchemaFromFields(
+  { balance: IntegerType() },
+  ExecutionAccount,
+);
+const loaderOptions = {
+  tableName: "execution_accounts",
+  fields: getDbFields(schema),
+  key: "id",
+};
+const options = {
+  ...loaderOptions,
+  ent: ExecutionAccount,
+  loaderFactory: new ObjectLoaderFactory(loaderOptions),
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+const load = (id: string) => loadEntX(viewer, id, options);
+class Guarded extends SimpleAction<ExecutionAccount> {
+  requiresTransaction() {
+    return true;
+  }
+}
+const create = () =>
+  new SimpleAction(
+    viewer,
+    schema,
+    new Map([["balance", 100]]),
+    WriteOperation.Insert,
+    null,
+  ).saveX();
+const edit = (ent: ExecutionAccount, balance: number) =>
+  new SimpleAction(
+    viewer,
+    schema,
+    new Map([["balance", balance]]),
+    WriteOperation.Edit,
+    ent,
+  );
+
+describe("transaction execution preparation generations", () => {
+  setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
+  beforeEach(() => context.cache.reset());
+  test.each([
+    "changeset",
+    "list executor",
+    "complex executor",
+    "executeOperations",
+    "iterator",
+  ])(
+    "stale %s rejects before preFetch and rolls back even when caught",
+    async (mode) => {
+      const owner = await create(),
+        other = await create();
+      let prefetched = false;
+      await expect(
+        withTransaction(async () => {
+          const first = await load(owner.id as string);
+          const retained = edit(first, first.data.balance - 30);
+          if (mode === "complex executor") {
+            const second = await load(other.id as string);
+            retained.getTriggers = () => [
+              { changeset: () => edit(second, 70).changeset() },
+            ];
+          }
+          const changeset = await retained.changeset();
+          const executor =
+            mode === "changeset" ? undefined : changeset.executor();
+          if (executor) {
+            const before = executor.preFetch?.bind(executor);
+            executor.preFetch = async (...args) => {
+              prefetched = true;
+              return before?.(...args);
+            };
+          }
+          await new Guarded(
+            viewer,
+            schema,
+            new Map([["balance", 80]]),
+            WriteOperation.Edit,
+            first,
+          ).saveX();
+          const execute = async () => {
+            if (mode === "iterator") return executor!.next();
+            if (mode === "executeOperations")
+              return executeOperations(executor!);
+            return (executor ?? changeset.executor()).execute();
+          };
+          await expect(execute()).rejects.toThrow(
+            "cannot cross transaction generations",
+          );
+        }),
+      ).rejects.toThrow("cannot cross transaction generations");
+      expect(prefetched).toBe(false);
+      expect((await load(owner.id as string)).data.balance).toBe(100);
+      expect((await load(other.id as string)).data.balance).toBe(100);
+    },
+  );
+  test.each(["list", "complex", "Transaction"])(
+    "same-generation ordinary %s batch and postcommit results remain supported",
+    async (mode) => {
+      const owner = await create(),
+        other = await create();
+      let observations = 0;
+      const retained = await withTransaction(async () => {
+        const first = edit(await load(owner.id as string), 70);
+        const second = edit(await load(other.id as string), 60);
+        first.getObservers = () => [
+          {
+            observe: async () => {
+              observations++;
+              expect((await first.editedEntX()).data.balance).toBe(70);
+            },
+          },
+        ];
+        if (mode === "Transaction")
+          await new Transaction(viewer, [first, second]).run();
+        else {
+          if (mode === "complex")
+            first.getTriggers = () => [{ changeset: () => second.changeset() }];
+          await (await first.changeset()).executor().execute();
+          if (mode === "list")
+            await (await second.changeset()).executor().execute();
+        }
+        return first;
+      });
+      expect((await retained.editedEntX()).data.balance).toBe(70);
+      expect(observations).toBe(1);
+      expect((await load(other.id as string)).data.balance).toBe(60);
+    },
+  );
+  test("ordinary changeset preparation cannot finish after a guarded save", async () => {
+    const owner = await create();
+    let start!: () => void;
+    let release!: () => void;
+    const started = new Promise<void>((resolve) => {
+      start = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await expect(
+      withTransaction(async () => {
+        const first = await load(owner.id as string);
+        const action = edit(first, 70);
+        action.getValidators = () => [
+          {
+            validate: async () => {
+              start();
+              await gate;
+            },
+          },
+        ];
+        const prepared = action.changeset();
+        const checked = expect(prepared).rejects.toThrow(
+          "cannot cross transaction generations",
+        );
+        await started;
+        try {
+          await new Guarded(
+            viewer,
+            schema,
+            new Map([["balance", 80]]),
+            WriteOperation.Edit,
+            first,
+          ).saveX();
+        } finally {
+          release();
+        }
+        await checked;
+      }),
+    ).rejects.toThrow("cannot cross transaction generations");
+    expect((await load(owner.id as string)).data.balance).toBe(100);
+  });
+});

--- a/ts/src/core/transaction_final_validation.test.ts
+++ b/ts/src/core/transaction_final_validation.test.ts
@@ -1,0 +1,726 @@
+import DB, { Dialect } from "./db";
+import { ScopeValidationContext, withTransactionScope } from "./transaction";
+import { loadEntX, loadRows } from "./ent";
+import { Eq } from "./clause";
+import { CustomClauseQuery } from "./query/custom_clause_query";
+import { Allow, Deny } from "./base";
+import { ObjectLoaderFactory } from "./loaders";
+import { BooleanType, IntegerType } from "../schema";
+import { WriteOperation } from "../action/action";
+import { AlwaysDenyPrivacyPolicy } from "./privacy";
+import { TestContext } from "../testutils/context/test_context";
+import { setupPostgres, getSchemaTable } from "../testutils/db/temp_db";
+import {
+  BaseEnt,
+  SimpleAction,
+  getBuilderSchemaFromFields,
+  getDbFields,
+} from "../testutils/builder";
+
+class FinalAccount extends BaseEnt {
+  nodeType = "FinalAccount";
+}
+const schema = getBuilderSchemaFromFields(
+  { amount: IntegerType(), admin: BooleanType() },
+  FinalAccount,
+);
+const context = new TestContext();
+const viewer = context.getViewer();
+const loaderOptions = {
+  tableName: "final_accounts",
+  fields: getDbFields(schema),
+  key: "id",
+};
+const options = {
+  ...loaderOptions,
+  ent: FinalAccount,
+  loaderFactory: new ObjectLoaderFactory(loaderOptions),
+};
+const load = (id: string) => loadEntX(viewer, id, options);
+const make = (amount = 10, admin = true, ent: FinalAccount | null = null) =>
+  new SimpleAction(
+    viewer,
+    schema,
+    new Map<string, any>([
+      ["amount", amount],
+      ["admin", admin],
+    ]),
+    ent ? WriteOperation.Edit : WriteOperation.Insert,
+    ent,
+  );
+const checked = (
+  action: SimpleAction<FinalAccount>,
+  validateBeforeCommit: (
+    context: ScopeValidationContext,
+  ) => Promise<void> | void,
+) => Object.assign(action, { validateBeforeCommit });
+const rows = () =>
+  DB.getInstance()
+    .getPool()
+    .query("SELECT amount, admin FROM final_accounts ORDER BY amount");
+const adminCheck = async (ctx: ScopeValidationContext) => {
+  const result = await ctx.query(
+    "SELECT count(*)::int AS count FROM final_accounts WHERE admin",
+  );
+  if (!result.rows[0].count) {
+    throw new Error("an administrator must remain");
+  }
+};
+
+setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
+beforeEach(() => context.cache.reset());
+
+test.each([
+  "saveX",
+  "builder",
+  "changeset",
+] as const)("%s registers final validation automatically", async (entry) => {
+  const order: string[] = [];
+  await withTransactionScope(async () => {
+    const action = checked(make(), async (ctx) => {
+      order.push("validate");
+      expect(
+        (await ctx.query("SELECT amount FROM final_accounts")).rows,
+      ).toEqual([{ amount: 10 }]);
+    });
+    action.getObservers = () => [
+      {
+        observe: () => {
+          order.push("observe");
+        },
+      },
+    ];
+    if (entry === "builder") {
+      await action.builder.saveX();
+    } else if (entry === "changeset") {
+      await (await action.changeset()).executor().execute();
+    } else {
+      await action.saveX();
+    }
+    order.push("saved");
+    expect(order).toEqual(["saved"]);
+  });
+  expect(order).toEqual(["saved", "validate", "observe"]);
+});
+
+test.each([
+  "saveX",
+  "builder",
+  "changeset",
+  "validX",
+] as const)("%s rejects a final validator outside a scope before preparation", async (entry) => {
+  const prepare = jest.fn();
+  const check = jest.fn();
+  const action = checked(make(), check);
+  action.getTriggers = () => [{ changeset: prepare }];
+  await expect(
+    entry === "builder" ? action.builder.saveX() : action[entry](),
+  ).rejects.toThrow("requires withTransactionScope");
+  expect(prepare).not.toHaveBeenCalled();
+  expect(check).not.toHaveBeenCalled();
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("overlapping child decisions roll back when final validation fails", async () => {
+  const first = await make(1).saveX();
+  const second = await make(2).saveX();
+  const observe = jest.fn();
+  await expect(
+    withTransactionScope(async () => {
+      const parent = make(3, false);
+      parent.getTriggers = () =>
+        [first.id, second.id].map((id) => ({
+          changeset: async () => {
+            const child = checked(
+              make(4, false, await load(id as string)),
+              adminCheck,
+            );
+            child.getObservers = () => [{ observe }];
+            return child.changeset();
+          },
+        }));
+      await parent.saveX();
+    }),
+  ).rejects.toThrow("an administrator must remain");
+  expect((await rows()).rows).toEqual([
+    { amount: 1, admin: true },
+    { amount: 2, admin: true },
+  ]);
+  expect(observe).not.toHaveBeenCalled();
+});
+
+test("an action's final check includes later roots and permits administrator replacement", async () => {
+  const before = await make().saveX();
+  await withTransactionScope(async () => {
+    await checked(
+      make(10, false, await load(before.id as string)),
+      adminCheck,
+    ).saveX();
+    await make(20, true).saveX();
+  });
+  expect((await rows()).rows).toEqual([
+    { amount: 10, admin: false },
+    { amount: 20, admin: true },
+  ]);
+});
+
+test("grandchildren register their checks even when parents have no scope requirement", async () => {
+  const calls: string[] = [];
+  await withTransactionScope(async () => {
+    const parent = make(1);
+    parent.getTriggers = () => [
+      {
+        changeset: async () => {
+          const child = make(2);
+          child.getTriggers = () => [
+            {
+              changeset: () =>
+                checked(make(3), async (ctx) => {
+                  calls.push("grandchild");
+                  expect(
+                    (
+                      await ctx.query(
+                        "SELECT count(*)::int AS count FROM final_accounts",
+                      )
+                    ).rows[0].count,
+                  ).toBe(3);
+                }).changeset(),
+            },
+          ];
+          return child.changeset();
+        },
+      },
+    ];
+    await parent.saveX();
+    expect(calls).toEqual([]);
+  });
+  expect(calls).toEqual(["grandchild"]);
+});
+
+test.each([
+  "valid",
+  "validX",
+  "validWithErrors",
+] as const)("%s does not retain checks from discarded children", async (entry) => {
+  const check = jest.fn();
+  await withTransactionScope(async () => {
+    const parent = make();
+    parent.getTriggers = () => [
+      { changeset: () => checked(make(2), check).changeset() },
+    ];
+    await parent[entry]();
+    parent.getTriggers = () => [];
+    await parent.saveX();
+  });
+  expect(check).not.toHaveBeenCalled();
+  expect((await rows()).rows).toEqual([{ amount: 10, admin: true }]);
+});
+
+test("an unexecuted changeset does not register its final check", async () => {
+  const check = jest.fn();
+  await withTransactionScope(() => checked(make(), check).changeset());
+  expect(check).not.toHaveBeenCalled();
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("silent privacy failures do not register final checks", async () => {
+  const original = await make().saveX();
+  const check = jest.fn();
+  await withTransactionScope(async () => {
+    const action = checked(
+      make(20, true, await load(original.id as string)),
+      check,
+    );
+    action.getPrivacyPolicy = () => AlwaysDenyPrivacyPolicy;
+    action.__failPrivacySilently = () => true;
+    await action.saveX();
+  });
+  expect(check).not.toHaveBeenCalled();
+  expect((await rows()).rows).toEqual([{ amount: 10, admin: true }]);
+});
+
+test("retries recreate registrations and observers only run for the committed attempt", async () => {
+  const attempts: number[] = [];
+  const observe = jest.fn();
+  await withTransactionScope(
+    async (scope) => {
+      const action = checked(make(scope.attempt), async (ctx) => {
+        attempts.push(ctx.attempt);
+        if (ctx.attempt === 0) {
+          throw Object.assign(new Error("serialization conflict"), {
+            code: "40001",
+          });
+        }
+      });
+      action.getObservers = () => [{ observe }];
+      await action.saveX();
+    },
+    { maxRetries: 1 },
+  );
+  expect(attempts).toEqual([0, 1]);
+  expect(observe).toHaveBeenCalledTimes(1);
+  expect((await rows()).rows).toEqual([{ amount: 1, admin: true }]);
+});
+
+test("business validation failures are not retried", async () => {
+  const check = jest.fn(() => {
+    throw new Error("invalid final state");
+  });
+  await expect(
+    withTransactionScope(() => checked(make(), check).saveX(), {
+      maxRetries: 3,
+    }),
+  ).rejects.toThrow("invalid final state");
+  expect(check).toHaveBeenCalledTimes(1);
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("final validation bypasses request caches, loader caches, and query caches", async () => {
+  const original = await make().saveX();
+  await load(original.id as string);
+  const db = DB.getInstance();
+  const acquire = db.getNewClient.bind(db);
+  let reads = 0;
+  const acquireSpy = jest
+    .spyOn(db, "getNewClient")
+    .mockImplementation(async () => {
+      const client = await acquire();
+      const query = client.query.bind(client);
+      client.query = (sql, values) => {
+        if (/^SELECT/i.test(sql)) {
+          reads++;
+        }
+        return query(sql, values);
+      };
+      return client;
+    });
+  try {
+    await withTransactionScope(async () => {
+      const action = checked(
+        make(20, true, await load(original.id as string)),
+        async (ctx) => {
+          const start = reads;
+          const first = await load(original.id as string);
+          const second = await load(original.id as string);
+          expect(first.data.amount).toBe(20);
+          expect(second.data.amount).toBe(20);
+          expect(second).not.toBe(first);
+          const loader = options.loaderFactory.createLoader(context);
+          expect((await loader.load(original.id))?.amount).toBe(20);
+          expect((await loader.load(original.id))?.amount).toBe(20);
+          const queryOptions = {
+            ...loaderOptions,
+            context,
+            clause: Eq("id", original.id),
+          };
+          expect((await loadRows(queryOptions))[0].amount).toBe(20);
+          expect((await loadRows(queryOptions))[0].amount).toBe(20);
+          expect(
+            (
+              await ctx.query(
+                "SELECT amount FROM final_accounts WHERE id = $1",
+                [original.id],
+              )
+            ).rows[0].amount,
+          ).toBe(20);
+          expect(reads - start).toBe(7);
+          const edgeQuery = new CustomClauseQuery(viewer, {
+            loadEntOptions: options,
+            clause: Eq("id", original.id),
+            name: "final-account",
+          });
+          for (const read of [
+            () => edgeQuery.queryEnts(),
+            () => edgeQuery.queryCount(),
+            () => edgeQuery.queryRawCount(),
+          ]) {
+            const before = reads;
+            await read();
+            const queried = reads;
+            expect(queried).toBeGreaterThan(before);
+            await read();
+            expect(reads).toBeGreaterThan(queried);
+          }
+        },
+      );
+      await action.saveX();
+    });
+  } finally {
+    acquireSpy.mockRestore();
+  }
+});
+
+test.each([
+  "UPDATE final_accounts SET amount = 99",
+  "WITH changed AS (DELETE FROM final_accounts RETURNING *) SELECT * FROM changed",
+  "SELECT 1; COMMIT",
+  "COMMIT",
+  "SELECT * INTO copied FROM final_accounts",
+  "SELECT * FROM final_accounts FOR UPDATE",
+])("caught validation SQL violation rolls back: %s", async (sql) => {
+  let failure: unknown;
+  await expect(
+    withTransactionScope(() =>
+      checked(make(), async (ctx) => {
+        try {
+          await ctx.query(sql);
+        } catch (error) {
+          failure = error;
+        }
+      }).saveX(),
+    ),
+  ).rejects.toThrow("single read query");
+  expect(failure).toBeInstanceOf(Error);
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("PostgreSQL blocks writes hidden in a function called by a validation query", async () => {
+  await DB.getInstance()
+    .getPool()
+    .query(
+      "CREATE FUNCTION change_final_amount() RETURNS integer LANGUAGE plpgsql AS $$ BEGIN UPDATE final_accounts SET amount = 99; RETURN 1; END $$",
+    );
+  await expect(
+    withTransactionScope(() =>
+      checked(make(), async (ctx) => {
+        await ctx.query("SELECT change_final_amount()");
+      }).saveX(),
+    ),
+  ).rejects.toThrow("read-only transaction");
+  expect((await rows()).rows).toEqual([]);
+});
+
+test.each([
+  "saveX",
+  "validX",
+] as const)("caught %s calls during final validation fail the scope", async (entry) => {
+  await expect(
+    withTransactionScope(() =>
+      checked(make(), async () => {
+        await expect(make(99)[entry]()).rejects.toThrow(
+          "during scope validation",
+        );
+      }).saveX(),
+    ),
+  ).rejects.toThrow("during scope validation");
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("a retained validation context cannot query after the scope closes", async () => {
+  let retained!: ScopeValidationContext;
+  await withTransactionScope(() =>
+    checked(make(), (ctx) => {
+      retained = ctx;
+    }).saveX(),
+  );
+  expect(() => retained.query("SELECT 1")).toThrow("outside its callback");
+});
+
+test("a validator cannot reuse a loader prepared before final validation", async () => {
+  await expect(
+    withTransactionScope(async () => {
+      const loader = options.loaderFactory.createLoader(context);
+      await checked(make(), async () => {
+        await loader.load("missing");
+      }).saveX();
+    }),
+  ).rejects.toThrow("cannot cross transaction generations");
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("fresh Ent reads enforce privacy again during final validation", async () => {
+  let allowed = true;
+  const privacy = jest.fn(async () => (allowed ? Allow() : Deny()));
+  class PrivateAccount extends FinalAccount {
+    getPrivacyPolicy() {
+      return { rules: [{ apply: privacy }] };
+    }
+  }
+  const privateLoad = (id: string) =>
+    loadEntX(viewer, id, { ...options, ent: PrivateAccount });
+  const original = await make().saveX();
+  await privateLoad(original.id as string);
+  await expect(
+    withTransactionScope(() =>
+      checked(make(), async () => {
+        allowed = false;
+        await privateLoad(original.id as string);
+      }).saveX(),
+    ),
+  ).rejects.toThrow();
+  expect(privacy).toHaveBeenCalledTimes(2);
+  expect((await rows()).rows).toHaveLength(1);
+});
+
+test("deferred foreign keys and database trigger writes finish before final validation", async () => {
+  const pool = DB.getInstance().getPool();
+  await pool.query(
+    "CREATE TABLE final_refs (account_id uuid REFERENCES final_accounts(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+  );
+  await pool.query(
+    "CREATE FUNCTION add_final_reference() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN INSERT INTO final_refs VALUES (NEW.id); UPDATE final_accounts SET amount = amount + 1 WHERE id = NEW.id; RETURN NULL; END $$",
+  );
+  await pool.query(
+    "CREATE CONSTRAINT TRIGGER final_reference AFTER INSERT ON final_accounts DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION add_final_reference()",
+  );
+  await withTransactionScope(() =>
+    checked(make(), async (ctx) => {
+      expect(
+        (await ctx.query("SELECT amount FROM final_accounts")).rows,
+      ).toEqual([{ amount: 11 }]);
+      expect(
+        (await ctx.query("SELECT count(*)::int AS count FROM final_refs"))
+          .rows[0].count,
+      ).toBe(1);
+    }).saveX(),
+  );
+  expect((await rows()).rows).toEqual([{ amount: 11, admin: true }]);
+  await pool.query("DROP TRIGGER final_reference ON final_accounts");
+  await pool.query("DROP FUNCTION add_final_reference()");
+  await pool.query("DROP TABLE final_refs");
+});
+
+test("an unawaited validation query aborts and drains before releasing the connection", async () => {
+  let pending!: Promise<unknown>;
+  await expect(
+    withTransactionScope(() =>
+      checked(make(), (ctx) => {
+        pending = ctx.query("SELECT pg_sleep(0.02)").catch((error) => error);
+      }).saveX(),
+    ),
+  ).rejects.toThrow("await all reads during scope validation");
+  expect(await pending).toBeInstanceOf(Error);
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("an unawaited save cannot enter final validation or commit", async () => {
+  let release!: () => void;
+  let started!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const beginning = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  const check = jest.fn();
+  let saving!: Promise<unknown>;
+  const outcome = withTransactionScope(async () => {
+    await checked(make(), check).saveX();
+    const action = make(20);
+    action.getTriggers = () => [
+      {
+        changeset: async () => {
+          started();
+          await gate;
+        },
+      },
+    ];
+    saving = action.saveX().catch((error) => error);
+    await beginning;
+  }).catch((error) => error);
+  await beginning;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  release();
+  expect(await outcome).toMatchObject({
+    message: expect.stringContaining("await each action save"),
+  });
+  expect(await saving).toBeInstanceOf(Error);
+  expect(check).not.toHaveBeenCalled();
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("scope validation waits for action result privacy before it can commit", async () => {
+  let started!: () => void;
+  let release!: () => void;
+  const start = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const check = jest.fn();
+  let saving!: Promise<unknown>;
+  let finished = false;
+  const outcome = withTransactionScope(async () => {
+    const action = checked(make(), check);
+    Object.assign(action, {
+      viewerForEntLoad: async () => {
+        started();
+        await gate;
+        return viewer;
+      },
+    });
+    saving = action.saveX().catch((error) => error);
+    await start;
+  }).then(
+    () => {
+      finished = true;
+    },
+    (error) => error,
+  );
+  await start;
+  await new Promise<void>((resolve) => setTimeout(resolve, 20));
+  const committedEarly = finished;
+  release();
+  const failure = await outcome;
+  await saving;
+  expect(committedEarly).toBe(false);
+  expect(failure).toMatchObject({
+    message: expect.stringContaining("await each action save"),
+  });
+  expect(check).not.toHaveBeenCalled();
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("repeated custom edge counts do not accumulate source identifiers", async () => {
+  const account = await make().saveX();
+  await withTransactionScope(() =>
+    checked(make(), async () => {
+      const { CustomEdgeQueryBase } = await import("./query/custom_query");
+      class AccountQuery extends CustomEdgeQueryBase<
+        FinalAccount,
+        FinalAccount
+      > {
+        async sourceEnt() {
+          return null;
+        }
+      }
+      const query = new AccountQuery(viewer, {
+        src: account.id,
+        groupCol: "id",
+        loadEntOptions: options,
+        name: "final-count",
+      });
+      expect(await query.queryRawCount()).toBe(1);
+      expect(await query.queryRawCount()).toBe(1);
+      expect(await query.queryCount()).toBe(1);
+      expect(await query.queryCount()).toBe(1);
+    }).saveX(),
+  );
+});
+
+test("conditional wrappers preserve silent privacy skips for final validation", async () => {
+  const account = await make().saveX();
+  const check = jest.fn(() => {
+    throw new Error("skipped rule must not run");
+  });
+  await withTransactionScope(async () => {
+    const parent = make(20);
+    parent.getTriggers = () => [
+      {
+        changeset: async () => {
+          const child = checked(
+            make(30, true, await load(account.id as string)),
+            check,
+          );
+          child.getPrivacyPolicy = () => AlwaysDenyPrivacyPolicy;
+          child.__failPrivacySilently = () => true;
+          return child.changesetWithOptions_BETA({
+            conditionalBuilder: parent.builder,
+          });
+        },
+      },
+    ];
+    await parent.saveX();
+  });
+  expect(check).not.toHaveBeenCalled();
+  expect((await rows()).rows).toEqual([
+    { amount: 10, admin: true },
+    { amount: 20, admin: true },
+  ]);
+});
+
+test("a failing final check preserves its error while draining an unawaited read", async () => {
+  const error = new Error("invalid final business state");
+  let pending!: Promise<unknown>;
+  await expect(
+    withTransactionScope(() =>
+      checked(make(), (context) => {
+        pending = context
+          .query("SELECT pg_sleep(0.02)")
+          .catch((error) => error);
+        throw error;
+      }).saveX(),
+    ),
+  ).rejects.toBe(error);
+  await pending;
+  expect((await rows()).rows).toEqual([]);
+});
+
+test("serializable final checks coordinate concurrent administrator removals", async () => {
+  const accounts = await Promise.all([make(1).saveX(), make(2).saveX()]);
+  let arrive!: () => void;
+  const bothRead = new Promise<void>((resolve) => {
+    arrive = resolve;
+  });
+  let readers = 0;
+  const attempts: number[] = [];
+  const outcomes = await Promise.allSettled(
+    accounts.map((account) =>
+      withTransactionScope(
+        async (scope) => {
+          attempts.push(scope.attempt);
+          await checked(
+            make(account.data.amount, false, await load(account.id as string)),
+            async (context) => {
+              const count = (
+                await context.query(
+                  "SELECT count(*)::int AS count FROM final_accounts WHERE admin",
+                )
+              ).rows[0].count;
+              if (scope.attempt === 0) {
+                if (++readers === 2) {
+                  arrive();
+                }
+                await bothRead;
+              }
+              if (!count) {
+                throw new Error("an administrator must remain");
+              }
+            },
+          ).saveX();
+        },
+        { maxRetries: 2 },
+      ),
+    ),
+  );
+  expect(
+    outcomes.filter((result) => result.status === "fulfilled"),
+  ).toHaveLength(1);
+  expect(outcomes.filter((result) => result.status === "rejected")).toEqual([
+    { status: "rejected", reason: new Error("an administrator must remain") },
+  ]);
+  expect(attempts).toContain(1);
+  expect((await rows()).rows.filter((row) => row.admin)).toHaveLength(1);
+});
+
+test("work inherited from the callback cannot write during final validation", async () => {
+  let finalStarted!: () => void;
+  const start = new Promise<void>((resolve) => {
+    finalStarted = resolve;
+  });
+  let finish!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  let late!: Promise<unknown>;
+  await expect(
+    withTransactionScope(async (scope) => {
+      late = start.then(async () => {
+        try {
+          await scope.query("UPDATE final_accounts SET amount = 0");
+        } catch (error) {
+          return error;
+        } finally {
+          finish();
+        }
+      });
+      await checked(make(), async () => {
+        finalStarted();
+        await gate;
+      }).saveX();
+    }),
+  ).rejects.toThrow("transaction callback is closed");
+  expect(await late).toBeInstanceOf(Error);
+  expect((await rows()).rows).toEqual([]);
+});

--- a/ts/src/core/transaction_generation.test.ts
+++ b/ts/src/core/transaction_generation.test.ts
@@ -1,0 +1,577 @@
+import DB, { Dialect } from "./db";
+import { withTransaction } from "./transaction";
+import { Allow, Data, EdgeQueryableDataOptions, ID } from "./base";
+import { Eq } from "./clause";
+import {
+  applyPrivacyPolicyForRow,
+  AssocEdge,
+  loadEntX,
+  loadEnts,
+  loadRow,
+  loadRows,
+  performRawQuery,
+  getEntLoaderPrivacyConcurrencyLimit,
+  setEntLoaderPrivacyConcurrencyLimit,
+} from "./ent";
+import { CustomClauseQuery } from "./query/custom_clause_query";
+import { CustomEdgeQueryBase } from "./query/custom_query";
+import { AssocEdgeQueryBase } from "./query/assoc_query";
+import { IDInfo } from "./query/query";
+import {
+  ObjectLoaderFactory,
+  QueryLoaderFactory,
+  RawCountLoader,
+  AssocEdgeLoaderFactory,
+  AssocEdgeCountLoaderFactory,
+} from "./loaders";
+import { ObjectCountLoader } from "./loaders/object_loader";
+import { InstrumentedDataLoader } from "./loaders/loader";
+import { WriteOperation } from "../action/action";
+import { BooleanType, IntegerType } from "../schema";
+import {
+  BaseEnt,
+  SimpleAction,
+  getBuilderSchemaFromFields,
+  getDbFields,
+} from "../testutils/builder";
+import {
+  setupPostgres,
+  getSchemaTable,
+  assoc_edge_config_table,
+  assoc_edge_table,
+} from "../testutils/db/temp_db";
+import { TestContext } from "../testutils/context/test_context";
+
+class GenerationAccount extends BaseEnt {
+  nodeType = "GenerationAccount";
+}
+const schema = getBuilderSchemaFromFields(
+  { balance: IntegerType(), admin: BooleanType() },
+  GenerationAccount,
+);
+const fields = getDbFields(schema);
+const loaderOptions = { tableName: "generation_accounts", fields, key: "id" };
+const factory = new ObjectLoaderFactory(loaderOptions);
+const options = {
+  ...loaderOptions,
+  ent: GenerationAccount,
+  loaderFactory: factory,
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+const edgeType = "10506d83-e3c0-46e8-83b6-41de7271f2ad";
+const edgeFactory = new AssocEdgeLoaderFactory(edgeType, AssocEdge);
+const countFactory = new AssocEdgeCountLoaderFactory(edgeType);
+const expired = "cannot cross transaction generations";
+const load = (id: ID) => loadEntX(viewer, id, options);
+
+class GuardedEdit extends SimpleAction<GenerationAccount> {
+  requiresTransaction() {
+    return true;
+  }
+}
+const edit = (ent: GenerationAccount, balance: number) =>
+  new GuardedEdit(
+    viewer,
+    schema,
+    new Map([["balance", balance]]),
+    WriteOperation.Edit,
+    ent,
+  );
+const makeQuery = (id: ID) =>
+  new CustomClauseQuery(viewer, {
+    loadEntOptions: options,
+    clause: Eq("id", id),
+    name: "generation-account",
+  });
+class AccountQuery extends CustomEdgeQueryBase<
+  GenerationAccount,
+  GenerationAccount
+> {
+  async sourceEnt() {
+    return null;
+  }
+}
+class AccountEdges extends AssocEdgeQueryBase<
+  GenerationAccount,
+  GenerationAccount,
+  AssocEdge
+> {
+  async sourceEnt() {
+    return null;
+  }
+}
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("transaction read generations", () => {
+  setupPostgres(() => [
+    getSchemaTable(schema, Dialect.Postgres),
+    assoc_edge_config_table(),
+    assoc_edge_table("generation_edges"),
+  ]);
+  beforeEach(async () => {
+    context.cache.reset();
+    await DB.getInstance()
+      .getPool()
+      .query(
+        "INSERT INTO assoc_edge_config (edge_type, edge_name, edge_table, symmetric_edge, created_at, updated_at) VALUES ($1, 'generation edge', 'generation_edges', false, now(), now()) ON CONFLICT DO NOTHING",
+        [edgeType],
+      );
+  });
+  const create = () =>
+    new SimpleAction(
+      viewer,
+      schema,
+      new Map<string, any>([
+        ["balance", 100],
+        ["admin", true],
+      ]),
+      WriteOperation.Insert,
+      null,
+    ).saveX();
+
+  test.each([
+    "queryEnts",
+    "queryAllEnts",
+    "queryEdges",
+    "queryAllEdges",
+    "queryIDs",
+    "queryAllIDs",
+    "queryCount",
+    "queryAllCount",
+    "queryRawCount",
+  ] as const)(
+    "retained clause query %s expires after a guarded save",
+    async (method) => {
+      const owner = await create();
+      await expect(
+        withTransaction(async () => {
+          const query = makeQuery(owner.id);
+          const first = await query[method]();
+          expect(await query[method]()).toEqual(first);
+          await edit(await load(owner.id), 80).saveX();
+          await expect(query[method]()).rejects.toThrow(expired);
+        }),
+      ).rejects.toThrow(expired);
+      expect((await load(owner.id)).data.balance).toBe(100);
+    },
+  );
+
+  test("rebuilding the query after each save computes 100 minus 20 minus 30 as 50", async () => {
+    const owner = await create();
+    await withTransaction(async () => {
+      const first = (await makeQuery(owner.id).queryEnts())[0];
+      await edit(first, first.data.balance - 20).saveX();
+      const second = (await makeQuery(owner.id).queryEnts())[0];
+      expect(second.data.balance).toBe(80);
+      await edit(second, second.data.balance - 30).saveX();
+    });
+    expect((await load(owner.id)).data.balance).toBe(50);
+  });
+
+  test.each([
+    "queryEnts",
+    "queryAllEnts",
+    "queryCount",
+    "queryRawCount",
+    "queryAllRawCount",
+  ] as const)(
+    "custom edge query %s follows the same generation boundary",
+    async (method) => {
+      const owner = await create();
+      await expect(
+        withTransaction(async () => {
+          const query = new AccountQuery(viewer, {
+            src: owner.id,
+            loadEntOptions: options,
+            groupCol: "id",
+            name: "generation-custom-edge",
+          });
+          await query[method]();
+          await edit(await load(owner.id), 80).saveX();
+          await query[method]();
+        }),
+      ).rejects.toThrow(expired);
+      expect((await load(owner.id)).data.balance).toBe(100);
+    },
+  );
+
+  test.each([
+    "queryEnts",
+    "queryAllEnts",
+    "queryRawCount",
+    "queryAllRawCount",
+    "queryID2",
+    "queryAllID2",
+  ] as const)(
+    "association query %s follows the same generation boundary",
+    async (method) => {
+      const owner = await create();
+      await expect(
+        withTransaction(async () => {
+          const query = new AccountEdges(
+            viewer,
+            owner.id,
+            countFactory,
+            edgeFactory,
+            options,
+          );
+          await query[method](owner.id);
+          await edit(await load(owner.id), 80).saveX();
+          await query[method](owner.id);
+        }),
+      ).rejects.toThrow(expired);
+    },
+  );
+
+  describe.each(["raw rows", "Ent materialization"] as const)(
+    "pending query after %s",
+    (phase) => {
+      test.each(
+        phase === "Ent materialization"
+          ? (["queryEnts", "queryAllEnts"] as const)
+          : ([
+              "queryEnts",
+              "queryAllEnts",
+              "queryIDs",
+              "queryAllIDs",
+              "queryCount",
+              "queryAllCount",
+            ] as const),
+      )("%s cannot return an older generation", async (method) => {
+        const owner = await create();
+        const started = deferred();
+        const finish = deferred();
+        class PausedQuery extends CustomClauseQuery<GenerationAccount> {
+          protected async loadRawData(
+            infos: IDInfo[],
+            opts: EdgeQueryableDataOptions,
+          ) {
+            await super.loadRawData(infos, opts);
+            if (phase === "raw rows") {
+              started.resolve();
+              await finish.promise;
+            }
+          }
+          protected async loadEntsFromEdges(id: ID, rows: Data[]) {
+            if (phase === "Ent materialization") {
+              started.resolve();
+              await finish.promise;
+            }
+            return super.loadEntsFromEdges(id, rows);
+          }
+        }
+        await expect(
+          withTransaction(async () => {
+            const query = new PausedQuery(viewer, {
+              loadEntOptions: options,
+              clause: Eq("id", owner.id),
+              name: "paused-generation",
+            });
+            const pending = query[method]();
+            await started.promise;
+            try {
+              await edit(await load(owner.id), 80).saveX();
+            } finally {
+              finish.resolve();
+            }
+            await expect(pending).rejects.toThrow(expired);
+          }),
+        ).rejects.toThrow(expired);
+        expect((await load(owner.id)).data.balance).toBe(100);
+      });
+    },
+  );
+
+  const loaderKinds = [
+    "object id",
+    "object ids",
+    "object clause",
+    "object clauses",
+    "object count",
+    "object counts",
+    "query",
+    "query direct",
+    "raw count",
+    "association",
+    "association direct",
+    "association count",
+  ] as const;
+  const reader = (
+    kind: (typeof loaderKinds)[number],
+    id: ID,
+    cached: boolean,
+  ) => {
+    const ctx = cached ? context : undefined;
+    const object = factory.createLoader(ctx);
+    const count = new ObjectCountLoader(loaderOptions, ctx);
+    const query = new QueryLoaderFactory({ ...loaderOptions, groupCol: "id" });
+    switch (kind) {
+      case "object id":
+        return () => object.load(id);
+      case "object ids":
+        return () => object.loadMany([id]);
+      case "object clause":
+        return () => object.load(Eq("id", id));
+      case "object clauses":
+        return () => object.loadMany([Eq("id", id)]);
+      case "object count":
+        return () => count.load(Eq("id", id));
+      case "object counts":
+        return () => count.loadMany([Eq("id", id)]);
+      case "query": {
+        const l = query.createLoader(ctx);
+        return () => l.load(id);
+      }
+      case "query direct": {
+        const l = query.createConfigurableLoader(
+          { clause: Eq("admin", true) },
+          ctx,
+        );
+        return () => l.load(id);
+      }
+      case "raw count": {
+        const l = new RawCountLoader(
+          { tableName: loaderOptions.tableName, groupCol: "id" },
+          ctx,
+        );
+        return () => l.load(id);
+      }
+      case "association": {
+        const l = edgeFactory.createLoader(ctx);
+        return () => l.load(id);
+      }
+      case "association direct": {
+        const l = edgeFactory.createConfigurableLoader(
+          { clause: Eq("id2", id) },
+          ctx,
+        );
+        return () => l.load(id);
+      }
+      case "association count": {
+        const l = countFactory.createLoader(ctx);
+        return () => l.load(id);
+      }
+    }
+  };
+  describe.each([true, false])("loaders with request context %s", (cached) => {
+    test.each(loaderKinds)(
+      "retained %s loader expires after a guarded save",
+      async (kind) => {
+        const owner = await create();
+        await expect(
+          withTransaction(async () => {
+            const read = reader(kind, owner.id, cached);
+            const first = await read();
+            expect(await read()).toEqual(first);
+            await edit(await load(owner.id), 80).saveX();
+            await read();
+          }),
+        ).rejects.toThrow(expired);
+        expect((await load(owner.id)).data.balance).toBe(100);
+      },
+    );
+  });
+
+  test.each(["load", "loadMany"] as const)(
+    "pending numeric DataLoader %s cannot cross a guarded write",
+    async (method) => {
+      const owner = await create();
+      const started = deferred();
+      const finish = deferred();
+      await expect(
+        withTransaction(async () => {
+          const loader = new InstrumentedDataLoader<ID, number>(
+            "pending-balance",
+            async (ids) => {
+              const rows = await loadRows({
+                ...loaderOptions,
+                clause: Eq("id", owner.id),
+              });
+              started.resolve();
+              await finish.promise;
+              return ids.map(() => rows[0].balance);
+            },
+            {},
+          );
+          const pending =
+            method === "load"
+              ? loader.load(owner.id)
+              : loader.loadMany([owner.id]);
+          await started.promise;
+          try {
+            await edit(await load(owner.id), 80).saveX();
+          } finally {
+            finish.resolve();
+          }
+          await expect(pending).rejects.toThrow(expired);
+        }),
+      ).rejects.toThrow(expired);
+      expect((await load(owner.id)).data.balance).toBe(100);
+    },
+  );
+
+  test.each([true, false])(
+    "raw rows retain their original provenance when loaded inside scope %s",
+    async (scoped) => {
+      const owner = await create();
+      const readRows = () =>
+        loadRows({ ...loaderOptions, clause: Eq("id", owner.id) });
+      const outside = scoped ? undefined : await readRows();
+      await expect(
+        withTransaction(async () => {
+          const rows = outside ?? (await readRows());
+          await edit(await load(owner.id), 80).saveX();
+          const stale = await applyPrivacyPolicyForRow(
+            viewer,
+            options,
+            rows[0],
+          );
+          expect(stale!.data.balance).toBe(100);
+          await edit(stale!, 70).saveX();
+        }),
+      ).rejects.toThrow("reload existingEnt");
+      expect((await load(owner.id)).data.balance).toBe(100);
+    },
+  );
+
+  test.each(["row", "rows", "raw"] as const)(
+    "pending primitive %s reads reject before returning or priming stale data",
+    async (kind) => {
+      const owner = await create();
+      const started = deferred();
+      const finish = deferred();
+      await expect(
+        withTransaction(async () => {
+          const pool = DB.getInstance().getPool();
+          const method = kind === "row" ? "query" : "queryAll";
+          const query = pool[method].bind(pool);
+          let paused = false;
+          const spy = jest
+            .spyOn(pool, method)
+            .mockImplementation(async (sql, values) => {
+              const result = await query(sql, values);
+              if (!paused) {
+                paused = true;
+                started.resolve();
+                await finish.promise;
+              }
+              return result;
+            });
+          try {
+            const opts = {
+              ...loaderOptions,
+              clause: Eq("id", owner.id),
+              context,
+            };
+            const pending =
+              kind === "row"
+                ? loadRow(opts)
+                : kind === "rows"
+                ? loadRows(opts)
+                : performRawQuery(
+                    "SELECT * FROM generation_accounts WHERE id = $1",
+                    [owner.id],
+                  );
+            await started.promise;
+            try {
+              await edit(await load(owner.id), 80).saveX();
+            } finally {
+              finish.resolve();
+            }
+            await expect(pending).rejects.toThrow(expired);
+          } finally {
+            spy.mockRestore();
+          }
+        }),
+      ).rejects.toThrow(expired);
+      expect((await load(owner.id)).data.balance).toBe(100);
+    },
+  );
+
+  test("fresh association readers work after guarded saves retire metadata loaders", async () => {
+    const owner = await create();
+    await withTransaction(async () => {
+      expect(await countFactory.createLoader(context).load(owner.id)).toBe(0);
+      await edit(await load(owner.id), 80).saveX();
+      expect(await countFactory.createLoader(context).load(owner.id)).toBe(0);
+      expect(await edgeFactory.createLoader(context).load(owner.id)).toEqual(
+        [],
+      );
+    });
+  });
+
+  test("outside a scoped transaction query reuse retains its existing snapshot behavior", async () => {
+    const owner = await create();
+    const query = makeQuery(owner.id);
+    expect((await query.queryEnts())[0].data.balance).toBe(100);
+    await new SimpleAction(
+      viewer,
+      schema,
+      new Map([["balance", 80]]),
+      WriteOperation.Edit,
+      owner,
+    ).saveX();
+    expect((await query.queryEnts())[0].data.balance).toBe(100);
+    const fresh = new CustomClauseQuery(new TestContext().getViewer(), {
+      loadEntOptions: options,
+      clause: Eq("id", owner.id),
+      name: "fresh-request",
+    });
+    expect((await fresh.queryEnts())[0].data.balance).toBe(80);
+  });
+
+  test("queued bulk privacy cannot stamp later rows with a newer generation", async () => {
+    const first = await create();
+    const second = await create();
+    const started = deferred();
+    const finish = deferred();
+    const previous = getEntLoaderPrivacyConcurrencyLimit();
+    setEntLoaderPrivacyConcurrencyLimit(1);
+    class PausedAccount extends GenerationAccount {
+      getPrivacyPolicy() {
+        return {
+          rules: [
+            {
+              apply: async (_viewer, ent) => {
+                if (ent.id === first.id) {
+                  started.resolve();
+                  await finish.promise;
+                }
+                return Allow();
+              },
+            },
+          ],
+        };
+      }
+    }
+    try {
+      await expect(
+        withTransaction(async () => {
+          const pending = loadEnts(
+            new TestContext().getViewer(),
+            { ...options, ent: PausedAccount },
+            first.id,
+            second.id,
+          );
+          await started.promise;
+          try {
+            await edit(await load(second.id), 80).saveX();
+          } finally {
+            finish.resolve();
+          }
+          await expect(pending).rejects.toThrow(expired);
+        }),
+      ).rejects.toThrow(expired);
+      expect((await load(second.id)).data.balance).toBe(100);
+    } finally {
+      setEntLoaderPrivacyConcurrencyLimit(previous);
+    }
+  });
+});

--- a/ts/src/core/transaction_generation.test.ts
+++ b/ts/src/core/transaction_generation.test.ts
@@ -1,5 +1,6 @@
 import DB, { Dialect } from "./db";
 import { withTransaction } from "./transaction";
+import { getTransactionState } from "./transaction_context";
 import { Allow, Data, EdgeQueryableDataOptions, ID } from "./base";
 import { Eq } from "./clause";
 import {
@@ -146,22 +147,19 @@ describe("transaction read generations", () => {
     "queryCount",
     "queryAllCount",
     "queryRawCount",
-  ] as const)(
-    "retained clause query %s expires after a guarded save",
-    async (method) => {
-      const owner = await create();
-      await expect(
-        withTransaction(async () => {
-          const query = makeQuery(owner.id);
-          const first = await query[method]();
-          expect(await query[method]()).toEqual(first);
-          await edit(await load(owner.id), 80).saveX();
-          await expect(query[method]()).rejects.toThrow(expired);
-        }),
-      ).rejects.toThrow(expired);
-      expect((await load(owner.id)).data.balance).toBe(100);
-    },
-  );
+  ] as const)("retained clause query %s expires after a guarded save", async (method) => {
+    const owner = await create();
+    await expect(
+      withTransaction(async () => {
+        const query = makeQuery(owner.id);
+        const first = await query[method]();
+        expect(await query[method]()).toEqual(first);
+        await edit(await load(owner.id), 80).saveX();
+        await expect(query[method]()).rejects.toThrow(expired);
+      }),
+    ).rejects.toThrow(expired);
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
 
   test("rebuilding the query after each save computes 100 minus 20 minus 30 as 50", async () => {
     const owner = await create();
@@ -181,26 +179,23 @@ describe("transaction read generations", () => {
     "queryCount",
     "queryRawCount",
     "queryAllRawCount",
-  ] as const)(
-    "custom edge query %s follows the same generation boundary",
-    async (method) => {
-      const owner = await create();
-      await expect(
-        withTransaction(async () => {
-          const query = new AccountQuery(viewer, {
-            src: owner.id,
-            loadEntOptions: options,
-            groupCol: "id",
-            name: "generation-custom-edge",
-          });
-          await query[method]();
-          await edit(await load(owner.id), 80).saveX();
-          await query[method]();
-        }),
-      ).rejects.toThrow(expired);
-      expect((await load(owner.id)).data.balance).toBe(100);
-    },
-  );
+  ] as const)("custom edge query %s follows the same generation boundary", async (method) => {
+    const owner = await create();
+    await expect(
+      withTransaction(async () => {
+        const query = new AccountQuery(viewer, {
+          src: owner.id,
+          loadEntOptions: options,
+          groupCol: "id",
+          name: "generation-custom-edge",
+        });
+        await query[method]();
+        await edit(await load(owner.id), 80).saveX();
+        await query[method]();
+      }),
+    ).rejects.toThrow(expired);
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
 
   test.each([
     "queryEnts",
@@ -209,85 +204,82 @@ describe("transaction read generations", () => {
     "queryAllRawCount",
     "queryID2",
     "queryAllID2",
-  ] as const)(
-    "association query %s follows the same generation boundary",
-    async (method) => {
-      const owner = await create();
-      await expect(
-        withTransaction(async () => {
-          const query = new AccountEdges(
-            viewer,
-            owner.id,
-            countFactory,
-            edgeFactory,
-            options,
-          );
-          await query[method](owner.id);
-          await edit(await load(owner.id), 80).saveX();
-          await query[method](owner.id);
-        }),
-      ).rejects.toThrow(expired);
-    },
-  );
+  ] as const)("association query %s follows the same generation boundary", async (method) => {
+    const owner = await create();
+    await expect(
+      withTransaction(async () => {
+        const query = new AccountEdges(
+          viewer,
+          owner.id,
+          countFactory,
+          edgeFactory,
+          options,
+        );
+        await query[method](owner.id);
+        await edit(await load(owner.id), 80).saveX();
+        await query[method](owner.id);
+      }),
+    ).rejects.toThrow(expired);
+  });
 
-  describe.each(["raw rows", "Ent materialization"] as const)(
-    "pending query after %s",
-    (phase) => {
-      test.each(
-        phase === "Ent materialization"
-          ? (["queryEnts", "queryAllEnts"] as const)
-          : ([
-              "queryEnts",
-              "queryAllEnts",
-              "queryIDs",
-              "queryAllIDs",
-              "queryCount",
-              "queryAllCount",
-            ] as const),
-      )("%s cannot return an older generation", async (method) => {
-        const owner = await create();
-        const started = deferred();
-        const finish = deferred();
-        class PausedQuery extends CustomClauseQuery<GenerationAccount> {
-          protected async loadRawData(
-            infos: IDInfo[],
-            opts: EdgeQueryableDataOptions,
-          ) {
-            await super.loadRawData(infos, opts);
-            if (phase === "raw rows") {
-              started.resolve();
-              await finish.promise;
-            }
-          }
-          protected async loadEntsFromEdges(id: ID, rows: Data[]) {
-            if (phase === "Ent materialization") {
-              started.resolve();
-              await finish.promise;
-            }
-            return super.loadEntsFromEdges(id, rows);
+  describe.each([
+    "raw rows",
+    "Ent materialization",
+  ] as const)("pending query after %s", (phase) => {
+    test.each(
+      phase === "Ent materialization"
+        ? (["queryEnts", "queryAllEnts"] as const)
+        : ([
+            "queryEnts",
+            "queryAllEnts",
+            "queryIDs",
+            "queryAllIDs",
+            "queryCount",
+            "queryAllCount",
+          ] as const),
+    )("%s cannot return an older generation", async (method) => {
+      const owner = await create();
+      const started = deferred();
+      const finish = deferred();
+      class PausedQuery extends CustomClauseQuery<GenerationAccount> {
+        protected async loadRawData(
+          infos: IDInfo[],
+          opts: EdgeQueryableDataOptions,
+        ) {
+          await super.loadRawData(infos, opts);
+          if (phase === "raw rows") {
+            started.resolve();
+            await finish.promise;
           }
         }
-        await expect(
-          withTransaction(async () => {
-            const query = new PausedQuery(viewer, {
-              loadEntOptions: options,
-              clause: Eq("id", owner.id),
-              name: "paused-generation",
-            });
-            const pending = query[method]();
-            await started.promise;
-            try {
-              await edit(await load(owner.id), 80).saveX();
-            } finally {
-              finish.resolve();
-            }
-            await expect(pending).rejects.toThrow(expired);
-          }),
-        ).rejects.toThrow(expired);
-        expect((await load(owner.id)).data.balance).toBe(100);
-      });
-    },
-  );
+        protected async loadEntsFromEdges(id: ID, rows: Data[]) {
+          if (phase === "Ent materialization") {
+            started.resolve();
+            await finish.promise;
+          }
+          return super.loadEntsFromEdges(id, rows);
+        }
+      }
+      await expect(
+        withTransaction(async () => {
+          const query = new PausedQuery(viewer, {
+            loadEntOptions: options,
+            clause: Eq("id", owner.id),
+            name: "paused-generation",
+          });
+          const pending = query[method]();
+          await started.promise;
+          try {
+            await edit(await load(owner.id), 80).saveX();
+          } finally {
+            finish.resolve();
+          }
+          await expect(pending).rejects.toThrow(expired);
+        }),
+      ).rejects.toThrow(expired);
+      expect((await load(owner.id)).data.balance).toBe(100);
+    });
+  });
 
   const loaderKinds = [
     "object id",
@@ -361,49 +353,124 @@ describe("transaction read generations", () => {
     }
   };
   describe.each([true, false])("loaders with request context %s", (cached) => {
-    test.each(loaderKinds)(
-      "retained %s loader expires after a guarded save",
-      async (kind) => {
-        const owner = await create();
-        await expect(
-          withTransaction(async () => {
-            const read = reader(kind, owner.id, cached);
-            const first = await read();
-            expect(await read()).toEqual(first);
-            await edit(await load(owner.id), 80).saveX();
-            await read();
-          }),
-        ).rejects.toThrow(expired);
-        expect((await load(owner.id)).data.balance).toBe(100);
-      },
-    );
-  });
-
-  test.each(["load", "loadMany"] as const)(
-    "pending numeric DataLoader %s cannot cross a guarded write",
-    async (method) => {
+    test.each(
+      loaderKinds,
+    )("retained %s loader expires after a guarded save", async (kind) => {
       const owner = await create();
-      const started = deferred();
-      const finish = deferred();
       await expect(
         withTransaction(async () => {
-          const loader = new InstrumentedDataLoader<ID, number>(
-            "pending-balance",
-            async (ids) => {
-              const rows = await loadRows({
-                ...loaderOptions,
-                clause: Eq("id", owner.id),
-              });
+          const read = reader(kind, owner.id, cached);
+          const first = await read();
+          expect(await read()).toEqual(first);
+          await edit(await load(owner.id), 80).saveX();
+          await read();
+        }),
+      ).rejects.toThrow(expired);
+      expect((await load(owner.id)).data.balance).toBe(100);
+    });
+  });
+
+  test.each([
+    "load",
+    "loadMany",
+  ] as const)("pending numeric DataLoader %s cannot cross a guarded write", async (method) => {
+    const owner = await create();
+    const started = deferred();
+    const finish = deferred();
+    await expect(
+      withTransaction(async () => {
+        const loader = new InstrumentedDataLoader<ID, number>(
+          "pending-balance",
+          async (ids) => {
+            const rows = await loadRows({
+              ...loaderOptions,
+              clause: Eq("id", owner.id),
+            });
+            started.resolve();
+            await finish.promise;
+            return ids.map(() => rows[0].balance);
+          },
+          {},
+        );
+        const pending =
+          method === "load"
+            ? loader.load(owner.id)
+            : loader.loadMany([owner.id]);
+        await started.promise;
+        try {
+          await edit(await load(owner.id), 80).saveX();
+        } finally {
+          finish.resolve();
+        }
+        await expect(pending).rejects.toThrow(expired);
+      }),
+    ).rejects.toThrow(expired);
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
+
+  test.each([
+    true,
+    false,
+  ])("raw rows retain their original provenance when loaded inside scope %s", async (scoped) => {
+    const owner = await create();
+    const readRows = () =>
+      loadRows({ ...loaderOptions, clause: Eq("id", owner.id) });
+    const outside = scoped ? undefined : await readRows();
+    await expect(
+      withTransaction(async () => {
+        const rows = outside ?? (await readRows());
+        await edit(await load(owner.id), 80).saveX();
+        const stale = await applyPrivacyPolicyForRow(viewer, options, rows[0]);
+        expect(stale!.data.balance).toBe(100);
+        await edit(stale!, 70).saveX();
+      }),
+    ).rejects.toThrow("reload existingEnt");
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
+
+  test.each([
+    "row",
+    "rows",
+    "raw",
+  ] as const)("pending primitive %s reads reject before returning or priming stale data", async (kind) => {
+    const owner = await create();
+    const started = deferred();
+    const finish = deferred();
+    await expect(
+      withTransaction(async () => {
+        const pool =
+          kind === "raw"
+            ? DB.getInstance().getPool()
+            : getTransactionState()!.readQueryer;
+        const method = kind === "row" ? "query" : "queryAll";
+        const query = pool[method].bind(pool);
+        let paused = false;
+        const spy = jest
+          .spyOn(pool, method)
+          .mockImplementation(async (sql, values) => {
+            const result = await query(sql, values);
+            if (!paused) {
+              paused = true;
               started.resolve();
               await finish.promise;
-              return ids.map(() => rows[0].balance);
-            },
-            {},
-          );
+            }
+            return result;
+          });
+        try {
+          const opts = {
+            ...loaderOptions,
+            clause: Eq("id", owner.id),
+            context,
+          };
           const pending =
-            method === "load"
-              ? loader.load(owner.id)
-              : loader.loadMany([owner.id]);
+            kind === "row"
+              ? loadRow(opts)
+              : kind === "rows"
+                ? loadRows(opts)
+                : performRawQuery(
+                    "SELECT * FROM generation_accounts WHERE id = $1",
+                    [owner.id],
+                  );
           await started.promise;
           try {
             await edit(await load(owner.id), 80).saveX();
@@ -411,89 +478,13 @@ describe("transaction read generations", () => {
             finish.resolve();
           }
           await expect(pending).rejects.toThrow(expired);
-        }),
-      ).rejects.toThrow(expired);
-      expect((await load(owner.id)).data.balance).toBe(100);
-    },
-  );
-
-  test.each([true, false])(
-    "raw rows retain their original provenance when loaded inside scope %s",
-    async (scoped) => {
-      const owner = await create();
-      const readRows = () =>
-        loadRows({ ...loaderOptions, clause: Eq("id", owner.id) });
-      const outside = scoped ? undefined : await readRows();
-      await expect(
-        withTransaction(async () => {
-          const rows = outside ?? (await readRows());
-          await edit(await load(owner.id), 80).saveX();
-          const stale = await applyPrivacyPolicyForRow(
-            viewer,
-            options,
-            rows[0],
-          );
-          expect(stale!.data.balance).toBe(100);
-          await edit(stale!, 70).saveX();
-        }),
-      ).rejects.toThrow("reload existingEnt");
-      expect((await load(owner.id)).data.balance).toBe(100);
-    },
-  );
-
-  test.each(["row", "rows", "raw"] as const)(
-    "pending primitive %s reads reject before returning or priming stale data",
-    async (kind) => {
-      const owner = await create();
-      const started = deferred();
-      const finish = deferred();
-      await expect(
-        withTransaction(async () => {
-          const pool = DB.getInstance().getPool();
-          const method = kind === "row" ? "query" : "queryAll";
-          const query = pool[method].bind(pool);
-          let paused = false;
-          const spy = jest
-            .spyOn(pool, method)
-            .mockImplementation(async (sql, values) => {
-              const result = await query(sql, values);
-              if (!paused) {
-                paused = true;
-                started.resolve();
-                await finish.promise;
-              }
-              return result;
-            });
-          try {
-            const opts = {
-              ...loaderOptions,
-              clause: Eq("id", owner.id),
-              context,
-            };
-            const pending =
-              kind === "row"
-                ? loadRow(opts)
-                : kind === "rows"
-                ? loadRows(opts)
-                : performRawQuery(
-                    "SELECT * FROM generation_accounts WHERE id = $1",
-                    [owner.id],
-                  );
-            await started.promise;
-            try {
-              await edit(await load(owner.id), 80).saveX();
-            } finally {
-              finish.resolve();
-            }
-            await expect(pending).rejects.toThrow(expired);
-          } finally {
-            spy.mockRestore();
-          }
-        }),
-      ).rejects.toThrow(expired);
-      expect((await load(owner.id)).data.balance).toBe(100);
-    },
-  );
+        } finally {
+          spy.mockRestore();
+        }
+      }),
+    ).rejects.toThrow(expired);
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
 
   test("fresh association readers work after guarded saves retire metadata loaders", async () => {
     const owner = await create();

--- a/ts/src/core/transaction_generation.test.ts
+++ b/ts/src/core/transaction_generation.test.ts
@@ -1,5 +1,5 @@
 import DB, { Dialect } from "./db";
-import { withTransaction } from "./transaction";
+import { withTransactionScope } from "./transaction";
 import { getTransactionState } from "./transaction_context";
 import { Allow, Data, EdgeQueryableDataOptions, ID } from "./base";
 import { Eq } from "./clause";
@@ -67,7 +67,7 @@ const expired = "cannot cross transaction generations";
 const load = (id: ID) => loadEntX(viewer, id, options);
 
 class GuardedEdit extends SimpleAction<GenerationAccount> {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return true;
   }
 }
@@ -147,10 +147,10 @@ describe("transaction read generations", () => {
     "queryCount",
     "queryAllCount",
     "queryRawCount",
-  ] as const)("retained clause query %s expires after a guarded save", async (method) => {
+  ] as const)("retained clause query %s expires after a scoped save", async (method) => {
     const owner = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const query = makeQuery(owner.id);
         const first = await query[method]();
         expect(await query[method]()).toEqual(first);
@@ -163,7 +163,7 @@ describe("transaction read generations", () => {
 
   test("rebuilding the query after each save computes 100 minus 20 minus 30 as 50", async () => {
     const owner = await create();
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const first = (await makeQuery(owner.id).queryEnts())[0];
       await edit(first, first.data.balance - 20).saveX();
       const second = (await makeQuery(owner.id).queryEnts())[0];
@@ -182,7 +182,7 @@ describe("transaction read generations", () => {
   ] as const)("custom edge query %s follows the same generation boundary", async (method) => {
     const owner = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const query = new AccountQuery(viewer, {
           src: owner.id,
           loadEntOptions: options,
@@ -207,7 +207,7 @@ describe("transaction read generations", () => {
   ] as const)("association query %s follows the same generation boundary", async (method) => {
     const owner = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const query = new AccountEdges(
           viewer,
           owner.id,
@@ -261,7 +261,7 @@ describe("transaction read generations", () => {
         }
       }
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           const query = new PausedQuery(viewer, {
             loadEntOptions: options,
             clause: Eq("id", owner.id),
@@ -355,10 +355,10 @@ describe("transaction read generations", () => {
   describe.each([true, false])("loaders with request context %s", (cached) => {
     test.each(
       loaderKinds,
-    )("retained %s loader expires after a guarded save", async (kind) => {
+    )("retained %s loader expires after a scoped save", async (kind) => {
       const owner = await create();
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           const read = reader(kind, owner.id, cached);
           const first = await read();
           expect(await read()).toEqual(first);
@@ -373,12 +373,12 @@ describe("transaction read generations", () => {
   test.each([
     "load",
     "loadMany",
-  ] as const)("pending numeric DataLoader %s cannot cross a guarded write", async (method) => {
+  ] as const)("pending numeric DataLoader %s cannot cross a scoped write", async (method) => {
     const owner = await create();
     const started = deferred();
     const finish = deferred();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const loader = new InstrumentedDataLoader<ID, number>(
           "pending-balance",
           async (ids) => {
@@ -417,7 +417,7 @@ describe("transaction read generations", () => {
       loadRows({ ...loaderOptions, clause: Eq("id", owner.id) });
     const outside = scoped ? undefined : await readRows();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const rows = outside ?? (await readRows());
         await edit(await load(owner.id), 80).saveX();
         const stale = await applyPrivacyPolicyForRow(viewer, options, rows[0]);
@@ -437,7 +437,7 @@ describe("transaction read generations", () => {
     const started = deferred();
     const finish = deferred();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const pool =
           kind === "raw"
             ? DB.getInstance().getPool()
@@ -486,9 +486,9 @@ describe("transaction read generations", () => {
     expect((await load(owner.id)).data.balance).toBe(100);
   });
 
-  test("fresh association readers work after guarded saves retire metadata loaders", async () => {
+  test("fresh association readers work after scoped saves retire metadata loaders", async () => {
     const owner = await create();
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       expect(await countFactory.createLoader(context).load(owner.id)).toBe(0);
       await edit(await load(owner.id), 80).saveX();
       expect(await countFactory.createLoader(context).load(owner.id)).toBe(0);
@@ -544,7 +544,7 @@ describe("transaction read generations", () => {
     }
     try {
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           const pending = loadEnts(
             new TestContext().getViewer(),
             { ...options, ent: PausedAccount },

--- a/ts/src/core/transaction_lifecycle.test.ts
+++ b/ts/src/core/transaction_lifecycle.test.ts
@@ -1,0 +1,183 @@
+import DB, { Client, Dialect } from "./db";
+import { withTransaction, getTransactionScope } from "./transaction";
+import { getTransactionState } from "./transaction_context";
+
+describe("scoped transaction lifecycle", () => {
+  const originalInstance = DB.instance;
+  let clients: Client[];
+  let queries: string[];
+  let behavior: (sql: string) => Promise<any>;
+  beforeEach(() => {
+    clients = [];
+    queries = [];
+    behavior = async () => ({ rows: [], rowCount: 0 });
+    DB.instance = {
+      db: { dialect: Dialect.Postgres },
+      async getNewClient() {
+        const query = jest.fn(async (sql: string) => {
+          queries.push(sql);
+          return behavior(sql);
+        });
+        const client = {
+          query,
+          queryAll: query,
+          exec: query,
+          release: jest.fn(),
+        };
+        clients.push(client);
+        return client;
+      },
+    } as unknown as DB;
+  });
+  afterEach(() => {
+    DB.instance = originalInstance;
+  });
+
+  test("BEGIN failure rolls back and releases without invoking callback", async () => {
+    const error = new Error("begin failed");
+    behavior = async (sql) => {
+      if (sql.startsWith("BEGIN")) throw error;
+    };
+    const callback = jest.fn();
+    await expect(withTransaction(callback)).rejects.toBe(error);
+    expect(callback).not.toHaveBeenCalled();
+    expect(queries).toEqual(["BEGIN ISOLATION LEVEL SERIALIZABLE", "ROLLBACK"]);
+    expect(clients[0].release).toHaveBeenCalledTimes(1);
+  });
+
+  test("rollback failure preserves original error and discards connection", async () => {
+    const error = new Error("callback failed");
+    behavior = async (sql) => {
+      if (sql === "ROLLBACK") throw new Error("rollback failed");
+    };
+    await expect(
+      withTransaction(async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+    expect(clients[0].release).toHaveBeenCalledWith(true);
+  });
+
+  test("unknown COMMIT result is never retried or marked committed", async () => {
+    const error = new Error("connection closed during COMMIT");
+    behavior = async (sql) => {
+      if (sql === "COMMIT") throw error;
+    };
+    const receipt = jest.fn();
+    const observer = jest.fn();
+    const callback = jest.fn(async () => {
+      getTransactionState()!.receipts.push(receipt);
+      getTransactionState()!.observers.push(observer);
+    });
+    await expect(withTransaction(callback, { maxRetries: 3 })).rejects.toBe(
+      error,
+    );
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(receipt).not.toHaveBeenCalled();
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    "40001",
+    "40P01",
+  ])("known PostgreSQL conflict %s reruns with a new scope and bounded attempts", async (code) => {
+    const error = Object.assign(new Error("conflict"), { code });
+    const scopes: unknown[] = [];
+    const callback = jest.fn(async (scope) => {
+      expect(scope.attempt).toBe(scopes.length);
+      scopes.push(getTransactionState());
+      expect(getTransactionScope()?.isolationLevel).toBe("serializable");
+      throw error;
+    });
+    await expect(withTransaction(callback, { maxRetries: 2 })).rejects.toBe(
+      error,
+    );
+    expect(callback).toHaveBeenCalledTimes(3);
+    expect(new Set(scopes).size).toBe(3);
+    expect(
+      clients.every((c) => (c.release as jest.Mock).mock.calls.length === 1),
+    ).toBe(true);
+  });
+
+  test("receipts precede observers; observer/release failures never retry committed work", async () => {
+    const order: string[] = [];
+    const callback = jest.fn(async () => {
+      getTransactionState()!.receipts.push(() => {
+        order.push("receipt");
+      });
+      getTransactionState()!.observers.push(async () => {
+        expect(getTransactionScope()).toBeUndefined();
+        order.push("observer");
+        throw Object.assign(new Error("observer failure"), { code: "40001" });
+      });
+      (clients[0].release as jest.Mock).mockRejectedValue(
+        new Error("release failure"),
+      );
+      return 42;
+    });
+    await expect(withTransaction(callback, { maxRetries: 3 })).resolves.toBe(
+      42,
+    );
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["receipt", "observer"]);
+    expect(queries).toEqual(["BEGIN ISOLATION LEVEL SERIALIZABLE", "COMMIT"]);
+  });
+
+  test("Bun SQL serialization errno and wrapped query errors retain retry information", async () => {
+    let calls = 0;
+    behavior = async (sql) => {
+      if (sql === "SELECT retry" && calls++ === 0) {
+        throw { code: "ERR_POSTGRES_SERVER_ERROR", errno: "40001" };
+      }
+      return { rows: [], rowCount: 0 };
+    };
+    const callback = jest.fn(async (tx) => {
+      await tx.query("SELECT retry").catch(() => {
+        throw new Error("wrapped query");
+      });
+    });
+    await withTransaction(callback, { maxRetries: 1 });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  test("unawaited in-flight queries finish before rollback and release", async () => {
+    let finish!: () => void;
+    const waiting = new Promise<void>((r) => {
+      finish = r;
+    });
+    behavior = async (sql) => {
+      if (sql === "SELECT slow") await waiting;
+      return { rows: [], rowCount: 0 };
+    };
+    const transaction = withTransaction(async (tx) => {
+      void tx.query("SELECT slow");
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(queries).toEqual([
+      "BEGIN ISOLATION LEVEL SERIALIZABLE",
+      "SELECT slow",
+    ]);
+    expect(clients[0].release).not.toHaveBeenCalled();
+    finish();
+    await expect(transaction).rejects.toThrow("await all queries");
+    expect(queries[queries.length - 1]).toBe("ROLLBACK");
+    expect(clients[0].release).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsupported dialects and options reject before acquiring resources", async () => {
+    DB.instance.db.dialect = Dialect.SQLite;
+    await expect(withTransaction(async () => {})).rejects.toThrow(
+      "SQLite is not supported",
+    );
+    DB.instance.db.dialect = Dialect.Postgres;
+    await expect(
+      withTransaction(async () => {}, {
+        isolationLevel: "repeatable read" as any,
+      }),
+    ).rejects.toThrow("unsupported");
+    await expect(
+      withTransaction(async () => {}, { maxRetries: -1 }),
+    ).rejects.toThrow("maxRetries");
+    expect(clients).toHaveLength(0);
+  });
+});

--- a/ts/src/core/transaction_lifecycle.test.ts
+++ b/ts/src/core/transaction_lifecycle.test.ts
@@ -36,7 +36,9 @@ describe("scoped transaction lifecycle", () => {
   test("BEGIN failure rolls back and releases without invoking callback", async () => {
     const error = new Error("begin failed");
     behavior = async (sql) => {
-      if (sql.startsWith("BEGIN")) throw error;
+      if (sql.startsWith("BEGIN")) {
+        throw error;
+      }
     };
     const callback = jest.fn();
     await expect(withTransaction(callback)).rejects.toBe(error);
@@ -48,7 +50,9 @@ describe("scoped transaction lifecycle", () => {
   test("rollback failure preserves original error and discards connection", async () => {
     const error = new Error("callback failed");
     behavior = async (sql) => {
-      if (sql === "ROLLBACK") throw new Error("rollback failed");
+      if (sql === "ROLLBACK") {
+        throw new Error("rollback failed");
+      }
     };
     await expect(
       withTransaction(async () => {
@@ -61,7 +65,9 @@ describe("scoped transaction lifecycle", () => {
   test("unknown COMMIT result is never retried or marked committed", async () => {
     const error = new Error("connection closed during COMMIT");
     behavior = async (sql) => {
-      if (sql === "COMMIT") throw error;
+      if (sql === "COMMIT") {
+        throw error;
+      }
     };
     const receipt = jest.fn();
     const observer = jest.fn();
@@ -146,7 +152,9 @@ describe("scoped transaction lifecycle", () => {
       finish = r;
     });
     behavior = async (sql) => {
-      if (sql === "SELECT slow") await waiting;
+      if (sql === "SELECT slow") {
+        await waiting;
+      }
       return { rows: [], rowCount: 0 };
     };
     const transaction = withTransaction(async (tx) => {

--- a/ts/src/core/transaction_lifecycle.test.ts
+++ b/ts/src/core/transaction_lifecycle.test.ts
@@ -1,5 +1,5 @@
 import DB, { Client, Dialect } from "./db";
-import { withTransaction, getTransactionScope } from "./transaction";
+import { withTransactionScope, getTransactionScope } from "./transaction";
 import { getTransactionState } from "./transaction_context";
 
 describe("scoped transaction lifecycle", () => {
@@ -41,7 +41,7 @@ describe("scoped transaction lifecycle", () => {
       }
     };
     const callback = jest.fn();
-    await expect(withTransaction(callback)).rejects.toBe(error);
+    await expect(withTransactionScope(callback)).rejects.toBe(error);
     expect(callback).not.toHaveBeenCalled();
     expect(queries).toEqual(["BEGIN ISOLATION LEVEL SERIALIZABLE", "ROLLBACK"]);
     expect(clients[0].release).toHaveBeenCalledTimes(1);
@@ -55,7 +55,7 @@ describe("scoped transaction lifecycle", () => {
       }
     };
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         throw error;
       }),
     ).rejects.toBe(error);
@@ -75,7 +75,7 @@ describe("scoped transaction lifecycle", () => {
       getTransactionState()!.receipts.push(receipt);
       getTransactionState()!.observers.push(observer);
     });
-    await expect(withTransaction(callback, { maxRetries: 3 })).rejects.toBe(
+    await expect(withTransactionScope(callback, { maxRetries: 3 })).rejects.toBe(
       error,
     );
     expect(callback).toHaveBeenCalledTimes(1);
@@ -95,7 +95,7 @@ describe("scoped transaction lifecycle", () => {
       expect(getTransactionScope()?.isolationLevel).toBe("serializable");
       throw error;
     });
-    await expect(withTransaction(callback, { maxRetries: 2 })).rejects.toBe(
+    await expect(withTransactionScope(callback, { maxRetries: 2 })).rejects.toBe(
       error,
     );
     expect(callback).toHaveBeenCalledTimes(3);
@@ -121,7 +121,7 @@ describe("scoped transaction lifecycle", () => {
       );
       return 42;
     });
-    await expect(withTransaction(callback, { maxRetries: 3 })).resolves.toBe(
+    await expect(withTransactionScope(callback, { maxRetries: 3 })).resolves.toBe(
       42,
     );
     expect(callback).toHaveBeenCalledTimes(1);
@@ -142,7 +142,7 @@ describe("scoped transaction lifecycle", () => {
         throw new Error("wrapped query");
       });
     });
-    await withTransaction(callback, { maxRetries: 1 });
+    await withTransactionScope(callback, { maxRetries: 1 });
     expect(callback).toHaveBeenCalledTimes(2);
   });
 
@@ -157,7 +157,7 @@ describe("scoped transaction lifecycle", () => {
       }
       return { rows: [], rowCount: 0 };
     };
-    const transaction = withTransaction(async (tx) => {
+    const transaction = withTransactionScope(async (tx) => {
       void tx.query("SELECT slow");
     });
     await new Promise((r) => setImmediate(r));
@@ -174,17 +174,17 @@ describe("scoped transaction lifecycle", () => {
 
   test("unsupported dialects and options reject before acquiring resources", async () => {
     DB.instance.db.dialect = Dialect.SQLite;
-    await expect(withTransaction(async () => {})).rejects.toThrow(
+    await expect(withTransactionScope(async () => {})).rejects.toThrow(
       "SQLite is not supported",
     );
     DB.instance.db.dialect = Dialect.Postgres;
     await expect(
-      withTransaction(async () => {}, {
+      withTransactionScope(async () => {}, {
         isolationLevel: "repeatable read" as any,
       }),
     ).rejects.toThrow("unsupported");
     await expect(
-      withTransaction(async () => {}, { maxRetries: -1 }),
+      withTransactionScope(async () => {}, { maxRetries: -1 }),
     ).rejects.toThrow("maxRetries");
     expect(clients).toHaveLength(0);
   });

--- a/ts/src/core/transaction_ordering.test.ts
+++ b/ts/src/core/transaction_ordering.test.ts
@@ -1,5 +1,5 @@
 import DB, { Dialect } from "./db";
-import { withTransaction } from "./transaction";
+import { withTransactionScope } from "./transaction";
 import { loadRows } from "./ent";
 import { Eq } from "./clause";
 import { WriteOperation } from "../action/action";
@@ -13,27 +13,27 @@ import {
 } from "../testutils/builder";
 import { TestContext } from "../testutils/context/test_context";
 
-class ResourceReservation extends BaseEnt {
-  nodeType = "ResourceReservation";
+class ScopeReservation extends BaseEnt {
+  nodeType = "ScopeReservation";
 }
 const schema = getBuilderSchemaFromFields(
   { amount: IntegerType() },
-  ResourceReservation,
+  ScopeReservation,
 );
 const context = new TestContext();
 const viewer = context.getViewer();
 const options = {
-  tableName: "resource_reservations",
+  tableName: "scope_reservations",
   fields: getDbFields(schema),
   context,
 };
-class Guarded extends SimpleAction<ResourceReservation> {
-  requiresTransaction() {
+class Scoped extends SimpleAction<ScopeReservation> {
+  requiresTransactionScope() {
     return true;
   }
 }
 const create = (amount = 1) =>
-  new Guarded(
+  new Scoped(
     viewer,
     schema,
     new Map([["amount", amount]]),
@@ -48,7 +48,7 @@ function deferred() {
   return { promise, resolve };
 }
 const rows = () =>
-  DB.getInstance().getPool().query("SELECT amount FROM resource_reservations");
+  DB.getInstance().getPool().query("SELECT amount FROM scope_reservations");
 
 setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
 beforeEach(() => context.cache.reset());
@@ -60,50 +60,44 @@ describe.each([
   "valid",
   "validX",
   "validWithErrors",
-] as const)("%s reserves roots before asynchronous resource resolution", (entry) => {
+] as const)("%s reserves roots before asynchronous preparation", (entry) => {
   test.each([
     "delay only",
     "invariant read",
     "nested validation",
-  ])("%s cannot overlap a second guarded root even when caught", async (mode) => {
+  ])("%s cannot overlap a second root even when caught", async (mode) => {
     const started = deferred();
     const release = deferred();
     const hooks: string[] = [];
     let caught: unknown;
     let outer: unknown;
     try {
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const make = (delay: boolean) => {
           let count = 0;
           const action = create();
-          Object.assign(action, {
-            getTransactionResources: async () => {
-              hooks.push(delay ? "slow" : "fast");
-              if (mode !== "delay only") {
-                count = (
-                  await loadRows({ ...options, clause: Eq("amount", 1) })
-                ).length;
-              }
-              if (mode === "nested validation") {
-                const nested = new SimpleAction(
-                  viewer,
-                  schema,
-                  new Map([["amount", 2]]),
-                  WriteOperation.Insert,
-                  null,
-                );
-                await nested.validX();
-              }
-              if (delay) {
-                started.resolve();
-                await release.promise;
-              }
-              return ["single-reservation"];
-            },
-          });
-          action.getValidators = () => [
+          action.getTriggers = () => [
             {
-              validate: async () => {
+              changeset: async () => {
+                hooks.push(delay ? "slow" : "fast");
+                if (mode !== "delay only") {
+                  count = (
+                    await loadRows({ ...options, clause: Eq("amount", 1) })
+                  ).length;
+                }
+                if (mode === "nested validation") {
+                  await new SimpleAction(
+                    viewer,
+                    schema,
+                    new Map([["amount", 2]]),
+                    WriteOperation.Insert,
+                    null,
+                  ).validX();
+                }
+                if (delay) {
+                  started.resolve();
+                  await release.promise;
+                }
                 if (count >= 1) {
                   throw new Error("already reserved");
                 }
@@ -138,27 +132,29 @@ describe.each([
     }
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toMatch(
-      "guarded root actions must be prepared and saved sequentially",
+      "root actions must be prepared and saved sequentially",
     );
     expect(outer).toBe(caught);
     expect(hooks).toEqual(["slow"]);
     expect((await rows()).rows).toEqual([]);
   });
 
-  test("a caught delayed resource failure aborts earlier writes", async () => {
+  test("a caught delayed preparation failure aborts earlier writes", async () => {
     const started = deferred();
     const release = deferred();
-    const failure = new Error("resource resolution failed");
-    const transaction = withTransaction(async () => {
+    const failure = new Error("preparation failed");
+    const transaction = withTransactionScope(async () => {
       await create().saveX();
       const action = create();
-      Object.assign(action, {
-        getTransactionResources: async () => {
-          started.resolve();
-          await release.promise;
-          throw failure;
+      action.getTriggers = () => [
+        {
+          changeset: async () => {
+            started.resolve();
+            await release.promise;
+            throw failure;
+          },
         },
-      });
+      ];
       await expect(
         entry === "builder.saveX" ? action.builder.saveX() : action[entry](),
       ).rejects.toBe(failure);
@@ -179,40 +175,30 @@ describe.each([
   });
 });
 
-test.each([
-  false,
-  true,
-])("parallel child resource hooks preserve overlap checks (shared keys: %s)", async (shared) => {
+test("child preparation can run in parallel under one root", async () => {
   const bothStarted = deferred();
   let arrivals = 0;
-  const transaction = withTransaction(async () => {
-    const parent = Object.assign(create(1), {
-      getTransactionResources: () => ["parent"],
-    });
-    const children = [2, 3].map((amount) =>
-      Object.assign(create(amount), {
-        getTransactionResources: async () => {
-          if (++arrivals === 2) {
-            bothStarted.resolve();
-          }
-          await bothStarted.promise;
-          return [shared ? "child" : `child:${amount}`];
+  await withTransactionScope(async () => {
+    const parent = create(1);
+    const children = [2, 3].map((amount) => {
+      const child = create(amount);
+      child.getTriggers = () => [
+        {
+          changeset: async () => {
+            if (++arrivals === 2) {
+              bothStarted.resolve();
+            }
+            await bothStarted.promise;
+          },
         },
-      }),
-    );
+      ];
+      return child;
+    });
     parent.getTriggers = () =>
       children.map((child) => ({ changeset: () => child.changeset() }));
     await parent.saveX();
   });
-  if (shared) {
-    await expect(transaction).rejects.toThrow(
-      "overlapping guarded action preparation branches",
-    );
-    expect((await rows()).rows).toEqual([]);
-  } else {
-    await transaction;
-    expect((await rows()).rows.map((row) => row.amount).sort()).toEqual([
-      1, 2, 3,
-    ]);
-  }
+  expect((await rows()).rows.map((row) => row.amount).sort()).toEqual([
+    1, 2, 3,
+  ]);
 });

--- a/ts/src/core/transaction_preparation.test.ts
+++ b/ts/src/core/transaction_preparation.test.ts
@@ -1,0 +1,184 @@
+import DB, { Dialect } from "./db";
+import { withTransaction } from "./transaction";
+import { loadRows } from "./ent";
+import { Eq } from "./clause";
+import { WriteOperation } from "../action/action";
+import { BooleanType, IntegerType, SQLStatementOperation } from "../schema";
+import { setupPostgres, getSchemaTable } from "../testutils/db/temp_db";
+import {
+  BaseEnt,
+  getBuilderSchemaFromFields,
+  SimpleAction,
+  getDbFields,
+} from "../testutils/builder";
+import { TestContext } from "../testutils/context/test_context";
+
+class PreparedAccount extends BaseEnt {
+  nodeType = "PreparedAccount";
+}
+const accountSchema = getBuilderSchemaFromFields(
+  { balance: IntegerType(), admin: BooleanType() },
+  PreparedAccount,
+);
+const options = {
+  tableName: "prepared_accounts",
+  fields: getDbFields(accountSchema),
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+class GuardedInsert extends SimpleAction<PreparedAccount> {
+  requiresTransaction() {
+    return true;
+  }
+}
+const sources = ["default", "action transform"] as const;
+function make(
+  source: (typeof sources)[number],
+  derive: () => number | Promise<number>,
+) {
+  const transformWrite = async () => ({
+    op: SQLStatementOperation.Insert,
+    data: { balance: await derive() },
+  });
+  const schema = getBuilderSchemaFromFields(
+    {
+      balance: IntegerType(
+        source === "default" ? { defaultValueOnCreate: derive } : {},
+      ),
+      admin: BooleanType(),
+    },
+    PreparedAccount,
+  );
+  const action = new GuardedInsert(
+    viewer,
+    schema,
+    new Map<string, any>(
+      source === "default"
+        ? [["admin", true]]
+        : [
+            ["admin", true],
+            ["balance", 0],
+          ],
+    ),
+    WriteOperation.Insert,
+    null,
+  );
+  if (source === "action transform") Object.assign(action, { transformWrite });
+  return action;
+}
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("transaction field preparation generations", () => {
+  setupPostgres(() => [getSchemaTable(accountSchema, Dialect.Postgres)]);
+  beforeEach(() => context.cache.reset());
+  const rows = () =>
+    DB.getInstance()
+      .getPool()
+      .query("SELECT balance FROM prepared_accounts ORDER BY balance");
+  test.each(
+    sources.flatMap((source) =>
+      ["valid", "validX", "validWithErrors", "getter", "privacy getter"].map(
+        (entry) => [source, entry] as const,
+      ),
+    ),
+  )(
+    "stale %s prepared by %s rejects and rolls back even when caught",
+    async (source, entry) => {
+      const next = async () =>
+        (await loadRows({ ...options, clause: Eq("admin", true), context }))
+          .length + 1;
+      await expect(
+        withTransaction(async () => {
+          const retained = make(source, next);
+          if (entry === "validX") await retained.validX();
+          else if (entry === "valid") expect(await retained.valid()).toBe(true);
+          else if (entry === "validWithErrors")
+            expect(await retained.validWithErrors()).toEqual([]);
+          else if (entry === "privacy getter")
+            await retained.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
+          else await retained.builder.orchestrator.getEditedData();
+          await make(source, next).saveX();
+          await expect(retained.saveX()).rejects.toThrow(
+            "cannot cross transaction generations",
+          );
+        }),
+      ).rejects.toThrow("cannot cross transaction generations");
+      expect((await rows()).rows).toEqual([]);
+    },
+  );
+  test.each(sources)(
+    "same-generation %s preserves stable ID and one preparation",
+    async (source) => {
+      let calls = 0;
+      const action = await withTransaction(async () => {
+        const action = make(source, () => {
+          calls++;
+          return 42;
+        });
+        const before = await action.builder.orchestrator.getEditedData();
+        await action.validX();
+        await action.validX();
+        action.viewerForEntLoad = async () => {
+          expect((await action.builder.orchestrator.getEditedData()).id).toBe(
+            before.id,
+          );
+          return viewer;
+        };
+        const ent = await action.saveX();
+        expect((await action.builder.orchestrator.getEditedData()).id).toBe(
+          before.id,
+        );
+        expect(ent.id).toBe(before.id);
+        expect(ent.data.balance).toBe(42);
+        expect(calls).toBe(1);
+        return { action, id: ent.id };
+      });
+      expect(
+        (await action.action.builder.orchestrator.getEditedData()).id,
+      ).toBe(action.id);
+      expect(calls).toBe(1);
+    },
+  );
+  test.each(sources)(
+    "pending %s preparation cannot finish after another guarded save",
+    async (source) => {
+      const started = deferred();
+      const release = deferred();
+      await expect(
+        withTransaction(async () => {
+          const action = make(source, async () => {
+            const n =
+              (
+                await loadRows({
+                  ...options,
+                  clause: Eq("admin", true),
+                  context,
+                })
+              ).length + 1;
+            started.resolve();
+            await release.promise;
+            return n;
+          });
+          const pending = action.builder.orchestrator.getEditedData();
+          const checked = expect(pending).rejects.toThrow(
+            "cannot cross transaction generations",
+          );
+          await started.promise;
+          try {
+            await make(source, () => 1).saveX();
+          } finally {
+            release.resolve();
+          }
+          await checked;
+        }),
+      ).rejects.toThrow("cannot cross transaction generations");
+      expect((await rows()).rows).toEqual([]);
+    },
+  );
+});

--- a/ts/src/core/transaction_preparation.test.ts
+++ b/ts/src/core/transaction_preparation.test.ts
@@ -1,5 +1,5 @@
 import DB, { Dialect } from "./db";
-import { withTransaction } from "./transaction";
+import { withTransactionScope } from "./transaction";
 import { loadRows } from "./ent";
 import { Eq } from "./clause";
 import { WriteOperation } from "../action/action";
@@ -27,7 +27,7 @@ const options = {
 const context = new TestContext();
 const viewer = context.getViewer();
 class GuardedInsert extends SimpleAction<PreparedAccount> {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return true;
   }
 }
@@ -96,7 +96,7 @@ describe("transaction field preparation generations", () => {
         (await loadRows({ ...options, clause: Eq("admin", true), context }))
           .length + 1;
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           const retained = make(source, next);
           if (entry === "validX") {
             await retained.validX();
@@ -123,7 +123,7 @@ describe("transaction field preparation generations", () => {
     "same-generation %s preserves stable ID and one preparation",
     async (source) => {
       let calls = 0;
-      const action = await withTransaction(async () => {
+      const action = await withTransactionScope(async () => {
         const action = make(source, () => {
           calls++;
           return 42;
@@ -153,12 +153,12 @@ describe("transaction field preparation generations", () => {
     },
   );
   test.each(sources)(
-    "pending %s preparation cannot finish after another guarded save",
+    "pending %s preparation cannot finish after another scoped save",
     async (source) => {
       const started = deferred();
       const release = deferred();
       await expect(
-        withTransaction(async () => {
+        withTransactionScope(async () => {
           const action = make(source, async () => {
             const n =
               (

--- a/ts/src/core/transaction_preparation.test.ts
+++ b/ts/src/core/transaction_preparation.test.ts
@@ -63,7 +63,9 @@ function make(
     WriteOperation.Insert,
     null,
   );
-  if (source === "action transform") Object.assign(action, { transformWrite });
+  if (source === "action transform") {
+    Object.assign(action, { transformWrite });
+  }
   return action;
 }
 function deferred() {
@@ -96,13 +98,18 @@ describe("transaction field preparation generations", () => {
       await expect(
         withTransaction(async () => {
           const retained = make(source, next);
-          if (entry === "validX") await retained.validX();
-          else if (entry === "valid") expect(await retained.valid()).toBe(true);
-          else if (entry === "validWithErrors")
+          if (entry === "validX") {
+            await retained.validX();
+          } else if (entry === "valid") {
+            expect(await retained.valid()).toBe(true);
+          }
+          else if (entry === "validWithErrors") {
             expect(await retained.validWithErrors()).toEqual([]);
-          else if (entry === "privacy getter")
+          } else if (entry === "privacy getter") {
             await retained.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
-          else await retained.builder.orchestrator.getEditedData();
+          } else {
+            await retained.builder.orchestrator.getEditedData();
+          }
           await make(source, next).saveX();
           await expect(retained.saveX()).rejects.toThrow(
             "cannot cross transaction generations",

--- a/ts/src/core/transaction_provenance.test.ts
+++ b/ts/src/core/transaction_provenance.test.ts
@@ -1,0 +1,353 @@
+import DB, { Dialect } from "./db";
+import { withTransaction } from "./transaction";
+import { Allow, Deny } from "./base";
+import { applyPrivacyPolicyForRow, loadEntX } from "./ent";
+import { ObjectLoaderFactory } from "./loaders";
+import { CustomEdgeQueryBase } from "./query/custom_query";
+import { IntegerType } from "../schema";
+import {
+  BaseEnt,
+  SimpleAction,
+  getBuilderSchemaFromFields,
+  getDbFields,
+} from "../testutils/builder";
+import { setupPostgres, getSchemaTable } from "../testutils/db/temp_db";
+import { TestContext } from "../testutils/context/test_context";
+import { WriteOperation } from "../action/action";
+class ConsumerAccount extends BaseEnt {
+  nodeType = "ConsumerAccount";
+}
+const schema = getBuilderSchemaFromFields(
+  { balance: IntegerType() },
+  ConsumerAccount,
+);
+const loader = {
+  tableName: "consumer_accounts",
+  fields: getDbFields(schema),
+  key: "id",
+};
+const options = {
+  ...loader,
+  ent: ConsumerAccount,
+  loaderFactory: new ObjectLoaderFactory(loader),
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+class GuardedEdit extends SimpleAction<ConsumerAccount> {
+  requiresTransaction() {
+    return true;
+  }
+}
+const create = () =>
+  new SimpleAction(
+    viewer,
+    schema,
+    new Map([["balance", 100]]),
+    WriteOperation.Insert,
+    null,
+  ).saveX();
+const load = (id: any) => loadEntX(viewer, id, options);
+const edit = (ent: ConsumerAccount, balance: number) =>
+  new GuardedEdit(
+    viewer,
+    schema,
+    new Map([["balance", balance]]),
+    WriteOperation.Edit,
+    ent,
+  );
+class AccountQuery extends CustomEdgeQueryBase<
+  ConsumerAccount,
+  ConsumerAccount
+> {
+  async sourceEnt(id: any) {
+    return load(id);
+  }
+  getPrivacyPolicy() {
+    return {
+      rules: [
+        {
+          async apply(_viewer: any, ent: any) {
+            return ent.data.balance === 100 ? Allow() : Deny();
+          },
+        },
+      ],
+    };
+  }
+}
+
+function accountQuery(src: any) {
+  return new AccountQuery(viewer, {
+    src,
+    loadEntOptions: options,
+    groupCol: "id",
+    name: "consumer-source",
+  });
+}
+describe("safe consumer provenance outcomes", () => {
+  setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
+  beforeEach(() => context.cache.reset());
+  describe.each([
+    "SELECT * FROM consumer_accounts WHERE id = $1",
+    "UPDATE consumer_accounts SET balance = balance WHERE id = $1 RETURNING *",
+  ])("%s", (sql) => {
+    test.each(["query", "queryAll", "exec"] as const)(
+      "%s stale rows cannot feed later guarded writes",
+      async (method) => {
+        const owner = await create();
+        let caught: unknown;
+        let outer: unknown;
+        try {
+          await withTransaction(async (tx) => {
+            const oldRow = (await tx[method](sql, [owner.id])).rows[0];
+            await edit(await load(owner.id), 80).saveX();
+            try {
+              const stale = await applyPrivacyPolicyForRow(
+                viewer,
+                options,
+                oldRow,
+              );
+              await edit(stale!, stale!.data.balance - 30).saveX();
+            } catch (error) {
+              caught = error;
+            }
+          });
+        } catch (error) {
+          outer = error;
+        }
+        expect(caught).toBeInstanceOf(Error);
+        expect(outer).toBe(caught);
+        expect((await load(owner.id)).data.balance).toBe(100);
+      },
+    );
+  });
+  test.each(["query", "queryAll", "exec"] as const)(
+    "%s fresh rows materialize and support sequential guarded saves",
+    async (method) => {
+      const owner = await create();
+      await withTransaction(async (tx) => {
+        const firstRow = (
+          await tx[method]("SELECT * FROM consumer_accounts WHERE id = $1", [
+            owner.id,
+          ])
+        ).rows[0];
+        const first = await applyPrivacyPolicyForRow(viewer, options, firstRow);
+        await edit(first!, first!.data.balance - 20).saveX();
+        const freshRow = (
+          await tx[method]("SELECT * FROM consumer_accounts WHERE id = $1", [
+            owner.id,
+          ])
+        ).rows[0];
+        const fresh = await applyPrivacyPolicyForRow(viewer, options, freshRow);
+        await edit(fresh!, fresh!.data.balance - 30).saveX();
+      });
+      expect((await load(owner.id)).data.balance).toBe(50);
+    },
+  );
+  test.each(["supplied", "sourceEnt fallback"] as const)(
+    "%s stale query source rejects and poisons the scope when caught",
+    async (mode) => {
+      const owner = await create();
+      let caught: unknown;
+      let outer: unknown;
+      try {
+        await withTransaction(async () => {
+          const stale = await load(owner.id);
+          await edit(stale, 80).saveX();
+          try {
+            const query = accountQuery(mode === "supplied" ? stale : owner.id);
+            if (mode === "sourceEnt fallback")
+              query.sourceEnt = async () => stale;
+            await query.queryRawCount();
+          } catch (error) {
+            caught = error;
+          }
+        });
+      } catch (error) {
+        outer = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(outer).toBe(caught);
+      expect((await load(owner.id)).data.balance).toBe(100);
+    },
+  );
+  test("fresh Ent and ID query sources keep correct privacy behavior after a guarded save", async () => {
+    const owner = await create();
+    await withTransaction(async () => {
+      const first = await load(owner.id);
+      expect(await accountQuery(first).queryRawCount()).toBe(1);
+      await edit(first, 80).saveX();
+      expect(await accountQuery(await load(owner.id)).queryRawCount()).toBe(0);
+      expect(await accountQuery(owner.id).queryRawCount()).toBe(0);
+    });
+    expect((await load(owner.id)).data.balance).toBe(80);
+  });
+  test("immediate action result can use itself as an edge-query privacy source", async () => {
+    const owner = await create();
+    const originalPrivacy = ConsumerAccount.prototype.getPrivacyPolicy;
+    try {
+      await withTransaction(async () => {
+        const existing = await load(owner.id);
+        ConsumerAccount.prototype.getPrivacyPolicy = function () {
+          return {
+            rules: [
+              {
+                async apply(_v: any, ent: any) {
+                  await accountQuery(ent).queryRawCount();
+                  return Allow();
+                },
+              },
+            ],
+          };
+        };
+        const result = await edit(existing, 80).saveX();
+        expect(result.data.balance).toBe(80);
+      });
+    } finally {
+      ConsumerAccount.prototype.getPrivacyPolicy = originalPrivacy;
+    }
+    expect((await load(owner.id)).data.balance).toBe(80);
+  });
+  test.each(["action privacy", "field privacy", "unsafe getter"])(
+    "proposed insert Ent supports %s inside its preparation generation",
+    async (kind) => {
+      let calls = 0;
+      const policy = {
+        rules: [
+          {
+            async apply(_viewer: any, ent: any) {
+              calls++;
+              expect(ent).toBeInstanceOf(ConsumerAccount);
+              expect(await accountQuery(ent).queryRawCount()).toBe(0);
+              return Allow();
+            },
+          },
+        ],
+      };
+      const insertSchema = getBuilderSchemaFromFields(
+        {
+          balance: IntegerType(
+            kind === "field privacy" ? { editPrivacyPolicy: policy } : {},
+          ),
+        },
+        ConsumerAccount,
+      );
+      await withTransaction(async () => {
+        const action = new GuardedEdit(
+          viewer,
+          insertSchema,
+          new Map([["balance", 100]]),
+          WriteOperation.Insert,
+          null,
+        );
+        if (kind === "action privacy") action.getPrivacyPolicy = () => policy;
+        if (kind === "unsafe getter") {
+          const proposed =
+            await action.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
+          expect(await accountQuery(proposed).queryRawCount()).toBe(0);
+        }
+        const result = await action.saveX();
+        expect(result.data.balance).toBe(100);
+      });
+      if (kind !== "unsafe getter") expect(calls).toBe(1);
+    },
+  );
+  test("retained proposed Ent cannot authorize a query after another guarded save", async () => {
+    const owner = await create();
+    await expect(
+      withTransaction(async () => {
+        const action = new GuardedEdit(
+          viewer,
+          schema,
+          new Map([["balance", 100]]),
+          WriteOperation.Insert,
+          null,
+        );
+        const proposed =
+          await action.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
+        await edit(await load(owner.id), 80).saveX();
+        await expect(accountQuery(proposed).queryRawCount()).rejects.toThrow(
+          "reload existingEnt",
+        );
+      }),
+    ).rejects.toThrow("reload existingEnt");
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
+  test.each(["query", "queryAll", "exec"] as const)(
+    "%s retained rows cannot cross scopes",
+    async (method) => {
+      const owner = await create();
+      const row = await withTransaction(
+        async (tx) =>
+          (
+            await tx[method]("SELECT * FROM consumer_accounts WHERE id=$1", [
+              owner.id,
+            ])
+          ).rows[0],
+      );
+      await expect(
+        withTransaction(async () => {
+          const old = await applyPrivacyPolicyForRow(viewer, options, row);
+          await expect(edit(old!, 70).saveX()).rejects.toThrow(
+            "reload existingEnt",
+          );
+        }),
+      ).rejects.toThrow("reload existingEnt");
+      expect((await load(owner.id)).data.balance).toBe(100);
+    },
+  );
+  test.each(["query", "queryAll", "exec"] as const)(
+    "%s pending rows cannot complete in another generation",
+    async (method) => {
+      const owner = await create();
+      let start!: () => void;
+      let release!: () => void;
+      const started = new Promise<void>((resolve) => {
+        start = resolve;
+      });
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const db = DB.getInstance();
+      const acquire = db.getNewClient.bind(db);
+      const spy = jest
+        .spyOn(db, "getNewClient")
+        .mockImplementationOnce(async () => {
+          const client = await acquire();
+          const query = client.query.bind(client);
+          client.query = async (sql, values) => {
+            const result = await query(sql, values);
+            if (sql.includes("paused_provenance")) {
+              start();
+              await gate;
+            }
+            return result;
+          };
+          return client;
+        });
+      try {
+        await expect(
+          withTransaction(async (tx) => {
+            const pending = tx[method](
+              "SELECT * FROM consumer_accounts WHERE id=$1 /* paused_provenance */",
+              [owner.id],
+            );
+            const checked = expect(pending).rejects.toThrow(
+              "cannot cross transaction generations",
+            );
+            await started;
+            try {
+              await edit(await load(owner.id), 80).saveX();
+            } finally {
+              release();
+            }
+            await checked;
+          }),
+        ).rejects.toThrow("cannot cross transaction generations");
+      } finally {
+        spy.mockRestore();
+        release();
+      }
+      expect((await load(owner.id)).data.balance).toBe(100);
+    },
+  );
+});

--- a/ts/src/core/transaction_provenance.test.ts
+++ b/ts/src/core/transaction_provenance.test.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "crypto";
 import DB, { Dialect } from "./db";
 import { withTransaction } from "./transaction";
 import { Allow, Deny } from "./base";
+import { AlwaysDenyPrivacyPolicy } from "./privacy";
 import { applyPrivacyPolicyForRow, loadEntX } from "./ent";
 import { ObjectLoaderFactory } from "./loaders";
 import { CustomEdgeQueryBase } from "./query/custom_query";
@@ -11,7 +13,12 @@ import {
   getBuilderSchemaFromFields,
   getDbFields,
 } from "../testutils/builder";
-import { setupPostgres, getSchemaTable } from "../testutils/db/temp_db";
+import {
+  setupPostgres,
+  getSchemaTable,
+  assoc_edge_config_table,
+  assoc_edge_table,
+} from "../testutils/db/temp_db";
 import { TestContext } from "../testutils/context/test_context";
 import { WriteOperation } from "../action/action";
 class ConsumerAccount extends BaseEnt {
@@ -84,81 +91,91 @@ function accountQuery(src: any) {
   });
 }
 describe("safe consumer provenance outcomes", () => {
-  setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
+  setupPostgres(() => [
+    getSchemaTable(schema, Dialect.Postgres),
+    assoc_edge_config_table(),
+    assoc_edge_table("provenance_edges"),
+  ]);
   beforeEach(() => context.cache.reset());
+  describe.each([
+    "root",
+    "child",
+    "privacy-skipped child",
+  ] as const)("%s result without row writes", (position) => {
+    const graph = (current: ConsumerAccount) => {
+      const noWrite = Object.assign(
+        new GuardedEdit(
+          viewer,
+          schema,
+          new Map(),
+          WriteOperation.Edit,
+          current,
+        ),
+        { getTransactionResources: () => ["unrelated-edges"] },
+      );
+      if (position === "privacy-skipped child") {
+        Object.assign(noWrite, {
+          getPrivacyPolicy: () => AlwaysDenyPrivacyPolicy,
+          __failPrivacySilently: () => true,
+        });
+      }
+      const writer = Object.assign(edit(current, 80), {
+        getTransactionResources: () => ["balance"],
+      });
+      const parent = position === "root" ? noWrite : writer;
+      const child = position === "root" ? writer : noWrite;
+      parent.getTriggers = () => [{ changeset: () => child.changeset() }];
+      return { parent, noWrite };
+    };
+
+    test("result reloads after graph writes before it becomes a fresh input", async () => {
+      const owner = await create();
+      await withTransaction(async () => {
+        const { parent, noWrite } = graph(await load(owner.id));
+        const result = await parent.saveX();
+        const snapshot =
+          position === "root" ? result : await noWrite.editedEntX();
+        expect(snapshot.data.balance).toBe(80);
+        await edit(snapshot, snapshot.data.balance - 30).saveX();
+      });
+      expect((await load(owner.id)).data.balance).toBe(50);
+    });
+
+    test("composition remains valid when the next action reloads", async () => {
+      const owner = await create();
+      await withTransaction(async () => {
+        const { parent } = graph(await load(owner.id));
+        await parent.saveX();
+        const fresh = await load(owner.id);
+        expect(fresh.data.balance).toBe(80);
+        await edit(fresh, fresh.data.balance - 30).saveX();
+      });
+      expect((await load(owner.id)).data.balance).toBe(50);
+    });
+  });
   describe.each([
     "SELECT * FROM consumer_accounts WHERE id = $1",
     "UPDATE consumer_accounts SET balance = balance WHERE id = $1 RETURNING *",
   ])("%s", (sql) => {
-    test.each(["query", "queryAll", "exec"] as const)(
-      "%s stale rows cannot feed later guarded writes",
-      async (method) => {
-        const owner = await create();
-        let caught: unknown;
-        let outer: unknown;
-        try {
-          await withTransaction(async (tx) => {
-            const oldRow = (await tx[method](sql, [owner.id])).rows[0];
-            await edit(await load(owner.id), 80).saveX();
-            try {
-              const stale = await applyPrivacyPolicyForRow(
-                viewer,
-                options,
-                oldRow,
-              );
-              await edit(stale!, stale!.data.balance - 30).saveX();
-            } catch (error) {
-              caught = error;
-            }
-          });
-        } catch (error) {
-          outer = error;
-        }
-        expect(caught).toBeInstanceOf(Error);
-        expect(outer).toBe(caught);
-        expect((await load(owner.id)).data.balance).toBe(100);
-      },
-    );
-  });
-  test.each(["query", "queryAll", "exec"] as const)(
-    "%s fresh rows materialize and support sequential guarded saves",
-    async (method) => {
-      const owner = await create();
-      await withTransaction(async (tx) => {
-        const firstRow = (
-          await tx[method]("SELECT * FROM consumer_accounts WHERE id = $1", [
-            owner.id,
-          ])
-        ).rows[0];
-        const first = await applyPrivacyPolicyForRow(viewer, options, firstRow);
-        await edit(first!, first!.data.balance - 20).saveX();
-        const freshRow = (
-          await tx[method]("SELECT * FROM consumer_accounts WHERE id = $1", [
-            owner.id,
-          ])
-        ).rows[0];
-        const fresh = await applyPrivacyPolicyForRow(viewer, options, freshRow);
-        await edit(fresh!, fresh!.data.balance - 30).saveX();
-      });
-      expect((await load(owner.id)).data.balance).toBe(50);
-    },
-  );
-  test.each(["supplied", "sourceEnt fallback"] as const)(
-    "%s stale query source rejects and poisons the scope when caught",
-    async (mode) => {
+    test.each([
+      "query",
+      "queryAll",
+      "exec",
+    ] as const)("%s stale rows cannot feed later guarded writes", async (method) => {
       const owner = await create();
       let caught: unknown;
       let outer: unknown;
       try {
-        await withTransaction(async () => {
-          const stale = await load(owner.id);
-          await edit(stale, 80).saveX();
+        await withTransaction(async (tx) => {
+          const oldRow = (await tx[method](sql, [owner.id])).rows[0];
+          await edit(await load(owner.id), 80).saveX();
           try {
-            const query = accountQuery(mode === "supplied" ? stale : owner.id);
-            if (mode === "sourceEnt fallback") {
-              query.sourceEnt = async () => stale;
-            }
-            await query.queryRawCount();
+            const stale = await applyPrivacyPolicyForRow(
+              viewer,
+              options,
+              oldRow,
+            );
+            await edit(stale!, stale!.data.balance - 30).saveX();
           } catch (error) {
             caught = error;
           }
@@ -169,8 +186,60 @@ describe("safe consumer provenance outcomes", () => {
       expect(caught).toBeInstanceOf(Error);
       expect(outer).toBe(caught);
       expect((await load(owner.id)).data.balance).toBe(100);
-    },
-  );
+    });
+  });
+  test.each([
+    "query",
+    "queryAll",
+    "exec",
+  ] as const)("%s fresh rows materialize and support sequential guarded saves", async (method) => {
+    const owner = await create();
+    await withTransaction(async (tx) => {
+      const firstRow = (
+        await tx[method]("SELECT * FROM consumer_accounts WHERE id = $1", [
+          owner.id,
+        ])
+      ).rows[0];
+      const first = await applyPrivacyPolicyForRow(viewer, options, firstRow);
+      await edit(first!, first!.data.balance - 20).saveX();
+      const freshRow = (
+        await tx[method]("SELECT * FROM consumer_accounts WHERE id = $1", [
+          owner.id,
+        ])
+      ).rows[0];
+      const fresh = await applyPrivacyPolicyForRow(viewer, options, freshRow);
+      await edit(fresh!, fresh!.data.balance - 30).saveX();
+    });
+    expect((await load(owner.id)).data.balance).toBe(50);
+  });
+  test.each([
+    "supplied",
+    "sourceEnt fallback",
+  ] as const)("%s stale query source rejects and poisons the scope when caught", async (mode) => {
+    const owner = await create();
+    let caught: unknown;
+    let outer: unknown;
+    try {
+      await withTransaction(async () => {
+        const stale = await load(owner.id);
+        await edit(stale, 80).saveX();
+        try {
+          const query = accountQuery(mode === "supplied" ? stale : owner.id);
+          if (mode === "sourceEnt fallback") {
+            query.sourceEnt = async () => stale;
+          }
+          await query.queryRawCount();
+        } catch (error) {
+          caught = error;
+        }
+      });
+    } catch (error) {
+      outer = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(outer).toBe(caught);
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
   test("fresh Ent and ID query sources keep correct privacy behavior after a guarded save", async () => {
     const owner = await create();
     await withTransaction(async () => {
@@ -182,9 +251,24 @@ describe("safe consumer provenance outcomes", () => {
     });
     expect((await load(owner.id)).data.balance).toBe(80);
   });
-  test("immediate action result can use itself as an edge-query privacy source", async () => {
+  test.each([
+    "row write",
+    "no-op",
+    "edge-only",
+    "no-op with writing child",
+    "edge-only with writing child",
+  ])("immediate %s result can use itself as an edge-query privacy source", async (mode) => {
     const owner = await create();
     const originalPrivacy = ConsumerAccount.prototype.getPrivacyPolicy;
+    const edgeType = randomUUID();
+    if (mode.startsWith("edge-only")) {
+      await DB.getInstance()
+        .getPool()
+        .query(
+          "INSERT INTO assoc_edge_config (edge_type, edge_name, symmetric_edge, edge_table, created_at, updated_at) VALUES ($1, 'ProvenancePeers', false, 'provenance_edges', now(), now())",
+          [edgeType],
+        );
+    }
     try {
       await withTransaction(async () => {
         const existing = await load(owner.id);
@@ -200,62 +284,97 @@ describe("safe consumer provenance outcomes", () => {
             ],
           };
         };
-        const result = await edit(existing, 80).saveX();
-        expect(result.data.balance).toBe(80);
+        const action =
+          mode === "row write"
+            ? edit(existing, 80)
+            : new GuardedEdit(
+                viewer,
+                schema,
+                new Map(),
+                WriteOperation.Edit,
+                existing,
+              );
+        if (mode.startsWith("edge-only")) {
+          action.builder.orchestrator.addOutboundEdge(
+            owner.id,
+            edgeType,
+            "ConsumerAccount",
+          );
+        }
+        if (mode.endsWith("writing child")) {
+          Object.assign(action, {
+            getTransactionResources: () => ["unrelated-edges"],
+          });
+          action.getTriggers = () => [
+            {
+              changeset: () =>
+                Object.assign(edit(existing, 80), {
+                  getTransactionResources: () => ["balance"],
+                }).changeset(),
+            },
+          ];
+        }
+        const result = await action.saveX();
+        expect(result.data.balance).toBe(
+          mode === "row write" || mode.endsWith("writing child") ? 80 : 100,
+        );
       });
     } finally {
       ConsumerAccount.prototype.getPrivacyPolicy = originalPrivacy;
     }
-    expect((await load(owner.id)).data.balance).toBe(80);
+    expect((await load(owner.id)).data.balance).toBe(
+      mode === "row write" || mode.endsWith("writing child") ? 80 : 100,
+    );
   });
-  test.each(["action privacy", "field privacy", "unsafe getter"])(
-    "proposed insert Ent supports %s inside its preparation generation",
-    async (kind) => {
-      let calls = 0;
-      const policy = {
-        rules: [
-          {
-            async apply(_viewer: any, ent: any) {
-              calls++;
-              expect(ent).toBeInstanceOf(ConsumerAccount);
-              expect(await accountQuery(ent).queryRawCount()).toBe(0);
-              return Allow();
-            },
-          },
-        ],
-      };
-      const insertSchema = getBuilderSchemaFromFields(
+  test.each([
+    "action privacy",
+    "field privacy",
+    "unsafe getter",
+  ])("proposed insert Ent supports %s inside its preparation generation", async (kind) => {
+    let calls = 0;
+    const policy = {
+      rules: [
         {
-          balance: IntegerType(
-            kind === "field privacy" ? { editPrivacyPolicy: policy } : {},
-          ),
+          async apply(_viewer: any, ent: any) {
+            calls++;
+            expect(ent).toBeInstanceOf(ConsumerAccount);
+            expect(await accountQuery(ent).queryRawCount()).toBe(0);
+            return Allow();
+          },
         },
-        ConsumerAccount,
+      ],
+    };
+    const insertSchema = getBuilderSchemaFromFields(
+      {
+        balance: IntegerType(
+          kind === "field privacy" ? { editPrivacyPolicy: policy } : {},
+        ),
+      },
+      ConsumerAccount,
+    );
+    await withTransaction(async () => {
+      const action = new GuardedEdit(
+        viewer,
+        insertSchema,
+        new Map([["balance", 100]]),
+        WriteOperation.Insert,
+        null,
       );
-      await withTransaction(async () => {
-        const action = new GuardedEdit(
-          viewer,
-          insertSchema,
-          new Map([["balance", 100]]),
-          WriteOperation.Insert,
-          null,
-        );
-        if (kind === "action privacy") {
-          action.getPrivacyPolicy = () => policy;
-        }
-        if (kind === "unsafe getter") {
-          const proposed =
-            await action.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
-          expect(await accountQuery(proposed).queryRawCount()).toBe(0);
-        }
-        const result = await action.saveX();
-        expect(result.data.balance).toBe(100);
-      });
-      if (kind !== "unsafe getter") {
-        expect(calls).toBe(1);
+      if (kind === "action privacy") {
+        action.getPrivacyPolicy = () => policy;
       }
-    },
-  );
+      if (kind === "unsafe getter") {
+        const proposed =
+          await action.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
+        expect(await accountQuery(proposed).queryRawCount()).toBe(0);
+      }
+      const result = await action.saveX();
+      expect(result.data.balance).toBe(100);
+    });
+    if (kind !== "unsafe getter") {
+      expect(calls).toBe(1);
+    }
+  });
   test("retained proposed Ent cannot authorize a query after another guarded save", async () => {
     const owner = await create();
     await expect(
@@ -277,82 +396,85 @@ describe("safe consumer provenance outcomes", () => {
     ).rejects.toThrow("reload existingEnt");
     expect((await load(owner.id)).data.balance).toBe(100);
   });
-  test.each(["query", "queryAll", "exec"] as const)(
-    "%s retained rows cannot cross scopes",
-    async (method) => {
-      const owner = await create();
-      const row = await withTransaction(
-        async (tx) =>
-          (
-            await tx[method]("SELECT * FROM consumer_accounts WHERE id=$1", [
-              owner.id,
-            ])
-          ).rows[0],
-      );
+  test.each([
+    "query",
+    "queryAll",
+    "exec",
+  ] as const)("%s retained rows cannot cross scopes", async (method) => {
+    const owner = await create();
+    const row = await withTransaction(
+      async (tx) =>
+        (
+          await tx[method]("SELECT * FROM consumer_accounts WHERE id=$1", [
+            owner.id,
+          ])
+        ).rows[0],
+    );
+    await expect(
+      withTransaction(async () => {
+        const old = await applyPrivacyPolicyForRow(viewer, options, row);
+        await expect(edit(old!, 70).saveX()).rejects.toThrow(
+          "reload existingEnt",
+        );
+      }),
+    ).rejects.toThrow("reload existingEnt");
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
+  test.each([
+    "query",
+    "queryAll",
+    "exec",
+  ] as const)("%s pending rows cannot complete in another generation", async (method) => {
+    const owner = await create();
+    let start!: () => void;
+    let release!: () => void;
+    const started = new Promise<void>((resolve) => {
+      start = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const db = DB.getInstance();
+    const acquire = db.getNewClient.bind(db);
+    const spy = jest
+      .spyOn(db, "getNewClient")
+      .mockImplementationOnce(async () => {
+        const client = await acquire();
+        const adapterMethod = method === "exec" ? "exec" : "query";
+        const query = client[adapterMethod].bind(client);
+        client[adapterMethod] = async (sql, values) => {
+          const result = await query(sql, values);
+          if (sql.includes("paused_provenance")) {
+            start();
+            await gate;
+          }
+          return result;
+        };
+        return client;
+      });
+    try {
       await expect(
-        withTransaction(async () => {
-          const old = await applyPrivacyPolicyForRow(viewer, options, row);
-          await expect(edit(old!, 70).saveX()).rejects.toThrow(
-            "reload existingEnt",
+        withTransaction(async (tx) => {
+          const pending = tx[method](
+            "SELECT * FROM consumer_accounts WHERE id=$1 /* paused_provenance */",
+            [owner.id],
           );
+          const checked = expect(pending).rejects.toThrow(
+            "cannot cross transaction generations",
+          );
+          await started;
+          try {
+            await edit(await load(owner.id), 80).saveX();
+          } finally {
+            release();
+          }
+          await checked;
         }),
-      ).rejects.toThrow("reload existingEnt");
-      expect((await load(owner.id)).data.balance).toBe(100);
-    },
-  );
-  test.each(["query", "queryAll", "exec"] as const)(
-    "%s pending rows cannot complete in another generation",
-    async (method) => {
-      const owner = await create();
-      let start!: () => void;
-      let release!: () => void;
-      const started = new Promise<void>((resolve) => {
-        start = resolve;
-      });
-      const gate = new Promise<void>((resolve) => {
-        release = resolve;
-      });
-      const db = DB.getInstance();
-      const acquire = db.getNewClient.bind(db);
-      const spy = jest
-        .spyOn(db, "getNewClient")
-        .mockImplementationOnce(async () => {
-          const client = await acquire();
-          const query = client.query.bind(client);
-          client.query = async (sql, values) => {
-            const result = await query(sql, values);
-            if (sql.includes("paused_provenance")) {
-              start();
-              await gate;
-            }
-            return result;
-          };
-          return client;
-        });
-      try {
-        await expect(
-          withTransaction(async (tx) => {
-            const pending = tx[method](
-              "SELECT * FROM consumer_accounts WHERE id=$1 /* paused_provenance */",
-              [owner.id],
-            );
-            const checked = expect(pending).rejects.toThrow(
-              "cannot cross transaction generations",
-            );
-            await started;
-            try {
-              await edit(await load(owner.id), 80).saveX();
-            } finally {
-              release();
-            }
-            await checked;
-          }),
-        ).rejects.toThrow("cannot cross transaction generations");
-      } finally {
-        spy.mockRestore();
-        release();
-      }
-      expect((await load(owner.id)).data.balance).toBe(100);
-    },
-  );
+      ).rejects.toThrow("cannot cross transaction generations");
+    } finally {
+      spy.mockRestore();
+      release();
+    }
+    expect((await load(owner.id)).data.balance).toBe(100);
+  });
 });

--- a/ts/src/core/transaction_provenance.test.ts
+++ b/ts/src/core/transaction_provenance.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import DB, { Dialect } from "./db";
-import { withTransaction } from "./transaction";
+import { withTransactionScope } from "./transaction";
 import { Allow, Deny } from "./base";
 import { AlwaysDenyPrivacyPolicy } from "./privacy";
 import { applyPrivacyPolicyForRow, loadEntX } from "./ent";
@@ -41,7 +41,7 @@ const options = {
 const context = new TestContext();
 const viewer = context.getViewer();
 class GuardedEdit extends SimpleAction<ConsumerAccount> {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return true;
   }
 }
@@ -103,15 +103,12 @@ describe("safe consumer provenance outcomes", () => {
     "privacy-skipped child",
   ] as const)("%s result without row writes", (position) => {
     const graph = (current: ConsumerAccount) => {
-      const noWrite = Object.assign(
-        new GuardedEdit(
-          viewer,
-          schema,
-          new Map(),
-          WriteOperation.Edit,
-          current,
-        ),
-        { getTransactionResources: () => ["unrelated-edges"] },
+      const noWrite = new GuardedEdit(
+        viewer,
+        schema,
+        new Map(),
+        WriteOperation.Edit,
+        current,
       );
       if (position === "privacy-skipped child") {
         Object.assign(noWrite, {
@@ -119,9 +116,7 @@ describe("safe consumer provenance outcomes", () => {
           __failPrivacySilently: () => true,
         });
       }
-      const writer = Object.assign(edit(current, 80), {
-        getTransactionResources: () => ["balance"],
-      });
+      const writer = edit(current, 80);
       const parent = position === "root" ? noWrite : writer;
       const child = position === "root" ? writer : noWrite;
       parent.getTriggers = () => [{ changeset: () => child.changeset() }];
@@ -130,7 +125,7 @@ describe("safe consumer provenance outcomes", () => {
 
     test("result reloads after graph writes before it becomes a fresh input", async () => {
       const owner = await create();
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const { parent, noWrite } = graph(await load(owner.id));
         const result = await parent.saveX();
         const snapshot =
@@ -143,7 +138,7 @@ describe("safe consumer provenance outcomes", () => {
 
     test("composition remains valid when the next action reloads", async () => {
       const owner = await create();
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const { parent } = graph(await load(owner.id));
         await parent.saveX();
         const fresh = await load(owner.id);
@@ -161,12 +156,12 @@ describe("safe consumer provenance outcomes", () => {
       "query",
       "queryAll",
       "exec",
-    ] as const)("%s stale rows cannot feed later guarded writes", async (method) => {
+    ] as const)("%s stale rows cannot feed later scoped writes", async (method) => {
       const owner = await create();
       let caught: unknown;
       let outer: unknown;
       try {
-        await withTransaction(async (tx) => {
+        await withTransactionScope(async (tx) => {
           const oldRow = (await tx[method](sql, [owner.id])).rows[0];
           await edit(await load(owner.id), 80).saveX();
           try {
@@ -192,9 +187,9 @@ describe("safe consumer provenance outcomes", () => {
     "query",
     "queryAll",
     "exec",
-  ] as const)("%s fresh rows materialize and support sequential guarded saves", async (method) => {
+  ] as const)("%s fresh rows materialize and support sequential scoped saves", async (method) => {
     const owner = await create();
-    await withTransaction(async (tx) => {
+    await withTransactionScope(async (tx) => {
       const firstRow = (
         await tx[method]("SELECT * FROM consumer_accounts WHERE id = $1", [
           owner.id,
@@ -220,7 +215,7 @@ describe("safe consumer provenance outcomes", () => {
     let caught: unknown;
     let outer: unknown;
     try {
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const stale = await load(owner.id);
         await edit(stale, 80).saveX();
         try {
@@ -240,9 +235,9 @@ describe("safe consumer provenance outcomes", () => {
     expect(outer).toBe(caught);
     expect((await load(owner.id)).data.balance).toBe(100);
   });
-  test("fresh Ent and ID query sources keep correct privacy behavior after a guarded save", async () => {
+  test("fresh Ent and ID query sources keep correct privacy behavior after a scoped save", async () => {
     const owner = await create();
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const first = await load(owner.id);
       expect(await accountQuery(first).queryRawCount()).toBe(1);
       await edit(first, 80).saveX();
@@ -270,7 +265,7 @@ describe("safe consumer provenance outcomes", () => {
         );
     }
     try {
-      await withTransaction(async () => {
+      await withTransactionScope(async () => {
         const existing = await load(owner.id);
         ConsumerAccount.prototype.getPrivacyPolicy = function () {
           return {
@@ -302,15 +297,10 @@ describe("safe consumer provenance outcomes", () => {
           );
         }
         if (mode.endsWith("writing child")) {
-          Object.assign(action, {
-            getTransactionResources: () => ["unrelated-edges"],
-          });
+          action;
           action.getTriggers = () => [
             {
-              changeset: () =>
-                Object.assign(edit(existing, 80), {
-                  getTransactionResources: () => ["balance"],
-                }).changeset(),
+              changeset: () => edit(existing, 80).changeset(),
             },
           ];
         }
@@ -352,7 +342,7 @@ describe("safe consumer provenance outcomes", () => {
       },
       ConsumerAccount,
     );
-    await withTransaction(async () => {
+    await withTransactionScope(async () => {
       const action = new GuardedEdit(
         viewer,
         insertSchema,
@@ -375,10 +365,10 @@ describe("safe consumer provenance outcomes", () => {
       expect(calls).toBe(1);
     }
   });
-  test("retained proposed Ent cannot authorize a query after another guarded save", async () => {
+  test("retained proposed Ent cannot authorize a query after another scoped save", async () => {
     const owner = await create();
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const action = new GuardedEdit(
           viewer,
           schema,
@@ -402,7 +392,7 @@ describe("safe consumer provenance outcomes", () => {
     "exec",
   ] as const)("%s retained rows cannot cross scopes", async (method) => {
     const owner = await create();
-    const row = await withTransaction(
+    const row = await withTransactionScope(
       async (tx) =>
         (
           await tx[method]("SELECT * FROM consumer_accounts WHERE id=$1", [
@@ -411,7 +401,7 @@ describe("safe consumer provenance outcomes", () => {
         ).rows[0],
     );
     await expect(
-      withTransaction(async () => {
+      withTransactionScope(async () => {
         const old = await applyPrivacyPolicyForRow(viewer, options, row);
         await expect(edit(old!, 70).saveX()).rejects.toThrow(
           "reload existingEnt",
@@ -454,7 +444,7 @@ describe("safe consumer provenance outcomes", () => {
       });
     try {
       await expect(
-        withTransaction(async (tx) => {
+        withTransactionScope(async (tx) => {
           const pending = tx[method](
             "SELECT * FROM consumer_accounts WHERE id=$1 /* paused_provenance */",
             [owner.id],

--- a/ts/src/core/transaction_provenance.test.ts
+++ b/ts/src/core/transaction_provenance.test.ts
@@ -155,8 +155,9 @@ describe("safe consumer provenance outcomes", () => {
           await edit(stale, 80).saveX();
           try {
             const query = accountQuery(mode === "supplied" ? stale : owner.id);
-            if (mode === "sourceEnt fallback")
+            if (mode === "sourceEnt fallback") {
               query.sourceEnt = async () => stale;
+            }
             await query.queryRawCount();
           } catch (error) {
             caught = error;
@@ -239,7 +240,9 @@ describe("safe consumer provenance outcomes", () => {
           WriteOperation.Insert,
           null,
         );
-        if (kind === "action privacy") action.getPrivacyPolicy = () => policy;
+        if (kind === "action privacy") {
+          action.getPrivacyPolicy = () => policy;
+        }
         if (kind === "unsafe getter") {
           const proposed =
             await action.builder.orchestrator.getPossibleUnsafeEntForPrivacy();
@@ -248,7 +251,9 @@ describe("safe consumer provenance outcomes", () => {
         const result = await action.saveX();
         expect(result.data.balance).toBe(100);
       });
-      if (kind !== "unsafe getter") expect(calls).toBe(1);
+      if (kind !== "unsafe getter") {
+        expect(calls).toBe(1);
+      }
     },
   );
   test("retained proposed Ent cannot authorize a query after another guarded save", async () => {

--- a/ts/src/core/transaction_resources.test.ts
+++ b/ts/src/core/transaction_resources.test.ts
@@ -1,0 +1,218 @@
+import DB, { Dialect } from "./db";
+import { withTransaction } from "./transaction";
+import { loadRows } from "./ent";
+import { Eq } from "./clause";
+import { WriteOperation } from "../action/action";
+import { IntegerType } from "../schema";
+import { setupPostgres, getSchemaTable } from "../testutils/db/temp_db";
+import {
+  BaseEnt,
+  getBuilderSchemaFromFields,
+  SimpleAction,
+  getDbFields,
+} from "../testutils/builder";
+import { TestContext } from "../testutils/context/test_context";
+
+class ResourceReservation extends BaseEnt {
+  nodeType = "ResourceReservation";
+}
+const schema = getBuilderSchemaFromFields(
+  { amount: IntegerType() },
+  ResourceReservation,
+);
+const context = new TestContext();
+const viewer = context.getViewer();
+const options = {
+  tableName: "resource_reservations",
+  fields: getDbFields(schema),
+  context,
+};
+class Guarded extends SimpleAction<ResourceReservation> {
+  requiresTransaction() {
+    return true;
+  }
+}
+const create = (amount = 1) =>
+  new Guarded(
+    viewer,
+    schema,
+    new Map([["amount", amount]]),
+    WriteOperation.Insert,
+    null,
+  );
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+const rows = () =>
+  DB.getInstance().getPool().query("SELECT amount FROM resource_reservations");
+
+setupPostgres(() => [getSchemaTable(schema, Dialect.Postgres)]);
+beforeEach(() => context.cache.reset());
+
+describe.each([
+  "saveX",
+  "builder.saveX",
+  "changeset",
+  "valid",
+  "validX",
+  "validWithErrors",
+] as const)("%s reserves roots before asynchronous resource resolution", (entry) => {
+  test.each([
+    "delay only",
+    "invariant read",
+    "nested validation",
+  ])("%s cannot overlap a second guarded root even when caught", async (mode) => {
+    const started = deferred();
+    const release = deferred();
+    const hooks: string[] = [];
+    let caught: unknown;
+    let outer: unknown;
+    try {
+      await withTransaction(async () => {
+        const make = (delay: boolean) => {
+          let count = 0;
+          const action = create();
+          Object.assign(action, {
+            getTransactionResources: async () => {
+              hooks.push(delay ? "slow" : "fast");
+              if (mode !== "delay only") {
+                count = (
+                  await loadRows({ ...options, clause: Eq("amount", 1) })
+                ).length;
+              }
+              if (mode === "nested validation") {
+                const nested = new SimpleAction(
+                  viewer,
+                  schema,
+                  new Map([["amount", 2]]),
+                  WriteOperation.Insert,
+                  null,
+                );
+                await nested.validX();
+              }
+              if (delay) {
+                started.resolve();
+                await release.promise;
+              }
+              return ["single-reservation"];
+            },
+          });
+          action.getValidators = () => [
+            {
+              validate: async () => {
+                if (count >= 1) {
+                  throw new Error("already reserved");
+                }
+              },
+            },
+          ];
+          return action;
+        };
+        const firstAction = make(true);
+        const firstCall =
+          entry === "builder.saveX"
+            ? firstAction.builder.saveX()
+            : firstAction[entry]();
+        const first = firstCall.then(
+          (value) => ({ value }),
+          (error) => ({ error }),
+        );
+        await started.promise;
+        try {
+          await make(false).saveX();
+        } catch (error) {
+          caught = error;
+        } finally {
+          release.resolve();
+          await first;
+        }
+      });
+    } catch (error) {
+      outer = error;
+    } finally {
+      release.resolve();
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(
+      "guarded root actions must be prepared and saved sequentially",
+    );
+    expect(outer).toBe(caught);
+    expect(hooks).toEqual(["slow"]);
+    expect((await rows()).rows).toEqual([]);
+  });
+
+  test("a caught delayed resource failure aborts earlier writes", async () => {
+    const started = deferred();
+    const release = deferred();
+    const failure = new Error("resource resolution failed");
+    const transaction = withTransaction(async () => {
+      await create().saveX();
+      const action = create();
+      Object.assign(action, {
+        getTransactionResources: async () => {
+          started.resolve();
+          await release.promise;
+          throw failure;
+        },
+      });
+      await expect(
+        entry === "builder.saveX" ? action.builder.saveX() : action[entry](),
+      ).rejects.toBe(failure);
+    });
+    const outcome = transaction.then(
+      (value) => ({ value }),
+      (error) => ({ error }),
+    );
+    try {
+      await started.promise;
+      release.resolve();
+      expect(await outcome).toEqual({ error: failure });
+      expect((await rows()).rows).toEqual([]);
+    } finally {
+      release.resolve();
+      await outcome;
+    }
+  });
+});
+
+test.each([
+  false,
+  true,
+])("parallel child resource hooks preserve overlap checks (shared keys: %s)", async (shared) => {
+  const bothStarted = deferred();
+  let arrivals = 0;
+  const transaction = withTransaction(async () => {
+    const parent = Object.assign(create(1), {
+      getTransactionResources: () => ["parent"],
+    });
+    const children = [2, 3].map((amount) =>
+      Object.assign(create(amount), {
+        getTransactionResources: async () => {
+          if (++arrivals === 2) {
+            bothStarted.resolve();
+          }
+          await bothStarted.promise;
+          return [shared ? "child" : `child:${amount}`];
+        },
+      }),
+    );
+    parent.getTriggers = () =>
+      children.map((child) => ({ changeset: () => child.changeset() }));
+    await parent.saveX();
+  });
+  if (shared) {
+    await expect(transaction).rejects.toThrow(
+      "overlapping guarded action preparation branches",
+    );
+    expect((await rows()).rows).toEqual([]);
+  } else {
+    await transaction;
+    expect((await rows()).rows.map((row) => row.amount).sort()).toEqual([
+      1, 2, 3,
+    ]);
+  }
+});

--- a/ts/src/core/transaction_runtime.test.ts
+++ b/ts/src/core/transaction_runtime.test.ts
@@ -1,0 +1,33 @@
+import { spawnSync } from "child_process";
+import path from "path";
+
+const fixture = path.join(__dirname, "../testutils/transaction_runtime.js");
+const bun = spawnSync("bun", ["--version"], { encoding: "utf8" });
+
+test("transaction scope in real Node/pg runtime", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["-r", "ts-node/register", fixture, "pg"],
+    {
+      encoding: "utf8",
+      timeout: 30000,
+    },
+  );
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("transaction runtime passed: node/pg");
+}, 35000);
+
+(bun.status === 0 ? describe : describe.skip)("Bun transaction scope", () => {
+  test.each(["pg", "bun"])("real Bun runtime with %s driver", (driver) => {
+    const result = spawnSync("bun", [fixture, driver], {
+      encoding: "utf8",
+      timeout: 30000,
+    });
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      `transaction runtime passed: bun/${driver}`,
+    );
+  }, 35000);
+});

--- a/ts/src/core/transaction_types.test.ts
+++ b/ts/src/core/transaction_types.test.ts
@@ -1,0 +1,56 @@
+import path from "path";
+import ts from "typescript";
+
+test("transaction metadata accepts custom viewers with strict function types", () => {
+  const fixture = path.join(__dirname, "../testutils/transaction_types.ts");
+  const program = ts.createProgram([fixture], {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    esModuleInterop: true,
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.CommonJS,
+  });
+  const source = program.getSourceFile(fixture)!;
+  const diagnostics = program.getSemanticDiagnostics(source);
+  expect(
+    diagnostics.map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    ),
+  ).toEqual([]);
+});
+
+test("conditional changeset preparation preserves custom viewer types", () => {
+  const file = path.join(__dirname, "../action/orchestrator.ts");
+  const program = ts.createProgram([file], {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    esModuleInterop: true,
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.CommonJS,
+  });
+  const source = program.getSourceFile(file)!;
+  const orchestrator = source.statements.find(
+    (statement): statement is ts.ClassDeclaration =>
+      ts.isClassDeclaration(statement) &&
+      statement.name?.text === "Orchestrator",
+  )!;
+  const method = orchestrator.members.find(
+    (member) => member.name?.getText(source) === "buildPlusChangeset",
+  )!;
+  expect(method).toBeDefined();
+  const diagnostics = program
+    .getSemanticDiagnostics(source)
+    .filter(
+      (diagnostic) =>
+        diagnostic.start !== undefined &&
+        diagnostic.start >= method.getStart(source) &&
+        diagnostic.start < method.end,
+    );
+  expect(
+    diagnostics.map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    ),
+  ).toEqual([]);
+});

--- a/ts/src/core/transaction_validation.test.ts
+++ b/ts/src/core/transaction_validation.test.ts
@@ -1,0 +1,30 @@
+import { assertValidationQuery } from "./transaction_validation";
+
+test.each([
+  "SELECT * FROM accounts WHERE id = $1",
+  "WITH rows AS (SELECT 1 AS n) SELECT n FROM rows; -- trailing comment",
+  "SELECT 'COMMIT; UPDATE accounts', \"update\" FROM accounts",
+  "SELECT $$COMMIT;$$, $tag$DELETE FROM accounts;$tag$",
+  "/* outer /* nested */ comment */ SELECT 1",
+  "VALUES (1), (2)",
+])("accepts a single validation read: %s", (sql) => {
+  expect(() => assertValidationQuery(sql)).not.toThrow();
+});
+
+test.each([
+  "SELECT 1; COMMIT; SELECT 2",
+  "SELECT 1 -- comment\r; COMMIT",
+  "SELECT foo$tag$ FROM accounts; COMMIT; SELECT foo$tag$ FROM accounts",
+  String.raw`SELECT '\' -- '; COMMIT; --`,
+  "SELECT 1 /* comment */; ROLLBACK",
+  "WITH changed AS (UPDATE accounts SET amount = 1 RETURNING *) SELECT * FROM changed",
+  "WITH changed AS (DELETE FROM accounts RETURNING *) SELECT * FROM changed",
+  "SELECT * FROM accounts FOR KEY SHARE",
+  "SELECT 1 INTO another_table",
+  "SELECT 'unfinished",
+  "SELECT $$unfinished",
+  "SELECT 1 /* unfinished",
+  "SET TRANSACTION READ WRITE",
+])("rejects writes, transaction control, and malformed validation SQL: %s", (sql) => {
+  expect(() => assertValidationQuery(sql)).toThrow("single read query");
+});

--- a/ts/src/core/transaction_validation.ts
+++ b/ts/src/core/transaction_validation.ts
@@ -1,0 +1,90 @@
+/** Restrict validation SQL to one query without transaction control or writes. */
+export function assertValidationQuery(sql: string): void {
+  const invalid = () => {
+    throw new Error("scope validation only supports a single read query");
+  };
+  let statement = "";
+  for (let i = 0; i < sql.length; ) {
+    if (sql.startsWith("--", i)) {
+      const offset = sql.slice(i + 2).search(/[\r\n]/);
+      i = offset === -1 ? sql.length : i + 2 + offset;
+      statement += " ";
+    } else if (sql.startsWith("/*", i)) {
+      let depth = 1;
+      i += 2;
+      while (i < sql.length && depth) {
+        if (sql.startsWith("/*", i)) {
+          depth++;
+          i += 2;
+        } else if (sql.startsWith("*/", i)) {
+          depth--;
+          i += 2;
+        } else {
+          i++;
+        }
+      }
+      if (depth) {
+        invalid();
+      }
+      statement += " ";
+    } else if (sql[i] === "'" || sql[i] === '"') {
+      const quote = sql[i];
+      const escaped =
+        quote === "'" &&
+        /(?:^|[^a-zA-Z0-9_$\u0080-\uffff])[eE]$/.test(sql.slice(0, i));
+      let closed = false;
+      i++;
+      while (i < sql.length) {
+        // Ordinary string escaping depends on a mutable PostgreSQL setting.
+        // Require parameters, dollar quotes, or explicit E strings for backslashes.
+        if (quote === "'" && !escaped && sql[i] === "\\") {
+          invalid();
+        }
+        if (escaped && sql[i] === "\\") {
+          i += 2;
+        } else if (sql[i] === quote) {
+          i++;
+          if (sql[i] === quote) {
+            i++;
+          } else {
+            closed = true;
+            break;
+          }
+        } else {
+          i++;
+        }
+      }
+      if (!closed) {
+        invalid();
+      }
+      statement += " ";
+    } else {
+      const tag =
+        sql[i] === "$" &&
+        (i === 0 || !/[a-zA-Z0-9_$\u0080-\uffff]/.test(sql[i - 1]))
+          ? sql.slice(i).match(/^\$(?:[a-zA-Z_][a-zA-Z_0-9]*)?\$/)?.[0]
+          : undefined;
+      if (tag) {
+        const end = sql.indexOf(tag, i + tag.length);
+        if (end === -1) {
+          invalid();
+        }
+        i = end + tag.length;
+        statement += " ";
+      } else {
+        statement += sql[i++];
+      }
+    }
+  }
+  statement = statement.trim().replace(/;$/, "");
+  if (
+    !/^(select|with|values)\b/i.test(statement) ||
+    statement.includes(";") ||
+    /\b(insert|update|delete|merge|into|call|do|copy|create|alter|drop|truncate|grant|revoke|lock|set|reset|discard|begin|start|commit|rollback|abort|savepoint|release|prepare|execute|deallocate|vacuum|analyze|cluster|refresh|reindex|checkpoint|listen|unlisten|notify)\b/i.test(
+      statement,
+    ) ||
+    /\bfor\s+(?:key\s+)?share\b/i.test(statement)
+  ) {
+    invalid();
+  }
+}

--- a/ts/src/core/transaction_validation_reads.test.ts
+++ b/ts/src/core/transaction_validation_reads.test.ts
@@ -108,7 +108,9 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
         const sql = mode === "SQL setup" || mode === "late SQL failure";
         const key = 1_000_000 + Math.floor(Math.random() * 1_000_000_000);
         const lock = sql ? await DB.getInstance().getNewClient() : undefined;
-        if (lock) await lock.query("SELECT pg_advisory_lock($1)", [key]);
+        if (lock) {
+          await lock.query("SELECT pg_advisory_lock($1)", [key]);
+        }
         let invalid = true;
         let settled = false;
         let settledBeforeRelease = false;
@@ -196,7 +198,9 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
                 {},
               );
               ent = await reader.load(records[2].id as string);
-            } else ent = await load(records[2].id as string);
+            } else {
+              ent = await load(records[2].id as string);
+            }
             const changeset = await independent(
               edit(ent, 70),
               "slow",
@@ -233,7 +237,9 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
             parent.getTriggers = () => [
               { changeset: () => intermediate.changeset() },
             ];
-          } else parent.getTriggers = () => [trigger];
+          } else {
+            parent.getTriggers = () => [trigger];
+          }
           const validation = parent[method]().then(
             () => {
               settled = true;
@@ -269,7 +275,9 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
           await new Promise<void>((resolve) => setImmediate(resolve));
           settledBeforeRelease = settled;
           release.resolve();
-          if (lock) await lock.query("SELECT pg_advisory_unlock($1)", [key]);
+          if (lock) {
+            await lock.query("SELECT pg_advisory_unlock($1)", [key]);
+          }
           const result = await transactionOutcome;
           if (mode === "late SQL failure") {
             expect(validationError).toBe(ordinary);

--- a/ts/src/core/transaction_validation_reads.test.ts
+++ b/ts/src/core/transaction_validation_reads.test.ts
@@ -1,7 +1,15 @@
 import DB, { Dialect } from "./db";
 import { withTransaction } from "./transaction";
 import { getTransactionState } from "./transaction_context";
-import { loadEntX } from "./ent";
+import {
+  applyPrivacyPolicyForRows,
+  getEntLoader,
+  loadCustomEnts,
+  loadEntViaKey,
+  loadEntX,
+  loadEntXViaKey,
+} from "./ent";
+import { Eq } from "./clause";
 import { Allow } from "./base";
 import { ObjectLoaderFactory } from "./loaders";
 import { InstrumentedDataLoader } from "./loaders/loader";
@@ -62,259 +70,464 @@ function independent<T extends SimpleAction<ScopedAccount>>(
   return Object.assign(action, { getTransactionResources: () => [resource] });
 }
 
-describe.each(["valid", "validX", "validWithErrors"] as const)(
-  "%s drains child setup reads",
-  (method) => {
-    setupPostgres(() => [getSchemaTable(accountSchema, Dialect.Postgres)]);
-    beforeEach(() => context.cache.reset());
-    const insert = () =>
-      new SimpleAction(
-        viewer,
-        accountSchema,
-        new Map<string, any>([
-          ["balance", 100],
-          ["admin", true],
-        ]),
-        WriteOperation.Insert,
-        null,
-      ).saveX();
-    const edit = (ent: ScopedAccount, balance: number) =>
-      new GuardedEdit(
-        viewer,
-        accountSchema,
-        new Map([["balance", balance]]),
-        WriteOperation.Edit,
-        ent,
-      );
+describe.each([
+  "valid",
+  "validX",
+  "validWithErrors",
+] as const)("%s drains child setup reads", (method) => {
+  setupPostgres(() => [getSchemaTable(accountSchema, Dialect.Postgres)]);
+  beforeEach(() => context.cache.reset());
+  const insert = () =>
+    new SimpleAction(
+      viewer,
+      accountSchema,
+      new Map<string, any>([
+        ["balance", 100],
+        ["admin", true],
+      ]),
+      WriteOperation.Insert,
+      null,
+    ).saveX();
+  const edit = (ent: ScopedAccount, balance: number) =>
+    new GuardedEdit(
+      viewer,
+      accountSchema,
+      new Map([["balance", balance]]),
+      WriteOperation.Edit,
+      ent,
+    );
 
-    test.each([
-      "SQL setup",
-      "Ent privacy setup",
-      "loader setup",
-      "nested grandchild Ent setup",
-      "late SQL failure",
-    ])(
-      "%s drains before closing standalone validation",
-      async (mode) => {
-        const records = await Promise.all([
-          insert(),
-          insert(),
-          insert(),
-          insert(),
-        ]);
-        const started = deferred(),
-          release = deferred();
-        const ordinary = new Error("correctable first child");
-        const sql = mode === "SQL setup" || mode === "late SQL failure";
-        const key = 1_000_000 + Math.floor(Math.random() * 1_000_000_000);
-        const lock = sql ? await DB.getInstance().getNewClient() : undefined;
-        if (lock) {
-          await lock.query("SELECT pg_advisory_lock($1)", [key]);
+  test.each([
+    { path: "bulk", sqlFailure: false },
+    { path: "custom", sqlFailure: false },
+    { path: "via key", sqlFailure: false },
+    { path: "via key X", sqlFailure: false },
+    { path: "bulk", sqlFailure: true },
+  ] as const)("drains cached $path privacy before closing validation (SQL failure: $sqlFailure)", async ({
+    path,
+    sqlFailure,
+  }) => {
+    const records = await Promise.all([insert(), insert(), insert(), insert()]);
+    const privacyStarted = deferred();
+    const cacheHit = deferred();
+    const release = deferred();
+    const ordinary = new Error("correctable child validation");
+    let invalid = true;
+    let validationSettled = false;
+    let settledBeforeRelease = false;
+    let privacyCalls = 0;
+    let setupCompletions = 0;
+    let observed = false;
+    let validationError: unknown;
+    let priorFailure: unknown;
+    let setupFailure: unknown;
+    const transaction = withTransaction(async (tx) => {
+      const earlier = edit(await load(records[3].id as string), 60);
+      earlier.getObservers = () => [
+        {
+          observe: () => {
+            observed = true;
+          },
+        },
+      ];
+      await earlier.saveX();
+      const row = (
+        await tx.query("SELECT * FROM scoped_accounts WHERE id = $1", [
+          records[2].id,
+        ])
+      ).rows[0];
+      const parent = independent(
+        edit(await load(records[0].id as string), 90),
+        "parent",
+      );
+      const bad = independent(
+        edit(await load(records[1].id as string), 80),
+        "bad",
+      );
+      bad.getValidators = () => [
+        { validate: () => (invalid ? ordinary : undefined) },
+      ];
+      class CachedPrivacyAccount extends ScopedAccount {
+        getPrivacyPolicy() {
+          return {
+            rules: [
+              {
+                apply: async () => {
+                  privacyCalls++;
+                  if (invalid) {
+                    privacyStarted.resolve();
+                    await release.promise;
+                    if (sqlFailure) {
+                      await tx.query("SELECT 1 / 0");
+                    }
+                  }
+                  return Allow();
+                },
+              },
+            ],
+          };
         }
-        let invalid = true;
-        let settled = false;
-        let settledBeforeRelease = false;
-        let setupCompletions = 0;
-        let setupError: any;
-        let validationError: any;
-        const observations: string[] = [];
-        const transaction = withTransaction(async (tx) => {
-          // Keep the earlier write after correcting validation errors. Roll it
-          // back if a later SQL operation fails.
-          const earlier = edit(await load(records[3].id as string), 60);
-          earlier.getObservers = () => [
-            {
-              observe: async () => {
-                observations.push("committed");
+      }
+      const cachedOptions = {
+        ...options,
+        ent: CachedPrivacyAccount,
+        loaderFactory: new ObjectLoaderFactory({
+          tableName: options.tableName,
+          fields,
+          key: "id",
+          instanceKey: "pending-cached-privacy",
+        }),
+      };
+      const priorRead = loadEntX(viewer, records[2].id, cachedOptions);
+      const priorOutcome = priorRead.then(
+        (value) => ({ value }),
+        (error: unknown) => {
+          priorFailure = error;
+          return { error };
+        },
+      );
+      await privacyStarted.promise;
+      const map = getEntLoader(viewer, cachedOptions).getMap();
+      const get = map.get.bind(map);
+      const cacheSpy = jest.spyOn(map, "get").mockImplementation((id) => {
+        const result = get(id);
+        if (result !== undefined) {
+          cacheHit.resolve();
+          cacheSpy.mockRestore();
+        }
+        return result;
+      });
+      const setup = async () => {
+        let ent: ScopedAccount | null;
+        switch (path) {
+          case "bulk":
+            [ent] = await applyPrivacyPolicyForRows(
+              viewer,
+              [row],
+              cachedOptions,
+            );
+            break;
+          case "custom":
+            [ent] = await loadCustomEnts(
+              viewer,
+              cachedOptions,
+              Eq("id", records[2].id),
+            );
+            break;
+          case "via key":
+            ent = await loadEntViaKey(viewer, records[2].id, cachedOptions);
+            break;
+          case "via key X":
+            ent = await loadEntXViaKey(viewer, records[2].id, cachedOptions);
+            break;
+        }
+        if (!ent) {
+          throw new Error("cached privacy read did not return an Ent");
+        }
+        if (invalid) {
+          expect(ent).toBe(await priorRead);
+        }
+        const changeset = await independent(edit(ent, 70), "slow").changeset();
+        setupCompletions++;
+        return changeset;
+      };
+      let setupOutcome!: Promise<unknown>;
+      parent.getTriggers = () => [
+        {
+          changeset: () => {
+            const pending = setup();
+            setupOutcome = pending.then(
+              (value) => ({ value }),
+              (error: unknown) => {
+                setupFailure = error;
+                return { error };
               },
-            },
-          ];
-          await earlier.saveX();
-          const parent = independent(
-            edit(await load(records[0].id as string), 90),
-            "parent",
-          );
-          const bad = independent(
-            edit(await load(records[1].id as string), 80),
-            "bad",
-          );
-          bad.getValidators = () => [
-            {
-              validate: async () => {
-                if (invalid) {
-                  await started.promise;
-                  return ordinary;
-                }
-              },
-            },
-          ];
-          class DelayedPrivacyAccount extends ScopedAccount {
-            getPrivacyPolicy() {
-              return {
-                rules: [
-                  {
-                    apply: async () => {
-                      if (invalid) {
-                        started.resolve();
-                        await release.promise;
-                      }
-                      return Allow();
-                    },
-                  },
-                ],
-              };
+            );
+            return Promise.all([bad.changeset(), pending]);
+          },
+        },
+      ];
+      validationError = await parent[method]().then(
+        () => {
+          validationSettled = true;
+        },
+        (error: unknown) => {
+          validationSettled = true;
+          return error;
+        },
+      );
+      const setupResult = await setupOutcome;
+      const priorResult = await priorOutcome;
+      expect(privacyCalls).toBe(1);
+      if (sqlFailure) {
+        expect(priorResult).toHaveProperty("error.code", "22012");
+        expect(setupResult).toHaveProperty("error.code", "22012");
+        return;
+      }
+      expect(setupResult).toHaveProperty("value");
+      expect(setupCompletions).toBe(1);
+      expect(getTransactionState()!.failed).toBe(false);
+      invalid = false;
+      await parent.saveX();
+    });
+    const outcome = transaction.then(
+      (value) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+    try {
+      await cacheHit.promise;
+      // Observe validation only after the pending privacy result is reused.
+      for (let turn = 0; turn < 3; turn++) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      settledBeforeRelease = validationSettled;
+      release.resolve();
+      const result = await outcome;
+      expect(validationError).toBe(ordinary);
+      expect(settledBeforeRelease).toBe(false);
+      if (sqlFailure) {
+        expect(result).toHaveProperty("error.code", "22012");
+        expect(priorFailure).toMatchObject({ code: "22012" });
+        expect(setupFailure).toBe(priorFailure);
+        if ("error" in result) {
+          expect(result.error).toBe(priorFailure);
+        }
+        expect(privacyCalls).toBe(1);
+        expect(observed).toBe(false);
+        expect((await load(records[3].id as string)).data.balance).toBe(100);
+      } else {
+        expect(result).not.toHaveProperty("error");
+        expect(setupCompletions).toBe(2);
+        expect(observed).toBe(true);
+        const balances = await Promise.all(
+          records.map(
+            async (record) => (await load(record.id as string)).data.balance,
+          ),
+        );
+        expect(balances).toEqual([90, 80, 70, 60]);
+      }
+    } finally {
+      release.resolve();
+      await outcome;
+    }
+  }, 10000);
+
+  test.each([
+    "SQL setup",
+    "Ent privacy setup",
+    "loader setup",
+    "nested grandchild Ent setup",
+    "late SQL failure",
+  ])("%s drains before closing standalone validation", async (mode) => {
+    const records = await Promise.all([insert(), insert(), insert(), insert()]);
+    const started = deferred(),
+      release = deferred();
+    const ordinary = new Error("correctable first child");
+    const sql = mode === "SQL setup" || mode === "late SQL failure";
+    const key = 1_000_000 + Math.floor(Math.random() * 1_000_000_000);
+    const lock = sql ? await DB.getInstance().getNewClient() : undefined;
+    if (lock) {
+      await lock.query("SELECT pg_advisory_lock($1)", [key]);
+    }
+    let invalid = true;
+    let settled = false;
+    let settledBeforeRelease = false;
+    let setupCompletions = 0;
+    let setupError: any;
+    let validationError: any;
+    const observations: string[] = [];
+    const transaction = withTransaction(async (tx) => {
+      // Keep the earlier write after correcting validation errors. Roll it
+      // back if a later SQL operation fails.
+      const earlier = edit(await load(records[3].id as string), 60);
+      earlier.getObservers = () => [
+        {
+          observe: async () => {
+            observations.push("committed");
+          },
+        },
+      ];
+      await earlier.saveX();
+      const parent = independent(
+        edit(await load(records[0].id as string), 90),
+        "parent",
+      );
+      const bad = independent(
+        edit(await load(records[1].id as string), 80),
+        "bad",
+      );
+      bad.getValidators = () => [
+        {
+          validate: async () => {
+            if (invalid) {
+              await started.promise;
+              return ordinary;
             }
-          }
-          const setup = async () => {
-            let ent: ScopedAccount;
-            if (sql && invalid) {
-              const query =
-                mode === "late SQL failure"
-                  ? tx.query(
-                      `DO $$ BEGIN PERFORM pg_advisory_xact_lock(${key}); RAISE EXCEPTION 'late SQL setup error' USING ERRCODE = '22012'; END $$`,
-                    )
-                  : tx.query("SELECT pg_advisory_xact_lock($1)", [key]);
-              started.resolve();
-              await query;
-              ent = await load(records[2].id as string);
-            } else if (
-              mode === "Ent privacy setup" ||
-              mode === "nested grandchild Ent setup"
-            ) {
-              ent = await loadEntX(viewer, records[2].id, {
-                ...options,
-                ent: DelayedPrivacyAccount,
-              });
-            } else if (mode === "loader setup") {
-              const reader = new InstrumentedDataLoader<string, ScopedAccount>(
-                "review-delayed-setup",
-                async (ids) => {
-                  const ents = await Promise.all(ids.map((id) => load(id)));
+          },
+        },
+      ];
+      class DelayedPrivacyAccount extends ScopedAccount {
+        getPrivacyPolicy() {
+          return {
+            rules: [
+              {
+                apply: async () => {
                   if (invalid) {
                     started.resolve();
                     await release.promise;
                   }
-                  return ents;
+                  return Allow();
                 },
-                {},
-              );
-              ent = await reader.load(records[2].id as string);
-            } else {
-              ent = await load(records[2].id as string);
-            }
-            const changeset = await independent(
-              edit(ent, 70),
-              "slow",
-            ).changeset();
-            setupCompletions++;
-            return changeset;
+              },
+            ],
           };
-          let setupOutcome: Promise<any> | undefined;
-          const trigger = {
-            changeset: () => {
-              const pending = setup();
-              setupOutcome = pending.then(
-                (value) => ({ value }),
-                (error) => ({ error }),
-              );
-              return Promise.all([bad.changeset(), pending]);
-            },
-          };
-          if (mode === "nested grandchild Ent setup") {
-            const intermediate = independent(
-              new GuardedEdit(
-                viewer,
-                accountSchema,
-                new Map<string, any>([
-                  ["balance", 50],
-                  ["admin", true],
-                ]),
-                WriteOperation.Insert,
-                null,
-              ),
-              "intermediate",
-            );
-            intermediate.getTriggers = () => [trigger];
-            parent.getTriggers = () => [
-              { changeset: () => intermediate.changeset() },
-            ];
-          } else {
-            parent.getTriggers = () => [trigger];
-          }
-          const validation = parent[method]().then(
-            () => {
-              settled = true;
-              return undefined;
-            },
-            (error) => {
-              settled = true;
-              return error;
-            },
-          );
-          validationError = await validation;
-          const outcome = await setupOutcome!;
-          setupError = outcome?.error;
-          if (mode === "late SQL failure") {
-            // Catch validation and SQL errors so
-            // withTransaction must enforce rollback.
-            return;
-          }
-          expect(validationError).toBe(ordinary);
-          expect(outcome).toHaveProperty("value");
-          expect(setupCompletions).toBe(1);
-          expect(settledBeforeRelease).toBe(false);
-          expect(getTransactionState()!.failed).toBe(false);
-          invalid = false;
-          await parent.saveX();
-        });
-        const transactionOutcome = transaction.then(
-          (value) => ({ value }),
-          (error) => ({ error }),
-        );
-        try {
-          await started.promise;
-          // Release this gate outside validation so waiting
-          // for reads cannot deadlock.
-          await new Promise<void>((resolve) => setImmediate(resolve));
-          settledBeforeRelease = settled;
-          release.resolve();
-          if (lock) {
-            await lock.query("SELECT pg_advisory_unlock($1)", [key]);
-          }
-          const result = await transactionOutcome;
-          if (mode === "late SQL failure") {
-            expect(validationError).toBe(ordinary);
-            expect(setupError?.code).toBe("22012");
-            expect((result as any).error?.code).toBe("22012");
-            expect(settledBeforeRelease).toBe(false);
-            expect(observations).toEqual([]);
-            expect((await load(records[3].id as string)).data.balance).toBe(
-              100,
-            );
-          } else {
-            expect(result).not.toHaveProperty("error");
-            expect(setupCompletions).toBe(2);
-            expect(observations).toEqual(["committed"]);
-            const balances = await Promise.all(
-              records.map(
-                async (record) =>
-                  (
-                    await load(record.id as string)
-                  ).data.balance,
-              ),
-            );
-            expect(balances).toEqual([90, 80, 70, 60]);
-          }
-        } finally {
-          release.resolve();
-          if (lock) {
-            await lock.query("SELECT pg_advisory_unlock($1)", [key]);
-            await lock.release();
-          }
-          await transactionOutcome;
         }
-      },
-      10000,
+      }
+      const setup = async () => {
+        let ent: ScopedAccount;
+        if (sql && invalid) {
+          const query =
+            mode === "late SQL failure"
+              ? tx.query(
+                  `DO $$ BEGIN PERFORM pg_advisory_xact_lock(${key}); RAISE EXCEPTION 'late SQL setup error' USING ERRCODE = '22012'; END $$`,
+                )
+              : tx.query("SELECT pg_advisory_xact_lock($1)", [key]);
+          started.resolve();
+          await query;
+          ent = await load(records[2].id as string);
+        } else if (
+          mode === "Ent privacy setup" ||
+          mode === "nested grandchild Ent setup"
+        ) {
+          ent = await loadEntX(viewer, records[2].id, {
+            ...options,
+            ent: DelayedPrivacyAccount,
+            loaderFactory: new ObjectLoaderFactory({
+              tableName: options.tableName,
+              fields,
+              key: "id",
+              instanceKey: "delayed-privacy",
+            }),
+          });
+        } else if (mode === "loader setup") {
+          const reader = new InstrumentedDataLoader<string, ScopedAccount>(
+            "review-delayed-setup",
+            async (ids) => {
+              const ents = await Promise.all(ids.map((id) => load(id)));
+              if (invalid) {
+                started.resolve();
+                await release.promise;
+              }
+              return ents;
+            },
+            {},
+          );
+          ent = await reader.load(records[2].id as string);
+        } else {
+          ent = await load(records[2].id as string);
+        }
+        const changeset = await independent(edit(ent, 70), "slow").changeset();
+        setupCompletions++;
+        return changeset;
+      };
+      let setupOutcome: Promise<any> | undefined;
+      const trigger = {
+        changeset: () => {
+          const pending = setup();
+          setupOutcome = pending.then(
+            (value) => ({ value }),
+            (error) => ({ error }),
+          );
+          return Promise.all([bad.changeset(), pending]);
+        },
+      };
+      if (mode === "nested grandchild Ent setup") {
+        const intermediate = independent(
+          new GuardedEdit(
+            viewer,
+            accountSchema,
+            new Map<string, any>([
+              ["balance", 50],
+              ["admin", true],
+            ]),
+            WriteOperation.Insert,
+            null,
+          ),
+          "intermediate",
+        );
+        intermediate.getTriggers = () => [trigger];
+        parent.getTriggers = () => [
+          { changeset: () => intermediate.changeset() },
+        ];
+      } else {
+        parent.getTriggers = () => [trigger];
+      }
+      const validation = parent[method]().then(
+        () => {
+          settled = true;
+          return undefined;
+        },
+        (error) => {
+          settled = true;
+          return error;
+        },
+      );
+      validationError = await validation;
+      const outcome = await setupOutcome!;
+      setupError = outcome?.error;
+      if (mode === "late SQL failure") {
+        // Catch validation and SQL errors so
+        // withTransaction must enforce rollback.
+        return;
+      }
+      expect(validationError).toBe(ordinary);
+      expect(outcome).toHaveProperty("value");
+      expect(setupCompletions).toBe(1);
+      expect(settledBeforeRelease).toBe(false);
+      expect(getTransactionState()!.failed).toBe(false);
+      invalid = false;
+      await parent.saveX();
+    });
+    const transactionOutcome = transaction.then(
+      (value) => ({ value }),
+      (error) => ({ error }),
     );
-  },
-);
+    try {
+      await started.promise;
+      // Release this gate outside validation so waiting
+      // for reads cannot deadlock.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      settledBeforeRelease = settled;
+      release.resolve();
+      if (lock) {
+        await lock.query("SELECT pg_advisory_unlock($1)", [key]);
+      }
+      const result = await transactionOutcome;
+      if (mode === "late SQL failure") {
+        expect(validationError).toBe(ordinary);
+        expect(setupError?.code).toBe("22012");
+        expect((result as any).error?.code).toBe("22012");
+        expect(settledBeforeRelease).toBe(false);
+        expect(observations).toEqual([]);
+        expect((await load(records[3].id as string)).data.balance).toBe(100);
+      } else {
+        expect(result).not.toHaveProperty("error");
+        expect(setupCompletions).toBe(2);
+        expect(observations).toEqual(["committed"]);
+        const balances = await Promise.all(
+          records.map(
+            async (record) => (await load(record.id as string)).data.balance,
+          ),
+        );
+        expect(balances).toEqual([90, 80, 70, 60]);
+      }
+    } finally {
+      release.resolve();
+      if (lock) {
+        await lock.query("SELECT pg_advisory_unlock($1)", [key]);
+        await lock.release();
+      }
+      await transactionOutcome;
+    }
+  }, 10000);
+});

--- a/ts/src/core/transaction_validation_reads.test.ts
+++ b/ts/src/core/transaction_validation_reads.test.ts
@@ -1,5 +1,5 @@
 import DB, { Dialect } from "./db";
-import { withTransaction } from "./transaction";
+import { withTransactionScope } from "./transaction";
 import { getTransactionState } from "./transaction_context";
 import {
   applyPrivacyPolicyForRows,
@@ -58,16 +58,9 @@ function deferred() {
   return { promise, resolve };
 }
 class GuardedEdit extends SimpleAction<ScopedAccount> {
-  requiresTransaction() {
+  requiresTransactionScope() {
     return true;
   }
-}
-
-function independent<T extends SimpleAction<ScopedAccount>>(
-  action: T,
-  resource: string,
-): T {
-  return Object.assign(action, { getTransactionResources: () => [resource] });
 }
 
 describe.each([
@@ -121,7 +114,7 @@ describe.each([
     let validationError: unknown;
     let priorFailure: unknown;
     let setupFailure: unknown;
-    const transaction = withTransaction(async (tx) => {
+    const transaction = withTransactionScope(async (tx) => {
       const earlier = edit(await load(records[3].id as string), 60);
       earlier.getObservers = () => [
         {
@@ -136,14 +129,8 @@ describe.each([
           records[2].id,
         ])
       ).rows[0];
-      const parent = independent(
-        edit(await load(records[0].id as string), 90),
-        "parent",
-      );
-      const bad = independent(
-        edit(await load(records[1].id as string), 80),
-        "bad",
-      );
+      const parent = edit(await load(records[0].id as string), 90);
+      const bad = edit(await load(records[1].id as string), 80);
       bad.getValidators = () => [
         { validate: () => (invalid ? ordinary : undefined) },
       ];
@@ -227,7 +214,7 @@ describe.each([
         if (invalid) {
           expect(ent).toBe(await priorRead);
         }
-        const changeset = await independent(edit(ent, 70), "slow").changeset();
+        const changeset = await edit(ent, 70).changeset();
         setupCompletions++;
         return changeset;
       };
@@ -336,7 +323,7 @@ describe.each([
     let setupError: any;
     let validationError: any;
     const observations: string[] = [];
-    const transaction = withTransaction(async (tx) => {
+    const transaction = withTransactionScope(async (tx) => {
       // Keep the earlier write after correcting validation errors. Roll it
       // back if a later SQL operation fails.
       const earlier = edit(await load(records[3].id as string), 60);
@@ -348,14 +335,8 @@ describe.each([
         },
       ];
       await earlier.saveX();
-      const parent = independent(
-        edit(await load(records[0].id as string), 90),
-        "parent",
-      );
-      const bad = independent(
-        edit(await load(records[1].id as string), 80),
-        "bad",
-      );
+      const parent = edit(await load(records[0].id as string), 90);
+      const bad = edit(await load(records[1].id as string), 80);
       bad.getValidators = () => [
         {
           validate: async () => {
@@ -426,7 +407,7 @@ describe.each([
         } else {
           ent = await load(records[2].id as string);
         }
-        const changeset = await independent(edit(ent, 70), "slow").changeset();
+        const changeset = await edit(ent, 70).changeset();
         setupCompletions++;
         return changeset;
       };
@@ -442,18 +423,15 @@ describe.each([
         },
       };
       if (mode === "nested grandchild Ent setup") {
-        const intermediate = independent(
-          new GuardedEdit(
-            viewer,
-            accountSchema,
-            new Map<string, any>([
-              ["balance", 50],
-              ["admin", true],
-            ]),
-            WriteOperation.Insert,
-            null,
-          ),
-          "intermediate",
+        const intermediate = new GuardedEdit(
+          viewer,
+          accountSchema,
+          new Map<string, any>([
+            ["balance", 50],
+            ["admin", true],
+          ]),
+          WriteOperation.Insert,
+          null,
         );
         intermediate.getTriggers = () => [trigger];
         parent.getTriggers = () => [
@@ -476,7 +454,7 @@ describe.each([
       const outcome = await setupOutcome!;
       setupError = outcome?.error;
       if (mode === "late SQL failure") {
-        // Catch both errors to verify that withTransaction still rolls back.
+        // Catch both errors to verify that withTransactionScope still rolls back.
         return;
       }
       expect(validationError).toBe(ordinary);

--- a/ts/src/core/transaction_validation_reads.test.ts
+++ b/ts/src/core/transaction_validation_reads.test.ts
@@ -476,8 +476,7 @@ describe.each([
       const outcome = await setupOutcome!;
       setupError = outcome?.error;
       if (mode === "late SQL failure") {
-        // Catch validation and SQL errors so
-        // withTransaction must enforce rollback.
+        // Catch both errors to verify that withTransaction still rolls back.
         return;
       }
       expect(validationError).toBe(ordinary);
@@ -494,8 +493,7 @@ describe.each([
     );
     try {
       await started.promise;
-      // Release this gate outside validation so waiting
-      // for reads cannot deadlock.
+      // Release outside validation so waiting for reads cannot deadlock.
       await new Promise<void>((resolve) => setImmediate(resolve));
       settledBeforeRelease = settled;
       release.resolve();

--- a/ts/src/core/transaction_validation_reads.test.ts
+++ b/ts/src/core/transaction_validation_reads.test.ts
@@ -119,7 +119,9 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
         let validationError: any;
         const observations: string[] = [];
         const transaction = withTransaction(async (tx) => {
-          // Earlier write must survive normal validation correction, and must roll back late SQL errors.
+          // Keep the earlier write after correcting validation errors. Roll it
+          // back
+          // if a later SQL operation fails.
           const earlier = edit(await load(records[3].id as string), 60);
           earlier.getObservers = () => [
             {
@@ -254,7 +256,8 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
           const outcome = await setupOutcome!;
           setupError = outcome?.error;
           if (mode === "late SQL failure") {
-            // Inspect and catch validation and SQL errors, letting withTransaction enforce failure.
+            // Catch validation and SQL errors so withTransaction must enforce
+            // rollback.
             return;
           }
           expect(validationError).toBe(ordinary);
@@ -271,7 +274,8 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
         );
         try {
           await started.promise;
-          // Scheduler gate is external to validation. Correct draining cannot deadlock on it.
+          // Release this gate outside validation so waiting for reads cannot
+          // deadlock.
           await new Promise<void>((resolve) => setImmediate(resolve));
           settledBeforeRelease = settled;
           release.resolve();

--- a/ts/src/core/transaction_validation_reads.test.ts
+++ b/ts/src/core/transaction_validation_reads.test.ts
@@ -120,8 +120,7 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
         const observations: string[] = [];
         const transaction = withTransaction(async (tx) => {
           // Keep the earlier write after correcting validation errors. Roll it
-          // back
-          // if a later SQL operation fails.
+          // back if a later SQL operation fails.
           const earlier = edit(await load(records[3].id as string), 60);
           earlier.getObservers = () => [
             {
@@ -256,8 +255,8 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
           const outcome = await setupOutcome!;
           setupError = outcome?.error;
           if (mode === "late SQL failure") {
-            // Catch validation and SQL errors so withTransaction must enforce
-            // rollback.
+            // Catch validation and SQL errors so
+            // withTransaction must enforce rollback.
             return;
           }
           expect(validationError).toBe(ordinary);
@@ -274,8 +273,8 @@ describe.each(["valid", "validX", "validWithErrors"] as const)(
         );
         try {
           await started.promise;
-          // Release this gate outside validation so waiting for reads cannot
-          // deadlock.
+          // Release this gate outside validation so waiting
+          // for reads cannot deadlock.
           await new Promise<void>((resolve) => setImmediate(resolve));
           settledBeforeRelease = settled;
           release.resolve();

--- a/ts/src/core/transaction_validation_reads.test.ts
+++ b/ts/src/core/transaction_validation_reads.test.ts
@@ -1,0 +1,309 @@
+import DB, { Dialect } from "./db";
+import { withTransaction } from "./transaction";
+import { getTransactionState } from "./transaction_context";
+import { loadEntX } from "./ent";
+import { Allow } from "./base";
+import { ObjectLoaderFactory } from "./loaders";
+import { InstrumentedDataLoader } from "./loaders/loader";
+import { WriteOperation } from "../action/action";
+import { BooleanType, IntegerType } from "../schema";
+import { setupPostgres, getSchemaTable } from "../testutils/db/temp_db";
+import {
+  BaseEnt,
+  getBuilderSchemaFromFields,
+  SimpleAction,
+  getDbFields,
+} from "../testutils/builder";
+import { TestContext } from "../testutils/context/test_context";
+
+class ScopedAccount extends BaseEnt {
+  nodeType = "ScopedAccount";
+}
+const accountSchema = getBuilderSchemaFromFields(
+  {
+    balance: IntegerType(),
+    admin: BooleanType(),
+  },
+  ScopedAccount,
+);
+const fields = getDbFields(accountSchema);
+const loaderFactory = new ObjectLoaderFactory({
+  tableName: "scoped_accounts",
+  fields,
+  key: "id",
+});
+const options = {
+  tableName: "scoped_accounts",
+  fields,
+  ent: ScopedAccount,
+  loaderFactory,
+};
+const context = new TestContext();
+const viewer = context.getViewer();
+const load = (id: string) => loadEntX(viewer, id, options);
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+class GuardedEdit extends SimpleAction<ScopedAccount> {
+  requiresTransaction() {
+    return true;
+  }
+}
+
+function independent<T extends SimpleAction<ScopedAccount>>(
+  action: T,
+  resource: string,
+): T {
+  return Object.assign(action, { getTransactionResources: () => [resource] });
+}
+
+describe.each(["valid", "validX", "validWithErrors"] as const)(
+  "%s drains child setup reads",
+  (method) => {
+    setupPostgres(() => [getSchemaTable(accountSchema, Dialect.Postgres)]);
+    beforeEach(() => context.cache.reset());
+    const insert = () =>
+      new SimpleAction(
+        viewer,
+        accountSchema,
+        new Map<string, any>([
+          ["balance", 100],
+          ["admin", true],
+        ]),
+        WriteOperation.Insert,
+        null,
+      ).saveX();
+    const edit = (ent: ScopedAccount, balance: number) =>
+      new GuardedEdit(
+        viewer,
+        accountSchema,
+        new Map([["balance", balance]]),
+        WriteOperation.Edit,
+        ent,
+      );
+
+    test.each([
+      "SQL setup",
+      "Ent privacy setup",
+      "loader setup",
+      "nested grandchild Ent setup",
+      "late SQL failure",
+    ])(
+      "%s drains before closing standalone validation",
+      async (mode) => {
+        const records = await Promise.all([
+          insert(),
+          insert(),
+          insert(),
+          insert(),
+        ]);
+        const started = deferred(),
+          release = deferred();
+        const ordinary = new Error("correctable first child");
+        const sql = mode === "SQL setup" || mode === "late SQL failure";
+        const key = 1_000_000 + Math.floor(Math.random() * 1_000_000_000);
+        const lock = sql ? await DB.getInstance().getNewClient() : undefined;
+        if (lock) await lock.query("SELECT pg_advisory_lock($1)", [key]);
+        let invalid = true;
+        let settled = false;
+        let settledBeforeRelease = false;
+        let setupCompletions = 0;
+        let setupError: any;
+        let validationError: any;
+        const observations: string[] = [];
+        const transaction = withTransaction(async (tx) => {
+          // Earlier write must survive normal validation correction, and must roll back late SQL errors.
+          const earlier = edit(await load(records[3].id as string), 60);
+          earlier.getObservers = () => [
+            {
+              observe: async () => {
+                observations.push("committed");
+              },
+            },
+          ];
+          await earlier.saveX();
+          const parent = independent(
+            edit(await load(records[0].id as string), 90),
+            "parent",
+          );
+          const bad = independent(
+            edit(await load(records[1].id as string), 80),
+            "bad",
+          );
+          bad.getValidators = () => [
+            {
+              validate: async () => {
+                if (invalid) {
+                  await started.promise;
+                  return ordinary;
+                }
+              },
+            },
+          ];
+          class DelayedPrivacyAccount extends ScopedAccount {
+            getPrivacyPolicy() {
+              return {
+                rules: [
+                  {
+                    apply: async () => {
+                      if (invalid) {
+                        started.resolve();
+                        await release.promise;
+                      }
+                      return Allow();
+                    },
+                  },
+                ],
+              };
+            }
+          }
+          const setup = async () => {
+            let ent: ScopedAccount;
+            if (sql && invalid) {
+              const query =
+                mode === "late SQL failure"
+                  ? tx.query(
+                      `DO $$ BEGIN PERFORM pg_advisory_xact_lock(${key}); RAISE EXCEPTION 'late SQL setup error' USING ERRCODE = '22012'; END $$`,
+                    )
+                  : tx.query("SELECT pg_advisory_xact_lock($1)", [key]);
+              started.resolve();
+              await query;
+              ent = await load(records[2].id as string);
+            } else if (
+              mode === "Ent privacy setup" ||
+              mode === "nested grandchild Ent setup"
+            ) {
+              ent = await loadEntX(viewer, records[2].id, {
+                ...options,
+                ent: DelayedPrivacyAccount,
+              });
+            } else if (mode === "loader setup") {
+              const reader = new InstrumentedDataLoader<string, ScopedAccount>(
+                "review-delayed-setup",
+                async (ids) => {
+                  const ents = await Promise.all(ids.map((id) => load(id)));
+                  if (invalid) {
+                    started.resolve();
+                    await release.promise;
+                  }
+                  return ents;
+                },
+                {},
+              );
+              ent = await reader.load(records[2].id as string);
+            } else ent = await load(records[2].id as string);
+            const changeset = await independent(
+              edit(ent, 70),
+              "slow",
+            ).changeset();
+            setupCompletions++;
+            return changeset;
+          };
+          let setupOutcome: Promise<any> | undefined;
+          const trigger = {
+            changeset: () => {
+              const pending = setup();
+              setupOutcome = pending.then(
+                (value) => ({ value }),
+                (error) => ({ error }),
+              );
+              return Promise.all([bad.changeset(), pending]);
+            },
+          };
+          if (mode === "nested grandchild Ent setup") {
+            const intermediate = independent(
+              new GuardedEdit(
+                viewer,
+                accountSchema,
+                new Map<string, any>([
+                  ["balance", 50],
+                  ["admin", true],
+                ]),
+                WriteOperation.Insert,
+                null,
+              ),
+              "intermediate",
+            );
+            intermediate.getTriggers = () => [trigger];
+            parent.getTriggers = () => [
+              { changeset: () => intermediate.changeset() },
+            ];
+          } else parent.getTriggers = () => [trigger];
+          const validation = parent[method]().then(
+            () => {
+              settled = true;
+              return undefined;
+            },
+            (error) => {
+              settled = true;
+              return error;
+            },
+          );
+          validationError = await validation;
+          const outcome = await setupOutcome!;
+          setupError = outcome?.error;
+          if (mode === "late SQL failure") {
+            // Inspect and catch validation and SQL errors, letting withTransaction enforce failure.
+            return;
+          }
+          expect(validationError).toBe(ordinary);
+          expect(outcome).toHaveProperty("value");
+          expect(setupCompletions).toBe(1);
+          expect(settledBeforeRelease).toBe(false);
+          expect(getTransactionState()!.failed).toBe(false);
+          invalid = false;
+          await parent.saveX();
+        });
+        const transactionOutcome = transaction.then(
+          (value) => ({ value }),
+          (error) => ({ error }),
+        );
+        try {
+          await started.promise;
+          // Scheduler gate is external to validation. Correct draining cannot deadlock on it.
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          settledBeforeRelease = settled;
+          release.resolve();
+          if (lock) await lock.query("SELECT pg_advisory_unlock($1)", [key]);
+          const result = await transactionOutcome;
+          if (mode === "late SQL failure") {
+            expect(validationError).toBe(ordinary);
+            expect(setupError?.code).toBe("22012");
+            expect((result as any).error?.code).toBe("22012");
+            expect(settledBeforeRelease).toBe(false);
+            expect(observations).toEqual([]);
+            expect((await load(records[3].id as string)).data.balance).toBe(
+              100,
+            );
+          } else {
+            expect(result).not.toHaveProperty("error");
+            expect(setupCompletions).toBe(2);
+            expect(observations).toEqual(["committed"]);
+            const balances = await Promise.all(
+              records.map(
+                async (record) =>
+                  (
+                    await load(record.id as string)
+                  ).data.balance,
+              ),
+            );
+            expect(balances).toEqual([90, 80, 70, 60]);
+          }
+        } finally {
+          release.resolve();
+          if (lock) {
+            await lock.query("SELECT pg_advisory_unlock($1)", [key]);
+            await lock.release();
+          }
+          await transactionOutcome;
+        }
+      },
+      10000,
+    );
+  },
+);

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -48,6 +48,8 @@ export { registerExtensionRuntime } from "./core/extensions";
 import DB from "./core/db";
 export * from "./core/loaders";
 export { DB };
+export { withTransaction, getTransactionScope } from "./core/transaction";
+export type { TransactionOptions, TransactionScope } from "./core/transaction";
 
 // TODO figure out if this should be its own import path e.g. @snowtop/ent/privacy
 export {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -48,8 +48,6 @@ export { registerExtensionRuntime } from "./core/extensions";
 import DB from "./core/db";
 export * from "./core/loaders";
 export { DB };
-export { withTransaction, getTransactionScope } from "./core/transaction";
-export type { TransactionOptions, TransactionScope } from "./core/transaction";
 
 // TODO figure out if this should be its own import path e.g. @snowtop/ent/privacy
 export {

--- a/ts/src/testutils/transaction_runtime.js
+++ b/ts/src/testutils/transaction_runtime.js
@@ -1,5 +1,5 @@
 // transaction_runtime.test.ts runs this regression test in a child process so
-// Node pg, Bun pg, and native Bun SQL cannot share singleton state.
+// Node with pg, Bun with pg, and native Bun SQL cannot share singleton state.
 const assert = require("node:assert/strict");
 const { randomUUID } = require("node:crypto");
 const { Client } = require("pg");

--- a/ts/src/testutils/transaction_runtime.js
+++ b/ts/src/testutils/transaction_runtime.js
@@ -5,14 +5,15 @@ const { randomUUID } = require("node:crypto");
 const { Client } = require("pg");
 const {
   DB,
-  withTransaction,
-  getTransactionScope,
   loadEntX,
   ObjectLoaderFactory,
   AlwaysAllowPrivacyPolicy,
   ContextCache,
   LoggedOutViewer,
 } = require("../index");
+const { withTransaction, getTransactionScope } = require("../action");
+assert.equal("withTransaction" in require("../index"), false);
+assert.equal("getTransactionScope" in require("../index"), false);
 
 async function main() {
   const admin = new Client({
@@ -112,6 +113,22 @@ async function main() {
       /abort/,
     );
     assert.equal((await load()).balance, 50);
+    await withTransaction(async (tx) => {
+      await tx.exec(
+        "UPDATE scope_accounts SET balance = 40; UPDATE scope_accounts SET balance = 30",
+      );
+      assert.equal((await load()).balance, 30);
+    });
+    await assert.rejects(
+      withTransaction(async (tx) => {
+        await tx.exec(
+          "UPDATE scope_accounts SET balance = 20; UPDATE scope_accounts SET balance = 10",
+        );
+        throw new Error("abort multiple commands");
+      }),
+      /abort multiple commands/,
+    );
+    assert.equal((await load()).balance, 30);
     assert.equal(getTransactionScope(), undefined);
     console.log(
       `transaction runtime passed: ${process.versions.bun ? "bun" : "node"}/${process.argv[2] || "pg"}`,

--- a/ts/src/testutils/transaction_runtime.js
+++ b/ts/src/testutils/transaction_runtime.js
@@ -1,0 +1,127 @@
+// Real-runtime regression. Invoked by transaction_runtime.test.ts in a child
+// process so pg, Bun/pg and native Bun SQL cannot share singleton state.
+const assert = require("node:assert/strict");
+const { randomUUID } = require("node:crypto");
+const { Client } = require("pg");
+const {
+  DB,
+  withTransaction,
+  getTransactionScope,
+  loadEntX,
+  ObjectLoaderFactory,
+  AlwaysAllowPrivacyPolicy,
+  ContextCache,
+  LoggedOutViewer,
+} = require("../index");
+
+async function main() {
+  const admin = new Client({
+    host: "localhost",
+    database: "postgres",
+    user: process.env.POSTGRES_USER || undefined,
+    password: process.env.POSTGRES_PASSWORD || undefined,
+  });
+  const database = `ent_scope_${randomUUID().replaceAll("-", "")}`;
+  await admin.connect();
+  await admin.query(`CREATE DATABASE ${database}`);
+  try {
+    delete process.env.DB_CONNECTION_STRING;
+    DB.initDB({
+      db: {
+        host: "localhost",
+        database,
+        user: process.env.POSTGRES_USER || undefined,
+        password: process.env.POSTGRES_PASSWORD || undefined,
+      },
+      runtime: process.versions.bun ? "bun" : "node",
+      postgresDriver: process.argv[2] || "pg",
+    });
+    await DB.getInstance()
+      .getPool()
+      .query(
+        "CREATE TABLE scope_accounts (id text PRIMARY KEY, balance integer NOT NULL)",
+      );
+    await DB.getInstance()
+      .getPool()
+      .query("INSERT INTO scope_accounts VALUES ('a',100)");
+    class Account {
+      nodeType = "Account";
+      constructor(viewer, row) {
+        this.viewer = viewer;
+        this.id = row.id;
+        this.balance = row.balance;
+      }
+      getPrivacyPolicy() {
+        return AlwaysAllowPrivacyPolicy;
+      }
+      __setRawDBData() {}
+    }
+    const context = {
+      cache: new ContextCache(),
+      getViewer() {
+        return viewer;
+      },
+    };
+    const viewer = new LoggedOutViewer(context);
+    const options = {
+      tableName: "scope_accounts",
+      fields: ["id", "balance"],
+      ent: Account,
+      loaderFactory: new ObjectLoaderFactory({
+        tableName: "scope_accounts",
+        fields: ["id", "balance"],
+        key: "id",
+        keyType: "text",
+      }),
+    };
+    const load = () => loadEntX(viewer, "a", options);
+    let meet;
+    const ready = new Promise((r) => {
+      meet = r;
+    });
+    let arrivals = 0;
+    const attempts = [];
+    const sell = (amount) =>
+      withTransaction(
+        async (tx) => {
+          attempts.push(tx.attempt);
+          assert.equal(getTransactionScope().isolationLevel, "serializable");
+          const account = await load();
+          if (tx.attempt === 0) {
+            if (++arrivals === 2) meet();
+            await ready;
+          }
+          await tx.query(
+            "UPDATE scope_accounts SET balance = $1 WHERE id = $2",
+            [account.balance - amount, "a"],
+          );
+          assert.equal((await load()).balance, account.balance - amount);
+        },
+        { maxRetries: 3 },
+      );
+    await Promise.all([sell(20), sell(30)]);
+    assert.equal((await load()).balance, 50);
+    assert.ok(attempts.includes(1));
+    await assert.rejects(
+      withTransaction(async (tx) => {
+        await tx.exec("UPDATE scope_accounts SET balance = 0");
+        throw new Error("abort");
+      }),
+      /abort/,
+    );
+    assert.equal((await load()).balance, 50);
+    assert.equal(getTransactionScope(), undefined);
+    console.log(
+      `transaction runtime passed: ${process.versions.bun ? "bun" : "node"}/${process.argv[2] || "pg"}`,
+    );
+  } finally {
+    if (DB.instance) await DB.getInstance().endPool();
+    await admin.query(`DROP DATABASE ${database} WITH (FORCE)`);
+    await admin.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/ts/src/testutils/transaction_runtime.js
+++ b/ts/src/testutils/transaction_runtime.js
@@ -11,8 +11,8 @@ const {
   ContextCache,
   LoggedOutViewer,
 } = require("../index");
-const { withTransaction, getTransactionScope } = require("../action");
-assert.equal("withTransaction" in require("../index"), false);
+const { withTransactionScope, getTransactionScope } = require("../action");
+assert.equal("withTransactionScope" in require("../index"), false);
 assert.equal("getTransactionScope" in require("../index"), false);
 
 async function main() {
@@ -83,7 +83,7 @@ async function main() {
     let arrivals = 0;
     const attempts = [];
     const sell = (amount) =>
-      withTransaction(
+      withTransactionScope(
         async (tx) => {
           attempts.push(tx.attempt);
           assert.equal(getTransactionScope().isolationLevel, "serializable");
@@ -106,21 +106,21 @@ async function main() {
     assert.equal((await load()).balance, 50);
     assert.ok(attempts.includes(1));
     await assert.rejects(
-      withTransaction(async (tx) => {
+      withTransactionScope(async (tx) => {
         await tx.exec("UPDATE scope_accounts SET balance = 0");
         throw new Error("abort");
       }),
       /abort/,
     );
     assert.equal((await load()).balance, 50);
-    await withTransaction(async (tx) => {
+    await withTransactionScope(async (tx) => {
       await tx.exec(
         "UPDATE scope_accounts SET balance = 40; UPDATE scope_accounts SET balance = 30",
       );
       assert.equal((await load()).balance, 30);
     });
     await assert.rejects(
-      withTransaction(async (tx) => {
+      withTransactionScope(async (tx) => {
         await tx.exec(
           "UPDATE scope_accounts SET balance = 20; UPDATE scope_accounts SET balance = 10",
         );
@@ -129,6 +129,42 @@ async function main() {
       /abort multiple commands/,
     );
     assert.equal((await load()).balance, 30);
+    const { ListBasedExecutor } = require("../action/executor");
+    const validate = async (amount, check) =>
+      withTransactionScope(async () => {
+        const builder = { placeholderID: randomUUID() };
+        const action = { validateBeforeCommit: check };
+        const operation = {
+          builder,
+          performWrite: (queryer) =>
+            queryer.query("UPDATE scope_accounts SET balance = $1", [amount]),
+        };
+        await new ListBasedExecutor(
+          viewer,
+          builder.placeholderID,
+          [operation],
+          { builder, action },
+        ).execute();
+      });
+    let finalBalance;
+    await validate(25, async (context) => {
+      finalBalance = (await context.query("SELECT balance FROM scope_accounts"))
+        .rows[0].balance;
+      assert.equal((await load()).balance, 25);
+    });
+    assert.equal(finalBalance, 25);
+    await assert.rejects(
+      validate(0, async () => {
+        throw new Error("final rule failed");
+      }),
+      /final rule failed/,
+    );
+    assert.equal((await load()).balance, 25);
+    await assert.rejects(
+      validate(0, (context) => context.query("SELECT 1; COMMIT")),
+      /single read query/,
+    );
+    assert.equal((await load()).balance, 25);
     assert.equal(getTransactionScope(), undefined);
     console.log(
       `transaction runtime passed: ${process.versions.bun ? "bun" : "node"}/${process.argv[2] || "pg"}`,

--- a/ts/src/testutils/transaction_runtime.js
+++ b/ts/src/testutils/transaction_runtime.js
@@ -1,5 +1,5 @@
-// Real-runtime regression. Invoked by transaction_runtime.test.ts in a child
-// process so pg, Bun/pg and native Bun SQL cannot share singleton state.
+// transaction_runtime.test.ts runs this regression test in a child process so
+// Node pg, Bun pg, and native Bun SQL cannot share singleton state.
 const assert = require("node:assert/strict");
 const { randomUUID } = require("node:crypto");
 const { Client } = require("pg");

--- a/ts/src/testutils/transaction_runtime.js
+++ b/ts/src/testutils/transaction_runtime.js
@@ -88,7 +88,9 @@ async function main() {
           assert.equal(getTransactionScope().isolationLevel, "serializable");
           const account = await load();
           if (tx.attempt === 0) {
-            if (++arrivals === 2) meet();
+            if (++arrivals === 2) {
+              meet();
+            }
             await ready;
           }
           await tx.query(
@@ -115,7 +117,9 @@ async function main() {
       `transaction runtime passed: ${process.versions.bun ? "bun" : "node"}/${process.argv[2] || "pg"}`,
     );
   } finally {
-    if (DB.instance) await DB.getInstance().endPool();
+    if (DB.instance) {
+      await DB.getInstance().endPool();
+    }
     await admin.query(`DROP DATABASE ${database} WITH (FORCE)`);
     await admin.end();
   }

--- a/ts/src/testutils/transaction_types.ts
+++ b/ts/src/testutils/transaction_types.ts
@@ -23,3 +23,21 @@ export function checkTransactionBuilderTypes<
   runInActionPreparation(builder, async () => undefined);
   setExecutorBuilders(executor, [builder]);
 }
+import type { Action } from "../action/action";
+import type { ScopeValidationContext } from "../action";
+
+export function checkFinalValidationTypes<
+  TEnt extends Ent<TViewer>,
+  TViewer extends Viewer,
+>(
+  action: Action<TEnt, Builder<TEnt, TViewer>, TViewer>,
+  context: ScopeValidationContext,
+) {
+  action.validateBeforeCommit?.(context);
+  context.query("SELECT 1");
+  context.queryAll("SELECT 1");
+  // @ts-expect-error Final validation cannot execute writes.
+  context.exec("UPDATE accounts SET amount = 0");
+  // @ts-expect-error Final validation cannot commit the scope.
+  context.commit();
+}

--- a/ts/src/testutils/transaction_types.ts
+++ b/ts/src/testutils/transaction_types.ts
@@ -1,0 +1,25 @@
+import type { Builder, Executor } from "../action/action";
+import type { Ent, Viewer } from "../core/base";
+import {
+  hasActionResultTransaction,
+  isPreparingAction,
+  recordActionResultTransaction,
+  runInActionPreparation,
+  setExecutorBuilders,
+} from "../core/transaction_context";
+
+export function checkTransactionBuilderTypes<
+  TEnt extends Ent<TViewer>,
+  TViewer extends Viewer,
+  TExistingEnt extends TEnt | null,
+>(
+  builder: Builder<TEnt, TViewer, TExistingEnt>,
+  ent: TEnt,
+  executor: Executor,
+) {
+  hasActionResultTransaction(builder);
+  isPreparingAction(builder);
+  recordActionResultTransaction(ent, builder);
+  runInActionPreparation(builder, async () => undefined);
+  setExecutorBuilders(executor, [builder]);
+}

--- a/work/transaction-scope-design.md
+++ b/work/transaction-scope-design.md
@@ -1,0 +1,75 @@
+# Transaction scope decisions
+
+- Objective: Implement the agreed transaction scope API and action-owned final validation.
+- Status: complete
+- Updated: 2026-09-10
+- Context: `codex/transaction-scoped-actions`, [PR #2035](https://github.com/lolopinto/ent/pull/2035).
+
+## Accepted contract
+
+1. Use `withTransactionScope` for the callback boundary. It begins before loads and action preparation and commits after final validation. Ordinary action transactions outside a scope retain their behavior.
+2. Use `requiresTransactionScope()` as an action precondition. Return `true` to accept either supported isolation level or `"serializable"` to require serializable isolation. The method does not create a scope or select different preparation rules.
+3. Apply the same rules to every action inside a scope. Prepare and save one root at a time. Reload data and create fresh readers after each save. Reject concurrent roots, prebuilt batches of roots, and multiple roots in `Transaction.run()` inside a scope.
+4. Preserve trigger children as one preparation graph. Children can prepare together before the graph writes. They do not observe earlier siblings' writes during preparation.
+5. Remove `getTransactionResources()`. Use ordered saves when decisions depend on earlier writes. Use final validation for rules about the operation's completed database state. Keep the duplicate row-mutation guard within each graph.
+6. Define `validateBeforeCommit(context: ScopeValidationContext)` on the action. Declaring this hook requires a scope; an explicit isolation requirement still applies. Ent registers the hook for executed actions, including children and grandchildren.
+7. Run hooks after the callback and deferred database constraints and triggers, before commit. Check the complete final state on the same reserved connection. Hook errors roll back the whole scope. Do not register checks from discarded standalone validation, unexecuted changesets, or actions skipped by conditional execution or silent privacy failure.
+8. Bypass supported Ent, request, scope, loader, query/count, and privacy result caches during final validation. Preserve privacy enforcement. Ordinary reads earlier in the scope keep attempt-local caches. Capture identifiers and query in the hook; arbitrary application memoization and captured Ent objects are not fresh reads.
+9. Make final validation read-only. Expose `query`, `queryAll`, `attempt`, and `isolationLevel`. Accept one read statement per query; reject action preparation, action saves, writes, and transaction control. PostgreSQL read-only mode protects persistent tables. Expire the context when validation ends.
+10. Keep PostgreSQL support, serializable isolation by default, optional whole-callback retries, zero retries by default, and no nested scopes or savepoints. Rebuild actions, reads, and registrations on every retry. Observers run after a successful commit and connection release.
+
+The framework comparison has been removed. The public guide is [Transactions](../docs/docs/actions/transactions.md).
+
+## Lifecycle
+
+```text
+Ordinary action:
+load -> prepare parent and children -> BEGIN -> writes -> COMMIT -> observers
+
+Transaction scope:
+BEGIN
+  load -> prepare root A and children -> write their changes
+  load -> prepare root B and children -> write their changes
+  finish deferred database constraints and triggers
+  validateBeforeCommit for each executed action
+    uncached reads on the same connection
+COMMIT
+observers
+```
+
+Final validation supplements privacy, input validation, and correct calculations. It does not infer missing rules or repair arbitrary stale calculations. Competing writers still need compatible serializable isolation or locking. An uncached serializable read sees the transaction snapshot and its own writes, rather than every later external commit.
+
+## Implementation and review checklist
+
+- Review baseline: `364350d9228f5ceb69c9e3b08d81a6d3d047a7f1`. Keep this baseline throughout the loop.
+- Original PR base for interaction checks: `37309a0c8b81fa071d170a5827530a5d283d5a52`.
+- Initial local changes: This untracked decision record only. Original copy: `/private/tmp/ent-scope-validation/design-before.md`.
+- Evidence directory: `/private/tmp/ent-scope-validation/`.
+- Review standard: `review-fix-loop` with `review-code`; Google writing style for introduced comments and documentation.
+- [x] Remove the framework comparison and record the accepted contract.
+- [x] Rename the scope APIs and remove resource declarations.
+- [x] Apply preparation and freshness checks uniformly inside scopes.
+- [x] Register action-owned final validators and run them before commit.
+- [x] Enforce uncached reads and prevent writes during final validation.
+- [x] Add package regressions, runtime driver coverage, and a generated consumer example.
+- [x] Update public documentation and the changelog.
+- [x] Review the full implementation diff and original PR interactions.
+- [x] Repair confirmed findings and run repository-required verification.
+- [x] Review the full target again after repairs and record the final result.
+
+## Verification
+
+- Baseline: 35 tests passed across the previous resource and lifecycle suites.
+- Final package run: 3,735 tests passed across 101 suites; one existing skipped test.
+- Focused final validation: 39 tests passed, including concurrent serializable final checks and late callback work.
+- TypeScript compilation, package lint, generator package tests, the complete Node/Bun/PostgreSQL codegen matrix, and the documentation build passed.
+- Example tests: Simple 183 passed (one existing skip), SQLite Todo 60 passed, RSVP 72 passed, Local Guide 15 passed, and Semantic Notes 4 passed. Total: 334 passing tests.
+- Four example typechecks passed. Simple's seven auth-test typing errors reproduce identically with the unmodified baseline runtime. They concern `SuperTest` versus `Agent` and are outside this change.
+- All example image builds and codegen flows were exercised. Local codegen required installed Python 3.11 dependencies in place of an empty Pipenv environment. SQLite codegen passed with a fresh database and one consistent local runtime package. Verification-generated files and npm lockfile churn were restored to the initial revision.
+- Review passes: 2 complete passes over the original implementation target and its repairs, with original PR interaction checks. No actionable findings remain in the reviewed scope.
+- Repair rounds: 1 after full review. All four findings reproduced before repair: unfinished result privacy could permit an early commit; repeated custom counts accumulated source IDs; conditional wrappers hid privacy skips; draining pending reads could replace the original business error.
+- Evidence: `review-pass1.md`, `review-pass1-repros.log`, `repair-round1.log`, `package-final.log`, `codegen-final.log`, `simple-types-baseline.log`, and the example logs in `/private/tmp/ent-scope-validation/`.
+
+## Publication
+
+These changes belong to [draft PR #2035](https://github.com/lolopinto/ent/pull/2035). The PR remains a draft.


### PR DESCRIPTION
Ordinary Ent action transactions begin after preparation, so reads used by privacy checks, triggers, and validators can fall outside the write transaction. This adds PostgreSQL `withTransactionScope` to include loads, preparation, writes, and final business validation in one transaction.

Actions can declare `requiresTransactionScope()` as a scope/isolation precondition and `validateBeforeCommit(context)` to check the completed database state. Ent registers final checks automatically for executed actions, including trigger children and grandchildren. Checks run after deferred database constraints and triggers, on the same connection, with uncached reads. A failed check rolls back every write; observers run after commit.

Every action inside a scope follows the same preparation rules: save roots sequentially and reload between saves, or return child changesets from one root. Known duplicate row mutations in one graph reject. Serializable isolation is the default; optional retries rebuild the entire callback. PostgreSQL is supported through Node/pg and Bun/pg or native Bun SQL. Ordinary transactions outside a scope retain their behavior.

Validation:

- Core regressions live in `ts/src/core/transaction*.test.ts` and the owning action/query suites. The package run passed 3,735 tests across 101 suites, with one existing skipped test.
- Compilation, lint, documentation build, generator package tests, and the complete Node/Bun/PostgreSQL codegen matrix passed.
- All five example test suites passed: 334 tests total. The Local Guide example covers generated `saveXFromID` registration and rollback.
- Four example typechecks passed. Simple's seven existing auth-test errors (`SuperTest` versus `Agent`) reproduce identically with the unmodified baseline runtime.
- Two complete review passes and one repair round. Regressions cover unfinished result privacy, repeated uncached counts, conditional privacy skips, failure preservation, deferred database triggers, and real concurrent serialization retries.

The transaction guide, lifecycle diagram, Unreleased changelog entry, and scope decision record are included. This PR remains a draft.
